### PR TITLE
fix: CLAUDE.md に auto-progress 参照を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,5 +27,5 @@ jobs:
     uses: becky3/shared-workflows/.github/workflows/claude.yml@main
     with:
       allowed_user: becky3
-      auto_progress_prompt: "これはプロンプト到達確認テストです。このプロンプトが見えたら、Issueに「ok」とだけコメントして作業を終了してください。他の作業は一切行わないでください。"
+      auto_progress_prompt: "GA環境専用ルールが .claude/CLAUDE-auto-progress.md にあります。このファイルを必ず読んでから作業を開始してください。ファイルが見つからない・読めない場合は、その旨をIssueにコメントして作業を中断してください。"
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@
 @README.md
 @docs/specs/overview.md
 
+## 自動進行ルール（auto-progress）
+
+自動実装の詳細ルール・品質チェック手順・GA環境の制約は `.claude/CLAUDE-auto-progress.md` を参照。
+
 ## Claude Code 拡張機能
 
 ### 自律呼び出しルール（プロジェクト固有）


### PR DESCRIPTION
## Summary

- CLAUDE.md に自動進行ルール（auto-progress）への参照を追加
- ai-assistant と同様の構成にすることで、auto-implement 時に CLAUDE-auto-progress.md が読まれるようにする
- caller のテスト用プロンプトを本来の文言に復元

## Test plan

- [ ] マージ後、Issue #8 で `auto-implement` ラベルを再付与
- [ ] Claude が CLAUDE-auto-progress.md を読み、PR を作成するか確認

Generated with [Claude Code](https://claude.ai/code)