### PR TITLE
feat(rag-knowledge): add ZennIngester for Zenn API article ingestion

### DIFF
--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -6,9 +6,11 @@ Issue: #62
 
 from .base import BaseIngester, IngestedContent
 from .web import WebIngester
+from .zenn import ZennIngester
 
 __all__ = [
     "BaseIngester",
     "IngestedContent",
     "WebIngester",
+    "ZennIngester",
 ]

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -1,0 +1,166 @@
+"""Zenn インジェスター: Zenn API 経由で記事を取得する
+
+仕様: docs/specs/rag-knowledge.md
+Issue: #73
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import aiohttp
+
+from .base import BaseIngester, IngestedContent
+
+logger = logging.getLogger(__name__)
+
+ZENN_API_BASE = "https://zenn.dev/api"
+"""Zenn API のベース URL."""
+
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+"""slug の形式: 英小文字・数字・ハイフン・アンダースコア."""
+
+
+class ZennIngester(BaseIngester):
+    """Zenn 記事取り込み用インジェスター.
+
+    Zenn API から記事を取得し、IngestedContent に変換する。
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> None:
+        """ZennIngester を初期化する.
+
+        Args:
+            timeout: HTTP リクエストのタイムアウト設定
+        """
+        self._timeout = timeout or aiohttp.ClientTimeout(total=30)
+
+    def validate_identifier(self, identifier: str) -> str:
+        """slug を検証し、正規化済み slug を返す.
+
+        Args:
+            identifier: 検証する slug
+
+        Returns:
+            正規化済み slug（小文字変換済み）
+
+        Raises:
+            ValueError: slug が不正な場合
+        """
+        slug = identifier.strip().lower()
+        if not slug:
+            raise ValueError("slugが空です")
+        if not _SLUG_PATTERN.match(slug):
+            raise ValueError(
+                f"不正なslug形式です: {identifier!r}"
+                "（英小文字・数字・ハイフン・アンダースコアのみ使用可能）"
+            )
+        return slug
+
+    async def fetch_single(self, identifier: str) -> IngestedContent | None:
+        """Zenn API から単一記事を取得する.
+
+        Args:
+            identifier: 記事の slug
+
+        Returns:
+            IngestedContent、または取得失敗時は None
+        """
+        slug = self.validate_identifier(identifier)
+        url = f"{ZENN_API_BASE}/articles/{slug}"
+
+        try:
+            async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                async with session.get(url) as resp:
+                    if resp.status == 404:
+                        logger.warning("Article not found: %s", slug)
+                        return None
+                    if resp.status != 200:
+                        logger.warning(
+                            "Zenn API error: status=%d, slug=%s",
+                            resp.status,
+                            slug,
+                        )
+                        return None
+                    data = await resp.json()
+        except (aiohttp.ClientError, TimeoutError) as e:
+            logger.warning("Failed to fetch article %s: %s", slug, e)
+            return None
+
+        article = data.get("article", {})
+        title = article.get("title", "")
+        body = article.get("body_markdown", "")
+        if not body:
+            logger.warning("Article has no body: %s", slug)
+            return None
+
+        return IngestedContent(
+            source_id=f"https://zenn.dev/articles/{slug}",
+            title=title,
+            text=body,
+            ingested_at=IngestedContent.now_iso(),
+            source_type="zenn",
+            metadata={
+                "slug": slug,
+                "emoji": article.get("emoji", ""),
+                "article_type": article.get("article_type", ""),
+                "published": article.get("published", False),
+            },
+        )
+
+    async def discover(self, source: str, **kwargs: object) -> list[str]:
+        """ユーザー名から記事 slug 一覧を取得する.
+
+        Args:
+            source: Zenn ユーザー名
+            **kwargs: 追加パラメータ（未使用）
+
+        Returns:
+            記事 slug のリスト
+        """
+        username = source.strip()
+        if not username:
+            return []
+
+        url = f"{ZENN_API_BASE}/articles"
+        slugs: list[str] = []
+        next_page: str | None = None
+
+        try:
+            async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                while True:
+                    params: dict[str, str] = {"username": username}
+                    if next_page is not None:
+                        params["next_page"] = next_page
+
+                    async with session.get(url, params=params) as resp:
+                        if resp.status != 200:
+                            logger.warning(
+                                "Zenn API error during discover: "
+                                "status=%d, username=%s",
+                                resp.status,
+                                username,
+                            )
+                            break
+                        data = await resp.json()
+
+                    articles = data.get("articles", [])
+                    for article in articles:
+                        slug = article.get("slug")
+                        if slug:
+                            slugs.append(slug)
+
+                    next_page = data.get("next_page")
+                    if not next_page:
+                        break
+        except (aiohttp.ClientError, TimeoutError) as e:
+            logger.warning(
+                "Failed to discover articles for %s: %s", username, e
+            )
+
+        return slugs

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -15,11 +15,9 @@ from .base import BaseIngester, IngestedContent
 
 logger = logging.getLogger(__name__)
 
