### PR TITLE
refactor: _RagMarkdownConverter を共有モジュールに切り出す (#179)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,6 +31,7 @@
 | `src/rag/cli.py` | CLI エントリーポイント（評価・DB 初期化） |
 | `src/rag/config.py` | pydantic-settings による環境変数・設定管理 |
 | `src/rag/rag_knowledge.py` | ナレッジサービス（取り込み・検索・削除のオーケストレーション） |
+| `src/rag/markdown.py` | RAG 用 Markdown コンバーター（リンク・画像 URL 除去） |
 | `src/rag/web_crawler.py` | Web クローラー（ページ取得・本文抽出・SSRF 対策・robots.txt 遵守） |
 | `src/rag/vector_store.py` | ベクトルストア（ChromaDB による Embedding 格納・検索） |
 | `src/rag/bm25_index.py` | BM25 インデックス（日本語形態素解析・ディスク永続化） |

--- a/src/rag/ingesters/zenn.py
+++ b/src/rag/ingesters/zenn.py
@@ -13,7 +13,7 @@ from urllib.parse import urlencode
 
 from bs4 import BeautifulSoup
 
-from ..web_crawler import _RagMarkdownConverter
+from ..markdown import RagMarkdownConverter
 from .base import BaseIngester, IngestedContent
 
 if TYPE_CHECKING:
@@ -101,7 +101,7 @@ class ZennIngester(BaseIngester):
         """
         self._client = client
         self._max_articles = _validate_max_articles(max_articles)
-        self._md_converter = _RagMarkdownConverter(
+        self._md_converter = RagMarkdownConverter(
             heading_style="ATX",
             table_infer_header=True,
             escape_underscores=False,

--- a/src/rag/markdown.py
+++ b/src/rag/markdown.py
@@ -1,0 +1,28 @@
+"""RAG用Markdownコンバーター
+
+仕様: docs/specs/rag-knowledge.md
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from markdownify import MarkdownConverter
+
+
+class RagMarkdownConverter(MarkdownConverter):  # type: ignore[misc]
+    """RAG用カスタムMarkdownコンバーター.
+
+    リンクURLと画像URLを除去し、テキスト情報のみを保持する。
+    RAGではリンク先URLはチャンクサイズの無駄遣いとなり、
+    出典情報は source_url メタデータで管理するため不要。
+    """
+
+    def convert_a(self, el: Any, text: str, convert_as_inline: bool) -> str:
+        """リンクはテキストのみ保持（URLは出典管理で別途管理）."""
+        return text or ""
+
+    def convert_img(self, el: Any, text: str, convert_as_inline: bool) -> str:
+        """画像タグはalt属性のみ保持（RAGでは画像不要）."""
+        alt: str = el.attrs.get("alt", None) or ""
+        return alt

--- a/src/rag/web_crawler.py
+++ b/src/rag/web_crawler.py
@@ -14,19 +14,18 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from urllib.parse import urldefrag, urljoin, urlparse
-from typing import Any
 from urllib.robotparser import RobotFileParser
 
 import httpx
 from bs4 import BeautifulSoup
 from charset_normalizer import from_bytes
-from markdownify import MarkdownConverter
-
 from py_common_lib.httpx import (
     ConstrainedClient,
     clamp_request_interval,
     clamp_request_timeout,
 )
+
+from .markdown import RagMarkdownConverter
 
 logger = logging.getLogger(__name__)
 
@@ -43,24 +42,6 @@ class _RobotsCacheEntry:
     parser: RobotFileParser
     fetched_at: float
     crawl_delay: float | None = field(default=None)
-
-
-class _RagMarkdownConverter(MarkdownConverter):  # type: ignore[misc]
-    """RAG用カスタムMarkdownコンバーター.
-
-    リンクURLと画像URLを除去し、テキスト情報のみを保持する。
-    RAGではリンク先URLはチャンクサイズの無駄遣いとなり、
-    出典情報は source_url メタデータで管理するため不要。
-    """
-
-    def convert_a(self, el: Any, text: str, convert_as_inline: bool) -> str:
-        """リンクはテキストのみ保持（URLは出典管理で別途管理）."""
-        return text or ""
-
-    def convert_img(self, el: Any, text: str, convert_as_inline: bool) -> str:
-        """画像タグはalt属性のみ保持（RAGでは画像不要）."""
-        alt: str = el.attrs.get("alt", None) or ""
-        return alt
 
 
 @dataclass
@@ -276,7 +257,7 @@ class WebCrawler:
             if respect_robots_txt
             else None
         )
-        self._md_converter = _RagMarkdownConverter(
+        self._md_converter = RagMarkdownConverter(
             heading_style="ATX",
             table_infer_header=True,
             escape_underscores=False,


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `_RagMarkdownConverter` を `web_crawler.py` から `src/rag/markdown.py` に切り出し、`RagMarkdownConverter` として公開
- `web_crawler.py` と `ingesters/zenn.py` の両方から共有モジュールをインポートするように変更
- ARCHITECTURE.md に `markdown.py` のエントリを追加

## Test plan

- [x] pytest 92件 全通過
- [x] ruff lint 問題なし
- [x] mypy 型エラーなし
- [x] コードレビュー通過（相対インポート・空行の指摘を修正済み）

## Related issues

Closes #179