### PR TITLE
fix(rag-knowledge): Embedding docstring のプレフィックス記述を修正

### DIFF
--- a/src/rag/embedding/lmstudio_embedding.py
+++ b/src/rag/embedding/lmstudio_embedding.py
@@ -45,13 +45,13 @@ class LMStudioEmbedding(EmbeddingProvider):
         return [item.embedding for item in response.data]
 
     async def embed_documents(self, texts: list[str]) -> list[list[float]]:
-        """ドキュメント用Embedding（プレフィックス有効時は検索文書:を付加）."""
+        """ドキュメント用Embedding（プレフィックス有効時はsearch_document:を付加）."""
         if self._prefix_enabled:
             texts = [self.DOCUMENT_PREFIX + t for t in texts]
         return await self.embed(texts)
 
     async def embed_query(self, text: str) -> list[float]:
-        """クエリ用Embedding（プレフィックス有効時は検索クエリ:を付加）."""
+        """クエリ用Embedding（プレフィックス有効時はsearch_query:を付加）."""
         if self._prefix_enabled:
             text = self.QUERY_PREFIX + text
         result = await self.embed([text])


### PR DESCRIPTION
## Summary
- 事後レビュー指摘 #67 対応
- embed_documents/embed_query の docstring で「検索文書:」「検索クエリ:」→「search_document:」「search_query:」に修正
- #66 で英語プレフィックスに戻した際の docstring 修正漏れ

## Change type
- [x] fix: バグ修正

## Test plan
- [x] テスト通過確認済み

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)