### PR TITLE
fix(rag-knowledge): PR #133 再レビュー指摘対応

### DIFF
--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -68,9 +68,9 @@ class RAGSettings(BaseSettings):
         default=0.75, ge=0.0, le=1.0
     )
 
-    # クロール（許容範囲は WebCrawler / ConstrainedClient でクランプされる）
-    rag_max_crawl_pages: int = Field(default=50, ge=1, le=500)
-    rag_crawl_delay_sec: float = Field(default=1.0, ge=0.5, le=60.0)
+    # クロール（範囲外の値は WebCrawler / ConstrainedClient が警告付きでクランプする）
+    rag_max_crawl_pages: int = Field(default=50, ge=1)
+    rag_crawl_delay_sec: float = Field(default=1.0, ge=0)
 
     # robots.txt
     rag_respect_robots_txt: bool = True

--- a/src/rag/safety/constrained_client.py
+++ b/src/rag/safety/constrained_client.py
@@ -113,7 +113,14 @@ class ConstrainedClient:
         return self._circuit_breaker
 
     async def __aenter__(self) -> ConstrainedClient:
-        """操作を開始する."""
+        """操作を開始する.
+
+        操作単位の状態（バジェット・サーキットブレーカー・レート制限）を
+        リセットし、新しい操作として開始する。
+        """
+        self._budget.reset()
+        self._circuit_breaker.reset()
+        self._last_request_time = 0.0
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self._request_timeout),
             headers=self._headers,

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -123,15 +123,18 @@ class TestIngestFromIndex:
         assert result["pages_crawled"] == 2
         assert result["chunks_stored"] >= 2
         assert result["errors"] == 0
-        # crawl_index_page は client= パラメータ付きで呼ばれる
+        # create_client() が呼ばれ、async context manager として使用されたこと
+        mock_web_crawler.create_client.assert_called_once()
+        mock_client = mock_web_crawler.create_client.return_value
+        # crawl_index_page に create_client() の同一インスタンスが渡されたこと
         mock_web_crawler.crawl_index_page.assert_called_once()
         call_args = mock_web_crawler.crawl_index_page.call_args
         assert call_args[0] == ("https://example.com/index", r"page\d")
-        assert "client" in call_args[1]  # client= kwarg が渡されている
-        # crawl_page が各URLに対して client= 付きで呼ばれたことを確認
+        assert call_args.kwargs["client"] is mock_client
+        # crawl_page が各URLに対して同一 client で呼ばれたことを確認
         assert mock_web_crawler.crawl_page.call_count == 2
         for call in mock_web_crawler.crawl_page.call_args_list:
-            assert "client" in call[1]
+            assert call.kwargs["client"] is mock_client
 
     async def test_ingest_from_index_with_errors(
         self,

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -57,6 +57,11 @@ def mock_web_crawler() -> MagicMock:
     mock.validate_url = MagicMock(side_effect=lambda url: url)
     # クロール間隔（進捗フィードバック機能で使用）
     mock._crawl_delay = 0.0  # テスト時は遅延なし
+    # create_client() が async context manager を返すようにモック
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock.create_client.return_value = mock_client
     return mock
 
 
@@ -122,8 +127,11 @@ class TestIngestFromIndex:
         mock_web_crawler.crawl_index_page.assert_called_once()
         call_args = mock_web_crawler.crawl_index_page.call_args
         assert call_args[0] == ("https://example.com/index", r"page\d")
-        # crawl_page が各URLに対して呼ばれたことを確認
+        assert "client" in call_args[1]  # client= kwarg が渡されている
+        # crawl_page が各URLに対して client= 付きで呼ばれたことを確認
         assert mock_web_crawler.crawl_page.call_count == 2
+        for call in mock_web_crawler.crawl_page.call_args_list:
+            assert "client" in call[1]
 
     async def test_ingest_from_index_with_errors(
         self,


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正

## Summary

PR #133（制約付き中間ライブラリ）の Copilot 再レビューで検出された 6 件の指摘に対応。

**即修正（3件）:**
- `tests/test_rag_knowledge.py`: `create_client` モックを async context manager 対応に修正、`client=` kwarg の検証追加
- `src/rag/config.py`: `Field(le=500, ge=0.5)` 等の制約を削除し、ランタイムクランプ（警告+継続）との矛盾を解消
- `src/rag/safety/constrained_client.py`: `__aenter__` で budget/circuit_breaker/last_request_time をリセットし、インスタンス使い回し時の状態持ち越しを防止

**Issue 化（3件）:**
- #134: test_safety.py のレート制限テストを疑似時間に変更
- #135: crawl_index_page のバジェット超過防止
- #132 に追記: 安全例外の明示的ハンドリング（同根の指摘）

## Test plan

- [x] pytest 全465テスト合格
- [x] ruff check 問題なし
- [x] mypy エラーなし

## Related issues

Closes #133 の再レビュー指摘