### PR TITLE
docs(architecture): ARCHITECTURE.md にインジェスター一覧を追記 (#187)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@
 | ディレクトリ | 責務 |
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
-| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester） |
+| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・LocalFileIngester） |
 
 ### ルートレベルファイル
 
@@ -48,6 +48,8 @@
 | 仕様書 | 実装モジュール |
 |---|---|
 | `rag-knowledge.md` | `src/rag/` 全体 |
+| `zenn-ingester.md` | `src/rag/ingesters/zenn.py` |
+| `local-file-ingester.md` | `src/rag/ingesters/local_file.py` |
 
 ### Claude Code 拡張
 


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md の `src/rag/ingesters/` セクションに ZennIngester・LocalFileIngester を追記
- 仕様書対応表に zenn-ingester.md・local-file-ingester.md を追加

Closes #187

## Change type
- [x] `docs` — ドキュメントのみの変更

## Test plan
- [ ] ドキュメントのみの変更のため、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)