### PR TITLE
feat(zenn-ingester): Zenn API 経由での記事取り込み機能を実装

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@
 | ディレクトリ | 責務 |
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
-| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester） |
+| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester） |
 
 ### ルートレベルファイル
 
@@ -47,6 +47,7 @@
 | 仕様書 | 実装モジュール |
 |---|---|
 | `rag-knowledge.md` | `src/rag/` 全体 |
+| `features/zenn-ingester.md` | `src/rag/ingesters/zenn.py`, `src/rag/rag_knowledge.py`, `src/rag/server.py`, `src/rag/cli.py` |
 
 ### agentic/
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -5,7 +5,7 @@
 外部 Web ページから収集した知識をベクトル DB に蓄積し、
 MCP クライアントからのクエリに対して関連情報を検索・提供する
 RAG（Retrieval-Augmented Generation）基盤。
-MCP サーバーとして独立動作し、6 つのツールを提供する。
+MCP サーバーとして独立動作し、8 つのツールを提供する。
 
 スコープ:
 
@@ -13,6 +13,7 @@ MCP サーバーとして独立動作し、6 つのツールを提供する。
 - 知識の検索（ベクトル検索・BM25 キーワード検索）
 - 知識の管理（統計表示・削除）
 - クロールプレビュー（対象ページの事前確認）
+- Zenn 記事の取り込み（API 経由での一括・単体取り込み）
 - 検索精度の評価（評価 CLI）
 
 ## 背景
@@ -33,7 +34,7 @@ MCP サーバーとして独立動作し、6 つのツールを提供する。
 
 ### MCP ツール
 
-MCP サーバーが公開する 6 つのツール。
+MCP サーバーが公開する 8 つのツール。
 
 | ツール | 入力 | 振る舞い |
 | --- | --- | --- |
@@ -43,6 +44,8 @@ MCP サーバーが公開する 6 つのツール。
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_delete | URL | ソース URL 指定でナレッジを削除する |
 | rag_stats | なし | 統計情報（総チャンク数、ソース URL 数）と蓄積データ概要（ドメイン別ソース URL 一覧・タイトル）を返す。表示件数上限は `RAG_STATS_MAX_SOURCES` で制御する |
+| rag_ingest_zenn | ユーザー名、dry_run、no_limit | Zenn ユーザーの記事を一括取り込みする。dry_run 時は記事一覧のみ返す。詳細は [zenn-ingester.md](features/zenn-ingester.md) を参照 |
+| rag_add_zenn | slug | Zenn 記事を slug 指定で単体取り込みする。詳細は [zenn-ingester.md](features/zenn-ingester.md) を参照 |
 
 ### 検索結果の設計
 
@@ -64,6 +67,8 @@ rag_search はベクトル検索と BM25 検索の生結果を個別に返す。
 | evaluate | 評価データセットで検索精度を計測しレポートを出力する。ベースライン比較でリグレッションを検出できる |
 | init-test-db | テスト用のベクトル DB と BM25 インデックスを初期化する |
 | crawl-preview | 指定 URL からクロール対象ページのタイトルと URL の一覧を表示する。`--format json` で JSON 出力に対応 |
+| ingest-zenn | Zenn ユーザーの記事を一括取り込みする。`--dry-run` で記事一覧のみ表示。`--no-limit` でページネーション上限を解除 |
+| add-zenn | Zenn 記事を slug 指定で単体取り込みする |
 
 評価指標: Precision、Recall、F1、NDCG@K、MRR
 
@@ -85,6 +90,7 @@ flowchart TB
 
     subgraph Ingesters["インジェスター"]
         WING["WebIngester"]
+        ZING["ZennIngester"]
     end
 
     CRAWLER["Web クローラー"]
@@ -153,6 +159,7 @@ flowchart LR
 | ナレッジサービス | 取り込み・検索・削除のオーケストレーション |
 | インジェスター基盤 | データソースの抽象化（BaseIngester / IngestedContent） |
 | WebIngester | Web ページ取り込み用インジェスター。WebCrawler に委譲し、Safe Browsing チェックを統合する |
+| ZennIngester | Zenn API 経由での記事取り込み用インジェスター。詳細は [zenn-ingester.md](features/zenn-ingester.md) を参照 |
 | Web クローラー | ページの取得と本文テキスト抽出。SSRF 対策・robots.txt 遵守を含む |
 | コンテンツタイプ検出 | テキストの種類（通常・テーブル・見出し付きテキスト）を判定する |
 | テキストチャンカー | 段落・文・文字数の優先順で分割する。チャンク間にオーバーラップを適用する |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1,6 +1,8 @@
-"""RAG評価CLIモジュール
+"""RAG CLIモジュール
 
