### PR TITLE
test(rag-knowledge): get_chunks_by_source / get_full_page_text のユニットテスト追加

### DIFF
--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -1024,6 +1024,64 @@ class TestSafeBrowsingIntegration:
         mock_web_crawler.crawl_page.assert_called_once()
 
 
+class TestGetFullPageText:
+    """get_full_page_text() のテスト (Issue #27)."""
+
+    async def test_get_full_page_text_joins_chunks(
+        self,
+        rag_service: RAGKnowledgeService,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """チャンクが '\\n' で結合されること."""
+        # Arrange
+        mock_vector_store.get_chunks_by_source = AsyncMock(
+            return_value=[
+                RetrievalResult(
+                    text="チャンク1のテキスト",
+                    metadata={"source_url": "https://example.com/page", "chunk_index": 0},
+                    distance=0.0,
+                ),
+                RetrievalResult(
+                    text="チャンク2のテキスト",
+                    metadata={"source_url": "https://example.com/page", "chunk_index": 1},
+                    distance=0.0,
+                ),
+                RetrievalResult(
+                    text="チャンク3のテキスト",
+                    metadata={"source_url": "https://example.com/page", "chunk_index": 2},
+                    distance=0.0,
+                ),
+            ]
+        )
+
+        # Act
+        result = await rag_service.get_full_page_text("https://example.com/page")
+
+        # Assert
+        assert result == "チャンク1のテキスト\nチャンク2のテキスト\nチャンク3のテキスト"
+        mock_vector_store.get_chunks_by_source.assert_called_once_with(
+            "https://example.com/page"
+        )
+
+    async def test_get_full_page_text_empty_chunks(
+        self,
+        rag_service: RAGKnowledgeService,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """チャンクが存在しない場合に空文字列が返ること."""
+        # Arrange
+        mock_vector_store.get_chunks_by_source = AsyncMock(return_value=[])
+
+        # Act
+        result = await rag_service.get_full_page_text("https://example.com/nonexistent")
+
+        # Assert
+        assert result == ""
+        mock_vector_store.get_chunks_by_source.assert_called_once_with(
+            "https://example.com/nonexistent"
+        )
+
+
 class TestRetrieveRawResults:
     """retrieve_raw_results() のテスト（準Agentic Search, Issue #548）."""
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -440,6 +440,105 @@ class TestAC38SimilarityThreshold:
         assert len(threshold_logs) > 0, "閾値フィルタリングのログが出力されていない"
 
 
+class TestGetChunksBySource:
+    """get_chunks_by_source() のテスト (Issue #27)."""
+
+    @pytest.mark.asyncio
+    async def test_get_chunks_by_source_returns_correct_results(
+        self,
+        ephemeral_store: VectorStore,
+    ) -> None:
+        """ソースURL指定で正しい結果が返ること."""
+        # Arrange: 2つのソースからドキュメントを追加
+        chunks = [
+            DocumentChunk(
+                id="page1_0",
+                text="Page1 チャンク0",
+                metadata={"source_url": "https://example.com/page1", "chunk_index": 0},
+            ),
+            DocumentChunk(
+                id="page1_1",
+                text="Page1 チャンク1",
+                metadata={"source_url": "https://example.com/page1", "chunk_index": 1},
+            ),
+            DocumentChunk(
+                id="page2_0",
+                text="Page2 チャンク0",
+                metadata={"source_url": "https://example.com/page2", "chunk_index": 0},
+            ),
+        ]
+        await ephemeral_store.add_documents(chunks)
+
+        # Act
+        results = await ephemeral_store.get_chunks_by_source("https://example.com/page1")
+
+        # Assert
+        assert len(results) == 2
+        assert all(isinstance(r, RetrievalResult) for r in results)
+        assert results[0].text == "Page1 チャンク0"
+        assert results[1].text == "Page1 チャンク1"
+        # distance は 0.0 固定
+        assert all(r.distance == 0.0 for r in results)
+
+    @pytest.mark.asyncio
+    async def test_get_chunks_by_source_sorted_by_chunk_index(
+        self,
+        ephemeral_store: VectorStore,
+    ) -> None:
+        """chunk_index 昇順でソートされること."""
+        # Arrange: chunk_index を逆順で追加
+        chunks = [
+            DocumentChunk(
+                id="page_2",
+                text="チャンク2",
+                metadata={"source_url": "https://example.com/page", "chunk_index": 2},
+            ),
+            DocumentChunk(
+                id="page_0",
+                text="チャンク0",
+                metadata={"source_url": "https://example.com/page", "chunk_index": 0},
+            ),
+            DocumentChunk(
+                id="page_1",
+                text="チャンク1",
+                metadata={"source_url": "https://example.com/page", "chunk_index": 1},
+            ),
+        ]
+        await ephemeral_store.add_documents(chunks)
+
+        # Act
+        results = await ephemeral_store.get_chunks_by_source("https://example.com/page")
+
+        # Assert: chunk_index 昇順
+        assert len(results) == 3
+        assert results[0].text == "チャンク0"
+        assert results[1].text == "チャンク1"
+        assert results[2].text == "チャンク2"
+        assert int(results[0].metadata["chunk_index"]) == 0
+        assert int(results[1].metadata["chunk_index"]) == 1
+        assert int(results[2].metadata["chunk_index"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_chunks_by_source_nonexistent_url(
+        self,
+        ephemeral_store: VectorStore,
+    ) -> None:
+        """存在しないURLに対して空リストが返ること."""
+        # Arrange: 別のURLのドキュメントを追加
+        chunk = DocumentChunk(
+            id="page1_0",
+            text="テスト",
+            metadata={"source_url": "https://example.com/page1", "chunk_index": 0},
+        )
+        await ephemeral_store.add_documents([chunk])
+
+        # Act
+        results = await ephemeral_store.get_chunks_by_source("https://example.com/nonexistent")
+
+        # Assert
+        assert results == []
+
+
 class TestEmbeddingMethodDispatch:
     """VectorStore が embed_documents()/embed_query() を呼ぶことの確認 (Issue #517)."""
 


### PR DESCRIPTION
## Change type

- [x] test: テスト追加・修正

## Summary

- `VectorStore.get_chunks_by_source()` の直接ユニットテストを3件追加（正常取得・chunk_index昇順ソート・存在しないURL）
- `RAGKnowledgeService.get_full_page_text()` の直接ユニットテストを2件追加（チャンク結合・空チャンク）

## Test plan

- [x] `uv run pytest` — 全349テスト通過
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run mypy src/` — no issues found
- [x] `npx markdownlint-cli2@0.20.0` — 0 errors

## Related issues

Closes #27