### PR TITLE
feat(rag-knowledge): add LocalFileIngester for local file ingestion

### DIFF
--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -5,10 +5,12 @@ Issue: #62
 """
 
 from .base import BaseIngester, IngestedContent
+from .local_file import LocalFileIngester
 from .web import WebIngester
 
 __all__ = [
     "BaseIngester",
     "IngestedContent",
+    "LocalFileIngester",
     "WebIngester",
 ]

--- a/src/rag/ingesters/local_file.py
+++ b/src/rag/ingesters/local_file.py
@@ -1,0 +1,151 @@
+"""ローカルファイルインジェスター: ローカルファイルの取り込み
+
+仕様: docs/specs/rag-knowledge.md
+Issue: #71
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .base import BaseIngester, IngestedContent
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_EXTENSIONS: frozenset[str] = frozenset({".md", ".txt"})
+
+
+class LocalFileIngester(BaseIngester):
+    """ローカルファイル取り込み用インジェスター.
+
+    Markdown (.md) やテキスト (.txt) ファイルを読み込み、
+    IngestedContent に変換する。
+    """
+
+    def validate_identifier(self, identifier: str) -> str:
+        """ファイルパスを検証し、正規化済みの絶対パスを返す.
+
+        Args:
+            identifier: 検証するファイルパス
+
+        Returns:
+            正規化済みの絶対パス文字列
+
+        Raises:
+            ValueError: パスが存在しない、ファイルでない、
+                        または未対応の拡張子の場合
+        """
+        path = Path(identifier).resolve()
+
+        if not path.exists():
+            raise ValueError(f"ファイルが存在しません: {path}")
+
+        if not path.is_file():
+            raise ValueError(f"ファイルではありません: {path}")
+
+        if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            raise ValueError(
+                f"未対応の拡張子です: {path.suffix} "
+                f"(対応: {', '.join(sorted(SUPPORTED_EXTENSIONS))})"
+            )
+
+        return str(path)
+
+    async def fetch_single(self, identifier: str) -> IngestedContent | None:
+        """単一ファイルを読み込み IngestedContent を返す.
+
+        1. パス検証
+        2. ファイル読み込み
+        3. タイトル抽出（Markdown の場合は最初の # 見出し）
+        4. IngestedContent に変換
+
+        Args:
+            identifier: 読み込むファイルパス
+
+        Returns:
+            IngestedContent、または読み込み失敗時は None
+        """
+        try:
+            validated_path = self.validate_identifier(identifier)
+        except ValueError:
+            logger.warning("Invalid file path: %s", identifier)
+            return None
+
+        path = Path(validated_path)
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("Failed to read file: %s", validated_path)
+            return None
+
+        title = self._extract_title(text, path)
+
+        return IngestedContent(
+            source_id=validated_path,
+            title=title,
+            text=text,
+            ingested_at=IngestedContent.now_iso(),
+            source_type="file",
+            metadata={
+                "file_extension": path.suffix.lower(),
+                "file_name": path.name,
+            },
+        )
+
+    async def discover(self, source: str, **kwargs: object) -> list[str]:
+        """ディレクトリ内のファイル一覧を返す.
+
+        Args:
+            source: 検索対象のディレクトリパス
+            **kwargs: pattern (str) — glob パターン（デフォルト: 全対応拡張子）
+
+        Returns:
+            発見されたファイルパスのリスト
+        """
+        dir_path = Path(source).resolve()
+
+        if not dir_path.exists():
+            raise ValueError(f"ディレクトリが存在しません: {dir_path}")
+
+        if not dir_path.is_dir():
+            raise ValueError(f"ディレクトリではありません: {dir_path}")
+
+        pattern = kwargs.get("pattern")
+        if isinstance(pattern, str):
+            paths = sorted(dir_path.glob(pattern))
+        else:
+            paths = sorted(
+                p
+                for ext in SUPPORTED_EXTENSIONS
+                for p in dir_path.glob(f"**/*{ext}")
+            )
+
+        return [
+            str(p.resolve())
+            for p in paths
+            if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+        ]
+
+    @staticmethod
+    def _extract_title(text: str, path: Path) -> str:
+        """テキストからタイトルを抽出する.
+
+        Markdown の場合、最初の ``# 見出し`` をタイトルとして使用する。
+        見出しがない場合やテキストファイルの場合、ファイル名（拡張子なし）を返す。
+
+        Args:
+            text: ファイルの内容
+            path: ファイルパス
+
+        Returns:
+            抽出されたタイトル
+        """
+        if path.suffix.lower() == ".md":
+            for line in text.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("# ") and not stripped.startswith("## "):
+                    return stripped[2:].strip()
+
+        return path.stem