-仕様: docs/specs/rag-knowledge.md
+仕様: docs/specs/rag-knowledge.md, docs/specs/features/zenn-ingester.md
+
+サブコマンド: evaluate, init-test-db, crawl-preview, ingest-zenn, add-zenn
 """
 
 from __future__ import annotations
@@ -250,6 +252,36 @@ def main() -> None:
         help="出力フォーマット（text/json）",
     )
 
+    # ingest-zenn サブコマンド
+    ingest_zenn_parser = subparsers.add_parser(
+        "ingest-zenn", help="Zenn 記事を一括取り込み",
+    )
+    ingest_zenn_parser.add_argument(
+        "--username",
+        required=True,
+        help="Zenn ユーザー名",
+    )
+    ingest_zenn_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="記事一覧を表示するのみで取り込みを行わない",
+    )
+    ingest_zenn_parser.add_argument(
+        "--no-limit",
+        action="store_true",
+        help="ページネーション上限（デフォルト10ページ）を解除する",
+    )
+
+    # add-zenn サブコマンド
+    add_zenn_parser = subparsers.add_parser(
+        "add-zenn", help="Zenn 記事を単体取り込み",
+    )
+    add_zenn_parser.add_argument(
+        "--slug",
+        required=True,
+        help="Zenn 記事の slug",
+    )
+
     args = parser.parse_args()
 
     if args.command == "evaluate":
@@ -258,6 +290,10 @@ def main() -> None:
         asyncio.run(init_test_db(args))
     elif args.command == "crawl-preview":
         asyncio.run(run_crawl_preview(args))
+    elif args.command == "ingest-zenn":
+        asyncio.run(run_ingest_zenn(args))
+    elif args.command == "add-zenn":
+        asyncio.run(run_add_zenn(args))
 
 
 async def create_rag_service(
@@ -786,6 +822,96 @@ async def run_crawl_preview(args: argparse.Namespace) -> None:
             title = page.title or "(タイトル取得不可)"
             print(f"{i}. {title}")
             print(f"   {page.url}")
+
+
+async def _create_zenn_service() -> "RAGKnowledgeService":
+    """Zenn 取り込み用の RAGKnowledgeService を生成する.
+
+    Returns:
+        ZennIngester が設定された RAGKnowledgeService インスタンス
+    """
+    from .config import get_settings
+    from .embedding.factory import get_embedding_provider
+    from .ingesters.zenn import ZennIngester
+    from .rag_knowledge import RAGKnowledgeService
+    from .vector_store import VectorStore
+    from .web_crawler import WebCrawler
+
+    settings = get_settings()
+    embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
+    vector_store = VectorStore(
+        embedding_provider=embedding_provider,
+        persist_directory=settings.chromadb_persist_dir,
+    )
+    web_crawler = WebCrawler()
+    zenn_ingester = ZennIngester()
+
+    return RAGKnowledgeService(
+        vector_store=vector_store,
+        web_crawler=web_crawler,
+        chunk_size=settings.rag_chunk_size,
+        chunk_overlap=settings.rag_chunk_overlap,
+        similarity_threshold=settings.rag_similarity_threshold,
+        zenn_ingester=zenn_ingester,
+    )
+
+
+async def run_ingest_zenn(args: argparse.Namespace) -> None:
+    """Zenn 記事の一括取り込みを実行する.
+
+    Args:
+        args: コマンドライン引数
+    """
+    logger.info("Starting Zenn ingest for user: %s", args.username)
+
+    service = await _create_zenn_service()
+
+    result = await service.ingest_zenn(
+        args.username,
+        dry_run=args.dry_run,
+        no_limit=args.no_limit,
+    )
+
+    if result["dry_run"]:
+        articles = result.get("articles", [])
+        found = result["articles_found"]
+        print(f"[dry-run] Zenn 記事一覧 ({args.username}): {found}件")
+        if isinstance(articles, list):
+            for i, article in enumerate(articles, start=1):
+                if isinstance(article, dict):
+                    slug = article.get("slug", "")
+                    print(f"  {i}. {slug}")
+    else:
+        found = result["articles_found"]
+        ingested = result["articles_ingested"]
+        chunks = result["chunks_stored"]
+        errors = result["errors"]
+        print(
+            f"Zenn 記事取り込み完了 ({args.username}): "
+            f"発見={found}件, 取り込み={ingested}件, "
+            f"チャンク={chunks}, エラー={errors}件"
+        )
+
+
+async def run_add_zenn(args: argparse.Namespace) -> None:
+    """Zenn 記事の単体取り込みを実行する.
+
+    Args:
+        args: コマンドライン引数
+    """
+    logger.info("Adding Zenn article: %s", args.slug)
+
+    service = await _create_zenn_service()
+
+    try:
+        chunks = await service.add_zenn(args.slug)
+        if chunks <= 0:
+            print(f"エラー: Zenn 記事の取り込みに失敗しました。slug: {args.slug}")
+            sys.exit(1)
+        print(f"Zenn 記事を取り込みました: {args.slug} ({chunks}チャンク)")
+    except ValueError as e:
+        print(f"エラー: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -866,31 +866,15 @@ async def run_ingest_zenn(args: argparse.Namespace) -> None:
 
     service = await _create_zenn_service()
 
+    from .ingesters.zenn import format_zenn_ingest_result
+
     result = await service.ingest_zenn(
         args.username,
         dry_run=args.dry_run,
         no_limit=args.no_limit,
     )
 
-    if result["dry_run"]:
-        articles = result.get("articles", [])
-        found = result["articles_found"]
-        print(f"[dry-run] Zenn 記事一覧 ({args.username}): {found}件")
-        if isinstance(articles, list):
-            for i, article in enumerate(articles, start=1):
-                if isinstance(article, dict):
-                    slug = article.get("slug", "")
-                    print(f"  {i}. {slug}")
-    else:
-        found = result["articles_found"]
-        ingested = result["articles_ingested"]
-        chunks = result["chunks_stored"]
-        errors = result["errors"]
-        print(
-            f"Zenn 記事取り込み完了 ({args.username}): "
-            f"発見={found}件, 取り込み={ingested}件, "
-            f"チャンク={chunks}, エラー={errors}件"
-        )
+    print(format_zenn_ingest_result(result, args.username))
 
 
 async def run_add_zenn(args: argparse.Namespace) -> None:

--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -6,9 +6,11 @@ Issue: #62
 
 from .base import BaseIngester, IngestedContent
 from .web import WebIngester
+from .zenn import ZennIngester
 
 __all__ = [
     "BaseIngester",
     "IngestedContent",
     "WebIngester",
+    "ZennIngester",
 ]

--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -6,11 +6,13 @@ Issue: #62
 
 from .base import BaseIngester, IngestedContent
 from .web import WebIngester
-from .zenn import ZennIngester
+from .zenn import DiscoverResult, ZennIngester, format_zenn_ingest_result
 
 __all__ = [
     "BaseIngester",
+    "DiscoverResult",
     "IngestedContent",
     "WebIngester",
     "ZennIngester",
+    "format_zenn_ingest_result",
 ]

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -1,0 +1,358 @@
+"""Zenn インジェスター: Zenn API 経由で記事を取得するインジェスター
+
+仕様: docs/specs/features/zenn-ingester.md
+Issue: #114
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+import aiohttp
+from markdownify import MarkdownConverter
+
+from .base import BaseIngester, IngestedContent
+
+logger = logging.getLogger(__name__)
+
+ZENN_API_BASE = "https://zenn.dev/api"
+USER_AGENT = "RAG-Knowledge/1.0"
+DEFAULT_MAX_PAGES = 10
+REQUEST_INTERVAL = 1.0
+REQUEST_TIMEOUT = 30
+MAX_RETRIES = 3
+BACKOFF_BASE = 1  # 指数バックオフ: 1s, 2s, 4s
+
+# slug / username の形式: 英数字・ハイフン・アンダースコア
+_IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+class _ZennMarkdownConverter(MarkdownConverter):  # type: ignore[misc]
+    """Zenn 記事用 Markdown コンバーター.
+
+    リンク URL と画像 URL を除去し、テキスト情報のみを保持する。
+    """
+
+    def convert_a(self, el: Any, text: str, convert_as_inline: bool) -> str:
+        """リンクはテキストのみ保持."""
+        return text or ""
+
+    def convert_img(self, el: Any, text: str, convert_as_inline: bool) -> str:
+        """画像は alt テキストのみ保持."""
+        return el.get("alt", "") or ""
+
+
+class ZennIngester(BaseIngester):
+    """Zenn API からの記事取得を担うインジェスター.
+
+    仕様: docs/specs/features/zenn-ingester.md
+
+    BaseIngester を継承し、Zenn API を使って記事を取得する。
+    ページネーション上限・リクエスト間隔・リトライ・タイムアウトの
+    安全制約を実装する。
+    """
+
+    def __init__(self, *, max_pages: int = DEFAULT_MAX_PAGES) -> None:
+        """ZennIngester を初期化する.
+
+        Args:
+            max_pages: ページネーション上限（0 で無制限）
+        """
+        self._max_pages = max_pages
+        self._last_limit_reached = False
+        self._timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+        self._md_converter = _ZennMarkdownConverter(
+            heading_style="ATX",
+            escape_underscores=False,
+            escape_asterisks=False,
+        )
+
+    def validate_identifier(self, identifier: str) -> str:
+        """slug の形式を検証する.
+
+        Args:
+            identifier: Zenn 記事の slug
+
+        Returns:
+            検証済み slug
+
+        Raises:
+            ValueError: slug の形式が不正な場合
+        """
+        if not identifier or not _IDENTIFIER_PATTERN.match(identifier):
+            raise ValueError(
+                f"不正な Zenn 記事 slug です: {identifier!r} "
+                "(英数字・ハイフン・アンダースコアのみ使用可能)"
+            )
+        return identifier
+
+    async def _request_with_retry(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+    ) -> dict[str, Any]:
+        """リトライ付きで GET リクエストを送信する.
+
+        Args:
+            session: aiohttp セッション
+            url: リクエスト先 URL
+
+        Returns:
+            JSON レスポンス
+
+        Raises:
+            aiohttp.ClientError: 最大リトライ回数超過
+            ValueError: レスポンスが JSON でない場合
+        """
+        last_error: BaseException | None = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                async with session.get(url) as resp:
+                    resp.raise_for_status()
+                    data: dict[str, Any] = await resp.json()
+                    return data
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                last_error = e
+                if attempt < MAX_RETRIES - 1:
+                    wait = BACKOFF_BASE * (2 ** attempt)
+                    logger.warning(
+                        "Request failed (attempt %d/%d), retrying in %ds: %s %s",
+                        attempt + 1,
+                        MAX_RETRIES,
+                        wait,
+                        url,
+                        e,
+                    )
+                    await asyncio.sleep(wait)
+                else:
+                    logger.error(
+                        "Request failed after %d retries: %s %s",
+                        MAX_RETRIES,
+                        url,
+                        e,
+                    )
+
+        assert last_error is not None
+        raise last_error
+
+    def _html_to_text(self, html: str) -> str:
+        """HTML をプレーンテキスト（Markdown）に変換する.
+
+        Args:
+            html: HTML 文字列
+
+        Returns:
+            Markdown テキスト
+        """
+        if not html:
+            return ""
+        text: str = self._md_converter.convert(html)
+        # 連続空行を 2 行に正規化、行末空白を除去
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = re.sub(r"[ \t]+\n", "\n", text)
+        return text.strip()
+
+    async def fetch_single(self, identifier: str) -> IngestedContent | None:
+        """単一の Zenn 記事を slug 指定で取得する.
+
+        Args:
+            identifier: Zenn 記事の slug
+
+        Returns:
+            IngestedContent、または取得失敗時は None
+        """
+        slug = self.validate_identifier(identifier)
+        url = f"{ZENN_API_BASE}/articles/{slug}"
+
+        try:
+            async with aiohttp.ClientSession(
+                timeout=self._timeout,
+                headers={"User-Agent": USER_AGENT},
+            ) as session:
+                data = await self._request_with_retry(session, url)
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            logger.error("Failed to fetch article: %s", slug)
+            return None
+
+        article = data.get("article")
+        if article is None or not isinstance(article, dict):
+            logger.error(
+                "API response missing 'article' field for slug: %s "
+                "(API schema may have changed)",
+                slug,
+            )
+            return None
+
+        # 必須フィールドチェック
+        body_html = article.get("body_html")
+        if body_html is None:
+            logger.error(
+                "API response missing 'body_html' for slug: %s "
+                "(API schema may have changed)",
+                slug,
+            )
+            return None
+
+        article_slug = article.get("slug", slug)
+        title = article.get("title", "")
+        source_url = f"https://zenn.dev/articles/{article_slug}"
+        text = self._html_to_text(body_html)
+
+        return IngestedContent(
+            source_id=source_url,
+            title=title,
+            text=text,
+            ingested_at=IngestedContent.now_iso(),
+            source_type="zenn",
+            metadata={
+                "slug": article_slug,
+                "username": article.get("user", {}).get("username", ""),
+                "published_at": article.get("published_at", ""),
+                "raw_html": body_html,
+            },
+        )
+
+    async def fetch_batch(self, identifiers: list[str]) -> list[IngestedContent]:
+        """複数の slug を順次取得する（リクエスト間隔 1 秒以上）.
+
+        Args:
+            identifiers: slug のリスト
+
+        Returns:
+            取得に成功した IngestedContent のリスト
+        """
+        if not identifiers:
+            return []
+
+        results: list[IngestedContent] = []
+        for i, slug in enumerate(identifiers):
+            if i > 0:
+                await asyncio.sleep(REQUEST_INTERVAL)
+            try:
+                content = await self.fetch_single(slug)
+                if content is not None:
+                    results.append(content)
+            except Exception:
+                logger.exception("Failed to fetch article: %s", slug)
+
+        return results
+
+    async def discover(self, source: str, **kwargs: object) -> list[str]:
+        """ユーザーの記事一覧を取得し、slug のリストを返す.
+
+        Args:
+            source: Zenn ユーザー名
+            **kwargs:
+                max_pages (int): ページネーション上限の上書き
+                no_limit (bool): ページネーション上限を解除
+
+        Returns:
+            発見された slug のリスト
+        """
+        username = source
+
+        # username のバリデーション
+        if not username or not _IDENTIFIER_PATTERN.match(username):
+            logger.error("Invalid Zenn username: %r", username)
+            return []
+
+        self._last_limit_reached = False
+
+        # max_pages の決定
+        no_limit = bool(kwargs.get("no_limit", False))
+        if no_limit:
+            max_pages = 0  # 無制限
+        else:
+            max_pages_override = kwargs.get("max_pages")
+            if max_pages_override is not None:
+                max_pages = int(str(max_pages_override))
+            else:
+                max_pages = self._max_pages
+
+        slugs: list[str] = []
+        page = 1
+
+        async with aiohttp.ClientSession(
+            timeout=self._timeout,
+            headers={"User-Agent": USER_AGENT},
+        ) as session:
+            while True:
+                # ページネーション上限チェック
+                if max_pages > 0 and page > max_pages:
+                    logger.warning(
+                        "Pagination limit reached (%d pages) for user: %s",
+                        max_pages,
+                        username,
+                    )
+                    self._last_limit_reached = True
+                    break
+
+                url = (
+                    f"{ZENN_API_BASE}/articles"
+                    f"?username={username}&order=latest&page={page}"
+                )
+
+                try:
+                    data = await self._request_with_retry(session, url)
+                except (aiohttp.ClientError, asyncio.TimeoutError):
+                    # 記事一覧取得のリトライ失敗時は処理全体を停止
+                    logger.error(
+                        "Failed to fetch article list for user: %s (page %d). "
+                        "Stopping pagination.",
+                        username,
+                        page,
+                    )
+                    break
+
+                # articles フィールドの検証
+                articles = data.get("articles")
+                if articles is None:
+                    logger.error(
+                        "API response missing 'articles' field for user: %s "
+                        "(API schema may have changed). Stopping.",
+                        username,
+                    )
+                    break
+
+                if not isinstance(articles, list):
+                    logger.error(
+                        "API response 'articles' is not a list for user: %s. Stopping.",
+                        username,
+                    )
+                    break
+
+                if not articles:
+                    # 空の articles = これ以上記事がない
+                    break
+
+                for article in articles:
+                    slug = article.get("slug")
+                    if slug is None:
+                        logger.error(
+                            "Article missing 'slug' field (API schema may have changed). "
+                            "Stopping.",
+                        )
+                        return slugs
+                    slugs.append(slug)
+
+                # next_page の検証
+                next_page = data.get("next_page")
+                if next_page is None:
+                    # 最終ページ
+                    break
+                if not isinstance(next_page, int) or next_page <= 0:
+                    logger.warning(
+                        "Unexpected next_page value: %r. Stopping pagination.",
+                        next_page,
+                    )
+                    break
+
+                page = next_page
+
+                # リクエスト間隔
+                await asyncio.sleep(REQUEST_INTERVAL)
+
+        return slugs

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from dataclasses import dataclass, field
 from typing import Any
 
 import aiohttp
