### PR TITLE
test(zenn-ingester): RAGSettings バリデーションテストと rag_crawl_zenn パラメータ伝播テストを追加 (#168)

### DIFF
--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -1,0 +1,123 @@
+"""RAGSettings のバリデーションテスト.
+
+Issue: #168
+
+テスト方針:
+- Zenn インジェスター設定項目のデフォルト値・許容範囲・境界値を検証
+- 環境変数からの読み込みを検証
+- pydantic ValidationError の発生を検証
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from rag.config import RAGSettings
+
+
+def _make_settings(**overrides: object) -> RAGSettings:
+    """テスト用 RAGSettings を生成する（.env を読み込まない）."""
+    return RAGSettings(_env_file=None, **overrides)  # type: ignore[call-arg]
+
+
+# --- Zenn インジェスター: rag_zenn_max_articles ---
+
+
+class TestZennMaxArticles:
+    """rag_zenn_max_articles のバリデーションテスト."""
+
+    def test_default_value(self) -> None:
+        """デフォルト値が 50 であること."""
+        settings = _make_settings()
+        assert settings.rag_zenn_max_articles == 50
+
+    def test_valid_value(self) -> None:
+        """許容範囲内の値が設定できること."""
+        settings = _make_settings(rag_zenn_max_articles=1)
+        assert settings.rag_zenn_max_articles == 1
+
+        settings = _make_settings(rag_zenn_max_articles=100)
+        assert settings.rag_zenn_max_articles == 100
+
+    def test_below_minimum(self) -> None:
+        """下限未満でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_max_articles=0)
+
+    def test_above_maximum(self) -> None:
+        """上限超過でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_max_articles=101)
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """環境変数から読み込めること."""
+        monkeypatch.setenv("RAG_ZENN_MAX_ARTICLES", "75")
+        settings = _make_settings()
+        assert settings.rag_zenn_max_articles == 75
+
+
+# --- Zenn インジェスター: rag_zenn_request_timeout ---
+
+
+class TestZennRequestTimeout:
+    """rag_zenn_request_timeout のバリデーションテスト."""
+
+    def test_default_value(self) -> None:
+        """デフォルト値が 30 であること."""
+        settings = _make_settings()
+        assert settings.rag_zenn_request_timeout == 30
+
+    def test_valid_range(self) -> None:
+        """許容範囲の境界値が設定できること."""
+        settings = _make_settings(rag_zenn_request_timeout=1)
+        assert settings.rag_zenn_request_timeout == 1
+
+        settings = _make_settings(rag_zenn_request_timeout=120)
+        assert settings.rag_zenn_request_timeout == 120
+
+    def test_below_minimum(self) -> None:
+        """下限未満でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_request_timeout=0)
+
+    def test_above_maximum(self) -> None:
+        """上限超過でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_request_timeout=121)
+
+
+# --- Zenn インジェスター: rag_zenn_request_interval ---
+
+
+class TestZennRequestInterval:
+    """rag_zenn_request_interval のバリデーションテスト."""
+
+    def test_default_value(self) -> None:
+        """デフォルト値が 1.0 であること."""
+        settings = _make_settings()
+        assert settings.rag_zenn_request_interval == 1.0
+
+    def test_valid_range(self) -> None:
+        """許容範囲の境界値が設定できること."""
+        settings = _make_settings(rag_zenn_request_interval=0.1)
+        assert settings.rag_zenn_request_interval == 0.1
+
+        settings = _make_settings(rag_zenn_request_interval=60.0)
+        assert settings.rag_zenn_request_interval == 60.0
+
+    def test_below_minimum(self) -> None:
+        """下限未満でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_request_interval=0.05)
+
+    def test_above_maximum(self) -> None:
+        """上限超過でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_zenn_request_interval=60.1)
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """環境変数から float として読み込めること."""
+        monkeypatch.setenv("RAG_ZENN_REQUEST_INTERVAL", "0.5")
+        settings = _make_settings()
+        assert settings.rag_zenn_request_interval == 0.5

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -15,6 +15,19 @@ from pydantic import ValidationError
 
 from rag.config import RAGSettings
 
+_ZENN_ENV_VARS = [
+    "RAG_ZENN_MAX_ARTICLES",
+    "RAG_ZENN_REQUEST_TIMEOUT",
+    "RAG_ZENN_REQUEST_INTERVAL",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_zenn_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """テスト間で Zenn 関連の環境変数をクリアする."""
+    for var in _ZENN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 def _make_settings(**overrides: object) -> RAGSettings:
     """テスト用 RAGSettings を生成する（.env を読み込まない）."""
@@ -85,6 +98,12 @@ class TestZennRequestTimeout:
         """上限超過でバリデーションエラーになること."""
         with pytest.raises(ValidationError):
             _make_settings(rag_zenn_request_timeout=121)
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """環境変数から読み込めること."""
+        monkeypatch.setenv("RAG_ZENN_REQUEST_TIMEOUT", "60")
+        settings = _make_settings()
+        assert settings.rag_zenn_request_timeout == 60
 
 
 # --- Zenn インジェスター: rag_zenn_request_interval ---

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1032,8 +1032,13 @@ class TestRagCrawlZennTool:
         """空のユーザー名でエラーメッセージを返すこと."""
         mod = import_module("rag.server")
         mock_service = AsyncMock()
+        mock_settings = MagicMock()
+        mock_settings.rag_zenn_max_articles = 50
 
-        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+        with (
+            patch.object(mod, "_get_rag_service", return_value=mock_service),
+            patch.object(mod, "get_settings", return_value=mock_settings),
+        ):
             result = await mod.rag_crawl_zenn("")
 
         assert "エラー" in result

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -986,3 +986,71 @@ class TestRagStatsOutput:
             result = await mod.rag_stats()
 
         assert "(タイトル取得不可)" in result
+
+
+class TestRagCrawlZennTool:
+    """rag_crawl_zenn ツールのテスト（#168）."""
+
+    @pytest.mark.asyncio
+    async def test_constrained_client_receives_settings(self) -> None:
+        """ConstrainedClient に設定値が正しく渡されること."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_service.ingest_content = AsyncMock(return_value=5)
+        mock_settings = MagicMock()
+        mock_settings.rag_zenn_max_articles = 50
+        mock_settings.rag_zenn_request_timeout = 15
+        mock_settings.rag_zenn_request_interval = 0.3
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.get = AsyncMock(
+            return_value=MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"articles": [], "next_page": None}),
+            )
+        )
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(
+            return_value=mock_client_instance
+        )
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(mod, "_get_rag_service", return_value=mock_service),
+            patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod, "ConstrainedClient", mock_client_cls),
+        ):
+            await mod.rag_crawl_zenn("testuser")
+
+        mock_client_cls.assert_called_once_with(
+            request_timeout=15,
+            request_interval=0.3,
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_username_returns_error(self) -> None:
+        """空のユーザー名でエラーメッセージを返すこと."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+
+        with patch.object(mod, "_get_rag_service", return_value=mock_service):
+            result = await mod.rag_crawl_zenn("")
+
+        assert "エラー" in result
+        assert "username" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_articles_returns_error(self) -> None:
+        """不正な max_articles でエラーメッセージを返すこと."""
+        mod = import_module("rag.server")
+        mock_service = AsyncMock()
+        mock_settings = MagicMock()
+        mock_settings.rag_zenn_max_articles = 50
+
+        with (
+            patch.object(mod, "_get_rag_service", return_value=mock_service),
+            patch.object(mod, "get_settings", return_value=mock_settings),
+        ):
+            result = await mod.rag_crawl_zenn("testuser", max_articles=-1)
+
+        assert "エラー" in result


### PR DESCRIPTION
## Change type

- [x] test: テスト追加・修正

## Summary

- `test_rag_config.py` 新規作成: Zenn インジェスター設定項目（max_articles, request_timeout, request_interval）のデフォルト値・境界値・環境変数読み込みテスト（14件）
- `test_rag_mcp_server.py` に `TestRagCrawlZennTool` 追加: ConstrainedClient へのパラメータ伝播・入力バリデーションテスト（3件）

## Test plan

- [x] pytest 50件 pass（新規14件 + 既存36件）
- [x] ruff check 違反なし
- [x] mypy 型エラーなし

## Related issues

Closes #168