--- a/src/rag/ingesters/local_file.py
+++ b/src/rag/ingesters/local_file.py
@@ -6,6 +6,7 @@ Issue: #71
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -75,7 +76,7 @@ class LocalFileIngester(BaseIngester):
         path = Path(validated_path)
 
         try:
-            text = path.read_text(encoding="utf-8")
+            text = await asyncio.to_thread(path.read_text, encoding="utf-8")
         except OSError:
             logger.warning("Failed to read file: %s", validated_path)
             return None
@@ -113,14 +114,17 @@ class LocalFileIngester(BaseIngester):
             raise ValueError(f"ディレクトリではありません: {dir_path}")
 
         pattern = kwargs.get("pattern")
-        if isinstance(pattern, str):
-            paths = sorted(dir_path.glob(pattern))
-        else:
-            paths = sorted(
+
+        def _glob() -> list[Path]:
+            if isinstance(pattern, str):
+                return sorted(dir_path.glob(pattern))
+            return sorted(
                 p
                 for ext in SUPPORTED_EXTENSIONS
                 for p in dir_path.glob(f"**/*{ext}")
             )
+
+        paths = await asyncio.to_thread(_glob)
 
         return [
             str(p.resolve())
@@ -145,7 +149,7 @@ class LocalFileIngester(BaseIngester):
         if path.suffix.lower() == ".md":
             for line in text.splitlines():
                 stripped = line.strip()
-                if stripped.startswith("# ") and not stripped.startswith("## "):
+                if stripped.startswith("# "):
                     return stripped[2:].strip()
 
         return path.stem

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -1,16 +1,18 @@
 """インジェスター基盤のテスト
 
 仕様: docs/specs/rag-knowledge.md
-Issue: #62
+Issue: #62, #71
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from rag.ingesters.base import BaseIngester, IngestedContent
+from rag.ingesters.local_file import SUPPORTED_EXTENSIONS, LocalFileIngester
 from rag.ingesters.web import WebIngester
 from rag.rag_knowledge import RAGKnowledgeService
 from rag.vector_store import VectorStore
@@ -634,3 +636,243 @@ class TestRAGServiceWithWebIngester:
         ).hexdigest()[:16]
         assert chunk.id.startswith(expected_hash)
         assert chunk.metadata["source_url"] == "https://example.com/page"
+
+
+# --- LocalFileIngester テスト ---
+
+
+@pytest.fixture
+def local_ingester() -> LocalFileIngester:
+    """LocalFileIngester インスタンスを作成する."""
+    return LocalFileIngester()
+
+
+class TestLocalFileIngesterValidate:
+    """LocalFileIngester.validate_identifier() のテスト."""
+
+    def test_validate_md_file(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """Markdown ファイルのパスが正常に検証されること."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("# Title\nContent", encoding="utf-8")
+
+        result = local_ingester.validate_identifier(str(md_file))
+        assert result == str(md_file.resolve())
+
+    def test_validate_txt_file(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """テキストファイルのパスが正常に検証されること."""
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("Plain text", encoding="utf-8")
+
+        result = local_ingester.validate_identifier(str(txt_file))
+        assert result == str(txt_file.resolve())
+
+    def test_validate_nonexistent_file(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """存在しないファイルで ValueError が発生すること."""
+        with pytest.raises(ValueError, match="ファイルが存在しません"):
+            local_ingester.validate_identifier(str(tmp_path / "nonexistent.md"))
+
+    def test_validate_directory(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """ディレクトリパスで ValueError が発生すること."""
+        with pytest.raises(ValueError, match="ファイルではありません"):
+            local_ingester.validate_identifier(str(tmp_path))
+
+    def test_validate_unsupported_extension(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """未対応の拡張子で ValueError が発生すること."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_text("content", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="未対応の拡張子です"):
+            local_ingester.validate_identifier(str(pdf_file))
+
+
+class TestLocalFileIngesterFetchSingle:
+    """LocalFileIngester.fetch_single() のテスト."""
+
+    async def test_fetch_md_file(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """Markdown ファイルを正常に読み込めること."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("# My Title\nSome content", encoding="utf-8")
+
+        result = await local_ingester.fetch_single(str(md_file))
+
+        assert result is not None
+        assert result.source_id == str(md_file.resolve())
+        assert result.title == "My Title"
+        assert result.text == "# My Title\nSome content"
+        assert result.source_type == "file"
+        assert result.metadata["file_extension"] == ".md"
+        assert result.metadata["file_name"] == "test.md"
+        assert result.ingested_at
+
+    async def test_fetch_txt_file(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """テキストファイルを正常に読み込めること."""
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text("Plain text content", encoding="utf-8")
+
+        result = await local_ingester.fetch_single(str(txt_file))
+
+        assert result is not None
+        assert result.title == "notes"
+        assert result.text == "Plain text content"
+        assert result.source_type == "file"
+        assert result.metadata["file_extension"] == ".txt"
+
+    async def test_fetch_md_without_heading(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """見出しなし Markdown のタイトルがファイル名になること."""
+        md_file = tmp_path / "no_heading.md"
+        md_file.write_text("No heading here", encoding="utf-8")
+
+        result = await local_ingester.fetch_single(str(md_file))
+
+        assert result is not None
+        assert result.title == "no_heading"
+
+    async def test_fetch_nonexistent_returns_none(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """存在しないファイルで None を返すこと."""
+        result = await local_ingester.fetch_single(str(tmp_path / "missing.md"))
+        assert result is None
+
+    async def test_fetch_unsupported_extension_returns_none(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """未対応拡張子で None を返すこと."""
+        pdf_file = tmp_path / "doc.pdf"
+        pdf_file.write_text("content", encoding="utf-8")
+
+        result = await local_ingester.fetch_single(str(pdf_file))
+        assert result is None
+
+
+class TestLocalFileIngesterDiscover:
+    """LocalFileIngester.discover() のテスト."""
+
+    async def test_discover_finds_supported_files(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """対応拡張子のファイルを発見すること."""
+        (tmp_path / "a.md").write_text("md", encoding="utf-8")
+        (tmp_path / "b.txt").write_text("txt", encoding="utf-8")
+        (tmp_path / "c.pdf").write_text("pdf", encoding="utf-8")
+
+        result = await local_ingester.discover(str(tmp_path))
+
+        assert len(result) == 2
+        names = [Path(p).name for p in result]
+        assert "a.md" in names
+        assert "b.txt" in names
+        assert "c.pdf" not in names
+
+    async def test_discover_recursive(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """サブディレクトリのファイルも再帰的に発見すること."""
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "root.md").write_text("root", encoding="utf-8")
+        (sub / "nested.md").write_text("nested", encoding="utf-8")
+
+        result = await local_ingester.discover(str(tmp_path))
+
+        assert len(result) == 2
+
+    async def test_discover_with_pattern(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """glob パターンでフィルタリングできること."""
+        (tmp_path / "a.md").write_text("md", encoding="utf-8")
+        (tmp_path / "b.txt").write_text("txt", encoding="utf-8")
+
+        result = await local_ingester.discover(str(tmp_path), pattern="*.md")
+
+        assert len(result) == 1
+        assert Path(result[0]).name == "a.md"
+
+    async def test_discover_nonexistent_directory(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """存在しないディレクトリで ValueError が発生すること."""
+        with pytest.raises(ValueError, match="ディレクトリが存在しません"):
+            await local_ingester.discover(str(tmp_path / "nonexistent"))
+
+    async def test_discover_file_as_directory(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """ファイルをディレクトリとして指定すると ValueError が発生すること."""
+        f = tmp_path / "file.md"
+        f.write_text("content", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="ディレクトリではありません"):
+            await local_ingester.discover(str(f))
+
+    async def test_discover_empty_directory(
+        self, local_ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """空ディレクトリで空リストを返すこと."""
+        result = await local_ingester.discover(str(tmp_path))
+        assert result == []
+
+
+class TestLocalFileIngesterExtractTitle:
+    """LocalFileIngester._extract_title() のテスト."""
+
+    def test_extract_title_from_h1(self) -> None:
+        """Markdown の # 見出しからタイトルを抽出すること."""
+        text = "# My Title\n\nContent"
+        title = LocalFileIngester._extract_title(text, Path("test.md"))
+        assert title == "My Title"
+
+    def test_skip_h2_heading(self) -> None:
+        """## 見出しはタイトルとして使わないこと."""
+        text = "## Sub Heading\n\nContent"
+        title = LocalFileIngester._extract_title(text, Path("test.md"))
+        assert title == "test"
+
+    def test_fallback_to_filename(self) -> None:
+        """見出しがない場合、ファイル名をタイトルとすること."""
+        text = "No heading here"
+        title = LocalFileIngester._extract_title(text, Path("my_notes.md"))
+        assert title == "my_notes"
+
+    def test_txt_uses_filename(self) -> None:
+        """テキストファイルはファイル名をタイトルとすること."""
+        text = "# Heading"
+        title = LocalFileIngester._extract_title(text, Path("notes.txt"))
+        assert title == "notes"
+
+    def test_first_h1_wins(self) -> None:
+        """複数 # 見出しがある場合、最初のものが使われること."""
+        text = "# First\n# Second"
+        title = LocalFileIngester._extract_title(text, Path("test.md"))
+        assert title == "First"
+
+
+class TestLocalFileIngesterReExport:
+    """__init__.py からの re-export テスト."""
+
+    def test_import_from_ingesters_package(self) -> None:
+        """rag.ingesters パッケージから LocalFileIngester をインポートできること."""
+        from rag.ingesters import LocalFileIngester as LFI
+
+        assert LFI is LocalFileIngester
+
+    def test_supported_extensions(self) -> None:
+        """対応拡張子が .md と .txt であること."""
+        assert SUPPORTED_EXTENSIONS == frozenset({".md", ".txt"})


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `LocalFileIngester` クラスを `src/rag/ingesters/local_file.py` に新規実装
  - `BaseIngester` を継承し、`fetch_single()` / `validate_identifier()` / `discover()` を実装
  - 対応フォーマット: `.md`, `.txt`
  - Markdown ファイルの `# 見出し` からタイトルを自動抽出
- `src/rag/ingesters/__init__.py` に re-export を追加
- `tests/test_ingesters.py` に 23 テストケースを追加

## Test plan

- [x] validate_identifier: .md / .txt の正常検証、存在しないファイル / ディレクトリ / 未対応拡張子のエラー
- [x] fetch_single: .md / .txt の読み込み、見出しなし Markdown のタイトル、存在しないファイル / 未対応拡張子で None
- [x] discover: 対応拡張子ファイルの発見、再帰検索、glob パターン、存在しないディレクトリ / ファイル指定のエラー、空ディレクトリ
- [x] _extract_title: h1 抽出、h2 スキップ、ファイル名フォールバック、txt ファイル、複数 h1 の先頭優先
- [x] re-export: パッケージからのインポート、対応拡張子の確認
- [x] 全テスト通過 (458 passed)、ruff / mypy / markdownlint all clear

## Related issues

Closes #71