### PR TITLE
feat(rag-knowledge): 評価パイプラインに失敗タグ分類機能を追加

### DIFF
--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -19,8 +19,17 @@ from urllib.parse import urldefrag
 
 from .evaluation import (
     EvaluationReport,
+    FailureTag,
     evaluate_retrieval,
 )
+
+# 失敗タグの日本語説明と改善ターゲット
+FAILURE_TAG_DESCRIPTIONS: dict[str, tuple[str, str]] = {
+    FailureTag.RETRIEVAL_MISS.value: ("関連文書が検索されなかった", "チャンキング / Embedding"),
+    FailureTag.RETRIEVAL_NOISE.value: ("無関係な文書が上位に来た", "スコアリング / フィルタリング"),
+    FailureTag.CHUNK_FRAGMENTATION.value: ("回答に必要な情報が分断された", "チャンクサイズ"),
+    FailureTag.QUERY_MISMATCH.value: ("クエリと文書の表現が異なる", "クエリ拡張 / Embedding"),
+}
 
 if TYPE_CHECKING:
     from .bm25_index import BM25Index
@@ -529,6 +538,7 @@ def write_json_report(
             "average_ndcg": report.average_ndcg,
             "average_mrr": report.average_mrr,
             "negative_source_violations": len(report.negative_source_violations),
+            "failure_tag_summary": report.failure_tag_summary,
         },
         "regression": regression,
         "query_results": [
@@ -543,6 +553,7 @@ def write_json_report(
                 "retrieved_sources": qr.retrieved_sources,
                 "expected_sources": qr.expected_sources,
                 "negative_violations": qr.negative_violations,
+                "failure_tags": [tag.value for tag in qr.failure_tags],
             }
             for qr in report.query_results
         ],
@@ -602,6 +613,18 @@ def write_markdown_report(
         "",
     ])
 
