### PR TITLE
feat: crawl_index_page でバジェット残量に応じた URL 数制限 (#135)

### DIFF
--- a/src/rag/web_crawler.py
+++ b/src/rag/web_crawler.py
@@ -611,7 +611,9 @@ class WebCrawler:
             urls = allowed_urls
 
         # バジェット残量に基づいて URL 数を制限
-        # 後続の crawl_pages / crawl_preview が各 URL に 1 リクエスト使うため
+        # 共有 client が渡された場合、インデックスページ取得分を含む先行消費により
+        # budget.remaining < max_pages となりうる（例: max_requests=500 で
+        # インデックス取得後は remaining=499）
         budget_remaining = client.budget.remaining
         if len(urls) > budget_remaining:
             logger.info(

--- a/src/rag/web_crawler.py
+++ b/src/rag/web_crawler.py
@@ -610,6 +610,17 @@ class WebCrawler:
                 )
             urls = allowed_urls
 
+        # バジェット残量に基づいて URL 数を制限
+        # 後続の crawl_pages / crawl_preview が各 URL に 1 リクエスト使うため
+        budget_remaining = client.budget.remaining
+        if len(urls) > budget_remaining:
+            logger.info(
+                "バジェット残量に合わせて URL 数を制限: %d → %d",
+                len(urls),
+                budget_remaining,
+            )
+            urls = urls[:budget_remaining]
+
         return urls
 
     async def crawl_preview(

--- a/tests/test_web_crawler.py
+++ b/tests/test_web_crawler.py
@@ -13,6 +13,8 @@ import pytest
 
 from rag.web_crawler import CrawlPreviewPage, CrawledPage, RobotsChecker, WebCrawler
 
+# モック用: バジェット残量のデフォルト値（十分大きい値）
+DEFAULT_MOCK_BUDGET_REMAINING = 999
 
 # テスト用HTMLサンプル
 SAMPLE_HTML_WITH_ARTICLE = """
@@ -127,7 +129,7 @@ class MockConstrainedClient:
         self._raw_bytes = raw_bytes
         self._url_responses = url_responses or {}
         self.budget = MagicMock()
-        self.budget.remaining = 999  # デフォルト: 十分大きい値
+        self.budget.remaining = DEFAULT_MOCK_BUDGET_REMAINING  # デフォルト: 十分大きい値
         self.circuit_breaker = MagicMock()
 
     async def __aenter__(self) -> "MockConstrainedClient":
@@ -1037,7 +1039,7 @@ class MockRobotsConstrainedClient:
         self._page_html = page_html
         self._page_status = page_status
         self.budget = MagicMock()
-        self.budget.remaining = 999
+        self.budget.remaining = DEFAULT_MOCK_BUDGET_REMAINING
         self.circuit_breaker = MagicMock()
 
     async def __aenter__(self) -> "MockRobotsConstrainedClient":
@@ -1399,7 +1401,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
-                self.budget.remaining = 999
+                self.budget.remaining = DEFAULT_MOCK_BUDGET_REMAINING
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientForPreview":
@@ -1460,7 +1462,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
-                self.budget.remaining = 999
+                self.budget.remaining = DEFAULT_MOCK_BUDGET_REMAINING
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientForPattern":
@@ -1496,7 +1498,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
-                self.budget.remaining = 999
+                self.budget.remaining = DEFAULT_MOCK_BUDGET_REMAINING
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientWithTitleError":

--- a/tests/test_web_crawler.py
+++ b/tests/test_web_crawler.py
@@ -127,6 +127,7 @@ class MockConstrainedClient:
         self._raw_bytes = raw_bytes
         self._url_responses = url_responses or {}
         self.budget = MagicMock()
+        self.budget.remaining = 999  # デフォルト: 十分大きい値
         self.circuit_breaker = MagicMock()
 
     async def __aenter__(self) -> "MockConstrainedClient":
@@ -620,6 +621,24 @@ class TestWebCrawlerCrawlIndexPage:
 
         assert len(urls) <= 2
 
+    @pytest.mark.asyncio
+    async def test_crawl_index_page_limits_by_budget_remaining(self) -> None:
+        """バジェット残量に基づいて URL 数を制限すること."""
+        # SAMPLE_INDEX_HTML には同一ドメインリンクが 5 件あるが、
+        # バジェット残量 2 に制限される
+        crawler = WebCrawler(max_pages=500, respect_robots_txt=False)
+
+        mock_client = MockConstrainedClient(200, SAMPLE_INDEX_HTML)
+        mock_client.budget.remaining = 2
+
+        with patch.object(
+            crawler, "create_client",
+            return_value=mock_client,
+        ):
+            urls = await crawler.crawl_index_page("https://example.com/articles")
+
+        assert len(urls) == 2
+
 
 class TestWebCrawlerCrawlPage:
     """WebCrawler.crawl_page のテスト."""
@@ -1018,6 +1037,7 @@ class MockRobotsConstrainedClient:
         self._page_html = page_html
         self._page_status = page_status
         self.budget = MagicMock()
+        self.budget.remaining = 999
         self.circuit_breaker = MagicMock()
 
     async def __aenter__(self) -> "MockRobotsConstrainedClient":
@@ -1379,6 +1399,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
+                self.budget.remaining = 999
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientForPreview":
@@ -1439,6 +1460,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
+                self.budget.remaining = 999
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientForPattern":
@@ -1474,6 +1496,7 @@ class TestWebCrawlerCrawlPreview:
 
             def __init__(self) -> None:
                 self.budget = MagicMock()
+                self.budget.remaining = 999
                 self.circuit_breaker = MagicMock()
 
             async def __aenter__(self) -> "MockConstrainedClientWithTitleError":


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `_crawl_index_page_impl` でバジェット残量（`client.budget.remaining`）を確認し、URL 数が残量を超える場合は先頭から切り詰める
- テスト用モッククラス（`MockConstrainedClient` 系）に `budget.remaining = 999` を設定し、比較演算の TypeError を解消
- バジェット制限テスト `test_crawl_index_page_limits_by_budget_remaining` を追加

## Test plan

- [x] pytest 全466テスト合格
- [x] ruff check 合格
- [x] mypy 合格

## Related issues

Closes #135