@@ -28,6 +29,54 @@ BACKOFF_BASE = 1  # 指数バックオフ: 1s, 2s, 4s
 
 # slug / username の形式: 英数字・ハイフン・アンダースコア
 _IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+@dataclass
+class DiscoverResult:
+    """discover() の戻り値.
+
+    slug のリストと、ページネーション上限到達フラグを保持する。
+    """
+
+    slugs: list[str] = field(default_factory=list)
+    limit_reached: bool = False
+
+
+def format_zenn_ingest_result(
+    result: dict[str, object],
+    username: str,
+) -> str:
+    """Zenn 一括取り込み結果をフォーマットする.
+
+    server.py（MCP ツール）と cli.py（CLI コマンド）で共用する。
+
+    Args:
+        result: ingest_zenn() の戻り値
+        username: Zenn ユーザー名
+
+    Returns:
+        フォーマット済み文字列
+    """
+    if result["dry_run"]:
+        articles = result.get("articles", [])
+        found = result["articles_found"]
+        lines: list[str] = [f"[dry-run] Zenn 記事一覧 ({username}): {found}件"]
+        if isinstance(articles, list):
+            for i, article in enumerate(articles, start=1):
+                if isinstance(article, dict):
+                    slug = article.get("slug", "")
+                    lines.append(f"  {i}. {slug}")
+        return "\n".join(lines)
+
+    found = result["articles_found"]
+    ingested = result["articles_ingested"]
+    chunks = result["chunks_stored"]
+    errors = result["errors"]
+    return (
+        f"Zenn 記事取り込み完了 ({username}): "
+        f"発見={found}件, 取り込み={ingested}件, "
+        f"チャンク={chunks}, エラー={errors}件"
+    )
 
 
 class _ZennMarkdownConverter(MarkdownConverter):  # type: ignore[misc]
@@ -62,7 +111,6 @@ class ZennIngester(BaseIngester):
             max_pages: ページネーション上限（0 で無制限）
         """
         self._max_pages = max_pages
-        self._last_limit_reached = False
         self._timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
         self._md_converter = _ZennMarkdownConverter(
             heading_style="ATX",
@@ -240,8 +288,8 @@ class ZennIngester(BaseIngester):
 
         return results
 
-    async def discover(self, source: str, **kwargs: object) -> list[str]:
-        """ユーザーの記事一覧を取得し、slug のリストを返す.
+    async def discover(self, source: str, **kwargs: object) -> DiscoverResult:  # type: ignore[override]
+        """ユーザーの記事一覧を取得し、DiscoverResult を返す.
 
         Args:
             source: Zenn ユーザー名
@@ -250,16 +298,16 @@ class ZennIngester(BaseIngester):
                 no_limit (bool): ページネーション上限を解除
 
         Returns:
-            発見された slug のリスト
+            DiscoverResult（slugs と limit_reached を含む）
         """
         username = source
 
         # username のバリデーション
         if not username or not _IDENTIFIER_PATTERN.match(username):
             logger.error("Invalid Zenn username: %r", username)
-            return []
+            return DiscoverResult()
 
-        self._last_limit_reached = False
+        limit_reached = False
 
         # max_pages の決定
         no_limit = bool(kwargs.get("no_limit", False))
@@ -287,7 +335,7 @@ class ZennIngester(BaseIngester):
                         max_pages,
                         username,
                     )
-                    self._last_limit_reached = True
+                    limit_reached = True
                     break
 
                 url = (
@@ -335,7 +383,7 @@ class ZennIngester(BaseIngester):
                             "Article missing 'slug' field (API schema may have changed). "
                             "Stopping.",
                         )
-                        return slugs
+                        return DiscoverResult(slugs=slugs, limit_reached=limit_reached)
                     slugs.append(slug)
 
                 # next_page の検証
@@ -355,4 +403,4 @@ class ZennIngester(BaseIngester):
                 # リクエスト間隔
                 await asyncio.sleep(REQUEST_INTERVAL)
 
-        return slugs
+        return DiscoverResult(slugs=slugs, limit_reached=limit_reached)

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from .bm25_index import BM25Index
     from .hybrid_search import HybridSearchEngine
     from .ingesters.web import WebIngester
+    from .ingesters.zenn import ZennIngester
     from .safe_browsing import SafeBrowsingClient
     from .web_crawler import CrawlPreviewPage, CrawledPage, WebCrawler
 
