### PR TITLE
ci: auto_progress_prompt 到達確認テスト

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,5 +27,5 @@ jobs:
     uses: becky3/shared-workflows/.github/workflows/claude.yml@main
     with:
       allowed_user: becky3
-      auto_progress_prompt: "GA環境専用ルールが .claude/CLAUDE-auto-progress.md にあります。このファイルを必ず読んでから作業を開始してください。ファイルが見つからない・読めない場合は、その旨をIssueにコメントして作業を中断してください。"
+      auto_progress_prompt: "これはプロンプト到達確認テストです。このプロンプトが見えたら、Issueに「ok」とだけコメントして作業を終了してください。他の作業は一切行わないでください。"
     secrets: inherit


### PR DESCRIPTION
## Summary

- `--append-system-prompt` が実際に Claude に届いているか検証するテスト
- プロンプトが見えたら「ok」とだけコメントして停止する指示に変更

## Test plan

- [ ] マージ後、Issue #8 に `auto-implement` ラベルを再付与
- [ ] Claude が「ok」とコメントすれば → プロンプト到達確認
- [ ] Claude が通常作業を行えば → プロンプト未到達

Generated with [Claude Code](https://claude.ai/code)