### PR TITLE
fix(rag-knowledge): Embeddingプレフィックスを英語に戻す

### DIFF
--- a/src/rag/embedding/lmstudio_embedding.py
+++ b/src/rag/embedding/lmstudio_embedding.py
@@ -20,8 +20,8 @@ class LMStudioEmbedding(EmbeddingProvider):
     仕様: docs/specs/rag-knowledge.md
     """
 
-    DOCUMENT_PREFIX = "検索文書: "
-    QUERY_PREFIX = "検索クエリ: "
+    DOCUMENT_PREFIX = "search_document: "
+    QUERY_PREFIX = "search_query: "
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- ruri-v3 のプレフィックスが日本語（検索文書: / 検索クエリ:）に変更されていたのを、正しい英語（search_document: / search_query:）に修正

## Test plan
- [ ] Embeddingプレフィックスが search_document: / search_query: であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)