@@ -160,6 +161,7 @@ class RAGKnowledgeService:
         min_combined_score: float | None = None,
         debug_log_enabled: bool = False,
         web_ingester: WebIngester | None = None,
+        zenn_ingester: ZennIngester | None = None,
     ) -> None:
         """RAGKnowledgeServiceを初期化する.
 
@@ -176,6 +178,7 @@ class RAGKnowledgeService:
             min_combined_score: combined_scoreの下限閾値（None=フィルタなし）
             debug_log_enabled: RAGデバッグログの有効/無効
             web_ingester: WebIngester（オプション、指定時はingest_page/ingest_from_indexで使用）
+            zenn_ingester: ZennIngester（オプション、指定時はingest_zenn/add_zennで使用）
         """
         self._vector_store = vector_store
         self._web_crawler = web_crawler
@@ -188,6 +191,7 @@ class RAGKnowledgeService:
         self._min_combined_score = min_combined_score
         self._debug_log_enabled = debug_log_enabled
         self._web_ingester = web_ingester
+        self._zenn_ingester = zenn_ingester
         self._hybrid_search_engine: HybridSearchEngine | None = None
 
         # ハイブリッド検索エンジンの初期化
@@ -624,6 +628,107 @@ class RAGKnowledgeService:
 
         logger.info("Ingested content %s: %d chunks", normalized_url, count)
         return count
+
+    async def ingest_zenn(
+        self,
+        username: str,
+        *,
+        dry_run: bool = False,
+        no_limit: bool = False,
+    ) -> dict[str, object]:
+        """Zenn 記事一括取り込み.
+
+        仕様: docs/specs/features/zenn-ingester.md
+
+        Args:
+            username: Zenn ユーザー名
+            dry_run: True の場合は記事一覧のみ返し、取り込みは行わない
+            no_limit: True の場合はページネーション上限を解除
+
+        Returns:
+            {"articles_found": N, "articles_ingested": M, "chunks_stored": C,
+             "errors": E, "dry_run": bool, "limit_reached": bool,
+             "articles": [{"slug": ..., "title": ...}, ...]}
+        """
+        if self._zenn_ingester is None:
+            raise RuntimeError("ZennIngester が設定されていません")
+
+        # 記事一覧を取得
+        slugs = await self._zenn_ingester.discover(
+            username, no_limit=no_limit,
+        )
+        limit_reached = self._zenn_ingester._last_limit_reached
+
+        if dry_run:
+            # dry_run: 個別記事の詳細を取得せず、slug のみ返す
+            articles_info: list[dict[str, str]] = [
+                {"slug": slug, "title": ""} for slug in slugs
+            ]
+            return {
+                "articles_found": len(slugs),
+                "articles_ingested": 0,
+                "chunks_stored": 0,
+                "errors": 0,
+                "dry_run": True,
+                "limit_reached": limit_reached,
+                "articles": articles_info,
+            }
+
+        # 各記事を取得してチャンキング・格納
+        contents = await self._zenn_ingester.fetch_batch(slugs)
+
+        total_chunks = 0
+        errors = len(slugs) - len(contents)
+        for content in contents:
+            try:
+                chunks_stored = await self._ingest_content(content)
+                total_chunks += chunks_stored
+            except Exception:
+                logger.exception("Failed to ingest Zenn article: %s", content.source_id)
+                errors += 1
+
+        logger.info(
+            "Zenn ingest complete: user=%s, found=%d, ingested=%d, chunks=%d, errors=%d",
+            username,
+            len(slugs),
+            len(contents),
+            total_chunks,
+            errors,
+        )
+
+        return {
+            "articles_found": len(slugs),
+            "articles_ingested": len(contents),
+            "chunks_stored": total_chunks,
+            "errors": errors,
+            "dry_run": False,
+            "limit_reached": limit_reached,
+            "articles": [],
+        }
+
+    async def add_zenn(self, slug: str) -> int:
+        """Zenn 記事単体取り込み.
+
+        仕様: docs/specs/features/zenn-ingester.md
+
+        Args:
+            slug: Zenn 記事の slug
+
+        Returns:
+            保存されたチャンク数
+
+        Raises:
+            RuntimeError: ZennIngester が未設定の場合
+            ValueError: slug が不正な場合
+        """
+        if self._zenn_ingester is None:
+            raise RuntimeError("ZennIngester が設定されていません")
+
+        content = await self._zenn_ingester.fetch_single(slug)
+        if content is None:
+            return 0
+
+        return await self._ingest_content(content)
 
     async def retrieve(self, query: str, n_results: int = 5) -> RAGRetrievalResult:
         """関連知識を検索し、結果を返す.

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -654,10 +654,11 @@ class RAGKnowledgeService:
             raise RuntimeError("ZennIngester が設定されていません")
 
         # 記事一覧を取得
-        slugs = await self._zenn_ingester.discover(
+        discover_result = await self._zenn_ingester.discover(
             username, no_limit=no_limit,
         )
-        limit_reached = self._zenn_ingester._last_limit_reached
+        slugs = discover_result.slugs
+        limit_reached = discover_result.limit_reached
 
         if dry_run:
             # dry_run: 個別記事の詳細を取得せず、slug のみ返す

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,13 +3,15 @@
 仕様: docs/specs/rag-knowledge.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 6 つの RAG ツールを公開する:
+FastMCP を使用して 8 つの RAG ツールを公開する:
 - rag_search: ナレッジベースから関連情報を検索
 - rag_add: 単一ページをナレッジベースに取り込み
 - rag_crawl: リンク集ページからクロール＆一括取り込み
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_delete: ソースURL指定でナレッジから削除
 - rag_stats: ナレッジベースの統計情報を表示
+- rag_ingest_zenn: Zenn ユーザーの記事を一括取り込み
+- rag_add_zenn: Zenn 記事を slug 指定で単体取り込み
 """
 
 from __future__ import annotations
@@ -36,6 +38,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .config import get_settings
     from .embedding.factory import get_embedding_provider
     from .ingesters.web import WebIngester
+    from .ingesters.zenn import ZennIngester
     from .rag_knowledge import RAGKnowledgeService
     from .safe_browsing import create_safe_browsing_client
     from .vector_store import VectorStore
@@ -118,6 +121,8 @@ def _build_rag_service() -> RAGKnowledgeService:
         safe_browsing_client=safe_browsing_client,
     )
 
+    zenn_ingester = ZennIngester()
+
     return RAGKnowledgeService(
         vector_store=vector_store,
         web_crawler=web_crawler,
@@ -131,6 +136,7 @@ def _build_rag_service() -> RAGKnowledgeService:
         min_combined_score=settings.rag_min_combined_score,
         debug_log_enabled=settings.rag_debug_log_enabled,
         web_ingester=web_ingester,
+        zenn_ingester=zenn_ingester,
     )
 
 
@@ -453,6 +459,87 @@ async def rag_stats() -> str:
     except Exception:
         logger.exception("Failed to get stats")
         return "エラー: 統計情報の取得に失敗しました。"
+
+
+@mcp.tool()
+async def rag_ingest_zenn(
+    username: str,
+    dry_run: bool = False,
+    no_limit: bool = False,
+) -> str:
+    """[rag-knowledge] RAG ingest Zenn - Zenn ユーザーの記事を一括取り込み.
+
+    knowledge base, ingest, Zenn, articles, bulk import.
+    Zenn API 経由で指定ユーザーの記事を取得し、ナレッジベースに取り込む。
+    --dry-run で取り込み対象の記事一覧をプレビューできる。
+
+    Args:
+        username: Zenn ユーザー名
+        dry_run: True の場合は記事一覧のみ表示し、取り込みを行わない
+        no_limit: True の場合はページネーション上限（デフォルト10ページ）を解除する
+
+    Returns:
+        取り込み結果のサマリー
+    """
+    service = await _get_rag_service()
+    try:
+        result = await service.ingest_zenn(
+            username, dry_run=dry_run, no_limit=no_limit,
+        )
+
+        if result["dry_run"]:
+            articles = result.get("articles", [])
+            found = result["articles_found"]
+            lines: list[str] = [f"[dry-run] Zenn 記事一覧 ({username}): {found}件"]
+            if isinstance(articles, list):
+                for i, article in enumerate(articles, start=1):
+                    if isinstance(article, dict):
+                        slug = article.get("slug", "")
+                        lines.append(f"  {i}. {slug}")
+            return "\n".join(lines)
+
+        found = result["articles_found"]
+        ingested = result["articles_ingested"]
+        chunks = result["chunks_stored"]
+        errors = result["errors"]
+        return (
+            f"Zenn 記事取り込み完了 ({username}): "
+            f"発見={found}件, 取り込み={ingested}件, "
+            f"チャンク={chunks}, エラー={errors}件"
+        )
+    except RuntimeError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception("Failed to ingest Zenn articles: %s", username)
+        return f"エラー: Zenn 記事の取り込みに失敗しました。ユーザー: {username}"
+
+
+@mcp.tool()
+async def rag_add_zenn(slug: str) -> str:
+    """[rag-knowledge] RAG add Zenn - Zenn 記事を単体取り込み.
+
+    knowledge base, ingest, Zenn, single article.
+    slug 指定で Zenn の単一記事を取得し、ナレッジベースに取り込む。
+
+    Args:
+        slug: Zenn 記事の slug（記事固有の識別子）
+
+    Returns:
+        取り込み結果のメッセージ
+    """
+    service = await _get_rag_service()
+    try:
+        chunks = await service.add_zenn(slug)
+        if chunks <= 0:
+            return f"エラー: Zenn 記事の取り込みに失敗しました。slug: {slug}"
+        return f"Zenn 記事を取り込みました: {slug} ({chunks}チャンク)"
+    except ValueError as e:
+        return f"エラー: {e}"
+    except RuntimeError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception("Failed to add Zenn article: %s", slug)
+        return f"エラー: Zenn 記事の取り込みに失敗しました。slug: {slug}"
 
 
 def _configure_and_run() -> None:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -38,7 +38,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .config import get_settings
     from .embedding.factory import get_embedding_provider
     from .ingesters.web import WebIngester