-ZENN_API_BASE = "https://zenn.dev/api"
-"""Zenn API のベース URL."""
+ZENN_API_BASE = "https://zenn.dev/api"  # Zenn API のベース URL.
 
-_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
-"""slug の形式: 英小文字・数字・ハイフン・アンダースコア."""
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")  # slug の形式: 英小文字・数字・ハイフン・アンダースコア.
 
 
 class ZennIngester(BaseIngester):

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 
 from rag.ingesters.base import BaseIngester, IngestedContent
 from rag.ingesters.web import WebIngester
+from rag.ingesters.zenn import ZennIngester
 from rag.rag_knowledge import RAGKnowledgeService
 from rag.vector_store import VectorStore
 from rag.web_crawler import CrawledPage, WebCrawler
@@ -634,3 +636,376 @@ class TestRAGServiceWithWebIngester:
         ).hexdigest()[:16]
         assert chunk.id.startswith(expected_hash)
         assert chunk.metadata["source_url"] == "https://example.com/page"
+
+
+# --- ZennIngester テスト ---
+
+
+class TestZennIngesterValidate:
+    """ZennIngester.validate_identifier() のテスト."""
+
+    def test_valid_slug(self) -> None:
+        """正常な slug が検証を通過すること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("my-article") == "my-article"
+
+    def test_valid_slug_with_numbers(self) -> None:
+        """数字を含む slug が検証を通過すること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("article123") == "article123"
+
+    def test_valid_slug_with_underscore(self) -> None:
+        """アンダースコアを含む slug が検証を通過すること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("my_article") == "my_article"
+
+    def test_slug_normalized_to_lowercase(self) -> None:
+        """大文字を含む slug が小文字に正規化されること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("My-Article") == "my-article"
+
+    def test_slug_trimmed(self) -> None:
+        """前後の空白がトリムされること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("  my-article  ") == "my-article"
+
+    def test_empty_slug_raises(self) -> None:
+        """空の slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="slugが空です"):
+            ingester.validate_identifier("")
+
+    def test_whitespace_only_slug_raises(self) -> None:
+        """空白のみの slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="slugが空です"):
+            ingester.validate_identifier("   ")
+
+    def test_invalid_slug_with_special_chars(self) -> None:
+        """特殊文字を含む slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="不正なslug形式です"):
+            ingester.validate_identifier("my article!")
+
+    def test_invalid_slug_with_slash(self) -> None:
+        """スラッシュを含む slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="不正なslug形式です"):
+            ingester.validate_identifier("user/article")
+
+
+class TestZennIngesterFetchSingle:
+    """ZennIngester.fetch_single() のテスト."""
+
+    async def test_fetch_single_success(self) -> None:
+        """正常に記事を取得して IngestedContent を返すこと."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "article": {
+                "title": "テスト記事",
+                "body_markdown": "# テスト\n\nこれはテスト記事です。",
+                "slug": "test-article",
+                "emoji": "📝",
+                "article_type": "tech",
+                "published": True,
+            }
+        })
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert result.source_id == "https://zenn.dev/articles/test-article"
+        assert result.title == "テスト記事"
+        assert result.text == "# テスト\n\nこれはテスト記事です。"
+        assert result.source_type == "zenn"
+        assert result.metadata["slug"] == "test-article"
+        assert result.metadata["emoji"] == "📝"
+        assert result.metadata["article_type"] == "tech"
+        assert result.metadata["published"] is True
+
+    async def test_fetch_single_not_found(self) -> None:
+        """404 レスポンスで None を返すこと."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 404
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.fetch_single("nonexistent")
+
+        assert result is None
+
+    async def test_fetch_single_api_error(self) -> None:
+        """API エラー（500）で None を返すこと."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 500
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.fetch_single("error-article")
+
+        assert result is None
+
+    async def test_fetch_single_network_error(self) -> None:
+        """ネットワークエラーで None を返すこと."""
+        ingester = ZennIngester()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(
+                        side_effect=aiohttp.ClientError("connection failed")
+                    ),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.fetch_single("test-article")
+
+        assert result is None
+
+    async def test_fetch_single_empty_body(self) -> None:
+        """本文が空の場合 None を返すこと."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "article": {
+                "title": "Empty Article",
+                "body_markdown": "",
+                "slug": "empty-article",
+            }
+        })
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.fetch_single("empty-article")
+
+        assert result is None
+
+
+class TestZennIngesterDiscover:
+    """ZennIngester.discover() のテスト."""
+
+    async def test_discover_returns_slugs(self) -> None:
+        """ユーザーの記事 slug 一覧を取得すること."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "articles": [
+                {"slug": "article-1"},
+                {"slug": "article-2"},
+                {"slug": "article-3"},
+            ],
+            "next_page": None,
+        })
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.discover("testuser")
+
+        assert result == ["article-1", "article-2", "article-3"]
+
+    async def test_discover_empty_username(self) -> None:
+        """空のユーザー名で空リストを返すこと."""
+        ingester = ZennIngester()
+        result = await ingester.discover("")
+        assert result == []
+
+    async def test_discover_api_error(self) -> None:
+        """API エラー時に途中までの結果を返すこと."""
+        ingester = ZennIngester()
+        mock_response = AsyncMock()
+        mock_response.status = 500
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.discover("testuser")
+
+        assert result == []
+
+    async def test_discover_network_error(self) -> None:
+        """ネットワークエラーでも空リストを返すこと."""
+        ingester = ZennIngester()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(
+                        side_effect=aiohttp.ClientError("connection failed")
+                    ),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.discover("testuser")
+
+        assert result == []
+
+    async def test_discover_pagination(self) -> None:
+        """ページネーションが正しく処理されること."""
+        ingester = ZennIngester()
+
+        page1_response = AsyncMock()
+        page1_response.status = 200
+        page1_response.json = AsyncMock(return_value={
+            "articles": [{"slug": "article-1"}],
+            "next_page": "2",
+        })
+
+        page2_response = AsyncMock()
+        page2_response.status = 200
+        page2_response.json = AsyncMock(return_value={
+            "articles": [{"slug": "article-2"}],
+            "next_page": None,
+        })
+
+        call_count = 0
+
+        def make_context_manager(*args: object, **kwargs: object) -> AsyncMock:
+            nonlocal call_count
+            call_count += 1
+            resp = page1_response if call_count == 1 else page2_response
+            return AsyncMock(
+                __aenter__=AsyncMock(return_value=resp),
+                __aexit__=AsyncMock(return_value=False),
+            )
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=make_context_manager)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            result = await ingester.discover("testuser")
+
+        assert result == ["article-1", "article-2"]
+
+
+class TestZennIngesterInheritance:
+    """ZennIngester が BaseIngester を正しく継承していることのテスト."""
+
+    def test_is_subclass_of_base_ingester(self) -> None:
+        """ZennIngester が BaseIngester のサブクラスであること."""
+        assert issubclass(ZennIngester, BaseIngester)
+
+    def test_instance_is_base_ingester(self) -> None:
+        """ZennIngester インスタンスが BaseIngester のインスタンスであること."""
+        ingester = ZennIngester()
+        assert isinstance(ingester, BaseIngester)
+
+    async def test_fetch_batch_inherited(self) -> None:
+        """fetch_batch() がデフォルト実装で動作すること."""
+        ingester = ZennIngester()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "article": {
+                "title": "Test",
+                "body_markdown": "Content",
+                "slug": "test",
+            }
+        })
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "aiohttp.ClientSession",
+                lambda **kwargs: AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(return_value=False),
+                ),
+            )
+            results = await ingester.fetch_batch(["test"])
+
+        assert len(results) == 1
+        assert results[0].source_type == "zenn"


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `ZennIngester` クラスを新規実装（`BaseIngester` 継承）
- Zenn API (`https://zenn.dev/api/articles/{slug}`) から記事本文（Markdown）を取得
- ユーザー名指定で記事一覧の発見（`discover()`）をサポート（ページネーション対応）
- slug 形式のバリデーション（`validate_identifier()`）を実装
- API エラー・ネットワークエラー時の適切なハンドリング
- `__init__.py` に `ZennIngester` の re-export を追加

## Test plan

- [x] `ZennIngester` が `BaseIngester` のサブクラスであること
- [x] slug バリデーション（正常系・異常系: 空文字、特殊文字、大文字正規化）
- [x] `fetch_single()` 正常取得・404・500・ネットワークエラー・空本文
- [x] `discover()` 正常取得・空ユーザー名・APIエラー・ネットワークエラー・ページネーション
- [x] `fetch_batch()` 継承動作確認
- [x] pytest 457 tests passed, ruff/mypy all clean

## Related issues

Closes #73