### PR TITLE
fix: .gitignore の lock ファイルパターンを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,4 @@ reports/
 
 # Claude Code local settings
 .claude/settings.local.json
-schedule_task.lock
+.claude/*.lock


### PR DESCRIPTION
## Summary
- `schedule_task.lock` → `.claude/*.lock` に変更
- Claude Code が生成するロックファイル全般（名前変更含む）をカバー

## Change type
- [x] fix: バグ修正

## Test plan
- [ ] `.claude/scheduled_tasks.lock` が git status に表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)