-    from .ingesters.zenn import ZennIngester
+    from .ingesters.zenn import ZennIngester, format_zenn_ingest_result
     from .rag_knowledge import RAGKnowledgeService
     from .safe_browsing import create_safe_browsing_client
     from .vector_store import VectorStore
@@ -486,27 +486,7 @@ async def rag_ingest_zenn(
         result = await service.ingest_zenn(
             username, dry_run=dry_run, no_limit=no_limit,
         )
-
-        if result["dry_run"]:
-            articles = result.get("articles", [])
-            found = result["articles_found"]
-            lines: list[str] = [f"[dry-run] Zenn 記事一覧 ({username}): {found}件"]
-            if isinstance(articles, list):
-                for i, article in enumerate(articles, start=1):
-                    if isinstance(article, dict):
-                        slug = article.get("slug", "")
-                        lines.append(f"  {i}. {slug}")
-            return "\n".join(lines)
-
-        found = result["articles_found"]
-        ingested = result["articles_ingested"]
-        chunks = result["chunks_stored"]
-        errors = result["errors"]
-        return (
-            f"Zenn 記事取り込み完了 ({username}): "
-            f"発見={found}件, 取り込み={ingested}件, "
-            f"チャンク={chunks}, エラー={errors}件"
-        )
+        return format_zenn_ingest_result(result, username)
     except RuntimeError as e:
         return f"エラー: {e}"
     except Exception:

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -28,8 +28,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_six_tools() -> None:
-    """RAG MCPサーバーが6つのツールを公開すること."""
+async def test_rag_server_exposes_tools() -> None:
+    """RAG MCPサーバーが8つのツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -38,19 +38,19 @@ async def test_rag_server_exposes_six_tools() -> None:
 
     expected = {
         "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_delete", "rag_stats",
+        "rag_delete", "rag_stats", "rag_ingest_zenn", "rag_add_zenn",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に6であること."""
+    """RAG MCPサーバーのツール数が正確に8であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 6
+    assert len(tools) == 8
 
 
 class TestRagSearchOutput:

--- a/tests/test_zenn_ingester.py
+++ b/tests/test_zenn_ingester.py
@@ -1,0 +1,786 @@
+"""Zenn インジェスターのテスト
+
+仕様: docs/specs/features/zenn-ingester.md
+Issue: #114
+
+テスト対象: ZennIngester クラスの全メソッド
+テスト手法: 単体テスト（Zenn API はモックで代替）
+重点観点:
+  - ページネーション上限（10 ページ）で正しく停止するか
+  - リクエスト間隔（1 秒以上）が守られているか
+  - リトライ（3 回・指数バックオフ）の動作
+  - 存在しないユーザー名 → 0 件で正常終了
+  - API スキーマ変更（必須フィールド欠落）→ エラー停止
+  - next_page の異常値 → ページネーション停止
+  - dry_run 時にデータ書き込みが発生しないこと
+  - body_html → テキスト/Markdown 変換の正確性
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from rag.ingesters.zenn import (
+    DEFAULT_MAX_PAGES,
+    ZennIngester,
+)
+
+
+# --- validate_identifier テスト ---
+
+
+class TestZennIngesterValidate:
+    """ZennIngester.validate_identifier() のテスト."""
+
+    def test_valid_slug(self) -> None:
+        """正常な slug が検証を通ること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("example-article") == "example-article"
+
+    def test_valid_slug_with_numbers(self) -> None:
+        """数字を含む slug が検証を通ること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("article-123") == "article-123"
+
+    def test_valid_slug_with_underscore(self) -> None:
+        """アンダースコアを含む slug が検証を通ること."""
+        ingester = ZennIngester()
+        assert ingester.validate_identifier("my_article") == "my_article"
+
+    def test_empty_slug_raises(self) -> None:
+        """空の slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="不正な Zenn 記事 slug"):
+            ingester.validate_identifier("")
+
+    def test_invalid_slug_with_spaces(self) -> None:
+        """スペースを含む slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="不正な Zenn 記事 slug"):
+            ingester.validate_identifier("invalid slug")
+
+    def test_invalid_slug_with_special_chars(self) -> None:
+        """特殊文字を含む slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+        with pytest.raises(ValueError, match="不正な Zenn 記事 slug"):
+            ingester.validate_identifier("slug/with/slashes")
+
+
+# --- _html_to_text テスト ---
+
+
+class TestZennIngesterHtmlToText:
+    """ZennIngester._html_to_text() のテスト."""
+
+    def test_basic_html_conversion(self) -> None:
+        """基本的な HTML が Markdown に変換されること."""
+        ingester = ZennIngester()
+        html = "<h1>Title</h1><p>Hello world</p>"
+        text = ingester._html_to_text(html)
+        assert "Title" in text
+        assert "Hello world" in text
+
+    def test_empty_html(self) -> None:
+        """空の HTML が空文字列を返すこと."""
+        ingester = ZennIngester()
+        assert ingester._html_to_text("") == ""
+
+    def test_html_with_code_block(self) -> None:
+        """コードブロックを含む HTML が変換されること."""
+        ingester = ZennIngester()
+        html = "<pre><code>print('hello')</code></pre>"
+        text = ingester._html_to_text(html)
+        assert "print('hello')" in text
+
+    def test_html_links_stripped(self) -> None:
+        """リンク URL が除去されテキストのみ残ること."""
+        ingester = ZennIngester()
+        html = '<a href="https://example.com">Link Text</a>'
+        text = ingester._html_to_text(html)
+        assert "Link Text" in text
+        assert "https://example.com" not in text
+
+    def test_html_images_stripped(self) -> None:
+        """画像 URL が除去され alt テキストのみ残ること."""
+        ingester = ZennIngester()
+        html = '<img src="https://example.com/img.png" alt="My Image">'
+        text = ingester._html_to_text(html)
+        assert "My Image" in text
+        assert "https://example.com" not in text
+
+    def test_consecutive_blank_lines_normalized(self) -> None:
+        """連続空行が 2 行に正規化されること."""
+        ingester = ZennIngester()
+        html = "<h1>Title</h1>\n\n\n\n\n<p>Content</p>"
+        text = ingester._html_to_text(html)
+        # 3 行以上の連続空行がないことを確認
+        assert "\n\n\n" not in text
+        assert "Title" in text
+        assert "Content" in text
+
+
+# --- fetch_single テスト ---
+
+
+class TestZennIngesterFetchSingle:
+    """ZennIngester.fetch_single() のテスト."""
+
+    async def test_fetch_single_success(self) -> None:
+        """正常に記事を取得して IngestedContent を返すこと."""
+        ingester = ZennIngester()
+        mock_response = {
+            "article": {
+                "slug": "test-article",
+                "title": "Test Article",
+                "body_html": "<h1>Test</h1><p>Content</p>",
+                "published_at": "2024-01-01T00:00:00.000+09:00",
+                "user": {"username": "testuser"},
+            }
+        }
+
+        with patch.object(
+            ingester, "_request_with_retry", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert result.source_id == "https://zenn.dev/articles/test-article"
+        assert result.title == "Test Article"
+        assert "Test" in result.text
+        assert "Content" in result.text
+        assert result.source_type == "zenn"
+        assert result.metadata["slug"] == "test-article"
+        assert result.metadata["username"] == "testuser"
+        assert result.metadata["raw_html"] == "<h1>Test</h1><p>Content</p>"
+
+    async def test_fetch_single_missing_body_html(self) -> None:
+        """body_html が欠落している場合に None を返すこと."""
+        ingester = ZennIngester()
+        mock_response = {
+            "article": {
+                "slug": "test-article",
+                "title": "Test Article",
+                # body_html がない
+            }
+        }
+
+        with patch.object(
+            ingester, "_request_with_retry", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            result = await ingester.fetch_single("test-article")
+
+        assert result is None
+
+    async def test_fetch_single_network_error(self) -> None:
+        """ネットワークエラー時に None を返すこと."""
+        ingester = ZennIngester()
+
+        with patch.object(
+            ingester, "_request_with_retry", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.side_effect = aiohttp.ClientError("Connection failed")
+
+            result = await ingester.fetch_single("test-article")
+
+        assert result is None
+
+    async def test_fetch_single_invalid_slug(self) -> None:
+        """不正な slug で ValueError が発生すること."""
+        ingester = ZennIngester()
+
+        with pytest.raises(ValueError, match="不正な Zenn 記事 slug"):
+            await ingester.fetch_single("invalid slug")
+
+
+# --- fetch_batch テスト ---
+
+
+class TestZennIngesterFetchBatch:
+    """ZennIngester.fetch_batch() のテスト."""
+
+    async def test_fetch_batch_respects_interval(self) -> None:
+        """リクエスト間隔（1 秒以上）が守られていること."""
+        ingester = ZennIngester()
+        mock_response = {
+            "article": {
+                "slug": "article-1",
+                "title": "Article 1",
+                "body_html": "<p>Content</p>",
+                "user": {"username": "user"},
+            }
+        }
+
+        call_times: list[float] = []
+        original_sleep = asyncio.sleep
+
+        async def mock_sleep(seconds: float) -> None:
+            call_times.append(seconds)
+            # Don't actually sleep in tests
+            await original_sleep(0)
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", side_effect=mock_sleep),
+        ):
+            mock_request.return_value = mock_response
+
+            await ingester.fetch_batch(["article-1", "article-2", "article-3"])
+
+        # fetch_batch の間隔: 2 回の sleep（2 番目と 3 番目の前）
+        assert len(call_times) == 2
+        assert all(t >= 1.0 for t in call_times)
+
+    async def test_fetch_batch_empty(self) -> None:
+        """空リストで空の結果を返すこと."""
+        ingester = ZennIngester()
+        results = await ingester.fetch_batch([])
+        assert results == []
+
+    async def test_fetch_batch_partial_failure(self) -> None:
+        """一部失敗しても成功分を返すこと."""
+        ingester = ZennIngester()
+
+        async def mock_fetch(slug: str) -> MagicMock | None:
+            if slug == "good-article":
+                content = MagicMock()
+                content.source_id = "https://zenn.dev/articles/good-article"
+                return content
+            return None
+
+        with patch.object(
+            ingester, "fetch_single", side_effect=mock_fetch,
+        ):
+            results = await ingester.fetch_batch(
+                ["good-article", "bad-article"]
+            )
+
+        assert len(results) == 1
+
+
+# --- _request_with_retry テスト ---
+
+
+class TestZennIngesterRetry:
+    """ZennIngester._request_with_retry() のテスト."""
+
+    async def test_retry_on_failure(self) -> None:
+        """失敗時にリトライが行われること."""
+        ingester = ZennIngester()
+        call_count = 0
+
+        def make_success_cm() -> MagicMock:
+            """成功するコンテキストマネージャを作成."""
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = AsyncMock(return_value={"articles": []})
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(return_value=resp)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        def make_failing_cm() -> MagicMock:
+            """失敗するコンテキストマネージャを作成."""
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(
+                side_effect=aiohttp.ClientError("error")
+            )
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        def mock_get(url: str) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return make_failing_cm()
+            return make_success_cm()
+
+        mock_session = MagicMock()
+        mock_session.get = mock_get
+
+        with patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock):
+            result = await ingester._request_with_retry(
+                mock_session, "https://example.com"
+            )
+
+        assert result == {"articles": []}
+        assert call_count == 3
+
+    async def test_retry_exhausted_raises(self) -> None:
+        """最大リトライ回数超過でエラーが発生すること."""
+        ingester = ZennIngester()
+
+        def failing_get(url: str) -> MagicMock:
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(
+                side_effect=aiohttp.ClientError("persistent error")
+            )
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        mock_session = MagicMock()
+        mock_session.get = failing_get
+
+        with (
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(aiohttp.ClientError),
+        ):
+            await ingester._request_with_retry(
+                mock_session, "https://example.com"
+            )
+
+
+# --- discover テスト ---
+
+
+class TestZennIngesterDiscover:
+    """ZennIngester.discover() のテスト."""
+
+    async def test_discover_basic(self) -> None:
+        """基本的な記事一覧取得が動作すること."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "articles": [
+                {"slug": "article-1"},
+                {"slug": "article-2"},
+            ],
+            "next_page": None,
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == ["article-1", "article-2"]
+
+    async def test_discover_pagination(self) -> None:
+        """ページネーションが正しく動作すること."""
+        ingester = ZennIngester(max_pages=3)
+
+        responses = [
+            {"articles": [{"slug": "a1"}], "next_page": 2},
+            {"articles": [{"slug": "a2"}], "next_page": 3},
+            {"articles": [{"slug": "a3"}], "next_page": None},
+        ]
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.side_effect = responses
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == ["a1", "a2", "a3"]
+        assert mock_request.call_count == 3
+
+    async def test_discover_pagination_limit(self) -> None:
+        """ページネーション上限（デフォルト10ページ）で停止すること."""
+        ingester = ZennIngester(max_pages=2)
+
+        responses = [
+            {"articles": [{"slug": "a1"}], "next_page": 2},
+            {"articles": [{"slug": "a2"}], "next_page": 3},
+            # Page 3 should NOT be requested
+        ]
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.side_effect = responses
+
+            slugs = await ingester.discover("testuser")
+
+        # 上限 2 ページで停止: a1, a2 のみ
+        assert slugs == ["a1", "a2"]
+        assert mock_request.call_count == 2
+
+    async def test_discover_default_pagination_limit(self) -> None:
+        """デフォルトのページネーション上限が 10 であること."""
+        ingester = ZennIngester()
+        assert ingester._max_pages == DEFAULT_MAX_PAGES
+        assert DEFAULT_MAX_PAGES == 10
+
+    async def test_discover_no_limit(self) -> None:
+        """no_limit=True でページネーション上限が解除されること."""
+        ingester = ZennIngester(max_pages=2)
+
+        responses = [
+            {"articles": [{"slug": "a1"}], "next_page": 2},
+            {"articles": [{"slug": "a2"}], "next_page": 3},
+            {"articles": [{"slug": "a3"}], "next_page": None},
+        ]
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.side_effect = responses
+
+            slugs = await ingester.discover("testuser", no_limit=True)
+
+        # no_limit なので 3 ページ全て取得
+        assert slugs == ["a1", "a2", "a3"]
+        assert mock_request.call_count == 3
+
+    async def test_discover_empty_user(self) -> None:
+        """存在しないユーザー（記事 0 件）で空リストを返すこと."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "articles": [],
+            "next_page": None,
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("nonexistent-user")
+
+        assert slugs == []
+
+    async def test_discover_missing_articles_field(self) -> None:
+        """API レスポンスに articles フィールドがない場合にエラー停止すること."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "data": [],  # articles フィールドがない
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == []
+
+    async def test_discover_missing_slug_in_article(self) -> None:
+        """記事に slug フィールドがない場合にエラー停止すること."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "articles": [
+                {"title": "No Slug Article"},  # slug がない
+            ],
+            "next_page": None,
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == []
+
+    async def test_discover_unexpected_next_page(self) -> None:
+        """next_page が予期しない値の場合にページネーションが停止すること."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "articles": [{"slug": "a1"}],
+            "next_page": "invalid",  # 文字列（整数でない）
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == ["a1"]
+        # 1 回のリクエストのみ（next_page が不正で停止）
+        assert mock_request.call_count == 1
+
+    async def test_discover_negative_next_page(self) -> None:
+        """next_page が負の値の場合にページネーションが停止すること."""
+        ingester = ZennIngester()
+
+        mock_response = {
+            "articles": [{"slug": "a1"}],
+            "next_page": -1,
+        }
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.return_value = mock_response
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == ["a1"]
+
+    async def test_discover_request_interval(self) -> None:
+        """ページ間のリクエスト間隔（1 秒以上）が守られていること."""
+        ingester = ZennIngester(max_pages=3)
+
+        responses = [
+            {"articles": [{"slug": "a1"}], "next_page": 2},
+            {"articles": [{"slug": "a2"}], "next_page": 3},
+            {"articles": [{"slug": "a3"}], "next_page": None},
+        ]
+
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", side_effect=mock_sleep),
+        ):
+            mock_request.side_effect = responses
+
+            await ingester.discover("testuser")
+
+        # 2 回のスリープ（2 ページ目と 3 ページ目の前）
+        assert len(sleep_calls) == 2
+        assert all(s >= 1.0 for s in sleep_calls)
+
+    async def test_discover_network_failure_stops(self) -> None:
+        """記事一覧取得のリトライ失敗時は処理全体が停止すること."""
+        ingester = ZennIngester()
+
+        with (
+            patch.object(
+                ingester, "_request_with_retry", new_callable=AsyncMock
+            ) as mock_request,
+            patch("rag.ingesters.zenn.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_request.side_effect = aiohttp.ClientError("network error")
+
+            slugs = await ingester.discover("testuser")
+
+        assert slugs == []
+
+
+# --- RAGKnowledgeService 統合テスト ---
+
+
+class TestRAGServiceZennIntegration:
+    """RAGKnowledgeService の Zenn インジェスター統合テスト."""
+
+    async def test_ingest_zenn_dry_run(self) -> None:
+        """dry_run 時にデータ書き込みが発生しないこと."""
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.add_documents = AsyncMock(return_value=1)
+        mock_vector_store.delete_stale_chunks = AsyncMock(return_value=0)
+
+        mock_web_crawler = MagicMock()
+        mock_zenn_ingester = MagicMock()
+        mock_zenn_ingester.discover = AsyncMock(
+            return_value=["slug-1", "slug-2", "slug-3"]
+        )
+        mock_zenn_ingester.fetch_batch = AsyncMock(return_value=[])
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+            zenn_ingester=mock_zenn_ingester,
+        )
+
+        result = await service.ingest_zenn("testuser", dry_run=True)
+
+        assert result["dry_run"] is True
+        assert result["articles_found"] == 3
+        assert result["articles_ingested"] == 0
+        assert result["chunks_stored"] == 0
+        # fetch_batch は呼ばれない（dry_run）
+        mock_zenn_ingester.fetch_batch.assert_not_called()
+        # ベクトルストアへの書き込みがないこと
+        mock_vector_store.add_documents.assert_not_called()
+
+    async def test_ingest_zenn_full(self) -> None:
+        """通常の一括取り込みが動作すること."""
+        from rag.ingesters.base import IngestedContent
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.add_documents = AsyncMock(return_value=2)
+        mock_vector_store.delete_stale_chunks = AsyncMock(return_value=0)
+
+        mock_web_crawler = MagicMock()
+        mock_zenn_ingester = MagicMock()
+        mock_zenn_ingester.discover = AsyncMock(
+            return_value=["slug-1", "slug-2"]
+        )
+        mock_zenn_ingester.fetch_batch = AsyncMock(
+            return_value=[
+                IngestedContent(
+                    source_id="https://zenn.dev/articles/slug-1",
+                    title="Article 1",
+                    text="Content 1",
+                    ingested_at="2024-01-01T00:00:00+00:00",
+                    source_type="zenn",
+                ),
+                IngestedContent(
+                    source_id="https://zenn.dev/articles/slug-2",
+                    title="Article 2",
+                    text="Content 2",
+                    ingested_at="2024-01-01T00:00:00+00:00",
+                    source_type="zenn",
+                ),
+            ]
+        )
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+            zenn_ingester=mock_zenn_ingester,
+        )
+
+        result = await service.ingest_zenn("testuser")
+
+        assert result["dry_run"] is False
+        assert result["articles_found"] == 2
+        assert result["articles_ingested"] == 2
+        assert result["chunks_stored"] == 4  # 2 articles * 2 chunks each
+        assert result["errors"] == 0
+
+    async def test_add_zenn_success(self) -> None:
+        """単体取り込みが動作すること."""
+        from rag.ingesters.base import IngestedContent
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_vector_store.add_documents = AsyncMock(return_value=3)
+        mock_vector_store.delete_stale_chunks = AsyncMock(return_value=0)
+
+        mock_web_crawler = MagicMock()
+        mock_zenn_ingester = MagicMock()
+        mock_zenn_ingester.fetch_single = AsyncMock(
+            return_value=IngestedContent(
+                source_id="https://zenn.dev/articles/test-slug",
+                title="Test Article",
+                text="Test content for chunking.",
+                ingested_at="2024-01-01T00:00:00+00:00",
+                source_type="zenn",
+            )
+        )
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+            zenn_ingester=mock_zenn_ingester,
+        )
+
+        result = await service.add_zenn("test-slug")
+
+        assert result == 3
+        mock_zenn_ingester.fetch_single.assert_called_once_with("test-slug")
+
+    async def test_add_zenn_not_found(self) -> None:
+        """記事が見つからない場合に 0 を返すこと."""
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_web_crawler = MagicMock()
+        mock_zenn_ingester = MagicMock()
+        mock_zenn_ingester.fetch_single = AsyncMock(return_value=None)
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+            zenn_ingester=mock_zenn_ingester,
+        )
+
+        result = await service.add_zenn("nonexistent-slug")
+
+        assert result == 0
+
+    async def test_ingest_zenn_without_ingester_raises(self) -> None:
+        """ZennIngester 未設定時に RuntimeError が発生すること."""
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_web_crawler = MagicMock()
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+            # zenn_ingester を設定しない
+        )
+
+        with pytest.raises(RuntimeError, match="ZennIngester が設定されていません"):
+            await service.ingest_zenn("testuser")
+
+    async def test_add_zenn_without_ingester_raises(self) -> None:
+        """ZennIngester 未設定時に RuntimeError が発生すること."""
+        from rag.rag_knowledge import RAGKnowledgeService
+
+        mock_vector_store = MagicMock()
+        mock_web_crawler = MagicMock()
+
+        service = RAGKnowledgeService(
+            vector_store=mock_vector_store,
+            web_crawler=mock_web_crawler,
+            chunk_size=200,
+            chunk_overlap=30,
+            similarity_threshold=None,
+        )
+
+        with pytest.raises(RuntimeError, match="ZennIngester が設定されていません"):
+            await service.add_zenn("test-slug")

