### PR TITLE
fix(zenn-ingester): テキスト抽出を markdownify による Markdown 形式に変更

### DIFF
--- a/docs/specs/zenn-ingester.md
+++ b/docs/specs/zenn-ingester.md
@@ -207,7 +207,7 @@ flowchart TD
     CHECK_NEXT{"next_page が null?"}
     CHECK_LIMIT{"走査上限 or 記事数上限?"}
     FETCH["各記事の詳細を取得"]
-    CONVERT["HTML → テキスト変換"]
+    CONVERT["HTML → Markdown 変換"]
     INGEST["チャンキング・ベクトル保存"]
     RESULT["結果サマリーを返却"]
 
@@ -242,7 +242,7 @@ flowchart TD
 
 1. 記事詳細 API（`/api/articles/{slug}`）にリクエストを送信する
 2. レスポンスから `body_html` を取得する
-3. HTML からテキストを抽出する（HTML タグの除去）
+3. HTML から Markdown 形式のテキストを抽出する（markdownify による HTML→Markdown 変換。Web クローラーと共通のカスタム Markdown コンバーターを使用し、リンク URL・画像 URL を除去してテキスト情報のみを保持する）
 4. IngestedContent を構築して返す:
    - `source_id`: `https://zenn.dev{path}`（記事の公開 URL。`path` は `/username/articles/slug` 形式で先頭 `/` を含むため、ホスト名の末尾に `/` を付けない）
    - `title`: 記事タイトル

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 
 from bs4 import BeautifulSoup
 
+from ..web_crawler import _RagMarkdownConverter
 from .base import BaseIngester, IngestedContent
 
 if TYPE_CHECKING:
@@ -100,6 +101,12 @@ class ZennIngester(BaseIngester):
         """
         self._client = client
         self._max_articles = _validate_max_articles(max_articles)
+        self._md_converter = _RagMarkdownConverter(
+            heading_style="ATX",
+            table_infer_header=True,
+            escape_underscores=False,
+            escape_asterisks=False,
+        )
 
     def validate_identifier(self, identifier: str) -> str:
         """slug を検証し、正規化済みの slug を返す.
@@ -283,7 +290,7 @@ class ZennIngester(BaseIngester):
             logger.warning("Empty body_html for article: %s", slug)
             return None
 
-        # HTML からテキストを抽出
+        # HTML から Markdown 形式のテキストを抽出
         text = self._extract_text_from_html(body_html)
         if not text.strip():
             logger.warning("No text extracted from article: %s", slug)
@@ -342,15 +349,17 @@ class ZennIngester(BaseIngester):
             metadata=metadata,
         )
 
-    @staticmethod
-    def _extract_text_from_html(html: str) -> str:
-        """HTML からテキストを抽出する.
+    def _extract_text_from_html(self, html: str) -> str:
+        """HTML から Markdown 形式のテキストを抽出する.
+
+        markdownify を使用して HTML→Markdown 変換を行い、
+        見出し・テーブル等の構造情報を保持する。
 
         Args:
             html: HTML 文字列
 
         Returns:
