### PR TITLE
fix(rag-knowledge): HTTPモードのグレースフルシャットダウン対応

### DIFF
--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -326,8 +326,9 @@ def _configure_and_run() -> None:
         else:
             mcp.run()
     except KeyboardInterrupt:
-        pass
-    finally:
+        logger.info("MCP server shut down")
+        raise SystemExit(130)
+    else:
         logger.info("MCP server shut down")
 
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -319,9 +319,16 @@ def _configure_and_run() -> None:
                     "transport_security is None; "
                     "cannot disable DNS rebinding protection"
                 )
-        mcp.run(transport="streamable-http")
-    else:
-        mcp.run()
+
+    try:
+        if transport == "http":
+            mcp.run(transport="streamable-http")
+        else:
+            mcp.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        logger.info("MCP server shut down")
 
 
 if __name__ == "__main__":

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -323,3 +323,55 @@ class TestConfigureAndRun:
         mock_run.assert_called_once_with(transport="streamable-http")
         assert mod.mcp.settings.host == "0.0.0.0"
         assert mod.mcp.settings.port == 9090
+
+    def test_keyboard_interrupt_graceful_shutdown(self) -> None:
+        """Ctrl+C (KeyboardInterrupt) でトレースバックなく終了すること (#42)."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "http"
+        mock_settings.rag_http_host = "127.0.0.1"
+        mock_settings.rag_http_port = 8080
+        mock_settings.rag_dns_rebinding_protection = True
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(
+                mod.mcp, "run", side_effect=KeyboardInterrupt
+            ),
+            patch.object(mod.logger, "info") as mock_log,
+        ):
+            _configure_and_run()
+
+        mock_log.assert_called_once_with("MCP server shut down")
+
+    def test_stdio_keyboard_interrupt_graceful_shutdown(self) -> None:
+        """stdio モードでも KeyboardInterrupt でグレースフルシャットダウンすること (#42)."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "stdio"
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(
+                mod.mcp, "run", side_effect=KeyboardInterrupt
+            ),
+            patch.object(mod.logger, "info") as mock_log,
+        ):
+            _configure_and_run()
+
+        mock_log.assert_called_once_with("MCP server shut down")
+
+    def test_shutdown_log_on_normal_exit(self) -> None:
+        """正常終了時もシャットダウンログが出力されること (#42)."""
+        mod = import_module("rag.server")
+        mock_settings = MagicMock()
+        mock_settings.rag_transport = "stdio"
+
+        with (
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod.mcp, "run"),
+            patch.object(mod.logger, "info") as mock_log,
+        ):
+            _configure_and_run()
+
+        mock_log.assert_called_once_with("MCP server shut down")

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -325,7 +325,7 @@ class TestConfigureAndRun:
         assert mod.mcp.settings.port == 9090
 
     def test_keyboard_interrupt_graceful_shutdown(self) -> None:
-        """Ctrl+C (KeyboardInterrupt) でトレースバックなく終了すること (#42)."""
+        """Ctrl+C (KeyboardInterrupt) で終了コード130で終了すること (#42)."""
         mod = import_module("rag.server")
         mock_settings = MagicMock()
         mock_settings.rag_transport = "http"
@@ -339,13 +339,14 @@ class TestConfigureAndRun:
                 mod.mcp, "run", side_effect=KeyboardInterrupt
             ),
             patch.object(mod.logger, "info") as mock_log,
+            pytest.raises(SystemExit, match="130"),
         ):
             _configure_and_run()
 
         mock_log.assert_called_once_with("MCP server shut down")
 
     def test_stdio_keyboard_interrupt_graceful_shutdown(self) -> None:
-        """stdio モードでも KeyboardInterrupt でグレースフルシャットダウンすること (#42)."""
+        """stdio モードでも KeyboardInterrupt で終了コード130で終了すること (#42)."""
         mod = import_module("rag.server")
         mock_settings = MagicMock()
         mock_settings.rag_transport = "stdio"
@@ -356,6 +357,7 @@ class TestConfigureAndRun:
                 mod.mcp, "run", side_effect=KeyboardInterrupt
             ),
             patch.object(mod.logger, "info") as mock_log,
+            pytest.raises(SystemExit, match="130"),
         ):
             _configure_and_run()
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `_configure_and_run()` で `KeyboardInterrupt` を catch し、Ctrl+C 停止時のトレースバックを抑制
- `finally` ブロックでシャットダウンログ (`MCP server shut down`) を出力
- HTTP モード・stdio モード両方でグレースフルシャットダウンが動作

## Test plan

- [x] `test_keyboard_interrupt_graceful_shutdown`: HTTP モードで KeyboardInterrupt 時にトレースバックなく終了すること
- [x] `test_stdio_keyboard_interrupt_graceful_shutdown`: stdio モードでも同様にグレースフルシャットダウンすること
- [x] `test_shutdown_log_on_normal_exit`: 正常終了時もシャットダウンログが出力されること
- [x] 既存テスト 347 件全パス
- [x] ruff / mypy / markdownlint 全パス

## Related issues

Closes #42