--- a/tests/test_zenn_ingester.py
+++ b/tests/test_zenn_ingester.py
@@ -26,6 +26,7 @@ import pytest
 
 from rag.ingesters.zenn import (
     DEFAULT_MAX_PAGES,
+    DiscoverResult,
     ZennIngester,
 )
 
@@ -365,9 +366,11 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == ["article-1", "article-2"]
+        assert isinstance(result, DiscoverResult)
+        assert result.slugs == ["article-1", "article-2"]
+        assert result.limit_reached is False
 
     async def test_discover_pagination(self) -> None:
         """ページネーションが正しく動作すること."""
@@ -387,9 +390,10 @@ class TestZennIngesterDiscover:
         ):
             mock_request.side_effect = responses
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == ["a1", "a2", "a3"]
+        assert result.slugs == ["a1", "a2", "a3"]
+        assert result.limit_reached is False
         assert mock_request.call_count == 3
 
     async def test_discover_pagination_limit(self) -> None:
@@ -410,10 +414,11 @@ class TestZennIngesterDiscover:
         ):
             mock_request.side_effect = responses
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
         # 上限 2 ページで停止: a1, a2 のみ
-        assert slugs == ["a1", "a2"]
+        assert result.slugs == ["a1", "a2"]
+        assert result.limit_reached is True
         assert mock_request.call_count == 2
 
     async def test_discover_default_pagination_limit(self) -> None:
