### PR TITLE
chore: .gitignore に Claude Code ローカル設定と lock ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,7 @@ bm25_index/
 
 # Evaluation reports
 reports/
+
+# Claude Code local settings
+.claude/settings.local.json
+schedule_task.lock


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json` と `schedule_task.lock` を `.gitignore` に追加

## Test plan
- [ ] 対象ファイルが git status に表示されないこと


🤖 Generated with [Claude Code](https://claude.com/claude-code)