### PR TITLE
ci: auto_progress_prompt にファイル読み取り失敗時の中断指示を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,5 +27,5 @@ jobs:
     uses: becky3/shared-workflows/.github/workflows/claude.yml@main
     with:
       allowed_user: becky3
-      auto_progress_prompt: "GA環境専用ルールが .claude/CLAUDE-auto-progress.md にあります。自動実装・品質チェック・完了処理の手順はこのファイルを必ず読んでから作業を開始してください。"
+      auto_progress_prompt: "GA環境専用ルールが .claude/CLAUDE-auto-progress.md にあります。このファイルを必ず読んでから作業を開始してください。ファイルが見つからない・読めない場合は、その旨をIssueにコメントして作業を中断してください。"
     secrets: inherit


### PR DESCRIPTION
## Summary

- auto_progress_prompt の文言を変更し、CLAUDE-auto-progress.md が読めない場合は Issue にコメントして作業を中断するよう指示を追加
- Claude が同ファイルを読まずに作業を進める問題の切り分け検証用

## Test plan

- [x] ワークフロー構文に問題なし
- [ ] Issue #8 に `auto-implement` ラベルを再付与して動作確認

Generated with [Claude Code](https://claude.ai/code)