@@ -440,10 +445,11 @@ class TestZennIngesterDiscover:
         ):
             mock_request.side_effect = responses
 
-            slugs = await ingester.discover("testuser", no_limit=True)
+            result = await ingester.discover("testuser", no_limit=True)
 
         # no_limit なので 3 ページ全て取得
-        assert slugs == ["a1", "a2", "a3"]
+        assert result.slugs == ["a1", "a2", "a3"]
+        assert result.limit_reached is False
         assert mock_request.call_count == 3
 
     async def test_discover_empty_user(self) -> None:
@@ -463,9 +469,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("nonexistent-user")
+            result = await ingester.discover("nonexistent-user")
 
-        assert slugs == []
+        assert result.slugs == []
 
     async def test_discover_missing_articles_field(self) -> None:
         """API レスポンスに articles フィールドがない場合にエラー停止すること."""
@@ -483,9 +489,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == []
+        assert result.slugs == []
 
     async def test_discover_missing_slug_in_article(self) -> None:
         """記事に slug フィールドがない場合にエラー停止すること."""
@@ -506,9 +512,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == []
+        assert result.slugs == []
 
     async def test_discover_unexpected_next_page(self) -> None:
         """next_page が予期しない値の場合にページネーションが停止すること."""
@@ -527,9 +533,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == ["a1"]
+        assert result.slugs == ["a1"]
         # 1 回のリクエストのみ（next_page が不正で停止）
         assert mock_request.call_count == 1
 
