### PR TITLE
feat(rag-knowledge): rag_ingest / rag_ingest_batch MCP ツールと CLI ingest サブコマンドの実装

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@
 | ファイル | 責務 |
 |---|---|
 | `src/rag/server.py` | MCP サーバー（FastMCP）エントリーポイント・ツール定義 |
-| `src/rag/cli.py` | CLI エントリーポイント（評価・DB 初期化） |
+| `src/rag/cli.py` | CLI エントリーポイント（評価・DB 初期化・取り込み・クロールプレビュー） |
 | `src/rag/config.py` | pydantic-settings による環境変数・設定管理 |
 | `src/rag/rag_knowledge.py` | ナレッジサービス（取り込み・検索・削除のオーケストレーション） |
 | `src/rag/web_crawler.py` | Web クローラー（ページ取得・本文抽出・SSRF 対策・robots.txt 遵守） |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import hashlib
+import io
 import json
 import logging
 import math
@@ -231,6 +233,33 @@ def main() -> None:
         help="BM25 bパラメータ（例: 0.75）",
     )
 
+    # ingest サブコマンド
+    ingest_parser = subparsers.add_parser("ingest", help="マルチソース取り込み")
+    ingest_parser.add_argument(
+        "--source-type",
+        required=True,
+        help="データソース種別（web, zenn, local_file 等）",
+    )
+    ingest_parser.add_argument(
+        "--identifier",
+        help="ソース識別子（URL、ファイルパス等）。単一取り込み時に使用",
+    )
+    ingest_parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="一括取り込みモード。--source と組み合わせて使用",
+    )
+    ingest_parser.add_argument(
+        "--source",
+        help="発見元（ユーザー名、ディレクトリパス等）。一括取り込み時に使用",
+    )
+    ingest_parser.add_argument(
+        "--option",
+        action="append",
+        default=[],
+        help="ソースタイプ固有のオプション（key=value 形式、複数指定可）",
+    )
+
     # crawl-preview サブコマンド
     preview_parser = subparsers.add_parser("crawl-preview", help="クロール対象ページをプレビュー")
     preview_parser.add_argument(
@@ -256,6 +285,8 @@ def main() -> None:
         asyncio.run(run_evaluation(args))
     elif args.command == "init-test-db":
         asyncio.run(init_test_db(args))
+    elif args.command == "ingest":
+        asyncio.run(run_ingest(args))
     elif args.command == "crawl-preview":
         asyncio.run(run_crawl_preview(args))
 
@@ -752,6 +783,148 @@ async def init_test_db(args: argparse.Namespace) -> None:
         "BM25 index persisted at %s (%d documents)",
         args.bm25_persist_dir, bm25_index.get_document_count(),
     )
