### PR TITLE
feat(rag-knowledge): LocalFileIngester の実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,11 @@ RAG_TRANSPORT=stdio
 # RAG_HTTP_PORT=8081
 # RAG_DNS_REBINDING_PROTECTION=true
 
+# Local File Ingester
+# Comma-separated list of allowed directories for local file ingestion
+# If not set, local file ingestion is disabled (fail-close)
+# RAG_LOCAL_FILE_ALLOWED_DIRS=/path/to/docs,/path/to/notes
+
 # Response Size Limit
 # RAG_MAX_RESPONSE_CHARS=
 

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -95,6 +95,9 @@ class RAGSettings(BaseSettings):
     # rag_stats ソース一覧の最大表示件数
     rag_stats_max_sources: int = Field(default=100, ge=1)
 
+    # ローカルファイル取り込み
+    rag_local_file_allowed_dirs: str = ""
+
     # デバッグ
     rag_debug_log_enabled: bool = False
 

--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -5,10 +5,12 @@ Issue: #62
 """
 
 from .base import BaseIngester, IngestedContent
+from .local_file import LocalFileIngester
 from .web import WebIngester
 
 __all__ = [
     "BaseIngester",
     "IngestedContent",
+    "LocalFileIngester",
     "WebIngester",
 ]

--- a/src/rag/ingesters/local_file.py
+++ b/src/rag/ingesters/local_file.py
@@ -1,0 +1,227 @@
+"""ローカルファイルインジェスター
+
+仕様: docs/specs/rag-knowledge.md (LocalFileIngester セクション)
+Issue: #98
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import logging
+from pathlib import Path
+
+from .base import BaseIngester, IngestedContent
+
+logger = logging.getLogger(__name__)
+
+# 対応拡張子
+ALLOWED_EXTENSIONS: frozenset[str] = frozenset({".md", ".txt"})
+
+
+class LocalFileIngester(BaseIngester):
+    """ローカルファイル取り込み用インジェスター.
+
+    Markdown・テキスト等のファイル読み込みに対応し、
+    ディレクトリ一括取り込み（discover + glob パターン）をサポートする。
+
+    セキュリティ:
+    - 許可ディレクトリによるアクセス制限（パストラバーサル防止）
+    - 未設定時はフェイルクローズ（取り込み拒否）
+    - シンボリックリンク解決後のパスチェック
+    """
+
+    def __init__(self, *, allowed_dirs: list[str] | None = None) -> None:
+        """LocalFileIngester を初期化する.
+
+        Args:
+            allowed_dirs: 許可ディレクトリのリスト。
+                None または空リストの場合はファイル取り込みを拒否する（フェイルクローズ）。
+        """
+        self._allowed_dirs: list[Path] = []
+        if allowed_dirs:
+            for d in allowed_dirs:
+                resolved = Path(d).resolve()
+                self._allowed_dirs.append(resolved)
+            logger.info(
+                "LocalFileIngester initialized with allowed dirs: %s",
+                [str(d) for d in self._allowed_dirs],
+            )
+        else:
+            logger.info(
+                "LocalFileIngester initialized without allowed dirs (fail-close)"
+            )
+
+    def _check_allowed_dirs_configured(self) -> None:
+        """許可ディレクトリが設定されていることを確認する.
+
+        Raises:
+            ValueError: 許可ディレクトリが未設定の場合
+        """
+        if not self._allowed_dirs:
+            raise ValueError(
+                "ローカルファイルの取り込みが許可されていません。"
+                "許可ディレクトリ（RAG_LOCAL_FILE_ALLOWED_DIRS）を設定してください。"
+            )
+
+    def _is_under_allowed_dir(self, resolved_path: Path) -> bool:
+        """解決済みパスが許可ディレクトリ配下かどうかを検証する.
+
+        Args:
+            resolved_path: resolve() 済みの絶対パス
+
+        Returns:
+            許可ディレクトリ配下であれば True
+        """
+        for allowed_dir in self._allowed_dirs:
+            try:
+                resolved_path.relative_to(allowed_dir)
+                return True
+            except ValueError:
+                continue
+        return False
+
+    def validate_identifier(self, identifier: str) -> str:
+        """ファイルパスを検証し、正規化済みの絶対パスを返す.
+
+        以下を検証する:
+        - 許可ディレクトリが設定されていること
+        - パスを正規化（シンボリックリンク解決・.. 展開）した上で、
+          許可ディレクトリ配下であること
+        - ファイルが存在すること
+        - 通常ファイルであること（ディレクトリ・デバイスファイル等は拒否）
+        - 拡張子が対応フォーマットに含まれること
+
+        Args:
+            identifier: 検証するファイルパス
+
+        Returns:
+            正規化済みの絶対パス文字列
+
+        Raises:
+            ValueError: バリデーション失敗時
+        """
+        self._check_allowed_dirs_configured()
+
+        path = Path(identifier)
+        resolved = path.resolve()
+
+        # 許可ディレクトリチェック
+        if not self._is_under_allowed_dir(resolved):
+            raise ValueError(
+                f"許可されていないディレクトリのファイルです: {identifier}"
+            )
+
+        # ファイル存在チェック
+        if not resolved.exists():
+            raise ValueError(f"ファイルが存在しません: {identifier}")
+
+        # 通常ファイルチェック
+        if not resolved.is_file():
+            raise ValueError(f"通常ファイルではありません: {identifier}")
+
+        # 拡張子チェック
+        suffix = resolved.suffix.lower()
+        if suffix not in ALLOWED_EXTENSIONS:
+            raise ValueError(
+                f"未対応の拡張子です: {suffix} "
+                f"(対応拡張子: {', '.join(sorted(ALLOWED_EXTENSIONS))})"
+            )
+
+        return str(resolved)
+
+    async def fetch_single(self, identifier: str) -> IngestedContent | None:
+        """単一ファイルを読み込み IngestedContent を返す.
+
+        Args:
+            identifier: ファイルパス
+
+        Returns:
+            IngestedContent、または読み込み失敗時は None
+        """
+        try:
+            validated_path = self.validate_identifier(identifier)
+        except ValueError as e:
+            logger.warning("Validation failed for %s: %s", identifier, e)
+            raise
+
+        path = Path(validated_path)
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            logger.warning("UTF-8 decode error: %s", validated_path)
+            return None
+        except PermissionError:
+            logger.warning("Permission denied: %s", validated_path)
+            return None
+        except OSError as e:
+            logger.warning("Failed to read file %s: %s", validated_path, e)
+            return None
+
+        # タイトルはファイル名（拡張子除去）から導出
+        title = path.stem
+
+        return IngestedContent(
+            source_id=validated_path,
+            title=title,
+            text=text,
+            ingested_at=IngestedContent.now_iso(),
+            source_type="local_file",
+        )
+
+    async def discover(self, source: str, **kwargs: object) -> list[str]:
+        """ディレクトリ内のファイルを glob パターンで発見する.
+
+        Args:
+            source: ディレクトリパス
+            **kwargs: pattern (str) — glob パターン（省略時はデフォルトパターン）
+
+        Returns:
+            発見されたファイルの絶対パスリスト
+        """
+        self._check_allowed_dirs_configured()
+
+        dir_path = Path(source).resolve()
+
+        # ディレクトリが許可ディレクトリ配下であることを検証
+        if not self._is_under_allowed_dir(dir_path):
+            raise ValueError(
+                f"許可されていないディレクトリです: {source}"
+            )
+
+        if not dir_path.is_dir():
+            raise ValueError(f"ディレクトリが存在しません: {source}")
+
+        pattern = str(kwargs.get("pattern", ""))
+
+        discovered: list[str] = []
+
+        if pattern:
+            # ユーザー指定の glob パターンを使用
+            full_pattern = str(dir_path / pattern)
+            for match in sorted(glob_module.glob(full_pattern, recursive=True)):
+                match_path = Path(match).resolve()
+                if (
+                    match_path.is_file()
+                    and match_path.suffix.lower() in ALLOWED_EXTENSIONS
+                    and self._is_under_allowed_dir(match_path)
+                ):
+                    discovered.append(str(match_path))
+        else:
+            # デフォルト: ディレクトリ直下の対応拡張子ファイル
+            for ext in sorted(ALLOWED_EXTENSIONS):
+                for f in sorted(dir_path.glob(f"*{ext}")):
+                    resolved_f = f.resolve()
+                    if (
+                        resolved_f.is_file()
+                        and self._is_under_allowed_dir(resolved_f)
+                    ):
+                        discovered.append(str(resolved_f))
+
+        logger.info(
+            "Discovered %d files in %s (pattern=%r)",
+            len(discovered),
+            source,
+            pattern or "(default)",
+        )
+        return discovered

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -23,6 +23,7 @@ from .vector_store import DocumentChunk, VectorStore
 if TYPE_CHECKING:
     from .bm25_index import BM25Index
     from .hybrid_search import HybridSearchEngine