+    if report.failure_tag_summary:
+        lines.extend([
+            "## 失敗タグ分類",
+            "",
+            "| タグ | 件数 | 意味 | 改善ターゲット |",
+            "|------|------|------|----------------|",
+        ])
+        for tag_value, count in sorted(report.failure_tag_summary.items(), key=lambda x: -x[1]):
+            desc, target = FAILURE_TAG_DESCRIPTIONS.get(tag_value, (tag_value, "-"))
+            lines.append(f"| {tag_value} | {count} | {desc} | {target} |")
+        lines.append("")
+
     if regression:
         lines.extend([
             "## リグレッション検出",
@@ -643,6 +666,9 @@ def write_markdown_report(
         ])
         if qr.negative_violations:
             lines.append(f"- **禁止ソース違反**: {qr.negative_violations}")
+        if qr.failure_tags:
+            tag_strs = [tag.value for tag in qr.failure_tags]
+            lines.append(f"- **失敗タグ**: {', '.join(tag_strs)}")
         lines.append("")
 
     with open(output_path, "w", encoding="utf-8") as f:

--- a/src/rag/evaluation.py
+++ b/src/rag/evaluation.py
@@ -191,7 +191,6 @@ def classify_failure_tags(
     retrieved_sources: list[str],
     expected_sources: list[str],
     ndcg: float,
-    mrr: float,
 ) -> list[FailureTag]:
     """検索結果のメトリクスから失敗タグを分類する.
 
@@ -200,7 +199,6 @@ def classify_failure_tags(
         retrieved_sources: RAG検索で取得されたソースURLリスト
         expected_sources: 期待されるソースURLリスト（正解データ）
         ndcg: NDCGスコア
-        mrr: MRRスコア
 
     Returns:
         該当する失敗タグのリスト（完璧な検索の場合は空リスト）
@@ -404,7 +402,6 @@ async def evaluate_retrieval(
             retrieved_sources=retrieved_sources,
             expected_sources=dataset_query.expected_sources,
             ndcg=ndcg,
-            mrr=mrr,
         )
 
         # 結果を記録

--- a/src/rag/evaluation.py
+++ b/src/rag/evaluation.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import json
 import logging
 import math
+from collections import Counter
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -175,6 +177,69 @@ def check_negative_sources(
     return list(retrieved_set & negative_set)
 
 
+class FailureTag(Enum):
+    """失敗タグ: 検索失敗の原因分類."""
+
+    RETRIEVAL_MISS = "retrieval_miss"
+    RETRIEVAL_NOISE = "retrieval_noise"
+    CHUNK_FRAGMENTATION = "chunk_fragmentation"
+    QUERY_MISMATCH = "query_mismatch"
+
+
+def classify_failure_tags(
+    pr_result: PrecisionRecallResult,
+    retrieved_sources: list[str],
+    expected_sources: list[str],
+    ndcg: float,
+    mrr: float,
+) -> list[FailureTag]:
+    """検索結果のメトリクスから失敗タグを分類する.
+
+    Args:
+        pr_result: Precision/Recall計算結果
+        retrieved_sources: RAG検索で取得されたソースURLリスト
+        expected_sources: 期待されるソースURLリスト（正解データ）
+        ndcg: NDCGスコア
+        mrr: MRRスコア
+
+    Returns:
+        該当する失敗タグのリスト（完璧な検索の場合は空リスト）
+    """
+    tags: list[FailureTag] = []
+
+    # 完璧な検索結果の場合はタグなし
+    if pr_result.precision == 1.0 and pr_result.recall == 1.0:
+        return tags
+
+    # retrieval_miss: 関連文書が検索されなかった（Recall < 1.0 で FN > 0）
+    if pr_result.false_negatives > 0:
+        tags.append(FailureTag.RETRIEVAL_MISS)
+
+    # retrieval_noise: 無関係な文書が上位に来た（Precision < 1.0 で FP > 0）
+    if pr_result.false_positives > 0:
+        tags.append(FailureTag.RETRIEVAL_NOISE)
+
+    # chunk_fragmentation: 回答に必要な情報が分断された
+    # 正解ソースが部分的に取得されている（Recall > 0 かつ Recall < 1.0）のに
+    # NDCGが低い場合、関連情報が分断されている可能性が高い
+    if (
+        pr_result.recall > 0.0
+        and pr_result.recall < 1.0
+        and ndcg < 0.5
+    ):
+        tags.append(FailureTag.CHUNK_FRAGMENTATION)
+
+    # query_mismatch: クエリと文書の表現が異なる
+    # 何も取得できない、または取得したが正解が1つも含まれない場合
+    if len(retrieved_sources) > 0 and pr_result.true_positives == 0 and len(expected_sources) > 0:
+        tags.append(FailureTag.QUERY_MISMATCH)
+    # 取得結果がゼロ（検索自体がヒットしなかった）場合もquery_mismatchの可能性
+    elif len(retrieved_sources) == 0 and len(expected_sources) > 0:
+        tags.append(FailureTag.QUERY_MISMATCH)
+
+    return tags
+
+
 @dataclass
 class QueryEvaluationResult:
     """個別クエリの評価結果."""
@@ -189,6 +254,7 @@ class QueryEvaluationResult:
     retrieved_sources: list[str]
     expected_sources: list[str]
     negative_violations: list[str]  # 検出された禁止ソース
+    failure_tags: list[FailureTag] = field(default_factory=list)
 
 
 @dataclass
@@ -203,6 +269,7 @@ class EvaluationReport:
     average_mrr: float
     negative_source_violations: list[str]  # 違反があったクエリIDリスト
     query_results: list[QueryEvaluationResult] = field(default_factory=list)
+    failure_tag_summary: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -331,6 +398,15 @@ async def evaluate_retrieval(
                 violations,
             )
 
+        # 失敗タグ分類
+        failure_tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=retrieved_sources,
+            expected_sources=dataset_query.expected_sources,
+            ndcg=ndcg,
+            mrr=mrr,
+        )
+
         # 結果を記録
         query_result = QueryEvaluationResult(
             query_id=dataset_query.id,
@@ -343,6 +419,7 @@ async def evaluate_retrieval(
             retrieved_sources=retrieved_sources,
             expected_sources=dataset_query.expected_sources,
             negative_violations=violations,
+            failure_tags=failure_tags,
         )
         query_results.append(query_result)
 
@@ -370,6 +447,13 @@ async def evaluate_retrieval(
     avg_ndcg = total_ndcg / num_queries
     avg_mrr = total_mrr / num_queries
 
+    # 失敗タグ集計
+    tag_counter: Counter[str] = Counter()
+    for qr in query_results:
+        for tag in qr.failure_tags:
+            tag_counter[tag.value] += 1
+    failure_tag_summary = dict(tag_counter)
+
     logger.info(
         "Evaluation complete: %d queries, avg_precision=%.3f, avg_recall=%.3f, "
         "avg_f1=%.3f, avg_ndcg=%.3f, avg_mrr=%.3f",
@@ -380,6 +464,8 @@ async def evaluate_retrieval(
         avg_ndcg,
         avg_mrr,
     )
+    if failure_tag_summary:
+        logger.info("Failure tag summary: %s", failure_tag_summary)
 
     return EvaluationReport(
         queries_evaluated=num_queries,
@@ -390,4 +476,5 @@ async def evaluate_retrieval(
         average_mrr=avg_mrr,
         negative_source_violations=negative_violations,
         query_results=query_results,
+        failure_tag_summary=failure_tag_summary,
     )

--- a/tests/test_rag_evaluation.py
+++ b/tests/test_rag_evaluation.py
@@ -674,7 +674,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://a.com", "https://b.com"],
             expected_sources=["https://a.com", "https://b.com"],
             ndcg=1.0,
-            mrr=1.0,
         )
         assert tags == []
 
@@ -689,7 +688,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://a.com"],
             expected_sources=["https://a.com", "https://b.com"],
             ndcg=1.0,
-            mrr=1.0,
         )
         assert FailureTag.RETRIEVAL_MISS in tags
 
@@ -704,7 +702,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://a.com", "https://x.com"],
             expected_sources=["https://a.com"],
             ndcg=1.0,
-            mrr=1.0,
         )
         assert FailureTag.RETRIEVAL_NOISE in tags
 
@@ -719,7 +716,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://a.com", "https://x.com"],
             expected_sources=["https://a.com", "https://b.com"],
             ndcg=0.3,
-            mrr=0.5,
         )
         assert FailureTag.CHUNK_FRAGMENTATION in tags
 
@@ -734,7 +730,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://a.com", "https://x.com"],
             expected_sources=["https://a.com", "https://b.com"],
             ndcg=0.8,
-            mrr=1.0,
         )
         assert FailureTag.CHUNK_FRAGMENTATION not in tags
 
@@ -749,7 +744,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://x.com", "https://y.com"],
             expected_sources=["https://a.com"],
             ndcg=0.0,
-            mrr=0.0,
         )
         assert FailureTag.QUERY_MISMATCH in tags
 
@@ -764,7 +758,6 @@ class TestClassifyFailureTags:
             retrieved_sources=[],
             expected_sources=["https://a.com"],
             ndcg=0.0,
-            mrr=0.0,
         )
         assert FailureTag.QUERY_MISMATCH in tags
         assert FailureTag.RETRIEVAL_MISS in tags
@@ -780,7 +773,6 @@ class TestClassifyFailureTags:
             retrieved_sources=["https://x.com", "https://y.com", "https://z.com"],
             expected_sources=["https://a.com", "https://b.com"],
             ndcg=0.0,
-            mrr=0.0,
         )
         assert FailureTag.RETRIEVAL_MISS in tags
         assert FailureTag.RETRIEVAL_NOISE in tags
@@ -797,7 +789,6 @@ class TestClassifyFailureTags:
             retrieved_sources=[],
             expected_sources=[],
             ndcg=1.0,
-            mrr=1.0,
         )
         assert tags == []
 

--- a/tests/test_rag_evaluation.py
+++ b/tests/test_rag_evaluation.py
@@ -14,12 +14,14 @@ import pytest
 from rag.evaluation import (
     EvaluationDatasetQuery,
     EvaluationReport,
+    FailureTag,
     PrecisionRecallResult,
     QueryEvaluationResult,
     calculate_ndcg,
     calculate_mrr,
     calculate_precision_recall,
     check_negative_sources,
+    classify_failure_tags,
     evaluate_retrieval,
     load_evaluation_dataset,
 )
@@ -656,3 +658,350 @@ class TestEvaluationDatasetQueryDataclass:
         assert query.expected_keywords == []
         assert query.description == ""
         assert query.notes == ""
+
+
+class TestClassifyFailureTags:
+    """classify_failure_tags() のテスト."""
+
+    def test_perfect_retrieval_no_tags(self) -> None:
+        """完璧な検索結果の場合、失敗タグなし."""
+        pr_result = PrecisionRecallResult(
+            precision=1.0, recall=1.0, f1=1.0,
+            true_positives=2, false_positives=0, false_negatives=0,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://a.com", "https://b.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            ndcg=1.0,
+            mrr=1.0,
+        )
+        assert tags == []
+
+    def test_retrieval_miss(self) -> None:
+        """関連文書が検索されなかった場合、retrieval_missタグ."""
+        pr_result = PrecisionRecallResult(
+            precision=1.0, recall=0.5, f1=0.667,
+            true_positives=1, false_positives=0, false_negatives=1,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://a.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            ndcg=1.0,
+            mrr=1.0,
+        )
+        assert FailureTag.RETRIEVAL_MISS in tags
+
+    def test_retrieval_noise(self) -> None:
+        """無関係な文書が上位に来た場合、retrieval_noiseタグ."""
+        pr_result = PrecisionRecallResult(
+            precision=0.5, recall=1.0, f1=0.667,
+            true_positives=1, false_positives=1, false_negatives=0,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://a.com", "https://x.com"],
+            expected_sources=["https://a.com"],
+            ndcg=1.0,
+            mrr=1.0,
+        )
+        assert FailureTag.RETRIEVAL_NOISE in tags
+
+    def test_chunk_fragmentation(self) -> None:
+        """情報が分断された場合、chunk_fragmentationタグ."""
+        pr_result = PrecisionRecallResult(
+            precision=0.5, recall=0.5, f1=0.5,
+            true_positives=1, false_positives=1, false_negatives=1,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://a.com", "https://x.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            ndcg=0.3,
+            mrr=0.5,
+        )
+        assert FailureTag.CHUNK_FRAGMENTATION in tags
+
+    def test_no_chunk_fragmentation_when_ndcg_high(self) -> None:
+        """NDCGが高い場合、chunk_fragmentationタグなし."""
+        pr_result = PrecisionRecallResult(
+            precision=0.5, recall=0.5, f1=0.5,
+            true_positives=1, false_positives=1, false_negatives=1,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://a.com", "https://x.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            ndcg=0.8,
+            mrr=1.0,
+        )
+        assert FailureTag.CHUNK_FRAGMENTATION not in tags
+
+    def test_query_mismatch_no_tp(self) -> None:
+        """取得したが正解が1つも含まれない場合、query_mismatchタグ."""
+        pr_result = PrecisionRecallResult(
+            precision=0.0, recall=0.0, f1=0.0,
+            true_positives=0, false_positives=2, false_negatives=1,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://x.com", "https://y.com"],
+            expected_sources=["https://a.com"],
+            ndcg=0.0,
+            mrr=0.0,
+        )
+        assert FailureTag.QUERY_MISMATCH in tags
+
+    def test_query_mismatch_empty_retrieval(self) -> None:
+        """取得結果がゼロの場合もquery_mismatchタグ."""
+        pr_result = PrecisionRecallResult(
+            precision=0.0, recall=0.0, f1=0.0,
+            true_positives=0, false_positives=0, false_negatives=1,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=[],
+            expected_sources=["https://a.com"],
+            ndcg=0.0,
+            mrr=0.0,
+        )
+        assert FailureTag.QUERY_MISMATCH in tags
+        assert FailureTag.RETRIEVAL_MISS in tags
+
+    def test_multiple_tags(self) -> None:
+        """複数の失敗タグが同時に付与されるケース."""
+        pr_result = PrecisionRecallResult(
+            precision=0.0, recall=0.0, f1=0.0,
+            true_positives=0, false_positives=3, false_negatives=2,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=["https://x.com", "https://y.com", "https://z.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            ndcg=0.0,
+            mrr=0.0,
+        )
+        assert FailureTag.RETRIEVAL_MISS in tags
+        assert FailureTag.RETRIEVAL_NOISE in tags
+        assert FailureTag.QUERY_MISMATCH in tags
+
+    def test_both_empty_no_tags(self) -> None:
+        """両方空の場合（完璧）、失敗タグなし."""
+        pr_result = PrecisionRecallResult(
+            precision=1.0, recall=1.0, f1=1.0,
+            true_positives=0, false_positives=0, false_negatives=0,
+        )
+        tags = classify_failure_tags(
+            pr_result=pr_result,
+            retrieved_sources=[],
+            expected_sources=[],
+            ndcg=1.0,
+            mrr=1.0,
+        )
+        assert tags == []
+
+
+class TestFailureTagEnum:
+    """FailureTag Enumのテスト."""
+
+    def test_values(self) -> None:
+        """各タグの値が正しいこと."""
+        assert FailureTag.RETRIEVAL_MISS.value == "retrieval_miss"
+        assert FailureTag.RETRIEVAL_NOISE.value == "retrieval_noise"
+        assert FailureTag.CHUNK_FRAGMENTATION.value == "chunk_fragmentation"
+        assert FailureTag.QUERY_MISMATCH.value == "query_mismatch"
+
+    def test_all_members(self) -> None:
+        """4つのタグが定義されていること."""
+        assert len(FailureTag) == 4
+
+
+class TestEvaluateRetrievalWithFailureTags:
+    """evaluate_retrieval() の失敗タグ統合テスト."""
+
+    @pytest.fixture
+    def mock_rag_service(self) -> MagicMock:
+        """モックRAGKnowledgeServiceを作成する."""
+        mock = MagicMock()
+        mock.retrieve = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def sample_dataset_path(self, tmp_path: Path) -> str:
+        """サンプルデータセットファイルを作成する."""
+        dataset = {
+            "queries": [
+                {
+                    "id": "q1",
+                    "query": "完璧な検索",
+                    "expected_sources": ["https://example.com/a.html"],
+                    "negative_sources": [],
+                },
+                {
+                    "id": "q2",
+                    "query": "失敗する検索",
+                    "expected_sources": [
+                        "https://example.com/b.html",
+                        "https://example.com/c.html",
+                    ],
+                    "negative_sources": [],
+                },
+            ]
+        }
+        dataset_path = tmp_path / "eval_dataset.json"
+        dataset_path.write_text(json.dumps(dataset, ensure_ascii=False), encoding="utf-8")
+        return str(dataset_path)
+
+    async def test_failure_tags_in_query_results(
+        self,
+        mock_rag_service: MagicMock,
+        sample_dataset_path: str,
+    ) -> None:
+        """クエリ結果に失敗タグが含まれること."""
+        mock_rag_service.retrieve.side_effect = [
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=["https://example.com/a.html"],
+            ),
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=["https://example.com/x.html"],  # 不正解のみ
+            ),
+        ]
+
+        report = await evaluate_retrieval(mock_rag_service, sample_dataset_path)
+
+        # q1: 完璧な検索 → タグなし
+        assert report.query_results[0].failure_tags == []
+        # q2: 不正解のみ → retrieval_miss + retrieval_noise + query_mismatch
+        q2_tags = report.query_results[1].failure_tags
+        assert FailureTag.RETRIEVAL_MISS in q2_tags
+        assert FailureTag.RETRIEVAL_NOISE in q2_tags
+        assert FailureTag.QUERY_MISMATCH in q2_tags
+
+    async def test_failure_tag_summary_in_report(
+        self,
+        mock_rag_service: MagicMock,
+        sample_dataset_path: str,
+    ) -> None:
+        """レポートに失敗タグ集計が含まれること."""
+        mock_rag_service.retrieve.side_effect = [
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=["https://example.com/a.html"],
+            ),
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=["https://example.com/x.html"],  # 不正解のみ
+            ),
+        ]
+
+        report = await evaluate_retrieval(mock_rag_service, sample_dataset_path)
+
+        assert report.failure_tag_summary is not None
+        assert report.failure_tag_summary.get("retrieval_miss", 0) >= 1
+        assert report.failure_tag_summary.get("retrieval_noise", 0) >= 1
+        assert report.failure_tag_summary.get("query_mismatch", 0) >= 1
+
+    async def test_perfect_retrieval_no_failure_tags(
+        self,
+        mock_rag_service: MagicMock,
+        sample_dataset_path: str,
+    ) -> None:
+        """完璧な検索結果の場合、失敗タグ集計が空."""
+        mock_rag_service.retrieve.side_effect = [
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=["https://example.com/a.html"],
+            ),
+            RAGRetrievalResult(
+                context="参考情報",
+                sources=[
+                    "https://example.com/b.html",
+                    "https://example.com/c.html",
+                ],
+            ),
+        ]
+
+        report = await evaluate_retrieval(mock_rag_service, sample_dataset_path)
+
+        assert report.failure_tag_summary == {}
+        for qr in report.query_results:
+            assert qr.failure_tags == []
+
+
+class TestQueryEvaluationResultFailureTags:
+    """QueryEvaluationResult の failure_tags フィールドテスト."""
+
+    def test_default_failure_tags(self) -> None:
+        """failure_tagsのデフォルト値は空リスト."""
+        result = QueryEvaluationResult(
+            query_id="q1",
+            query="テスト",
+            precision=0.8,
+            recall=0.6,
+            f1=0.685,
+            ndcg=0.9,
+            mrr=1.0,
+            retrieved_sources=["https://a.com"],
+            expected_sources=["https://a.com", "https://b.com"],
+            negative_violations=[],
+        )
+        assert result.failure_tags == []
+
+    def test_failure_tags_with_values(self) -> None:
+        """failure_tagsに値を設定できること."""
+        result = QueryEvaluationResult(
+            query_id="q1",
+            query="テスト",
+            precision=0.0,
+            recall=0.0,
+            f1=0.0,
+            ndcg=0.0,
+            mrr=0.0,
+            retrieved_sources=[],
+            expected_sources=["https://a.com"],
+            negative_violations=[],
+            failure_tags=[FailureTag.RETRIEVAL_MISS, FailureTag.QUERY_MISMATCH],
+        )
+        assert len(result.failure_tags) == 2
+        assert FailureTag.RETRIEVAL_MISS in result.failure_tags
+        assert FailureTag.QUERY_MISMATCH in result.failure_tags
+
+
+class TestEvaluationReportFailureTagSummary:
+    """EvaluationReport の failure_tag_summary フィールドテスト."""
+
+    def test_default_failure_tag_summary(self) -> None:
+        """failure_tag_summaryのデフォルト値は空辞書."""
+        report = EvaluationReport(
+            queries_evaluated=0,
+            average_precision=0.0,
+            average_recall=0.0,
+            average_f1=0.0,
+            average_ndcg=0.0,
+            average_mrr=0.0,
+            negative_source_violations=[],
+        )
+        assert report.failure_tag_summary == {}
+
+    def test_failure_tag_summary_with_values(self) -> None:
+        """failure_tag_summaryに値を設定できること."""
+        report = EvaluationReport(
+            queries_evaluated=5,
+            average_precision=0.5,
+            average_recall=0.5,
+            average_f1=0.5,
+            average_ndcg=0.5,
+            average_mrr=0.5,
+            negative_source_violations=[],
+            failure_tag_summary={
+                "retrieval_miss": 3,
+                "retrieval_noise": 2,
+                "query_mismatch": 1,
+            },
+        )
+        assert report.failure_tag_summary["retrieval_miss"] == 3
+        assert report.failure_tag_summary["retrieval_noise"] == 2
+        assert report.failure_tag_summary["query_mismatch"] == 1


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `FailureTag` Enum を追加（`retrieval_miss`, `retrieval_noise`, `chunk_fragmentation`, `query_mismatch`）
- `classify_failure_tags()` 関数で検索メトリクス（Precision/Recall, NDCG, MRR）から失敗原因を自動分類
- `QueryEvaluationResult` に `failure_tags` フィールドを追加
- `EvaluationReport` に `failure_tag_summary` 集計を追加
- JSON レポートに `failure_tag_summary`（サマリー）と `failure_tags`（クエリ別）を出力
- Markdown レポートに「失敗タグ分類」セクション（タグ・件数・意味・改善ターゲット）を追加
- テスト19件を追加

## Test plan

- [x] 全400テスト通過（`uv run pytest`）
- [x] ruff チェック通過
- [x] mypy 型チェック通過
- [x] markdownlint 通過

## Related issues

Closes #61