### PR TITLE
feat(rag-knowledge): HTTP トランスポート対応 + ツール公開制限

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ cp .env.example .env  # Embedding 設定等を編集
 ## 起動
 
 ```bash
-# MCP サーバー (stdio モード)
+# MCP サーバー (stdio モード、デフォルト)
+uv run python -m rag.server
+
+# MCP サーバー (HTTP モード)
+# .env で RAG_TRANSPORT=http を設定
 uv run python -m rag.server
 
 # CLI

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -26,6 +26,8 @@ MCP サーバーとして独立動作し、5 つのツールを提供する。
 - プロジェクトルートの `.env` で設定を管理する
 - Embedding モデルを変更した場合、既存データとの類似度計算が不正確になるため、コレクション再構築が必要
 - 呼び出し元が MCP クライアントとして本サーバーに接続することで RAG 機能を利用できる
+- トランスポートは stdio（デフォルト）と http（Streamable HTTP）を切替可能。環境変数でトランスポート種別・ホスト・ポート・DNS リバインディング保護を設定する
+- HTTP モード時はデータ変更ツール（`rag_add`, `rag_crawl`, `rag_delete`）を非公開にし、読み取り専用ツールのみ提供する
 
 ## インターフェース
 
@@ -85,7 +87,7 @@ flowchart TB
     BM25["BM25 インデックス"]
     EMBED["Embedding プロバイダー"]
 
-    CLIENT --> TOOLS
+    CLIENT -->|stdio / http| TOOLS
     TOOLS --> Service
     Service --> CRAWLER
     Service --> CHUNKER

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -83,7 +83,7 @@ class RAGSettings(BaseSettings):
     # トランスポート
     rag_transport: Literal["stdio", "http"] = "stdio"
     rag_http_host: str = "127.0.0.1"
-    rag_http_port: int = 8081
+    rag_http_port: int = Field(default=8081, ge=1, le=65535)
     rag_dns_rebinding_protection: bool = True
 
     # デバッグ

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -80,6 +80,12 @@ class RAGSettings(BaseSettings):
     rag_url_safety_fail_open: bool = True
     rag_url_safety_timeout: float = Field(default=5.0, gt=0)
 
+    # トランスポート
+    rag_transport: Literal["stdio", "http"] = "stdio"
+    rag_http_host: str = "127.0.0.1"
+    rag_http_port: int = 8081
+    rag_dns_rebinding_protection: bool = True
+
     # デバッグ
     rag_debug_log_enabled: bool = False
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -292,5 +292,44 @@ async def rag_stats() -> str:
         return "エラー: 統計情報の取得に失敗しました。"
 
 
+def _configure_and_run() -> None:
+    """トランスポート設定に基づいて MCP サーバーを起動する.
+
+    HTTP モード時はデータ変更ツール（rag_add, rag_crawl, rag_delete）を
+    削除し、読み取り専用ツールのみ公開する。
+    """
+    settings = get_settings()
+    transport = settings.rag_transport
+
+    if transport == "http":
+        # HTTP モードではデータ変更ツールを非公開にする
+        # （外部公開時の安全性のため、読み取り専用ツールのみ提供）
+        _write_tools = ["rag_add", "rag_crawl", "rag_delete"]
+        for tool_name in _write_tools:
+            try:
+                mcp.remove_tool(tool_name)
+            except KeyError:
+                pass
+        logger.info(
+            "HTTP mode: write tools removed, exposing read-only tools only"
+        )
+
+        mcp.settings.host = settings.rag_http_host
+        mcp.settings.port = settings.rag_http_port
+        if not settings.rag_dns_rebinding_protection:
+            if mcp.settings.transport_security is not None:
+                mcp.settings.transport_security.enable_dns_rebinding_protection = (
+                    False
+                )
+            else:
+                logger.warning(
+                    "transport_security is None; "
+                    "cannot disable DNS rebinding protection"
+                )
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run()
+
+
 if __name__ == "__main__":
-    mcp.run()
+    _configure_and_run()

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -305,11 +305,17 @@ def _configure_and_run() -> None:
         # HTTP モードではデータ変更ツールを非公開にする
         # （外部公開時の安全性のため、読み取り専用ツールのみ提供）
         _write_tools = ["rag_add", "rag_crawl", "rag_delete"]
+        _failed: list[str] = []
         for tool_name in _write_tools:
             try:
                 mcp.remove_tool(tool_name)
             except KeyError:
-                pass
+                _failed.append(tool_name)
+        if _failed:
+            raise RuntimeError(
+                f"HTTP mode: failed to remove write tools {_failed}. "
+                "Aborting to prevent unintended tool exposure."
+            )
         logger.info(
             "HTTP mode: write tools removed, exposing read-only tools only"
         )

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -17,7 +17,7 @@ from rag.rag_knowledge import (
     RawSearchResults,
     VectorSearchItem,
 )
-from rag.server import _reset_rag_service
+from rag.server import _configure_and_run, _reset_rag_service
 
 
 @pytest.fixture(autouse=True)
@@ -286,3 +286,79 @@ class TestRagSearchOutput:
         assert "全文テキスト" in result
         # Result 2 には参照テキストが出る
         assert "ベクトル検索結果 Result 1 に掲載済み" in result
+
+
+class TestConfigureAndRun:
+    """_configure_and_run の起動分岐テスト."""
+
+    def test_stdio_mode_calls_run_without_transport(self) -> None:
+        """stdio モードでは mcp.run() が引数なしで呼ばれること."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "stdio"
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod.mcp, "run") as mock_run,
+        ):
+            _configure_and_run()
+
+        mock_run.assert_called_once_with()
+
+    def test_http_mode_removes_write_tools(self) -> None:
+        """HTTP モードでは write ツールが削除されること."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "http"
+        mock_settings.rag_http_host = "127.0.0.1"
+        mock_settings.rag_http_port = 8081
+        mock_settings.rag_dns_rebinding_protection = True
+
+        removed_tools: list[str] = []
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(
+                mod.mcp,
+                "remove_tool",
+                side_effect=lambda name: removed_tools.append(name),
+            ),
+            patch.object(mod.mcp, "run"),
+        ):
+            _configure_and_run()
+
+        assert set(removed_tools) == {"rag_add", "rag_crawl", "rag_delete"}
+
+    def test_http_mode_calls_run_with_streamable_http(self) -> None:
+        """HTTP モードでは mcp.run(transport='streamable-http') が呼ばれること."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "http"
+        mock_settings.rag_http_host = "0.0.0.0"
+        mock_settings.rag_http_port = 9090
+        mock_settings.rag_dns_rebinding_protection = True
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod.mcp, "remove_tool"),
+            patch.object(mod.mcp, "run") as mock_run,
+        ):
+            _configure_and_run()
+
+        mock_run.assert_called_once_with(transport="streamable-http")
+        assert mod.mcp.settings.host == "0.0.0.0"
+        assert mod.mcp.settings.port == 9090
+
+    def test_http_mode_aborts_if_tool_removal_fails(self) -> None:
+        """HTTP モードで write ツール削除に失敗したら RuntimeError で中断すること."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "http"
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod.mcp, "remove_tool", side_effect=KeyError("rag_add")),
+            patch.object(mod.mcp, "run"),
+            pytest.raises(RuntimeError, match="failed to remove write tools"),
+        ):
+            _configure_and_run()


### PR DESCRIPTION
## Summary

- FastMCP の HTTP トランスポート（streamable-http）を追加
- `RAG_TRANSPORT` 環境変数で stdio / http の切り替えに対応
- HTTP モード時はデータ変更ツール（`rag_add`, `rag_crawl`, `rag_delete`）を非公開にし、読み取り専用ツールのみ提供
- DNS リバインディング保護の設定を追加
- 仕様書・README を更新

## Test plan

- [x] 既存テスト 342件 全通過
- [x] ruff / mypy クリア

## Related issues

Related becky3/ai-assistant#747