+    from .ingesters.base import BaseIngester
     from .ingesters.web import WebIngester
     from .safe_browsing import SafeBrowsingClient
     from .web_crawler import CrawlPreviewPage, CrawledPage, WebCrawler
@@ -190,6 +191,9 @@ class RAGKnowledgeService:
         self._web_ingester = web_ingester
         self._hybrid_search_engine: HybridSearchEngine | None = None
 
+        # インジェスターレジストリ
+        self._ingesters: dict[str, BaseIngester] = {}
+
         # ハイブリッド検索エンジンの初期化
         if hybrid_search_enabled and bm25_index is not None:
             from .hybrid_search import HybridSearchEngine
@@ -200,6 +204,124 @@ class RAGKnowledgeService:
                 vector_weight=vector_weight,
             )
             logger.info("Hybrid search engine initialized")
+
+    def register_ingester(self, source_type: str, ingester: BaseIngester) -> None:
+        """インジェスターを登録する.
+
+        Args:
+            source_type: ソースタイプ名
+            ingester: インジェスターインスタンス
+        """
+        self._ingesters[source_type] = ingester
+        logger.info("Registered ingester for source type: %s", source_type)
+
+    def _get_ingester(self, source_type: str) -> BaseIngester:
+        """ソースタイプに対応するインジェスターを取得する.
+
+        Args:
+            source_type: ソースタイプ名
+
+        Returns:
+            対応するインジェスター
+
+        Raises:
+            ValueError: 未登録のソースタイプの場合
+        """
+        ingester = self._ingesters.get(source_type)
+        if ingester is None:
+            available = ", ".join(sorted(self._ingesters.keys())) or "(なし)"
+            raise ValueError(
+                f"未登録のソースタイプです: {source_type} "
+                f"(利用可能: {available})"
+            )
+        return ingester
+
+    async def ingest(
+        self,
+        source_type: str,
+        identifier: str,
+        options: dict[str, object] | None = None,
+    ) -> int:
+        """汎用単一コンテンツ取り込み.
+
+        Args:
+            source_type: データソース種別
+            identifier: ソース固有の識別子
+            options: ソースタイプ固有の追加パラメータ
+
+        Returns:
+            保存されたチャンク数
+
+        Raises:
+            ValueError: ソースタイプ未登録、または識別子が不正な場合
+        """
+        ingester = self._get_ingester(source_type)
+        content = await ingester.fetch_single(identifier)
+        if content is None:
+            return 0
+        return await self._ingest_content(content)
+
+    async def ingest_batch(
+        self,
+        source_type: str,
+        source: str,
+        options: dict[str, object] | None = None,
+    ) -> dict[str, int]:
+        """汎用一括取り込み.
+
+        discover で対象を発見し、バッチで取り込む。
+
+        Args:
+            source_type: データソース種別
+            source: 発見元（ディレクトリパス、ユーザー名等）
+            options: ソースタイプ固有の追加パラメータ
+
+        Returns:
+            {"ingested": N, "chunks_stored": M, "errors": E}
+        """
+        ingester = self._get_ingester(source_type)
+
+        # discover で取り込み対象の識別子リストを取得
+        kwargs: dict[str, object] = {}
+        if options:
+            kwargs.update(options)
+
+        identifiers = await ingester.discover(source, **kwargs)
+        if not identifiers:
+            logger.info("No items discovered for source_type=%s source=%s", source_type, source)
+            return {"ingested": 0, "chunks_stored": 0, "errors": 0}
+
+        # 各コンテンツを取得・取り込み
+        total_chunks = 0
+        ingested_count = 0
+        error_count = 0
+
+        for identifier in identifiers:
+            try:
+                content = await ingester.fetch_single(identifier)
+                if content is None:
+                    error_count += 1
+                    continue
+                chunks = await self._ingest_content(content)
+                total_chunks += chunks
+                ingested_count += 1
+            except ValueError as e:
+                logger.warning("Validation error for %s (%s): %s", identifier, source_type, e)
+                error_count += 1
+            except Exception:
+                logger.exception("Failed to ingest %s: %s", source_type, identifier)
+                error_count += 1
+
+        logger.info(
+            "Batch ingest complete: source_type=%s ingested=%d chunks=%d errors=%d",
+            source_type, ingested_count, total_chunks, error_count,
+        )
+
+        return {
+            "ingested": ingested_count,
+            "chunks_stored": total_chunks,
+            "errors": error_count,
+        }
 
     async def crawl_preview(
         self,

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,13 +3,15 @@
 仕様: docs/specs/rag-knowledge.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 6 つの RAG ツールを公開する:
+FastMCP を使用して 8 つの RAG ツールを公開する:
 - rag_search: ナレッジベースから関連情報を検索
 - rag_add: 単一ページをナレッジベースに取り込み
 - rag_crawl: リンク集ページからクロール＆一括取り込み
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_delete: ソースURL指定でナレッジから削除
 - rag_stats: ナレッジベースの統計情報を表示
+- rag_ingest: 汎用単一コンテンツ取り込み（マルチソース対応）
+- rag_ingest_batch: 汎用一括取り込み（マルチソース対応）
 """
 
 from __future__ import annotations
@@ -35,6 +37,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
     from .config import get_settings
     from .embedding.factory import get_embedding_provider
+    from .ingesters.local_file import LocalFileIngester
     from .ingesters.web import WebIngester
     from .rag_knowledge import RAGKnowledgeService
     from .safe_browsing import create_safe_browsing_client
@@ -118,7 +121,16 @@ def _build_rag_service() -> RAGKnowledgeService:
         safe_browsing_client=safe_browsing_client,
     )
 
-    return RAGKnowledgeService(
+    # LocalFileIngester: 許可ディレクトリの設定
+    allowed_dirs_str = settings.rag_local_file_allowed_dirs
+    allowed_dirs: list[str] | None = None
+    if allowed_dirs_str:
+        allowed_dirs = [
+            d.strip() for d in allowed_dirs_str.split(",") if d.strip()
+        ]
+    local_file_ingester = LocalFileIngester(allowed_dirs=allowed_dirs)
+
+    service = RAGKnowledgeService(
         vector_store=vector_store,
         web_crawler=web_crawler,
         chunk_size=settings.rag_chunk_size,
@@ -132,6 +144,12 @@ def _build_rag_service() -> RAGKnowledgeService:
         debug_log_enabled=settings.rag_debug_log_enabled,
         web_ingester=web_ingester,
     )
+
+    # インジェスター登録
+    service.register_ingester("web", web_ingester)
+    service.register_ingester("local_file", local_file_ingester)
+
+    return service
 
 
 # --- MCP ツール定義 ---
@@ -453,6 +471,79 @@ async def rag_stats() -> str:
     except Exception:
         logger.exception("Failed to get stats")
         return "エラー: 統計情報の取得に失敗しました。"
+
+
+@mcp.tool()
+async def rag_ingest(
+    source_type: str,
+    identifier: str,
+    options: dict[str, object] | None = None,
+) -> str:
+    """[rag-knowledge] RAG ingest - 汎用単一コンテンツ取り込み.
+
+    knowledge base, ingest, local file, multi-source.
+    指定されたソースタイプに対応するインジェスターで単一コンテンツを取り込む。
+    同一識別子の再取り込み時は既存の知識を最新に置き換える。
+
+    Args:
+        source_type: データソース種別（web, local_file 等）
+        identifier: ソース固有の識別子（URL、ファイルパス等）
+        options: ソースタイプ固有の追加パラメータ
+
+    Returns:
+        取り込み結果のメッセージ
+    """
+    service = await _get_rag_service()
+    try:
+        chunks = await service.ingest(source_type, identifier, options)
+        if chunks <= 0:
+            return f"エラー: コンテンツの取り込みに失敗しました。source_type={source_type}, identifier={identifier}"
+        return f"取り込み完了: {identifier} ({chunks}チャンク)"
+    except ValueError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception(
+            "Failed to ingest: source_type=%s identifier=%s", source_type, identifier
+        )
+        return f"エラー: コンテンツの取り込みに失敗しました。source_type={source_type}, identifier={identifier}"
+
+
+@mcp.tool()
+async def rag_ingest_batch(
+    source_type: str,
+    source: str,
+    options: dict[str, object] | None = None,
+) -> str:
+    """[rag-knowledge] RAG ingest batch - 汎用一括取り込み.
+
+    knowledge base, bulk ingest, batch, discover, local file, multi-source.
+    指定されたソースタイプに対応するインジェスターで一括取り込みを行う。
+    discover で対象を発見し、バッチで取り込む。
+
+    Args:
+        source_type: データソース種別（web, local_file 等）
+        source: 発見元（ディレクトリパス、ユーザー名、リンク集 URL 等）
+        options: ソースタイプ固有の追加パラメータ
+
+    Returns:
+        取り込み結果のサマリー
+    """
+    service = await _get_rag_service()
+    try:
+        result = await service.ingest_batch(source_type, source, options)
+        ingested = result["ingested"]
+        chunks = result["chunks_stored"]
+        errors = result["errors"]
+        if ingested == 0 and errors == 0:
+            return f"取り込み対象が見つかりませんでした。source_type={source_type}, source={source}"
+        return f"一括取り込み完了: {ingested}件 / {chunks}チャンク / エラー: {errors}件"
+    except ValueError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception(
+            "Failed to batch ingest: source_type=%s source=%s", source_type, source
+        )
+        return f"エラー: 一括取り込みに失敗しました。source_type={source_type}, source={source}"
 
 
 def _configure_and_run() -> None:

--- a/tests/test_local_file_ingester.py
+++ b/tests/test_local_file_ingester.py
@@ -1,0 +1,428 @@
+"""LocalFileIngester のテスト
+
+仕様: docs/specs/rag-knowledge.md (LocalFileIngester セクション)
+Issue: #98
+
+テスト方針:
+- バリデーションテスト（正常パス、許可外パス、パストラバーサル試行、未対応拡張子）
+- fetch_single テスト（正常読み込み、UTF-8 デコードエラー、空ファイル、権限なし）
+- discover テスト（glob パターン、サブディレクトリ、対象 0 件）
+- セキュリティテスト（.. エスケープ、シンボリックリンク経由のエスケープ、許可ディレクトリ未設定時の拒否）
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from rag.ingesters.local_file import ALLOWED_EXTENSIONS, LocalFileIngester
+
+
+@pytest.fixture
+def tmp_allowed_dir(tmp_path: Path) -> Path:
+    """許可ディレクトリとしての一時ディレクトリを作成する."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    return allowed
+
+
+@pytest.fixture
+def ingester(tmp_allowed_dir: Path) -> LocalFileIngester:
+    """許可ディレクトリ付き LocalFileIngester を作成する."""
+    return LocalFileIngester(allowed_dirs=[str(tmp_allowed_dir)])
+
+
+@pytest.fixture
+def ingester_no_dirs() -> LocalFileIngester:
+    """許可ディレクトリ未設定の LocalFileIngester を作成する."""
+    return LocalFileIngester()
+
+
+# --- バリデーションテスト ---
+
+
+class TestValidateIdentifier:
+    """validate_identifier() のテスト."""
+
+    def test_valid_md_file(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """正常な .md ファイルが検証を通過すること."""
+        md_file = tmp_allowed_dir / "test.md"
+        md_file.write_text("# Hello", encoding="utf-8")
+
+        result = ingester.validate_identifier(str(md_file))
+        assert result == str(md_file.resolve())
+
+    def test_valid_txt_file(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """正常な .txt ファイルが検証を通過すること."""
+        txt_file = tmp_allowed_dir / "test.txt"
+        txt_file.write_text("Hello", encoding="utf-8")
+
+        result = ingester.validate_identifier(str(txt_file))
+        assert result == str(txt_file.resolve())
+
+    def test_disallowed_directory(
+        self, ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """許可外ディレクトリのファイルで ValueError が発生すること."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        outside_file = outside / "test.md"
+        outside_file.write_text("Content", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="許可されていないディレクトリ"):
+            ingester.validate_identifier(str(outside_file))
+
+    def test_path_traversal_dotdot(
+        self, ingester: LocalFileIngester, tmp_path: Path, tmp_allowed_dir: Path
+    ) -> None:
+        """.. によるパストラバーサルが拒否されること."""
+        # tmp_allowed_dir の親に別のファイルを作成
+        outside_file = tmp_path / "secret.md"
+        outside_file.write_text("Secret", encoding="utf-8")
+
+        traversal_path = str(tmp_allowed_dir / ".." / "secret.md")
+        with pytest.raises(ValueError, match="許可されていないディレクトリ"):
+            ingester.validate_identifier(traversal_path)
+
+    def test_file_not_found(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """存在しないファイルで ValueError が発生すること."""
+        nonexistent = tmp_allowed_dir / "nonexistent.md"
+
+        with pytest.raises(ValueError, match="ファイルが存在しません"):
+            ingester.validate_identifier(str(nonexistent))
+
+    def test_directory_rejected(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """ディレクトリが通常ファイルではないとして拒否されること."""
+        subdir = tmp_allowed_dir / "subdir"
+        subdir.mkdir()
+
+        with pytest.raises(ValueError, match="通常ファイルではありません"):
+            ingester.validate_identifier(str(subdir))
+
+    def test_unsupported_extension(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """未対応拡張子で ValueError が発生すること."""
+        py_file = tmp_allowed_dir / "test.py"
+        py_file.write_text("print('hello')", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="未対応の拡張子"):
+            ingester.validate_identifier(str(py_file))
+
+    def test_no_allowed_dirs_fails(
+        self, ingester_no_dirs: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """許可ディレクトリ未設定時に ValueError が発生すること（フェイルクローズ）."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("Content", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="許可ディレクトリ"):
+            ingester_no_dirs.validate_identifier(str(md_file))
+
+
+# --- セキュリティテスト ---
+
+
+class TestSecurityConstraints:
+    """セキュリティ制約のテスト."""
+
+    def test_symlink_escape_rejected(
+        self,
+        ingester: LocalFileIngester,
+        tmp_path: Path,
+        tmp_allowed_dir: Path,
+    ) -> None:
+        """シンボリックリンク経由の許可ディレクトリ外エスケープが拒否されること."""
+        # 許可外にファイルを作成
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret_file = outside / "secret.md"
+        secret_file.write_text("Secret", encoding="utf-8")
+
+        # 許可ディレクトリ内にシンボリックリンクを作成
+        symlink = tmp_allowed_dir / "link.md"
+        symlink.symlink_to(secret_file)
+
+        with pytest.raises(ValueError, match="許可されていないディレクトリ"):
+            ingester.validate_identifier(str(symlink))
+
+    def test_symlink_within_allowed_dir(
+        self,
+        ingester: LocalFileIngester,
+        tmp_allowed_dir: Path,
+    ) -> None:
+        """許可ディレクトリ内のシンボリックリンクは許可されること."""
+        real_file = tmp_allowed_dir / "real.md"
+        real_file.write_text("Content", encoding="utf-8")
+
+        symlink = tmp_allowed_dir / "link.md"
+        symlink.symlink_to(real_file)
+
+        result = ingester.validate_identifier(str(symlink))
+        assert result == str(real_file.resolve())
+
+    def test_broken_symlink_rejected(
+        self,
+        ingester: LocalFileIngester,
+        tmp_allowed_dir: Path,
+    ) -> None:
+        """リンク切れシンボリックリンクが拒否されること."""
+        target = tmp_allowed_dir / "nonexistent.md"
+        symlink = tmp_allowed_dir / "broken_link.md"
+        symlink.symlink_to(target)
+
+        with pytest.raises(ValueError, match="ファイルが存在しません"):
+            ingester.validate_identifier(str(symlink))
+
+    def test_fail_close_no_dirs(self, ingester_no_dirs: LocalFileIngester) -> None:
+        """許可ディレクトリ未設定時にフェイルクローズすること."""
+        with pytest.raises(ValueError, match="許可ディレクトリ"):
+            ingester_no_dirs.validate_identifier("/any/path/file.md")
+
+    def test_fail_close_empty_dirs(self) -> None:
+        """空の許可ディレクトリリストでフェイルクローズすること."""
+        ingester = LocalFileIngester(allowed_dirs=[])
+        with pytest.raises(ValueError, match="許可ディレクトリ"):
+            ingester.validate_identifier("/any/path/file.md")
+
+
+# --- fetch_single テスト ---
+
+
+class TestFetchSingle:
+    """fetch_single() のテスト."""
+
+    async def test_fetch_md_file(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """正常な .md ファイルを読み込めること."""
+        md_file = tmp_allowed_dir / "document.md"
+        md_file.write_text("# Title\n\nContent here.", encoding="utf-8")
+
+        result = await ingester.fetch_single(str(md_file))
+
+        assert result is not None
+        assert result.source_id == str(md_file.resolve())
+        assert result.title == "document"
+        assert result.text == "# Title\n\nContent here."
+        assert result.source_type == "local_file"
+        assert result.ingested_at  # ISO 8601 文字列であること
+
+    async def test_fetch_txt_file(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """正常な .txt ファイルを読み込めること."""
+        txt_file = tmp_allowed_dir / "notes.txt"
+        txt_file.write_text("Plain text content.", encoding="utf-8")
+
+        result = await ingester.fetch_single(str(txt_file))
+
+        assert result is not None
+        assert result.title == "notes"
+        assert result.text == "Plain text content."
+
+    async def test_fetch_empty_file(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """空ファイルが空テキストとして取り込まれること."""
+        empty_file = tmp_allowed_dir / "empty.md"
+        empty_file.write_text("", encoding="utf-8")
+
+        result = await ingester.fetch_single(str(empty_file))
+
+        assert result is not None
+        assert result.text == ""
+
+    async def test_fetch_utf8_decode_error(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """UTF-8 デコードエラー時に None を返すこと."""
+        binary_file = tmp_allowed_dir / "binary.txt"
+        binary_file.write_bytes(b"\xff\xfe\x00\x01\x80\x81\x82")
+
+        result = await ingester.fetch_single(str(binary_file))
+        assert result is None
+
+    async def test_fetch_permission_denied(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """読み取り権限がない場合に None を返すこと."""
+        no_read_file = tmp_allowed_dir / "no_read.md"
+        no_read_file.write_text("Content", encoding="utf-8")
+        no_read_file.chmod(0o000)
+
+        try:
+            result = await ingester.fetch_single(str(no_read_file))
+            assert result is None
+        finally:
+            # テスト後にクリーンアップのため権限を戻す
+            no_read_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    async def test_fetch_validation_error_raises(
+        self, ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """バリデーションエラー時に ValueError が raise されること."""
+        outside_file = tmp_path / "outside.md"
+        outside_file.write_text("Content", encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            await ingester.fetch_single(str(outside_file))
+
+
+# --- discover テスト ---
+
+
+class TestDiscover:
+    """discover() のテスト."""
+
+    async def test_discover_default_pattern(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """デフォルトパターンでディレクトリ直下のファイルを発見すること."""
+        (tmp_allowed_dir / "a.md").write_text("A", encoding="utf-8")
+        (tmp_allowed_dir / "b.txt").write_text("B", encoding="utf-8")
+        (tmp_allowed_dir / "c.py").write_text("C", encoding="utf-8")  # 未対応
+
+        result = await ingester.discover(str(tmp_allowed_dir))
+
+        # .md と .txt のみ
+        assert len(result) == 2
+        filenames = [Path(p).name for p in result]
+        assert "a.md" in filenames
+        assert "b.txt" in filenames
+        assert "c.py" not in filenames
+
+    async def test_discover_with_glob_pattern(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """glob パターン指定でファイルを発見すること."""
+        subdir = tmp_allowed_dir / "sub"
+        subdir.mkdir()
+        (subdir / "doc.md").write_text("Doc", encoding="utf-8")
+        (tmp_allowed_dir / "top.md").write_text("Top", encoding="utf-8")
+
+        result = await ingester.discover(
+            str(tmp_allowed_dir), pattern="**/*.md"
+        )
+
+        assert len(result) == 2
+        filenames = [Path(p).name for p in result]
+        assert "doc.md" in filenames
+        assert "top.md" in filenames
+
+    async def test_discover_subdirectory_not_included_by_default(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """デフォルトではサブディレクトリ内のファイルが含まれないこと."""
+        subdir = tmp_allowed_dir / "sub"
+        subdir.mkdir()
+        (subdir / "nested.md").write_text("Nested", encoding="utf-8")
+        (tmp_allowed_dir / "top.md").write_text("Top", encoding="utf-8")
+
+        result = await ingester.discover(str(tmp_allowed_dir))
+
+        assert len(result) == 1
+        assert Path(result[0]).name == "top.md"
+
+    async def test_discover_zero_matches(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """対象が 0 件の場合に空リストを返すこと."""
+        result = await ingester.discover(str(tmp_allowed_dir))
+        assert result == []
+
+    async def test_discover_outside_allowed_dir(
+        self, ingester: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """許可外ディレクトリで discover すると ValueError が発生すること."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        with pytest.raises(ValueError, match="許可されていないディレクトリ"):
+            await ingester.discover(str(outside))
+
+    async def test_discover_nonexistent_directory(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """存在しないディレクトリで discover すると ValueError が発生すること."""
+        nonexistent = tmp_allowed_dir / "nonexistent"
+
+        with pytest.raises(ValueError, match="ディレクトリが存在しません"):
+            await ingester.discover(str(nonexistent))
+
+    async def test_discover_no_allowed_dirs(
+        self, ingester_no_dirs: LocalFileIngester, tmp_path: Path
+    ) -> None:
+        """許可ディレクトリ未設定時にフェイルクローズすること."""
+        with pytest.raises(ValueError, match="許可ディレクトリ"):
+            await ingester_no_dirs.discover(str(tmp_path))
+
+    async def test_discover_filters_unsupported_extensions(
+        self, ingester: LocalFileIngester, tmp_allowed_dir: Path
+    ) -> None:
+        """glob パターンで発見されても未対応拡張子はフィルタされること."""
+        (tmp_allowed_dir / "doc.md").write_text("Doc", encoding="utf-8")
+        (tmp_allowed_dir / "script.py").write_text("Script", encoding="utf-8")
+
+        result = await ingester.discover(
+            str(tmp_allowed_dir), pattern="*.*"
+        )
+
+        assert len(result) == 1
+        assert Path(result[0]).name == "doc.md"
+
+
+# --- 複数許可ディレクトリテスト ---
+
+
+class TestMultipleAllowedDirs:
+    """複数の許可ディレクトリのテスト."""
+
+    async def test_multiple_allowed_dirs(self, tmp_path: Path) -> None:
+        """複数の許可ディレクトリが正しく動作すること."""
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        (dir1 / "file1.md").write_text("Content 1", encoding="utf-8")
+        (dir2 / "file2.md").write_text("Content 2", encoding="utf-8")
+
+        ingester = LocalFileIngester(allowed_dirs=[str(dir1), str(dir2)])
+
+        result1 = await ingester.fetch_single(str(dir1 / "file1.md"))
+        result2 = await ingester.fetch_single(str(dir2 / "file2.md"))
+
+        assert result1 is not None
+        assert result1.text == "Content 1"
+        assert result2 is not None
+        assert result2.text == "Content 2"
+
+
+# --- ALLOWED_EXTENSIONS 定数テスト ---
+
+
+class TestAllowedExtensions:
+    """ALLOWED_EXTENSIONS 定数のテスト."""
+
+    def test_md_is_allowed(self) -> None:
+        """.md が許可されていること."""
+        assert ".md" in ALLOWED_EXTENSIONS
+
+    def test_txt_is_allowed(self) -> None:
+        """.txt が許可されていること."""
+        assert ".txt" in ALLOWED_EXTENSIONS
+
+    def test_py_is_not_allowed(self) -> None:
+        """.py が許可されていないこと."""
+        assert ".py" not in ALLOWED_EXTENSIONS

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1,7 +1,8 @@
 """RAG MCPサーバーのテスト.
 
 仕様: docs/specs/rag-knowledge.md
-5つのRAGツール（rag_search, rag_add, rag_crawl, rag_delete, rag_stats）が
+8つのRAGツール（rag_search, rag_add, rag_crawl, rag_crawl_preview,
+rag_delete, rag_stats, rag_ingest, rag_ingest_batch）が
 MCPサーバーとして公開されていることを検証する。
 """
 
@@ -28,8 +29,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_six_tools() -> None:
-    """RAG MCPサーバーが6つのツールを公開すること."""
+async def test_rag_server_exposes_eight_tools() -> None:
+    """RAG MCPサーバーが8つのツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -38,19 +39,19 @@ async def test_rag_server_exposes_six_tools() -> None:
 
     expected = {
         "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_delete", "rag_stats",
+        "rag_delete", "rag_stats", "rag_ingest", "rag_ingest_batch",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に6であること."""
+    """RAG MCPサーバーのツール数が正確に8であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 6
+    assert len(tools) == 8
 
 
 class TestRagSearchOutput:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] test: テスト追加・修正

## Summary

- `LocalFileIngester` を `BaseIngester` 継承で実装（`src/rag/ingesters/local_file.py`）
- 許可ディレクトリによるパストラバーサル防止（フェイルクローズ設計）
- シンボリックリンク解決後のパスチェック、拡張子バリデーション（`.md`, `.txt`）
- `discover()` による glob パターンでのディレクトリ一括取り込み
- `RAGKnowledgeService` にインジェスターレジストリ（`register_ingester` / `_get_ingester`）を追加
- `rag_ingest` / `rag_ingest_batch` MCP ツールを追加（汎用マルチソース対応）
- 環境変数 `RAG_LOCAL_FILE_ALLOWED_DIRS` を追加（カンマ区切り複数指定可）
- テスト 31 件追加（バリデーション・セキュリティ・fetch_single・discover）
- 既存テスト（ツール数検証）を 6→8 に更新

## Test plan

- [x] `uv run pytest` — 466 テスト全通過
- [x] `uv run ruff check src/ tests/` — 通過
- [x] `uv run mypy src/` — 通過
- [x] `npx markdownlint-cli2@0.20.0` — 既存問題のみ（本PR起因なし）

## Related issues

Closes #98

Generated with [Claude Code](https://claude.ai/code)