### PR TITLE
feat(rag-knowledge): Embeddingモデルを ruri-v3-310m に切り替え

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 
 # Embedding
 EMBEDDING_PROVIDER=local
-EMBEDDING_MODEL_LOCAL=nomic-embed-text
+EMBEDDING_MODEL_LOCAL=ruri-v3-310m
 EMBEDDING_MODEL_ONLINE=text-embedding-3-small
 EMBEDDING_PREFIX_ENABLED=true
 LMSTUDIO_BASE_URL=http://localhost:1234

--- a/scripts/embedding_prefix_comparison.py
+++ b/scripts/embedding_prefix_comparison.py
@@ -1,6 +1,6 @@
 """Embeddingプレフィックスあり/なし比較スクリプト.
 
-nomic-embed-text のタスク固有プレフィックス（search_document: / search_query:）が
+Embeddingモデルのタスク固有プレフィックス（検索文書: / 検索クエリ:）が
 検索品質に与える影響を計測する。
 
 Usage:
@@ -19,7 +19,7 @@ Usage:
       --fixture tests/fixtures/rag_evaluation_extended/rag_test_documents_extended.json
 
 Note:
-    LM Studio が起動中で nomic-embed-text がロード済みである必要がある。
+    LM Studio が起動中で Embeddingモデルがロード済みである必要がある。
 """
 
 from __future__ import annotations

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -36,7 +36,7 @@ class RAGSettings(BaseSettings):
 
     # Embedding設定
     embedding_provider: Literal["local", "online"] = "local"
-    embedding_model_local: str = "nomic-embed-text"
+    embedding_model_local: str = "ruri-v3-310m"
     embedding_model_online: str = "text-embedding-3-small"
     embedding_prefix_enabled: bool = True
     lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL

--- a/src/rag/embedding/lmstudio_embedding.py
+++ b/src/rag/embedding/lmstudio_embedding.py
@@ -20,13 +20,13 @@ class LMStudioEmbedding(EmbeddingProvider):
     仕様: docs/specs/rag-knowledge.md
     """
 
-    DOCUMENT_PREFIX = "search_document: "
-    QUERY_PREFIX = "search_query: "
+    DOCUMENT_PREFIX = "検索文書: "
+    QUERY_PREFIX = "検索クエリ: "
 
     def __init__(
         self,
         base_url: str = DEFAULT_LMSTUDIO_BASE_URL,
-        model: str = "nomic-embed-text",
+        model: str = "ruri-v3-310m",
         prefix_enabled: bool = False,
     ) -> None:
         normalized = base_url.rstrip("/")
@@ -45,13 +45,13 @@ class LMStudioEmbedding(EmbeddingProvider):
         return [item.embedding for item in response.data]
 
     async def embed_documents(self, texts: list[str]) -> list[list[float]]:
-        """ドキュメント用Embedding（プレフィックス有効時はsearch_document:を付加）."""
+        """ドキュメント用Embedding（プレフィックス有効時は検索文書:を付加）."""
         if self._prefix_enabled:
             texts = [self.DOCUMENT_PREFIX + t for t in texts]
         return await self.embed(texts)
 
     async def embed_query(self, text: str) -> list[float]:
-        """クエリ用Embedding（プレフィックス有効時はsearch_query:を付加）."""
+        """クエリ用Embedding（プレフィックス有効時は検索クエリ:を付加）."""
         if self._prefix_enabled:
             text = self.QUERY_PREFIX + text
         result = await self.embed([text])

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -41,7 +41,7 @@ async def test_lmstudio_embedding_converts_text() -> None:
     """AC2: LMStudioEmbedding が LM Studio 経由でテキストをベクトルに変換できること."""
     provider = LMStudioEmbedding(
         base_url=DEFAULT_LMSTUDIO_BASE_URL,
-        model="nomic-embed-text",
+        model="ruri-v3-310m",
     )
 
     # AsyncOpenAI.embeddings.create をモック
@@ -59,7 +59,7 @@ async def test_lmstudio_embedding_converts_text() -> None:
 
     assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
+        model="ruri-v3-310m",
         input=["hello", "world"],
     )
 
@@ -158,7 +158,7 @@ def test_embedding_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("EMBEDDING_MODEL_ONLINE", raising=False)
     settings = Settings(_env_file=None)  # type: ignore[call-arg]
     assert settings.embedding_provider == "local"
-    assert settings.embedding_model_local == "nomic-embed-text"
+    assert settings.embedding_model_local == "ruri-v3-310m"
     assert settings.embedding_model_online == "text-embedding-3-small"
 
 
@@ -179,7 +179,7 @@ def test_lmstudio_embedding_default_params() -> None:
     assert provider._client.base_url.host == "localhost"
     # base_url にホストのみ指定しても /v1 がコード側で付加される
     assert provider._client.base_url.path == "/v1/"
-    assert provider._model == "nomic-embed-text"
+    assert provider._model == "ruri-v3-310m"
 
 
 def test_lmstudio_embedding_custom_params() -> None:
@@ -216,7 +216,7 @@ async def test_embed_documents_default_delegates_to_embed() -> None:
     result = await provider.embed_documents(["hello"])
     assert result == [[0.1, 0.2, 0.3]]
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
+        model="ruri-v3-310m",
         input=["hello"],
     )
 
@@ -235,7 +235,7 @@ async def test_embed_query_default_delegates_to_embed() -> None:
     result = await provider.embed_query("hello")
     assert result == [0.4, 0.5, 0.6]
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
+        model="ruri-v3-310m",
         input=["hello"],
     )
 
@@ -253,8 +253,8 @@ async def test_prefix_enabled_adds_document_prefix() -> None:
 
     await provider.embed_documents(["hello"])
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
-        input=["search_document: hello"],
+        model="ruri-v3-310m",
+        input=["検索文書: hello"],
     )
 
 
@@ -271,8 +271,8 @@ async def test_prefix_enabled_adds_query_prefix() -> None:
 
     await provider.embed_query("hello")
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
-        input=["search_query: hello"],
+        model="ruri-v3-310m",
+        input=["検索クエリ: hello"],
     )
 
 
@@ -289,7 +289,7 @@ async def test_prefix_disabled_no_prefix_on_documents() -> None:
 
     await provider.embed_documents(["hello"])
     provider._client.embeddings.create.assert_awaited_once_with(
-        model="nomic-embed-text",
+        model="ruri-v3-310m",
         input=["hello"],
     )
 


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- デフォルトEmbeddingモデルを `nomic-embed-text` から `ruri-v3-310m`（日本語特化）に変更
- Embeddingプレフィックスを ruri-v3 形式に更新（`search_document: ` → `検索文書: `、`search_query: ` → `検索クエリ: `）
- `.env.example`、`config.py`、`lmstudio_embedding.py` のデフォルト値を更新
- テストを新しいデフォルト値に合わせて更新
- 比較スクリプトのコメントを更新

## Test plan

- [x] pytest: 382 tests passed
- [x] ruff check: All checks passed
- [x] mypy: no issues found
- [x] markdownlint: 0 errors

## Related issues

Closes #59

---

> ⚠️ **注意**: Embeddingモデルの変更に伴い、既存のChromaDBデータの再取り込みが必要です。
> 切り替え前後の精度比較は `uv run python -m rag.cli evaluate` で実施してください。

Generated with [Claude Code](https://claude.ai/code)