-            抽出されたテキスト
+            Markdown 形式のテキスト
         """
         soup = BeautifulSoup(html, "html.parser")
 
@@ -359,8 +368,12 @@ class ZennIngester(BaseIngester):
             for tag in soup.find_all(tag_name):
                 tag.decompose()
 
-        text = soup.get_text(separator="\n")
+        # HTML→Markdown変換
+        markdown_text = self._md_converter.convert_soup(soup)
 
-        # 連続する空白行を整理
+        # クリーンアップ
+        # 行末空白を除去（空白のみの行も空行に正規化）
+        text = re.sub(r"[ \t]+\n", "\n", markdown_text)
+        # 連続する空白行を1つにまとめる
         text = re.sub(r"\n{3,}", "\n\n", text)
         return text.strip()

--- a/tests/test_zenn_ingester.py
+++ b/tests/test_zenn_ingester.py
@@ -435,7 +435,7 @@ class TestZennIngesterFetchSingle:
     async def test_fetch_single_html_extraction(
         self, ingester: ZennIngester, mock_client: MagicMock
     ) -> None:
-        """HTML タグが正しく除去されること."""
+        """HTML が Markdown 形式に変換され、不要タグが除去されること."""
         mock_client.get.return_value = _make_article_detail_response(
             body_html=(
                 "<h1>Title</h1>"
@@ -451,9 +451,52 @@ class TestZennIngesterFetchSingle:
         assert result is not None
         assert "alert" not in result.text
         assert ".hidden" not in result.text
-        assert "Title" in result.text
+        # 見出しが Markdown 形式で保持されること
+        assert "# Title" in result.text
         assert "Paragraph 1" in result.text
         assert "Paragraph 2" in result.text
+
+    async def test_fetch_single_markdown_heading_structure(
+        self, ingester: ZennIngester, mock_client: MagicMock
+    ) -> None:
+        """複数レベルの Markdown 見出し構造が保持されること."""
+        mock_client.get.return_value = _make_article_detail_response(
+            body_html=(
+                "<h2>Section 1</h2>"
+                "<p>Content of section 1</p>"
+                "<h2>Section 2</h2>"
+                "<p>Content of section 2</p>"
+                "<h3>Subsection 2.1</h3>"
+                "<p>Content of subsection 2.1</p>"
+            ),
+        )
+
+        result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert "## Section 1" in result.text
+        assert "## Section 2" in result.text
+        assert "### Subsection 2.1" in result.text
+
+    async def test_fetch_single_markdown_table_structure(
+        self, ingester: ZennIngester, mock_client: MagicMock
+    ) -> None:
+        """テーブル構造が Markdown 形式で保持されること."""
+        mock_client.get.return_value = _make_article_detail_response(
+            body_html=(
+                "<table>"
+                "<thead><tr><th>Name</th><th>Value</th></tr></thead>"
+                "<tbody><tr><td>A</td><td>1</td></tr></tbody>"
+                "</table>"
+            ),
+        )
+
+        result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert "| Name | Value |" in result.text
+        assert "| --- | --- |" in result.text
+        assert "| A | 1 |" in result.text
 
     async def test_fetch_single_topics_parsing(
         self, ingester: ZennIngester, mock_client: MagicMock

--- a/tests/test_zenn_ingester.py
+++ b/tests/test_zenn_ingester.py
@@ -498,6 +498,45 @@ class TestZennIngesterFetchSingle:
         assert "| --- | --- |" in result.text
         assert "| A | 1 |" in result.text
 
+    async def test_fetch_single_markdown_link_url_removal(
+        self, ingester: ZennIngester, mock_client: MagicMock
+    ) -> None:
+        """リンク URL が除去され、テキストのみ保持されること."""
+        mock_client.get.return_value = _make_article_detail_response(
+            body_html=(
+                "<p>See <a href=\"https://example.com/page\">this link</a> for details.</p>"
+                "<p>Visit <a href=\"https://example.com/other\">example site</a>.</p>"
+            ),
+        )
+
+        result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert "this link" in result.text
+        assert "example site" in result.text
+        assert "https://example.com/page" not in result.text
+        assert "https://example.com/other" not in result.text
+
+    async def test_fetch_single_markdown_image_url_removal(
+        self, ingester: ZennIngester, mock_client: MagicMock
+    ) -> None:
+        """画像 URL が除去され、alt テキストのみ保持されること."""
+        mock_client.get.return_value = _make_article_detail_response(
+            body_html=(
+                "<p>Here is an image:</p>"
+                '<img src="https://example.com/image.png" alt="example image">'
+                "<p>And another:</p>"
+                '<img src="https://example.com/photo.jpg" alt="">'
+            ),
+        )
+
+        result = await ingester.fetch_single("test-article")
+
+        assert result is not None
+        assert "example image" in result.text
+        assert "https://example.com/image.png" not in result.text
+        assert "https://example.com/photo.jpg" not in result.text
+
     async def test_fetch_single_topics_parsing(
         self, ingester: ZennIngester, mock_client: MagicMock
     ) -> None:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `_extract_text_from_html` の実装を `BeautifulSoup.get_text()` から `markdownify` に変更し、見出し・テーブル等の構造情報を Markdown 形式で保持するようにした
- Web クローラーと同じカスタム Markdown コンバーター（`_RagMarkdownConverter`）を再利用し、リンク URL・画像 URL を除去してテキスト情報のみを保持
- テストに見出し構造保持・テーブル構造保持の検証を追加（38 tests all pass）
- 仕様書の処理手順・フローチャートを Markdown 変換に更新

## Test plan

- [x] `pytest tests/test_zenn_ingester.py -v` — 38 passed
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] 見出し構造（h2/h3）が `## / ###` として保持されることを確認
- [x] テーブル構造が Markdown テーブル形式で保持されることを確認
- [x] script/style タグが除去されることを確認

## Related issues

Closes #172