+
+
+def _parse_options(option_list: list[str]) -> dict[str, object]:
+    """--option key=value リストを辞書に変換する.
+
+    Args:
+        option_list: key=value 形式の文字列リスト
+
+    Returns:
+        パースされたオプション辞書
+
+    Raises:
+        SystemExit: key=value 形式でない場合
+    """
+    options: dict[str, object] = {}
+    for item in option_list:
+        if "=" not in item:
+            logger.error("--option は key=value 形式で指定してください: %s", item)
+            sys.exit(1)
+        key, _, value = item.partition("=")
+        options[key.strip()] = value.strip()
+    return options
+
+
+async def _create_ingest_service() -> "RAGKnowledgeService":
+    """取り込み用の RAGKnowledgeService を生成する.
+
+    WebIngester を web ソースタイプとして登録済みのサービスを返す。
+
+    Returns:
+        RAGKnowledgeServiceインスタンス
+    """
+    from .config import get_settings
+    from .embedding.factory import get_embedding_provider
+    from .ingesters.web import WebIngester
+    from .rag_knowledge import RAGKnowledgeService
+    from .safe_browsing import create_safe_browsing_client
+    from .vector_store import VectorStore
+    from .web_crawler import WebCrawler
+
+    settings = get_settings()
+    embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        vector_store = VectorStore(
+            embedding_provider=embedding_provider,
+            persist_directory=settings.chromadb_persist_dir,
+        )
+        web_crawler = WebCrawler(
+            max_pages=settings.rag_max_crawl_pages,
+            crawl_delay=settings.rag_crawl_delay_sec,
+            respect_robots_txt=settings.rag_respect_robots_txt,
+            robots_txt_cache_ttl=settings.rag_robots_txt_cache_ttl,
+        )
+    safe_browsing_client = create_safe_browsing_client(settings)
+
+    web_ingester = WebIngester(
+        web_crawler=web_crawler,
+        safe_browsing_client=safe_browsing_client,
+    )
+
+    from .bm25_index import BM25Index
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        bm25_index = BM25Index(
+            k1=settings.rag_bm25_k1,
+            b=settings.rag_bm25_b,
+            persist_dir=settings.bm25_persist_dir,
+        )
+
+    service = RAGKnowledgeService(
+        vector_store=vector_store,
+        web_crawler=web_crawler,
+        chunk_size=settings.rag_chunk_size,
+        chunk_overlap=settings.rag_chunk_overlap,
+        similarity_threshold=settings.rag_similarity_threshold,
+        safe_browsing_client=safe_browsing_client,
+        bm25_index=bm25_index,
+        web_ingester=web_ingester,
+    )
+
+    service.register_ingester("web", web_ingester)
+
+    return service
+
+
+async def run_ingest(args: argparse.Namespace) -> None:
+    """マルチソース取り込みを実行する.
+
+    Args:
+        args: コマンドライン引数
+    """
+    source_type: str = args.source_type
+    is_batch: bool = args.batch
+    options = _parse_options(args.option) if args.option else None
+
+    if is_batch:
+        # 一括取り込みモード
+        if not args.source:
+            logger.error("一括取り込みモードでは --source が必要です")
+            sys.exit(1)
+
+        logger.info(
+            "Starting batch ingest: source_type=%s, source=%s",
+            source_type,
+            args.source,
+        )
+
+        service = await _create_ingest_service()
+        try:
+            result = await service.ingest_batch(
+                source_type, args.source, options
+            )
+            ingested = result["ingested"]
+            chunks = result["chunks_stored"]
+            errors = result["errors"]
+            print(f"完了: {ingested}件取り込み / {chunks}チャンク / エラー: {errors}件")
+        except ValueError as e:
+            logger.error("取り込みエラー: %s", e)
+            sys.exit(1)
+    else:
+        # 単一取り込みモード
+        if not args.identifier:
+            logger.error("単一取り込みモードでは --identifier が必要です")
+            sys.exit(1)
+
+        logger.info(
+            "Starting single ingest: source_type=%s, identifier=%s",
+            source_type,
+            args.identifier,
+        )
+
+        service = await _create_ingest_service()
+        try:
+            chunks = await service.ingest(source_type, args.identifier, options)
+            if chunks <= 0:
+                print(f"エラー: コンテンツの取り込みに失敗しました。identifier={args.identifier}")
+                sys.exit(1)
+            print(f"取り込み完了: {args.identifier} ({chunks}チャンク)")
+        except ValueError as e:
+            logger.error("取り込みエラー: %s", e)
+            sys.exit(1)
 
 
 async def run_crawl_preview(args: argparse.Namespace) -> None:

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -23,6 +23,7 @@ from .vector_store import DocumentChunk, VectorStore
 if TYPE_CHECKING:
     from .bm25_index import BM25Index
     from .hybrid_search import HybridSearchEngine
+    from .ingesters.base import BaseIngester
     from .ingesters.web import WebIngester
     from .safe_browsing import SafeBrowsingClient
     from .web_crawler import CrawlPreviewPage, CrawledPage, WebCrawler
@@ -188,6 +189,7 @@ class RAGKnowledgeService:
         self._min_combined_score = min_combined_score
         self._debug_log_enabled = debug_log_enabled
         self._web_ingester = web_ingester
+        self._ingesters: dict[str, BaseIngester] = {}
         self._hybrid_search_engine: HybridSearchEngine | None = None
 
         # ハイブリッド検索エンジンの初期化
@@ -200,6 +202,144 @@ class RAGKnowledgeService:
                 vector_weight=vector_weight,
             )
             logger.info("Hybrid search engine initialized")
