### PR TITLE
feat: safe_browsing.py を ConstrainedClient 経由に移行し post() メソッド追加 (#131)

### DIFF
--- a/src/rag/safe_browsing.py
+++ b/src/rag/safe_browsing.py
@@ -17,7 +17,6 @@ import aiohttp
 
 if TYPE_CHECKING:
     from .config import RAGSettings
-    from .safety.constrained_client import ConstrainedClient
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +116,7 @@ class SafeBrowsingClient:
         client_id: str = "rag-knowledge",
         client_version: str = "1.0.0",
         max_cache_size: int | None = None,
-        constrained_client: ConstrainedClient | None = None,
+        constrained_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """SafeBrowsingClient を初期化する.
 
@@ -129,7 +128,8 @@ class SafeBrowsingClient:
             client_id: クライアント識別子
             client_version: クライアントバージョン
             max_cache_size: キャッシュの最大エントリ数（None の場合はデフォルト値を使用）
-            constrained_client: 制約付き HTTP クライアント（指定時は aiohttp 直接利用の代わりに使用）
+            constrained_client_kwargs: ConstrainedClient の生成パラメータ。
+                指定時は API 呼び出しごとに ConstrainedClient を都度生成する。
         """
         self._api_key = api_key
         self._timeout = aiohttp.ClientTimeout(total=timeout)
@@ -140,7 +140,7 @@ class SafeBrowsingClient:
         self._max_cache_size = max_cache_size if max_cache_size is not None else self.MAX_CACHE_SIZE
         self._cache: dict[str, CacheEntry] = {}
         self._cache_lock = asyncio.Lock()
-        self._constrained_client = constrained_client
+        self._cc_kwargs = constrained_client_kwargs
 
     def _get_cache_key(self, url: str) -> str:
         """URLからキャッシュキーを生成する."""
@@ -311,21 +311,28 @@ class SafeBrowsingClient:
 
     async def _call_api(self, urls: list[str]) -> dict[str, SafeBrowsingResult]:
         """Safe Browsing API を呼び出す."""
+        from .safety.constrained_client import ConstrainedClient
+
         request_body = self._build_request_body(urls)
 
-        if self._constrained_client is not None:
-            async with self._constrained_client as client:
+        if self._cc_kwargs is not None:
+            # 都度生成: 再入・並行利用による状態干渉を防ぐ
+            cc = ConstrainedClient(**self._cc_kwargs)
+            async with cc as client:
                 resp = await client.post(
                     self.API_URL,
                     params={"key": self._api_key},
                     json=request_body,
                 )
-                if resp.status != 200:
-                    error_text = await resp.text()
-                    raise RuntimeError(
-                        f"Safe Browsing API error: {resp.status} - {error_text}"
-                    )
-                response_data = await resp.json()
+                try:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        raise RuntimeError(
+                            f"Safe Browsing API error: {resp.status} - {error_text}"
+                        )
+                    response_data = await resp.json()
+                finally:
+                    resp.release()
         else:
             async with aiohttp.ClientSession(timeout=self._timeout) as session:
                 async with session.post(
@@ -390,8 +397,6 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
     Returns:
         SafeBrowsingClient または None（無効時）
     """
-    from .safety.constrained_client import ConstrainedClient
-
     if not settings.rag_url_safety_check:
         logger.debug("URL safety check is disabled")
         return None
@@ -407,16 +412,14 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
     if settings.rag_url_safety_cache_ttl > 0:
         cache_ttl = float(settings.rag_url_safety_cache_ttl)
 
-    constrained_client = ConstrainedClient(
-        request_timeout=settings.rag_url_safety_timeout,
-        max_requests=10,
-        circuit_breaker_threshold=3,
-    )
-
     return SafeBrowsingClient(
         api_key=settings.google_safe_browsing_api_key,
         timeout=settings.rag_url_safety_timeout,
         cache_ttl=cache_ttl,
         fail_open=settings.rag_url_safety_fail_open,
-        constrained_client=constrained_client,
+        constrained_client_kwargs={
+            "request_timeout": settings.rag_url_safety_timeout,
+            "max_requests": 10,
+            "circuit_breaker_threshold": 3,
+        },
     )

--- a/src/rag/safe_browsing.py
+++ b/src/rag/safe_browsing.py
@@ -17,6 +17,7 @@ import aiohttp
 
 if TYPE_CHECKING:
     from .config import RAGSettings
+    from .safety.constrained_client import ConstrainedClient
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +117,7 @@ class SafeBrowsingClient:
         client_id: str = "rag-knowledge",
         client_version: str = "1.0.0",
         max_cache_size: int | None = None,
+        constrained_client: ConstrainedClient | None = None,
     ) -> None:
         """SafeBrowsingClient を初期化する.
 
@@ -127,6 +129,7 @@ class SafeBrowsingClient:
             client_id: クライアント識別子
             client_version: クライアントバージョン
             max_cache_size: キャッシュの最大エントリ数（None の場合はデフォルト値を使用）
+            constrained_client: 制約付き HTTP クライアント（指定時は aiohttp 直接利用の代わりに使用）
         """
         self._api_key = api_key
         self._timeout = aiohttp.ClientTimeout(total=timeout)
@@ -137,6 +140,7 @@ class SafeBrowsingClient:
         self._max_cache_size = max_cache_size if max_cache_size is not None else self.MAX_CACHE_SIZE
         self._cache: dict[str, CacheEntry] = {}
         self._cache_lock = asyncio.Lock()
+        self._constrained_client = constrained_client
 
     def _get_cache_key(self, url: str) -> str:
         """URLからキャッシュキーを生成する."""
@@ -309,16 +313,30 @@ class SafeBrowsingClient:
         """Safe Browsing API を呼び出す."""
         request_body = self._build_request_body(urls)
 
-        async with aiohttp.ClientSession(timeout=self._timeout) as session:
-            async with session.post(
-                self.API_URL, params={"key": self._api_key}, json=request_body
-            ) as resp:
+        if self._constrained_client is not None:
+            async with self._constrained_client as client:
+                resp = await client.post(
+                    self.API_URL,
+                    params={"key": self._api_key},
+                    json=request_body,
+                )
                 if resp.status != 200:
                     error_text = await resp.text()
                     raise RuntimeError(
                         f"Safe Browsing API error: {resp.status} - {error_text}"
                     )
                 response_data = await resp.json()
+        else:
+            async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                async with session.post(
+                    self.API_URL, params={"key": self._api_key}, json=request_body
+                ) as resp:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        raise RuntimeError(
+                            f"Safe Browsing API error: {resp.status} - {error_text}"
+                        )
+                    response_data = await resp.json()
 
         return self._parse_response(response_data, urls)
 
@@ -372,6 +390,8 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
     Returns:
         SafeBrowsingClient または None（無効時）
     """
+    from .safety.constrained_client import ConstrainedClient
+
     if not settings.rag_url_safety_check:
         logger.debug("URL safety check is disabled")
         return None
@@ -387,9 +407,16 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
     if settings.rag_url_safety_cache_ttl > 0:
         cache_ttl = float(settings.rag_url_safety_cache_ttl)
 
+    constrained_client = ConstrainedClient(
+        request_timeout=settings.rag_url_safety_timeout,
+        max_requests=10,
+        circuit_breaker_threshold=3,
+    )
+
     return SafeBrowsingClient(
         api_key=settings.google_safe_browsing_api_key,
         timeout=settings.rag_url_safety_timeout,
         cache_ttl=cache_ttl,
         fail_open=settings.rag_url_safety_fail_open,
+        constrained_client=constrained_client,
     )

--- a/src/rag/safety/constrained_client.py
+++ b/src/rag/safety/constrained_client.py
@@ -161,6 +161,47 @@ class ConstrainedClient:
             if elapsed < self._request_interval:
                 await asyncio.sleep(self._request_interval - elapsed)
 
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        """セッションの存在を確認し返す.
+
+        Raises:
+            RuntimeError: context manager 外での呼び出し
+        """
+        if self._session is None:
+            raise RuntimeError(
+                "ConstrainedClient は async context manager として使用してください"
+            )
+        return self._session
+
+    async def _apply_constraints(self) -> None:
+        """全制約チェック（タイムアウト・サーキットブレーカー・レート制限・バジェット）を適用する.
+
+        Raises:
+            BudgetExhaustedError: バジェット上限到達
+            CircuitBreakerOpenError: サーキットブレーカー発動中
+            TimeoutError: 操作全体タイムアウト
+        """
+        # 操作全体タイムアウトチェック
+        self._check_operation_timeout()
+
+        # サーキットブレーカーチェック（発動中なら例外）
+        if self._circuit_breaker.is_open:
+            raise CircuitBreakerOpenError(
+                self._circuit_breaker.consecutive_failures,
+                self._circuit_breaker.threshold,
+            )
+
+        # レート制限待機（ロックで直列化）
+        async with self._rate_lock:
+            await self._wait_interval()
+            self._last_request_time = time.monotonic()
+
+        # レート制限待機後に操作タイムアウトを再チェック
+        self._check_operation_timeout()
+
+        # バジェット消費（実リクエスト直前で消費）
+        self._budget.consume()
+
     async def get(
         self,
         url: str,
@@ -190,35 +231,56 @@ class ConstrainedClient:
             TimeoutError: 操作全体タイムアウト
             RuntimeError: context manager 外での呼び出し
         """
-        if self._session is None:
-            raise RuntimeError(
-                "ConstrainedClient は async context manager として使用してください"
-            )
-
-        # 操作全体タイムアウトチェック
-        self._check_operation_timeout()
-
-        # サーキットブレーカーチェック（発動中なら例外）
-        if self._circuit_breaker.is_open:
-            raise CircuitBreakerOpenError(
-                self._circuit_breaker.consecutive_failures,
-                self._circuit_breaker.threshold,
-            )
-
-        # レート制限待機（ロックで直列化）
-        async with self._rate_lock:
-            await self._wait_interval()
-            self._last_request_time = time.monotonic()
-
-        # レート制限待機後に操作タイムアウトを再チェック
-        self._check_operation_timeout()
-
-        # バジェット消費（実リクエスト直前で消費）
-        self._budget.consume()
+        session = self._ensure_session()
+        await self._apply_constraints()
 
         try:
-            resp = await self._session.get(url, allow_redirects=allow_redirects)
+            resp = await session.get(url, allow_redirects=allow_redirects)
             # 成功 = HTTP レスポンスを受信できた（ステータスコードによらず）
+            self._circuit_breaker.record_success()
+            return resp
+        except Exception:
+            self._circuit_breaker.record_failure()
+            raise
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: object = None,
+        params: dict[str, str] | None = None,
+        allow_redirects: bool = False,
+    ) -> aiohttp.ClientResponse:
+        """POST リクエストを実行する.
+
+        GET と同じ制約（バジェット・サーキットブレーカー・レート制限・
+        操作タイムアウト）を適用する。
+
+        Args:
+            url: リクエスト先 URL
+            json: JSON ボディ
+            params: クエリパラメータ
+            allow_redirects: リダイレクト追従の有無（デフォルト: False、SSRF 対策）
+
+        Returns:
+            aiohttp.ClientResponse（使用後に release() で解放すること）
+
+        Raises:
+            BudgetExhaustedError: バジェット上限到達
+            CircuitBreakerOpenError: サーキットブレーカー発動中
+            TimeoutError: 操作全体タイムアウト
+            RuntimeError: context manager 外での呼び出し
+        """
+        session = self._ensure_session()
+        await self._apply_constraints()
+
+        try:
+            resp = await session.post(
+                url,
+                json=json,
+                params=params,
+                allow_redirects=allow_redirects,
+            )
             self._circuit_breaker.record_success()
             return resp
         except Exception:

--- a/tests/test_safe_browsing.py
+++ b/tests/test_safe_browsing.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from unittest.mock import AsyncMock
 
 from rag.safe_browsing import (
     CacheEntry,
@@ -525,8 +523,8 @@ class TestCreateSafeBrowsingClient:
         assert client is not None
         assert client._fail_open is False
 
-    def test_create_client_has_constrained_client(self) -> None:
-        """ファクトリ関数で ConstrainedClient が設定されること."""
+    def test_create_client_has_constrained_client_kwargs(self) -> None:
+        """ファクトリ関数で ConstrainedClient kwargs が設定されること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
         mock_settings.google_safe_browsing_api_key = "test-api-key"
@@ -536,8 +534,9 @@ class TestCreateSafeBrowsingClient:
 
         client = create_safe_browsing_client(mock_settings)
         assert client is not None
-        assert client._constrained_client is not None
-        assert isinstance(client._constrained_client, ConstrainedClient)
+        assert client._cc_kwargs is not None
+        assert client._cc_kwargs["request_timeout"] == 5.0
+        assert client._cc_kwargs["max_requests"] == 10
 
 
 class TestSafeBrowsingWithConstrainedClient:
@@ -546,16 +545,19 @@ class TestSafeBrowsingWithConstrainedClient:
     @pytest.mark.asyncio
     async def test_call_api_via_constrained_client(self) -> None:
         """ConstrainedClient 経由で API が呼び出されること."""
-        cc = ConstrainedClient(request_timeout=5.0, request_interval=0.5)
         client = SafeBrowsingClient(
             api_key="test-key",
-            constrained_client=cc,
+            constrained_client_kwargs={
+                "request_timeout": 5.0,
+                "request_interval": 0.5,
+            },
         )
 
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.json = AsyncMock(return_value={})
         mock_resp.text = AsyncMock(return_value="")
+        mock_resp.release = MagicMock()
 
         with patch.object(
             ConstrainedClient,
@@ -569,14 +571,17 @@ class TestSafeBrowsingWithConstrainedClient:
             assert call_kwargs.kwargs["params"] == {"key": "test-key"}
 
         assert result.is_safe is True
+        mock_resp.release.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_call_api_via_constrained_client_error(self) -> None:
         """ConstrainedClient 経由でのエラーが fail-open で処理されること."""
-        cc = ConstrainedClient(request_timeout=5.0, request_interval=0.5)
         client = SafeBrowsingClient(
             api_key="test-key",
-            constrained_client=cc,
+            constrained_client_kwargs={
+                "request_timeout": 5.0,
+                "request_interval": 0.5,
+            },
             fail_open=True,
         )
 
@@ -584,6 +589,7 @@ class TestSafeBrowsingWithConstrainedClient:
         mock_resp.status = 500
         mock_resp.json = AsyncMock(return_value={"error": "Server Error"})
         mock_resp.text = AsyncMock(return_value="Server Error")
+        mock_resp.release = MagicMock()
 
         with patch.object(
             ConstrainedClient,
@@ -595,3 +601,5 @@ class TestSafeBrowsingWithConstrainedClient:
 
         assert result.is_safe is True
         assert result.error is not None
+        # エラー時でも release が呼ばれること
+        mock_resp.release.assert_called_once()

--- a/tests/test_safe_browsing.py
+++ b/tests/test_safe_browsing.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from unittest.mock import AsyncMock
+
 from rag.safe_browsing import (
     CacheEntry,
     SafeBrowsingClient,
@@ -19,6 +21,7 @@ from rag.safe_browsing import (
     ThreatType,
     create_safe_browsing_client,
 )
+from rag.safety.constrained_client import ConstrainedClient
 
 
 class MockResponse:
@@ -521,3 +524,74 @@ class TestCreateSafeBrowsingClient:
         client = create_safe_browsing_client(mock_settings)
         assert client is not None
         assert client._fail_open is False
+
+    def test_create_client_has_constrained_client(self) -> None:
+        """ファクトリ関数で ConstrainedClient が設定されること."""
+        mock_settings = MagicMock()
+        mock_settings.rag_url_safety_check = True
+        mock_settings.google_safe_browsing_api_key = "test-api-key"
+        mock_settings.rag_url_safety_cache_ttl = 300
+        mock_settings.rag_url_safety_fail_open = True
+        mock_settings.rag_url_safety_timeout = 5.0
+
+        client = create_safe_browsing_client(mock_settings)
+        assert client is not None
+        assert client._constrained_client is not None
+        assert isinstance(client._constrained_client, ConstrainedClient)
+
+
+class TestSafeBrowsingWithConstrainedClient:
+    """ConstrainedClient 経由での SafeBrowsingClient テスト."""
+
+    @pytest.mark.asyncio
+    async def test_call_api_via_constrained_client(self) -> None:
+        """ConstrainedClient 経由で API が呼び出されること."""
+        cc = ConstrainedClient(request_timeout=5.0, request_interval=0.5)
+        client = SafeBrowsingClient(
+            api_key="test-key",
+            constrained_client=cc,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={})
+        mock_resp.text = AsyncMock(return_value="")
+
+        with patch.object(
+            ConstrainedClient,
+            "post",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ) as mock_post:
+            result = await client.check_url("https://safe-site.com")
+            mock_post.assert_called_once()
+            call_kwargs = mock_post.call_args
+            assert call_kwargs.kwargs["params"] == {"key": "test-key"}
+
+        assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_call_api_via_constrained_client_error(self) -> None:
+        """ConstrainedClient 経由でのエラーが fail-open で処理されること."""
+        cc = ConstrainedClient(request_timeout=5.0, request_interval=0.5)
+        client = SafeBrowsingClient(
+            api_key="test-key",
+            constrained_client=cc,
+            fail_open=True,
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status = 500
+        mock_resp.json = AsyncMock(return_value={"error": "Server Error"})
+        mock_resp.text = AsyncMock(return_value="Server Error")
+
+        with patch.object(
+            ConstrainedClient,
+            "post",
+            new_callable=AsyncMock,
+            return_value=mock_resp,
+        ):
+            result = await client.check_url("https://test-site.com")
+
+        assert result.is_safe is True
+        assert result.error is not None

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -327,3 +327,58 @@ class TestConstrainedClient:
                 mock_get.assert_called_once_with(
                     "http://example.com", allow_redirects=False
                 )
+
+    @pytest.mark.asyncio
+    async def test_post_applies_constraints(self) -> None:
+        """POST でもバジェット・サーキットブレーカー等の制約が適用される."""
+        cc = ConstrainedClient(
+            max_requests=2,
+            request_interval=0.5,
+            request_timeout=5.0,
+        )
+        mock_resp = MagicMock(spec=aiohttp.ClientResponse)
+
+        async with cc:
+            with patch.object(cc._session, "post", new_callable=AsyncMock, return_value=mock_resp) as mock_post:
+                await cc.post("http://example.com/api", json={"key": "value"}, params={"q": "test"})
+                mock_post.assert_called_once_with(
+                    "http://example.com/api",
+                    json={"key": "value"},
+                    params={"q": "test"},
+                    allow_redirects=False,
+                )
+                assert cc.budget.used == 1
+
+                await cc.post("http://example.com/api2")
+                with pytest.raises(BudgetExhaustedError):
+                    await cc.post("http://example.com/api3")
+
+    @pytest.mark.asyncio
+    async def test_post_without_context_manager_raises(self) -> None:
+        """context manager 外での POST 呼び出しで RuntimeError."""
+        cc = ConstrainedClient()
+        with pytest.raises(RuntimeError, match="context manager"):
+            await cc.post("http://example.com")
+
+    @pytest.mark.asyncio
+    async def test_post_circuit_breaker(self) -> None:
+        """POST でもサーキットブレーカーが機能する."""
+        cc = ConstrainedClient(
+            circuit_breaker_threshold=2,
+            request_interval=0.5,
+            request_timeout=5.0,
+            max_requests=100,
+        )
+
+        async with cc:
+            with patch.object(
+                cc._session,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=aiohttp.ClientError("connection failed"),
+            ):
+                with pytest.raises(aiohttp.ClientError):
+                    await cc.post("http://example.com/1")
+
+                with pytest.raises(CircuitBreakerOpenError):
+                    await cc.post("http://example.com/2")


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `ConstrainedClient` に `post()` メソッドを追加（GET と同じ制約を適用）
- `get()` と `post()` の共通制約チェックロジックを `_apply_constraints()` / `_ensure_session()` に抽出
- `SafeBrowsingClient` に `constrained_client` パラメータを追加し、指定時は `ConstrainedClient` 経由で API を呼び出す
- `create_safe_browsing_client` ファクトリで `ConstrainedClient` を自動生成・注入
- `ConstrainedClient.post()` のユニットテスト（バジェット消費・サーキットブレーカー・context manager チェック）を追加
- `SafeBrowsingClient` の `ConstrainedClient` 経由テスト（正常系・エラー系）を追加

## Test plan

- [x] pytest 全471テスト合格
- [x] ruff check 合格
- [x] mypy 合格

## Related issues

Closes #131