### PR TITLE
refactor(rag-knowledge): _ingest_content を公開 API に変更 (#164)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ reports/
 # Claude Code local settings
 .claude/settings.local.json
 .claude/*.lock
+scheduled_tasks.lock

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -326,7 +326,7 @@ class RAGKnowledgeService:
 
         for content in contents:
             try:
-                chunks_stored = await self._ingest_content(content)
+                chunks_stored = await self.ingest_content(content)
                 total_chunks += chunks_stored
             except Exception:
                 logger.exception("Failed to ingest content: %s", content.source_id)
@@ -487,7 +487,7 @@ class RAGKnowledgeService:
             content = await self._web_ingester.fetch_single(url)
             if content is None:
                 return 0
-            return await self._ingest_content(content)
+            return await self.ingest_content(content)
 
         # レガシーパス（WebIngester 未設定時）
         # URL検証を先に行い、失敗時は例外を投げる（ユーザーにエラー理由を伝えるため）
@@ -584,7 +584,7 @@ class RAGKnowledgeService:
         logger.info("Ingested page %s: %d chunks", normalized_url, count)
         return count
 
-    async def _ingest_content(self, content: IngestedContent) -> int:
+    async def ingest_content(self, content: IngestedContent) -> int:
         """IngestedContent をチャンキングして保存する.
 
         Args:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -414,7 +414,7 @@ async def rag_crawl_zenn(username: str, max_articles: int | None = None) -> str:
                     if content is None:
                         skipped += 1
                         continue
-                    chunks = await service._ingest_content(content)
+                    chunks = await service.ingest_content(content)
                     total_chunks += chunks
                     ingested_count += 1
                 except Exception:

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -547,7 +547,7 @@ class TestRAGServiceWithWebIngester:
         mock_vector_store: MagicMock,
         mock_web_crawler_for_service: MagicMock,
     ) -> None:
-        """_ingest_content() がチャンキング・保存を行うこと."""
+        """ingest_content() がチャンキング・保存を行うこと."""
         mock_vector_store.add_documents.return_value = 1
 
         service = RAGKnowledgeService(
@@ -566,7 +566,7 @@ class TestRAGServiceWithWebIngester:
             source_type="web",
         )
 
-        result = await service._ingest_content(content)
+        result = await service.ingest_content(content)
 
         assert result == 1
         mock_vector_store.add_documents.assert_called_once()
@@ -594,7 +594,7 @@ class TestRAGServiceWithWebIngester:
             source_type="web",
         )
 
-        result = await service._ingest_content(content)
+        result = await service.ingest_content(content)
         assert result == 0
         mock_vector_store.add_documents.assert_not_called()
 
@@ -603,7 +603,7 @@ class TestRAGServiceWithWebIngester:
         mock_vector_store: MagicMock,
         mock_web_crawler_for_service: MagicMock,
     ) -> None:
-        """_ingest_content() がフラグメント付き URL を正規化すること."""
+        """ingest_content() がフラグメント付き URL を正規化すること."""
         import hashlib
 
         mock_vector_store.add_documents.return_value = 1
@@ -624,7 +624,7 @@ class TestRAGServiceWithWebIngester:
             source_type="web",
         )
 
-        await service._ingest_content(content)
+        await service.ingest_content(content)
 
         # add_documents に渡されたチャンクを検証
         call_args = mock_vector_store.add_documents.call_args[0][0]


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `RAGKnowledgeService._ingest_content()` を公開メソッド `ingest_content()` にリネーム
- `server.py` の `rag_crawl_zenn` ツールからプライベートメソッドへの依存を解消
- 内部呼び出し（`rag_knowledge.py` 2箇所）、外部呼び出し（`server.py` 1箇所）、テスト（`test_ingesters.py` 3箇所 + docstring 2箇所）を一括更新

## Test plan

- [x] pytest 65件 pass（test_ingesters.py 26件 + test_rag_knowledge.py 39件）
- [x] ruff check 違反なし
- [x] mypy 型エラーなし
- [x] コードレビュー 指摘なし

## Related issues

Closes #164