### PR TITLE
refactor(rag-knowledge): Embedding デフォルトモデル名を定数に集約 (#85)

### DIFF
--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -18,6 +18,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # LM Studio のデフォルトベースURL
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
 
+# デフォルトEmbeddingモデル名
+DEFAULT_EMBEDDING_MODEL_LOCAL = "nomic-embed-text"
+
 # プロジェクトルートの .env を参照
 _ENV_FILE = Path(__file__).parent.parent.parent / ".env"
 
@@ -36,7 +39,7 @@ class RAGSettings(BaseSettings):
 
     # Embedding設定
     embedding_provider: Literal["local", "online"] = "local"
-    embedding_model_local: str = "nomic-embed-text"
+    embedding_model_local: str = DEFAULT_EMBEDDING_MODEL_LOCAL
     embedding_model_online: str = "text-embedding-3-small"
     embedding_prefix_enabled: bool = True
     lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL

--- a/src/rag/embedding/lmstudio_embedding.py
+++ b/src/rag/embedding/lmstudio_embedding.py
@@ -8,7 +8,7 @@ import logging
 
 from openai import AsyncOpenAI
 
-from ..config import DEFAULT_LMSTUDIO_BASE_URL
+from ..config import DEFAULT_EMBEDDING_MODEL_LOCAL, DEFAULT_LMSTUDIO_BASE_URL
 from .base import EmbeddingProvider
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class LMStudioEmbedding(EmbeddingProvider):
     def __init__(
         self,
         base_url: str = DEFAULT_LMSTUDIO_BASE_URL,
-        model: str = "nomic-embed-text",
+        model: str = DEFAULT_EMBEDDING_MODEL_LOCAL,
         prefix_enabled: bool = False,
     ) -> None:
         normalized = base_url.rstrip("/")


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `config.py` に `DEFAULT_EMBEDDING_MODEL_LOCAL` 定数を追加
- `lmstudio_embedding.py` の `__init__` デフォルト引数がその定数を参照するよう変更
- デフォルトモデル名の定義を1箇所に集約し、変更時の更新漏れリスクを解消

## Test plan

- [x] pytest: 28 tests passed
- [x] ruff check: All checks passed
- [x] mypy: no issues found

## Related issues

Closes #85