+
+    def register_ingester(self, source_type: str, ingester: BaseIngester) -> None:
+        """ソースタイプに対応するインジェスターを登録する.
+
+        Args:
+            source_type: データソース種別
+            ingester: インジェスターインスタンス
+        """
+        self._ingesters[source_type] = ingester
+        logger.info("Registered ingester for source_type=%s", source_type)
+
+    def _get_ingester(self, source_type: str) -> BaseIngester:
+        """ソースタイプに対応するインジェスターを取得する.
+
+        Args:
+            source_type: データソース種別
+
+        Returns:
+            対応するインジェスター
+
+        Raises:
+            ValueError: 未登録のソースタイプが指定された場合
+        """
+        ingester = self._ingesters.get(source_type)
+        if ingester is None:
+            registered = ", ".join(sorted(self._ingesters.keys())) or "(なし)"
+            raise ValueError(
+                f"未登録のソースタイプです: {source_type} "
+                f"(登録済み: {registered})"
+            )
+        return ingester
+
+    async def ingest(
+        self,
+        source_type: str,
+        identifier: str,
+        options: dict[str, object] | None = None,
+    ) -> int:
+        """ソースタイプに基づいて単一コンテンツを取り込む.
+
+        仕様: docs/specs/rag-knowledge.md (rag_ingest)
+
+        Args:
+            source_type: データソース種別
+            identifier: ソース固有の識別子（URL、ファイルパス等）
+            options: ソースタイプ固有の追加パラメータ
+
+        Returns:
+            保存されたチャンク数
+
+        Raises:
+            ValueError: 未登録のソースタイプ、または識別子の検証エラー
+        """
+        ingester = self._get_ingester(source_type)
+        content = await ingester.fetch_single(identifier)
+        if content is None:
+            return 0
+        return await self._ingest_content(content)
+
+    async def ingest_batch(
+        self,
+        source_type: str,
+        source: str,
+        options: dict[str, object] | None = None,
+        progress_callback: Callable[[int, int], Awaitable[None]] | None = None,
+    ) -> dict[str, int]:
+        """ソースタイプに基づいて一括取り込みを行う.
+
+        仕様: docs/specs/rag-knowledge.md (rag_ingest_batch)
+
+        Args:
+            source_type: データソース種別
+            source: 発見元（リンク集 URL、ユーザー名、ディレクトリパス等）
+            options: ソースタイプ固有の追加パラメータ
+            progress_callback: 進捗コールバック関数
+
+        Returns:
+            {"ingested": N, "chunks_stored": M, "errors": E}
+
+        Raises:
+            ValueError: 未登録のソースタイプ
+        """
+        ingester = self._get_ingester(source_type)
+
+        # discover で取り込み対象を発見
+        discover_kwargs: dict[str, object] = {}
+        if options:
+            discover_kwargs.update(options)
+        identifiers = await ingester.discover(source, **discover_kwargs)
+        if not identifiers:
+            logger.info(
+                "No items discovered for source_type=%s source=%s",
+                source_type,
+                source,
+            )
+            return {"ingested": 0, "chunks_stored": 0, "errors": 0}
+
+        total = len(identifiers)
+        ingested_count = 0
+        total_chunks = 0
+        errors = 0
+
+        for i, identifier in enumerate(identifiers, start=1):
+            try:
+                content = await ingester.fetch_single(identifier)
+                if content is None:
+                    errors += 1
+                    continue
+                chunks_stored = await self._ingest_content(content)
+                total_chunks += chunks_stored
+                ingested_count += 1
+            except Exception:
+                logger.exception(
+                    "Failed to ingest %s (source_type=%s)",
+                    identifier,
+                    source_type,
+                )
+                errors += 1
+
+            if progress_callback:
+                try:
+                    await progress_callback(i, total)
+                except Exception:
+                    logger.debug("Progress callback failed", exc_info=True)
+
+        logger.info(
+            "Batch ingest complete: source_type=%s ingested=%d chunks=%d errors=%d",
+            source_type,
+            ingested_count,
+            total_chunks,
+            errors,
+        )
+
+        return {
+            "ingested": ingested_count,
+            "chunks_stored": total_chunks,
+            "errors": errors,
+        }
 
     async def crawl_preview(
         self,

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,13 +3,15 @@
 仕様: docs/specs/rag-knowledge.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 6 つの RAG ツールを公開する:
+FastMCP を使用して 8 つの RAG ツールを公開する:
 - rag_search: ナレッジベースから関連情報を検索
 - rag_add: 単一ページをナレッジベースに取り込み
 - rag_crawl: リンク集ページからクロール＆一括取り込み
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_delete: ソースURL指定でナレッジから削除
 - rag_stats: ナレッジベースの統計情報を表示
+- rag_ingest: マルチソース単一コンテンツ取り込み
+- rag_ingest_batch: マルチソース一括取り込み
 """
 
 from __future__ import annotations
@@ -118,7 +120,7 @@ def _build_rag_service() -> RAGKnowledgeService:
         safe_browsing_client=safe_browsing_client,
     )
 
-    return RAGKnowledgeService(
+    service = RAGKnowledgeService(
         vector_store=vector_store,
         web_crawler=web_crawler,
         chunk_size=settings.rag_chunk_size,
@@ -132,6 +134,11 @@ def _build_rag_service() -> RAGKnowledgeService:
         debug_log_enabled=settings.rag_debug_log_enabled,
         web_ingester=web_ingester,
     )
+
+    # ソースタイプ → インジェスターの登録
+    service.register_ingester("web", web_ingester)
+
+    return service
 
 
 # --- MCP ツール定義 ---
@@ -453,6 +460,80 @@ async def rag_stats() -> str:
     except Exception:
         logger.exception("Failed to get stats")
         return "エラー: 統計情報の取得に失敗しました。"
+
+
+@mcp.tool()
+async def rag_ingest(
+    source_type: str,
+    identifier: str,
+    options: dict[str, object] | None = None,
+) -> str:
+    """[rag-knowledge] RAG ingest - マルチソース単一コンテンツ取り込み.
+
+    knowledge base, ingest, multi-source, single content.
+    ソースタイプに対応するインジェスターで単一コンテンツを取り込む。
+
+    Args:
+        source_type: データソース種別（web, zenn, local_file 等）
+        identifier: ソース固有の識別子（URL、ファイルパス、記事スラッグ等）
+        options: ソースタイプ固有の追加パラメータ（JSON オブジェクト、任意）
+
+    Returns:
+        取り込み結果のメッセージ
+    """
+    service = await _get_rag_service()
+    try:
+        chunks = await service.ingest(source_type, identifier, options)
+        if chunks <= 0:
+            return f"エラー: コンテンツの取り込みに失敗しました。source_type={source_type}, identifier={identifier}"
+        return f"取り込み完了: source_type={source_type}, identifier={identifier} ({chunks}チャンク)"
+    except ValueError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception(
+            "Failed to ingest: source_type=%s, identifier=%s",
+            source_type,
+            identifier,
+        )
+        return f"エラー: コンテンツの取り込みに失敗しました。source_type={source_type}, identifier={identifier}"
+
+
+@mcp.tool()
+async def rag_ingest_batch(
+    source_type: str,
+    source: str,
+    options: dict[str, object] | None = None,
+) -> str:
+    """[rag-knowledge] RAG ingest batch - マルチソース一括取り込み.
+
+    knowledge base, bulk ingest, multi-source, batch, discover.
+    ソースタイプに対応するインジェスターで一括取り込みを行う。
+    discover で対象を発見し、バッチで取り込む。
+
+    Args:
+        source_type: データソース種別（web, zenn, local_file 等）
+        source: 発見元（リンク集 URL、ユーザー名、ディレクトリパス等）
+        options: ソースタイプ固有の追加パラメータ（JSON オブジェクト、任意）
+
+    Returns:
+        取り込み結果のサマリー
+    """
+    service = await _get_rag_service()
+    try:
+        result = await service.ingest_batch(source_type, source, options)
+        ingested = result["ingested"]
+        chunks = result["chunks_stored"]
+        errors = result["errors"]
+        return f"完了: {ingested}件取り込み / {chunks}チャンク / エラー: {errors}件"
+    except ValueError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception(
+            "Failed to ingest batch: source_type=%s, source=%s",
+            source_type,
+            source,
+        )
+        return f"エラー: 一括取り込みに失敗しました。source_type={source_type}, source={source}"
 
 
 def _configure_and_run() -> None:

--- a/tests/test_ingest_routing.py
+++ b/tests/test_ingest_routing.py
@@ -1,0 +1,617 @@
+"""rag_ingest / rag_ingest_batch ルーティングとMCPツール・CLIのテスト
+
+仕様: docs/specs/rag-knowledge.md
+Issue: #91
+"""
+
+from __future__ import annotations
+
+import argparse
+from importlib import import_module
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rag.ingesters.web import WebIngester
+from rag.rag_knowledge import RAGKnowledgeService
+from rag.server import _reset_rag_service
+from rag.vector_store import VectorStore
+from rag.web_crawler import CrawledPage, WebCrawler
+
+
+# --- フィクスチャ ---
+
+
+@pytest.fixture
+def mock_vector_store() -> MagicMock:
+    """モック VectorStore を作成する."""
+    mock = MagicMock(spec=VectorStore)
+    mock.add_documents = AsyncMock(return_value=1)
+    mock.search = AsyncMock(return_value=[])
+    mock.delete_by_source = AsyncMock(return_value=0)
+    mock.delete_stale_chunks = AsyncMock(return_value=0)
+    mock.get_stats = MagicMock(return_value={
+        "total_chunks": 0,
+        "source_count": 0,
+        "sources": [],
+    })
+    return mock
+
+
+@pytest.fixture
+def mock_web_crawler() -> MagicMock:
+    """モック WebCrawler を作成する."""
+    mock = MagicMock(spec=WebCrawler)
+    mock.crawl_page = AsyncMock(return_value=None)
+    mock.crawl_index_page = AsyncMock(return_value=[])
+    mock.validate_url = MagicMock(side_effect=lambda url: url)
+    mock._crawl_delay = 0.0
+    return mock
+
+
+@pytest.fixture
+def service_with_web_ingester(
+    mock_vector_store: MagicMock,
+    mock_web_crawler: MagicMock,
+) -> RAGKnowledgeService:
+    """web インジェスター登録済みの RAGKnowledgeService を作成する."""
+    web_ingester = WebIngester(web_crawler=mock_web_crawler)
+    service = RAGKnowledgeService(
+        vector_store=mock_vector_store,
+        web_crawler=mock_web_crawler,
+        chunk_size=200,
+        chunk_overlap=30,
+        similarity_threshold=None,
+        web_ingester=web_ingester,
+    )
+    service.register_ingester("web", web_ingester)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def _reset_rag_global_state() -> None:
+    """各テスト前にRAGサービスのグローバル状態をリセットする."""
+    _reset_rag_service()
+
+
+# --- ルーティング機構テスト ---
+
+
+class TestIngesterRouting:
+    """ソースタイプ → インジェスターのルーティングテスト."""
+
+    def test_register_ingester(
+        self,
+        mock_vector_store: MagicMock,
+        mock_web_crawler: MagicMock,
+    ) -> None:
+        """インジェスターが正しく登録されること."""
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+        )
+        web_ingester = WebIngester(web_crawler=mock_web_crawler)
+        service.register_ingester("web", web_ingester)
+
+        # _get_ingester で取得できること
+        assert service._get_ingester("web") is web_ingester
+
+    def test_get_ingester_unregistered_raises(
+        self,
+        mock_vector_store: MagicMock,
+        mock_web_crawler: MagicMock,
+    ) -> None:
+        """未登録のソースタイプで ValueError が発生すること."""
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+        )
+        with pytest.raises(ValueError, match="未登録のソースタイプです: zenn"):
+            service._get_ingester("zenn")
+
+    def test_get_ingester_shows_registered_types(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+    ) -> None:
+        """未登録エラーメッセージに登録済みソースタイプが含まれること."""
+        with pytest.raises(ValueError, match="登録済み: web"):
+            service_with_web_ingester._get_ingester("local_file")
+
+
+# --- ingest テスト ---
+
+
+class TestIngest:
+    """RAGKnowledgeService.ingest() のテスト."""
+
+    async def test_ingest_web_source_type(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """web ソースタイプで単一コンテンツが取り込まれること."""
+        mock_web_crawler.crawl_page.return_value = CrawledPage(
+            url="https://example.com/page",
+            title="Test Page",
+            text="Test content for ingesting.",
+            crawled_at="2024-01-01T00:00:00+00:00",
+        )
+        mock_vector_store.add_documents.return_value = 1
+
+        result = await service_with_web_ingester.ingest(
+            "web", "https://example.com/page"
+        )
+
+        assert result == 1
+        mock_vector_store.add_documents.assert_called_once()
+
+    async def test_ingest_unregistered_source_type(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+    ) -> None:
+        """未登録のソースタイプで ValueError が発生すること."""
+        with pytest.raises(ValueError, match="未登録のソースタイプです: unknown"):
+            await service_with_web_ingester.ingest(
+                "unknown", "some-identifier"
+            )
+
+    async def test_ingest_returns_zero_on_fetch_failure(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+    ) -> None:
+        """fetch_single が None を返した場合に 0 を返すこと."""
+        mock_web_crawler.crawl_page.return_value = None
+
+        result = await service_with_web_ingester.ingest(
+            "web", "https://example.com/fail"
+        )
+
+        assert result == 0
+
+
+# --- ingest_batch テスト ---
+
+
+class TestIngestBatch:
+    """RAGKnowledgeService.ingest_batch() のテスト."""
+
+    async def test_ingest_batch_web_source_type(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """web ソースタイプで一括取り込みが動作すること."""
+        mock_web_crawler.crawl_index_page.return_value = [
+            "https://example.com/p1",
+            "https://example.com/p2",
+        ]
+        mock_web_crawler.crawl_page.side_effect = [
+            CrawledPage(
+                url="https://example.com/p1",
+                title="P1",
+                text="Content 1 for testing.",
+                crawled_at="2024-01-01T00:00:00+00:00",
+            ),
+            CrawledPage(
+                url="https://example.com/p2",
+                title="P2",
+                text="Content 2 for testing.",
+                crawled_at="2024-01-01T00:00:00+00:00",
+            ),
+        ]
+        mock_vector_store.add_documents.return_value = 1
+
+        result = await service_with_web_ingester.ingest_batch(
+            "web",
+            "https://example.com/index",
+            {"url_pattern": r"p\d"},
+        )
+
+        assert result["ingested"] == 2
+        assert result["chunks_stored"] >= 2
+        assert result["errors"] == 0
+
+    async def test_ingest_batch_unregistered_source_type(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+    ) -> None:
+        """未登録のソースタイプで ValueError が発生すること."""
+        with pytest.raises(ValueError, match="未登録のソースタイプです"):
+            await service_with_web_ingester.ingest_batch(
+                "unknown", "some-source"
+            )
+
+    async def test_ingest_batch_no_items_discovered(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+    ) -> None:
+        """discover で 0 件の場合にエラーなしで返ること."""
+        mock_web_crawler.crawl_index_page.return_value = []
+
+        result = await service_with_web_ingester.ingest_batch(
+            "web", "https://example.com/empty"
+        )
+
+        assert result["ingested"] == 0
+        assert result["chunks_stored"] == 0
+        assert result["errors"] == 0
+
+    async def test_ingest_batch_partial_failure(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """一部失敗しても成功分が取り込まれ、エラーが記録されること."""
+        mock_web_crawler.crawl_index_page.return_value = [
+            "https://example.com/ok",
+            "https://example.com/fail",
+        ]
+        mock_web_crawler.crawl_page.side_effect = [
+            CrawledPage(
+                url="https://example.com/ok",
+                title="OK",
+                text="Content that works.",
+                crawled_at="2024-01-01T00:00:00+00:00",
+            ),
+            None,  # 失敗
+        ]
+        mock_vector_store.add_documents.return_value = 1
+
+        result = await service_with_web_ingester.ingest_batch(
+            "web", "https://example.com/index"
+        )
+
+        assert result["ingested"] == 1
+        assert result["errors"] == 1
+
+    async def test_ingest_batch_progress_callback(
+        self,
+        service_with_web_ingester: RAGKnowledgeService,
+        mock_web_crawler: MagicMock,
+        mock_vector_store: MagicMock,
+    ) -> None:
+        """進捗コールバックが呼ばれること."""
+        mock_web_crawler.crawl_index_page.return_value = [
+            "https://example.com/p1",
+        ]
+        mock_web_crawler.crawl_page.return_value = CrawledPage(
+            url="https://example.com/p1",
+            title="P1",
+            text="Content.",
+            crawled_at="2024-01-01T00:00:00+00:00",
+        )
+        mock_vector_store.add_documents.return_value = 1
+
+        callback = AsyncMock()
+        await service_with_web_ingester.ingest_batch(
+            "web",
+            "https://example.com/index",
+            progress_callback=callback,
+        )
+
+        callback.assert_called_once_with(1, 1)
+
+
+# --- MCP ツールテスト ---
+
+
+class TestRagIngestTool:
+    """rag_ingest MCP ツールのテスト."""
+
+    async def test_rag_ingest_success(self) -> None:
+        """正常取り込みで成功メッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(return_value=5)
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest("web", "https://example.com/page")
+
+        assert "取り込み完了" in result
+        assert "5チャンク" in result
+        mock_service.ingest.assert_called_once_with(
+            "web", "https://example.com/page", None
+        )
+
+    async def test_rag_ingest_with_options(self) -> None:
+        """オプション付きで呼び出せること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(return_value=3)
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest(
+                "web", "https://example.com/page", {"key": "value"}
+            )
+
+        assert "取り込み完了" in result
+        mock_service.ingest.assert_called_once_with(
+            "web", "https://example.com/page", {"key": "value"}
+        )
+
+    async def test_rag_ingest_value_error(self) -> None:
+        """ValueError 時にエラーメッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(
+            side_effect=ValueError("未登録のソースタイプです: unknown")
+        )
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest("unknown", "identifier")
+
+        assert "エラー:" in result
+        assert "未登録のソースタイプです" in result
+
+    async def test_rag_ingest_zero_chunks(self) -> None:
+        """0 チャンク（取り込み失敗）時にエラーメッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(return_value=0)
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest("web", "https://example.com/fail")
+
+        assert "エラー:" in result
+
+    async def test_rag_ingest_unexpected_error(self) -> None:
+        """予期しないエラー時にエラーメッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(side_effect=RuntimeError("Unexpected"))
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest("web", "https://example.com/page")
+
+        assert "エラー:" in result
+
+
+class TestRagIngestBatchTool:
+    """rag_ingest_batch MCP ツールのテスト."""
+
+    async def test_rag_ingest_batch_success(self) -> None:
+        """正常取り込みでサマリーが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest_batch = AsyncMock(
+            return_value={"ingested": 3, "chunks_stored": 15, "errors": 0}
+        )
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest_batch(
+                "web", "https://example.com/index"
+            )
+
+        assert "完了" in result
+        assert "3件取り込み" in result
+        assert "15チャンク" in result
+        assert "エラー: 0件" in result
+
+    async def test_rag_ingest_batch_with_options(self) -> None:
+        """オプション付きで呼び出せること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest_batch = AsyncMock(
+            return_value={"ingested": 1, "chunks_stored": 5, "errors": 0}
+        )
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest_batch(
+                "web",
+                "https://example.com/index",
+                {"url_pattern": r"page\d+"},
+            )
+
+        assert "完了" in result
+        mock_service.ingest_batch.assert_called_once_with(
+            "web",
+            "https://example.com/index",
+            {"url_pattern": r"page\d+"},
+        )
+
+    async def test_rag_ingest_batch_value_error(self) -> None:
+        """ValueError 時にエラーメッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest_batch = AsyncMock(
+            side_effect=ValueError("未登録のソースタイプです: bad")
+        )
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest_batch("bad", "source")
+
+        assert "エラー:" in result
+        assert "未登録のソースタイプです" in result
+
+    async def test_rag_ingest_batch_unexpected_error(self) -> None:
+        """予期しないエラー時にエラーメッセージが返ること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest_batch = AsyncMock(
+            side_effect=RuntimeError("Unexpected")
+        )
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_ingest_batch("web", "source")
+
+        assert "エラー:" in result
+
+
+# --- MCP サーバーツール数テスト ---
+
+
+class TestMcpServerToolRegistration:
+    """MCP サーバーのツール登録テスト."""
+
+    async def test_rag_server_exposes_eight_tools(self) -> None:
+        """RAG MCPサーバーが8つのツールを公開すること."""
+        mod = import_module("rag.server")
+        server = mod.mcp
+
+        tools = await server.list_tools()
+        tool_names = {t.name for t in tools}
+
+        expected = {
+            "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
+            "rag_delete", "rag_stats", "rag_ingest", "rag_ingest_batch",
+        }
+        assert tool_names == expected, f"Expected {expected}, got {tool_names}"
+
+    async def test_rag_server_tool_count(self) -> None:
+        """RAG MCPサーバーのツール数が正確に8であること."""
+        mod = import_module("rag.server")
+        server = mod.mcp
+
+        tools = await server.list_tools()
+        assert len(tools) == 8
+
+
+# --- CLI ingest サブコマンドテスト ---
+
+
+class TestCliIngestParseOptions:
+    """CLI _parse_options のテスト."""
+
+    def test_parse_single_option(self) -> None:
+        """単一オプションが正しくパースされること."""
+        from rag.cli import _parse_options
+
+        result = _parse_options(["key=value"])
+        assert result == {"key": "value"}
+
+    def test_parse_multiple_options(self) -> None:
+        """複数オプションが正しくパースされること."""
+        from rag.cli import _parse_options
+
+        result = _parse_options(["k1=v1", "k2=v2"])
+        assert result == {"k1": "v1", "k2": "v2"}
+
+    def test_parse_option_with_equals_in_value(self) -> None:
+        """値に = が含まれる場合も正しくパースされること."""
+        from rag.cli import _parse_options
+
+        result = _parse_options(["pattern=a=b"])
+        assert result == {"pattern": "a=b"}
+
+    def test_parse_invalid_option_exits(self) -> None:
+        """key=value 形式でない場合に SystemExit が発生すること."""
+        from rag.cli import _parse_options
+
+        with pytest.raises(SystemExit):
+            _parse_options(["invalid"])
+
+
+class TestCliIngestSubcommand:
+    """CLI ingest サブコマンドのテスト."""
+
+    async def test_single_ingest_mode(self) -> None:
+        """単一取り込みモードが正しく動作すること."""
+        from rag.cli import run_ingest
+
+        args = argparse.Namespace(
+            source_type="web",
+            identifier="https://example.com/page",
+            batch=False,
+            source=None,
+            option=[],
+        )
+
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(return_value=3)
+
+        with patch("rag.cli._create_ingest_service", return_value=mock_service):
+            await run_ingest(args)
+
+        mock_service.ingest.assert_called_once_with(
+            "web", "https://example.com/page", None
+        )
+
+    async def test_batch_ingest_mode(self) -> None:
+        """一括取り込みモードが正しく動作すること."""
+        from rag.cli import run_ingest
+
+        args = argparse.Namespace(
+            source_type="web",
+            identifier=None,
+            batch=True,
+            source="https://example.com/index",
+            option=["url_pattern=page\\d+"],
+        )
+
+        mock_service = AsyncMock()
+        mock_service.ingest_batch = AsyncMock(
+            return_value={"ingested": 2, "chunks_stored": 10, "errors": 0}
+        )
+
+        with patch("rag.cli._create_ingest_service", return_value=mock_service):
+            await run_ingest(args)
+
+        mock_service.ingest_batch.assert_called_once_with(
+            "web",
+            "https://example.com/index",
+            {"url_pattern": "page\\d+"},
+        )
+
+    async def test_single_mode_missing_identifier_exits(self) -> None:
+        """単一モードで --identifier がない場合に SystemExit が発生すること."""
+        from rag.cli import run_ingest
+
+        args = argparse.Namespace(
+            source_type="web",
+            identifier=None,
+            batch=False,
+            source=None,
+            option=[],
+        )
+
+        with pytest.raises(SystemExit):
+            await run_ingest(args)
+
+    async def test_batch_mode_missing_source_exits(self) -> None:
+        """一括モードで --source がない場合に SystemExit が発生すること."""
+        from rag.cli import run_ingest
+
+        args = argparse.Namespace(
+            source_type="web",
+            identifier=None,
+            batch=True,
+            source=None,
+            option=[],
+        )
+
+        with pytest.raises(SystemExit):
+            await run_ingest(args)
+
+    async def test_single_mode_value_error_exits(self) -> None:
+        """単一モードで ValueError が発生した場合に SystemExit が発生すること."""
+        from rag.cli import run_ingest
+
+        args = argparse.Namespace(
+            source_type="unknown",
+            identifier="something",
+            batch=False,
+            source=None,
+            option=[],
+        )
+
+        mock_service = AsyncMock()
+        mock_service.ingest = AsyncMock(
+            side_effect=ValueError("未登録のソースタイプです")
+        )
+
+        with (
+            patch("rag.cli._create_ingest_service", return_value=mock_service),
+            pytest.raises(SystemExit),
+        ):
+            await run_ingest(args)

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1,7 +1,8 @@
 """RAG MCPサーバーのテスト.
 
 仕様: docs/specs/rag-knowledge.md
-5つのRAGツール（rag_search, rag_add, rag_crawl, rag_delete, rag_stats）が
+8つのRAGツール（rag_search, rag_add, rag_crawl, rag_crawl_preview,
+rag_delete, rag_stats, rag_ingest, rag_ingest_batch）が
 MCPサーバーとして公開されていることを検証する。
 """
 
@@ -28,8 +29,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_six_tools() -> None:
-    """RAG MCPサーバーが6つのツールを公開すること."""
+async def test_rag_server_exposes_eight_tools() -> None:
+    """RAG MCPサーバーが8つのツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -38,19 +39,19 @@ async def test_rag_server_exposes_six_tools() -> None:
 
     expected = {
         "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_delete", "rag_stats",
+        "rag_delete", "rag_stats", "rag_ingest", "rag_ingest_batch",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に6であること."""
+    """RAG MCPサーバーのツール数が正確に8であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 6
+    assert len(tools) == 8
 
 
 class TestRagSearchOutput:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] test: テスト追加・修正

## Summary

- RAGKnowledgeService にソースタイプ → インジェスターのルーティング機構を追加（`register_ingester` / `_get_ingester` / `ingest` / `ingest_batch`）
- `server.py` に `rag_ingest` / `rag_ingest_batch` MCP ツールを追加（6ツール → 8ツール体制）
- `cli.py` に `ingest` サブコマンドを追加（`--source-type`, `--identifier`, `--batch`, `--source`, `--option` パラメータ）
- `web` ソースタイプを既存 WebIngester に接続（`rag_add` / `rag_crawl` と同等の動作）
- 未登録ソースタイプ指定時のエラーハンドリング
- ARCHITECTURE.md の `cli.py` 責務説明を更新

## Test plan

- [x] ルーティング機構の単体テスト（登録済み/未登録ソースタイプ）
- [x] `rag_ingest` の web ソースタイプでの動作テスト
- [x] `rag_ingest_batch` の web ソースタイプでの動作テスト（部分失敗、0件発見、進捗コールバック含む）
- [x] MCP ツール出力フォーマットテスト（成功/エラー各パターン）
- [x] CLI `ingest` サブコマンドのパラメータパーステスト
- [x] 未登録ソースタイプ指定時のエラーレスポンス確認
- [x] 既存テスト全466件通過（ツール数テストを6→8に更新済み）
- [x] ruff check / mypy 通過

## Related issues

Closes #91