@@ -550,9 +556,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.return_value = mock_response
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == ["a1"]
+        assert result.slugs == ["a1"]
 
     async def test_discover_request_interval(self) -> None:
         """ページ間のリクエスト間隔（1 秒以上）が守られていること."""
@@ -595,9 +601,9 @@ class TestZennIngesterDiscover:
         ):
             mock_request.side_effect = aiohttp.ClientError("network error")
 
-            slugs = await ingester.discover("testuser")
+            result = await ingester.discover("testuser")
 
-        assert slugs == []
+        assert result.slugs == []
 
 
 # --- RAGKnowledgeService 統合テスト ---
@@ -617,7 +623,9 @@ class TestRAGServiceZennIntegration:
         mock_web_crawler = MagicMock()
         mock_zenn_ingester = MagicMock()
         mock_zenn_ingester.discover = AsyncMock(
-            return_value=["slug-1", "slug-2", "slug-3"]
+            return_value=DiscoverResult(
+                slugs=["slug-1", "slug-2", "slug-3"],
+            )
         )
         mock_zenn_ingester.fetch_batch = AsyncMock(return_value=[])
 
@@ -653,7 +661,7 @@ class TestRAGServiceZennIntegration:
         mock_web_crawler = MagicMock()
         mock_zenn_ingester = MagicMock()
         mock_zenn_ingester.discover = AsyncMock(
-            return_value=["slug-1", "slug-2"]
+            return_value=DiscoverResult(slugs=["slug-1", "slug-2"])
         )
         mock_zenn_ingester.fetch_batch = AsyncMock(
             return_value=[

--- a/tests/test_zenn_mcp_tools.py
+++ b/tests/test_zenn_mcp_tools.py
@@ -1,0 +1,226 @@
+"""Zenn MCP ツールの統合テスト
+
+仕様: docs/specs/features/zenn-ingester.md
+Issue: #114
+
+テスト対象: MCP ツール rag_ingest_zenn, rag_add_zenn の統合
+テスト手法: サービス層のモックを使った統合テスト
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rag.server import _reset_rag_service, rag_add_zenn, rag_ingest_zenn
+
+
+@pytest.fixture(autouse=True)
+def _reset_service() -> None:
+    """各テスト前にグローバルサービスをリセットする."""
+    _reset_rag_service()
+
+
+# --- rag_ingest_zenn テスト ---
+
+
+class TestRagIngestZennTool:
+    """MCP ツール rag_ingest_zenn のテスト."""
+
+    async def test_ingest_zenn_dry_run(self) -> None:
+        """dry_run 時に記事一覧が表示されること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            return_value={
+                "articles_found": 3,
+                "articles_ingested": 0,
+                "chunks_stored": 0,
+                "errors": 0,
+                "dry_run": True,
+                "limit_reached": False,
+                "articles": [
+                    {"slug": "article-1", "title": ""},
+                    {"slug": "article-2", "title": ""},
+                    {"slug": "article-3", "title": ""},
+                ],
+            }
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_ingest_zenn(
+                username="testuser", dry_run=True,
+            )
+
+        assert "[dry-run]" in result
+        assert "3件" in result
+        assert "article-1" in result
+        assert "article-2" in result
+        assert "article-3" in result
+        mock_service.ingest_zenn.assert_called_once_with(
+            "testuser", dry_run=True, no_limit=False,
+        )
+
+    async def test_ingest_zenn_full(self) -> None:
+        """通常の一括取り込みが動作すること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            return_value={
+                "articles_found": 5,
+                "articles_ingested": 5,
+                "chunks_stored": 25,
+                "errors": 0,
+                "dry_run": False,
+                "limit_reached": False,
+                "articles": [],
+            }
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_ingest_zenn(username="testuser")
+
+        assert "取り込み完了" in result
+        assert "発見=5件" in result
+        assert "取り込み=5件" in result
+        assert "チャンク=25" in result
+        assert "エラー=0件" in result
+
+    async def test_ingest_zenn_with_errors(self) -> None:
+        """エラーが含まれる場合にエラー数が表示されること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            return_value={
+                "articles_found": 5,
+                "articles_ingested": 3,
+                "chunks_stored": 15,
+                "errors": 2,
+                "dry_run": False,
+                "limit_reached": False,
+                "articles": [],
+            }
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_ingest_zenn(username="testuser")
+
+        assert "エラー=2件" in result
+
+    async def test_ingest_zenn_no_limit(self) -> None:
+        """no_limit パラメータが正しくサービスに渡されること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            return_value={
+                "articles_found": 100,
+                "articles_ingested": 100,
+                "chunks_stored": 500,
+                "errors": 0,
+                "dry_run": False,
+                "limit_reached": False,
+                "articles": [],
+            }
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            await rag_ingest_zenn(
+                username="testuser", no_limit=True,
+            )
+
+        mock_service.ingest_zenn.assert_called_once_with(
+            "testuser", dry_run=False, no_limit=True,
+        )
+
+    async def test_ingest_zenn_runtime_error(self) -> None:
+        """RuntimeError 時にエラーメッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            side_effect=RuntimeError("ZennIngester が設定されていません")
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_ingest_zenn(username="testuser")
+
+        assert "エラー:" in result
+        assert "ZennIngester" in result
+
+    async def test_ingest_zenn_unexpected_error(self) -> None:
+        """予期しないエラー時にエラーメッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.ingest_zenn = AsyncMock(
+            side_effect=Exception("unexpected error")
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_ingest_zenn(username="testuser")
+
+        assert "エラー:" in result
+        assert "testuser" in result
+
+
+# --- rag_add_zenn テスト ---
+
+
+class TestRagAddZennTool:
+    """MCP ツール rag_add_zenn のテスト."""
+
+    async def test_add_zenn_success(self) -> None:
+        """正常に記事を取り込めること."""
+        mock_service = MagicMock()
+        mock_service.add_zenn = AsyncMock(return_value=5)
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_add_zenn(slug="test-article")
+
+        assert "取り込みました" in result
+        assert "test-article" in result
+        assert "5チャンク" in result
+        mock_service.add_zenn.assert_called_once_with("test-article")
+
+    async def test_add_zenn_not_found(self) -> None:
+        """記事が見つからない場合にエラーメッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.add_zenn = AsyncMock(return_value=0)
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_add_zenn(slug="nonexistent")
+
+        assert "エラー:" in result
+        assert "nonexistent" in result
+
+    async def test_add_zenn_invalid_slug(self) -> None:
+        """不正な slug で ValueError メッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.add_zenn = AsyncMock(
+            side_effect=ValueError("不正な Zenn 記事 slug です")
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_add_zenn(slug="invalid slug")
+
+        assert "エラー:" in result
+        assert "不正な Zenn 記事 slug" in result
+
+    async def test_add_zenn_runtime_error(self) -> None:
+        """RuntimeError 時にエラーメッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.add_zenn = AsyncMock(
+            side_effect=RuntimeError("ZennIngester が設定されていません")
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_add_zenn(slug="test-article")
+
+        assert "エラー:" in result
+        assert "ZennIngester" in result
+
+    async def test_add_zenn_unexpected_error(self) -> None:
+        """予期しないエラー時にエラーメッセージが返されること."""
+        mock_service = MagicMock()
+        mock_service.add_zenn = AsyncMock(
+            side_effect=Exception("unexpected error")
+        )
+
+        with patch("rag.server._get_rag_service", return_value=mock_service):
+            result = await rag_add_zenn(slug="test-article")
+
+        assert "エラー:" in result
+        assert "test-article" in result


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- ZennIngester クラスを新規作成（`src/rag/ingesters/zenn.py`）。Zenn API を使った記事の一括・単体取り込み機能を実装
- 安全制約を実装: ページネーション上限（10ページ）、リクエスト間隔（1秒）、リトライ（3回指数バックオフ 1s/2s/4s）、タイムアウト（30秒）
- MCP ツール `rag_ingest_zenn`（一括取り込み）と `rag_add_zenn`（単体取り込み）を登録
- CLI コマンド `ingest-zenn`（`--dry-run`, `--no-limit` オプション付き）と `add-zenn` を登録
- `RAGKnowledgeService` に `ingest_zenn()`, `add_zenn()` メソッドを追加
- 関連ドキュメント更新: `rag-knowledge.md`（ツール数 6→8、コンポーネント追加）、`ARCHITECTURE.md`、`server.py` / `cli.py` docstring

## Test plan

- [x] pytest 485 テスト全通過（新規 50 テスト含む）
- [x] ruff lint 違反なし
- [x] mypy 型エラーなし（24 ソースファイル）
- [x] セルフコードレビュー完了（Critical/Warning 指摘対応済み）
- [x] ドキュメントレビュー完了（周辺ドキュメント整合性修正済み）

## Related issues

Closes #114