### PR TITLE
feat(bluesky-ingester): BlueSky インジェスターの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | **URL 安全性チェック** | Google Safe Browsing API による URL 検証 |
 | **クロールプレビュー** | クロール対象ページのタイトル・URL 一覧を事前確認 |
 | **Zenn インジェスター** | Zenn 記事を API 経由で取得・ナレッジベースに取り込み |
+| **BlueSky インジェスター** | BlueSky 投稿を AT Protocol API 経由で取得・ナレッジベースに取り込み |
 | **ローカルファイルインジェスター** | ローカルファイル（Markdown、テキスト、PDF、AsciiDoc）をナレッジベースに取り込み |
 | **制約付き HTTP クライアント** | バジェット・サーキットブレーカー・レート制限を統合した安全な HTTP アクセス（py-common-lib 提供） |
 
@@ -115,6 +116,7 @@ git-flow ベースのブランチ戦略を採用。詳細は `~/.claude/docs/spe
 
 - [RAG ナレッジ](docs/specs/rag-knowledge.md)
 - [Zenn インジェスター](docs/specs/zenn-ingester.md)
+- [BlueSky インジェスター](docs/specs/bluesky-ingester.md)
 - [ローカルファイルインジェスター](docs/specs/local-file-ingester.md)
 
 ### Claude Code 拡張（agentic）

--- a/docs/specs/bluesky-ingester.md
+++ b/docs/specs/bluesky-ingester.md
@@ -196,8 +196,6 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 
 既存の `rag_crawl`（URL ベースの Web クロール）および `rag_crawl_zenn`（Zenn 記事取り込み）とは独立した新規ツールとして追加する。BlueSky は AT Protocol API 経由でのデータ取得であり、Web クロールや Zenn API とは取得方式・制約が異なるため分離する。
 
-> **Note**: 本仕様書は設計先行（`docs(pre-impl)`）で作成している。後続の実装フェーズで `rag-knowledge.md` のツール数・ツール一覧も併せて更新する。
-
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
 | rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -5,11 +5,11 @@
 外部 Web ページから収集した知識をベクトル DB に蓄積し、
 MCP クライアントからのクエリに対して関連情報を検索・提供する
 RAG（Retrieval-Augmented Generation）基盤。
-MCP サーバーとして独立動作し、9 つのツールを提供する。
+MCP サーバーとして独立動作し、10 個のツールを提供する。
 
 スコープ:
 
-- 知識の取り込み（クロール・単一ページ追加・Zenn 記事取り込み・ローカルファイル取り込み）
+- 知識の取り込み（クロール・単一ページ追加・Zenn 記事取り込み・BlueSky 投稿取り込み・ローカルファイル取り込み）
 - 知識の検索（ベクトル検索・BM25 キーワード検索）
 - 知識の管理（統計表示・削除）
 - クロールプレビュー（対象ページの事前確認）
@@ -79,7 +79,7 @@ MCP サーバーとして独立動作し、9 つのツールを提供する。
 
 ### MCP ツール
 
-MCP サーバーが公開する 9 つのツール。
+MCP サーバーが公開する 10 個のツール。
 
 | ツール | 入力 | 振る舞い |
 | --- | --- | --- |
@@ -88,6 +88,7 @@ MCP サーバーが公開する 9 つのツール。
 | rag_crawl | URL、パターン | リンク集ページから一括クロールして取り込む。同一ドメインのみ対象 |
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_crawl_zenn | username、max_articles（任意） | 指定ユーザーの Zenn 記事を API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（記事の公開 URL）の一致で検出し、既存の知識を最新に置き換える |
+| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
 | rag_add_local | file_path | 単一ローカルファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_local | dir_path、pattern（任意） | 指定ディレクトリ内のファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_delete | URL | ソース URL 指定でナレッジを削除する |
@@ -311,4 +312,5 @@ flowchart LR
 ## 関連ドキュメント
 
 - [zenn-ingester.md](zenn-ingester.md) — Zenn インジェスター仕様
+- [bluesky-ingester.md](bluesky-ingester.md) — BlueSky インジェスター仕様
 - [local-file-ingester.md](local-file-ingester.md) — ローカルファイルインジェスター仕様

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -88,7 +88,7 @@ MCP サーバーが公開する 10 個のツール。
 | rag_crawl | URL、パターン | リンク集ページから一括クロールして取り込む。同一ドメインのみ対象 |
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_crawl_zenn | username、max_articles（任意） | 指定ユーザーの Zenn 記事を API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（記事の公開 URL）の一致で検出し、既存の知識を最新に置き換える |
-| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
+| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。max_posts はオリジナル投稿のみに適用（リポストは独立走査、バジェット上限で制限）。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
 | rag_add_local | file_path | 単一ローカルファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_local | dir_path、pattern（任意） | 指定ディレクトリ内のファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_delete | URL | ソース URL 指定でナレッジを削除する |

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -103,6 +103,13 @@ class RAGSettings(BaseSettings):
     # ローカルファイルインジェスター
     rag_local_supported_extensions: str = ".md,.txt,.pdf,.adoc"
 
+    # BlueSky インジェスター
+    rag_bluesky_pds_url: str = "https://bsky.social"
+    rag_bluesky_max_posts: int = Field(default=200, ge=1, le=1000)
+    rag_bluesky_request_timeout: int = Field(default=30, ge=1, le=120)
+    rag_bluesky_request_interval: float = Field(default=1.0, ge=0.1, le=60.0)
+    rag_bluesky_include_reposts: bool = False
+
     # デバッグ
     rag_debug_log_enabled: bool = False
 

--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -5,12 +5,14 @@ Issue: #62
 """
 
 from .base import BaseIngester, IngestedContent
+from .bluesky import BlueskyIngester
 from .local_file import LocalFileIngester
 from .web import WebIngester
 from .zenn import ZennIngester
 
 __all__ = [
     "BaseIngester",
+    "BlueskyIngester",
     "IngestedContent",
     "LocalFileIngester",
     "WebIngester",

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -1,0 +1,749 @@
+"""BlueSky インジェスター: AT Protocol API 経由で BlueSky 投稿を取得しナレッジベースに取り込む
+
+仕様: docs/specs/bluesky-ingester.md
+Issue: #185
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode
+
+from .base import BaseIngester, IngestedContent
+
+if TYPE_CHECKING:
+    from py_common_lib.httpx import ConstrainedClient
+
+logger = logging.getLogger(__name__)
+
+# --- ハードリミット（コード内定数。設定・引数・環境変数で緩和不可） ---
+MAX_POSTS_HARD_LIMIT = 1000
+"""投稿取得上限（オリジナル投稿のみ。リポストは対象外）"""
+
+# --- AT Protocol ---
+LISTRECORDS_PAGE_SIZE = 100
+"""listRecords API の 1 ページあたり取得件数（API 上限）"""
+
+COLLECTION_POST = "app.bsky.feed.post"
+"""オリジナル投稿のコレクション"""
+
+COLLECTION_REPOST = "app.bsky.feed.repost"
+"""リポストのコレクション"""
+
+# --- バリデーション ---
+_AT_URI_PATTERN = re.compile(
+    r"^at://(?P<did>did:[a-z]+:[a-zA-Z0-9._:%-]+)"
+    r"/(?P<collection>[a-zA-Z0-9.]+)"
+    r"/(?P<rkey>[a-zA-Z0-9._~-]+)$"
+)
+"""AT URI のパターン"""
+
+# --- テキスト抽出 ---
+TITLE_MAX_LENGTH = 50
+"""タイトルの最大文字数"""
+
+
+def _validate_max_posts(value: int) -> int:
+    """max_posts をバリデーションし、必要に応じてクランプする.
+
+    仕様: docs/specs/bluesky-ingester.md「バリデーションとクランプの使い分け」
+
+    - バリデーションエラー（拒否）: 型不正、0、負数
+    - クランプ（警告ログ付き）: 正の整数だが許容範囲外
+
+    Args:
+        value: 検証する値
+
+    Returns:
+        検証済みの値（クランプ適用後）
+
+    Raises:
+        ValueError: 0 または負数の場合
+        TypeError: 整数でない場合
+    """
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(
+            f"max_posts must be an integer, got {type(value).__name__}"
+        )
+    if value <= 0:
+        raise ValueError(
+            f"max_posts must be a positive integer, got {value}"
+        )
+    if value > MAX_POSTS_HARD_LIMIT:
+        logger.warning(
+            "max_posts=%d exceeds hard limit %d, clamping to %d",
+            value,
+            MAX_POSTS_HARD_LIMIT,
+            MAX_POSTS_HARD_LIMIT,
+        )
+        return MAX_POSTS_HARD_LIMIT
+    return value
+
+
+def _parse_at_uri(uri: str) -> tuple[str, str, str] | None:
+    """AT URI を解析して (did, collection, rkey) を返す.
+
+    Args:
+        uri: AT URI 文字列
+
+    Returns:
+        (did, collection, rkey) のタプル、またはパース失敗時は None
+    """
+    m = _AT_URI_PATTERN.match(uri)
+    if m is None:
+        return None
+    return m.group("did"), m.group("collection"), m.group("rkey")
+
+
+def _extract_text_from_post(value: dict[str, Any]) -> str:
+    """投稿レコードからテキストを抽出する.
+
+    仕様: docs/specs/bluesky-ingester.md「テキスト抽出」
+
+    抽出対象:
+    - 投稿テキスト (value.text)
+    - 画像 ALT テキスト (value.embed.images[].alt)
+    - 動画 ALT テキスト (value.embed.alt)
+    - リンクカードタイトル (value.embed.external.title)
+    - リンクカード説明 (value.embed.external.description)
+    - recordWithMedia 時の media 配下も同様
+
+    Args:
+        value: 投稿レコードの value オブジェクト
+
+    Returns:
+        改行で連結されたプレーンテキスト
+    """
+    parts: list[str] = []
+
+    # 投稿テキスト
+    text = value.get("text", "")
+    if text:
+        parts.append(text)
+
+    embed = value.get("embed")
+    if isinstance(embed, dict):
+        _extract_embed_text(embed, parts)
+
+    return "\n".join(parts)
+
+
+def _extract_embed_text(embed: dict[str, Any], parts: list[str]) -> None:
+    """embed オブジェクトからテキストを抽出する.
+
+    Args:
+        embed: embed オブジェクト
+        parts: テキストパーツのリスト（破壊的に追加）
+    """
+    embed_type = embed.get("$type", "")
+
+    if embed_type == "app.bsky.embed.recordWithMedia":
+        # recordWithMedia: media 配下にメディア情報がネスト
+        media = embed.get("media")
+        if isinstance(media, dict):
+            _extract_media_text(media, parts)
+    else:
+        # 通常の embed
+        _extract_media_text(embed, parts)
+
+
+def _extract_media_text(media: dict[str, Any], parts: list[str]) -> None:
+    """メディアオブジェクトからテキストを抽出する.
+
+    Args:
+        media: メディアオブジェクト（embed または embed.media）
+        parts: テキストパーツのリスト（破壊的に追加）
+    """
+    # 画像 ALT テキスト
+    images = media.get("images")
+    if isinstance(images, list):
+        for img in images:
+            if isinstance(img, dict):
+                alt = img.get("alt", "")
+                if alt:
+                    parts.append(alt)
+
+    # 動画 ALT テキスト
+    video_alt = media.get("alt", "")
+    if video_alt:
+        parts.append(video_alt)
+
+    # リンクカード
+    external = media.get("external")
+    if isinstance(external, dict):
+        ext_title = external.get("title", "")
+        if ext_title:
+            parts.append(ext_title)
+        ext_desc = external.get("description", "")
+        if ext_desc:
+            parts.append(ext_desc)
+
+
+def _make_title(text: str) -> str:
+    """投稿テキストからタイトルを生成する.
+
+    Args:
+        text: 投稿テキスト
+
+    Returns:
+        先頭 50 文字（超過時は末尾に「...」を付加）
+    """
+    # 改行を空白に置換してフラット化
+    flat = text.replace("\n", " ").strip()
+    if len(flat) > TITLE_MAX_LENGTH:
+        return flat[:TITLE_MAX_LENGTH] + "..."
+    return flat
+
+
+class BlueskyIngester(BaseIngester):
+    """BlueSky 投稿取り込み用インジェスター.
+
+    仕様: docs/specs/bluesky-ingester.md
+
+    AT Protocol API を使用して投稿一覧を走査し、テキストを抽出する。
+    全 HTTP リクエストは ConstrainedClient 経由で実行する。
+    """
+
+    def __init__(
+        self,
+        client: ConstrainedClient,
+        *,
+        pds_url: str = "https://bsky.social",
+        max_posts: int = 200,
+    ) -> None:
+        """BlueskyIngester を初期化する.
+
+        Args:
+            client: ConstrainedClient インスタンス
+            pds_url: PDS のベース URL（デフォルト: https://bsky.social）
+            max_posts: 取得する最大投稿数（デフォルト: 200、許容範囲: 1〜1000）
+
+        Raises:
+            ValueError: max_posts が 0 または負数の場合
+            TypeError: max_posts が整数でない場合
+        """
+        self._client = client
+        self._pds_url = pds_url.rstrip("/")
+        self._max_posts = _validate_max_posts(max_posts)
+
+    def validate_identifier(self, identifier: str) -> str:
+        """AT URI を検証し、正規化済みの AT URI を返す.
+
+        Args:
+            identifier: 検証する AT URI
+
+        Returns:
+            正規化済み AT URI
+
+        Raises:
+            ValueError: AT URI が不正な場合
+        """
+        if not identifier or not identifier.strip():
+            raise ValueError("AT URI must not be empty")
+        uri = identifier.strip()
+        parsed = _parse_at_uri(uri)
+        if parsed is None:
+            raise ValueError(
+                f"Invalid AT URI format: {uri!r}. "
+                "Expected format: at://did:xxx/collection/rkey"
+            )
+        return uri
+
+    async def fetch_single(self, identifier: str) -> IngestedContent | None:
+        """AT URI による個別投稿取得.
+
+        getRecord API で単一投稿を取得し、IngestedContent を構築する。
+
+        Args:
+            identifier: AT URI（例: at://did:plc:xxx/app.bsky.feed.post/rkey）
+
+        Returns:
+            IngestedContent、または取得失敗時は None
+        """
+        uri = self.validate_identifier(identifier)
+        parsed = _parse_at_uri(uri)
+        if parsed is None:
+            return None
+
+        did, collection, rkey = parsed
+        record = await self._get_record(did, collection, rkey)
+        if record is None:
+            return None
+
+        value = record.get("value")
+        if not isinstance(value, dict):
+            logger.warning("Unexpected record value type for %s", uri)
+            return None
+
+        text = _extract_text_from_post(value)
+        if not text.strip():
+            logger.warning("No text extracted from post: %s", uri)
+            return None
+
+        return self._build_content(
+            did=did,
+            rkey=rkey,
+            value=value,
+            text=text,
+            handle=did,
+            is_repost=False,
+        )
+
+    async def crawl(
+        self,
+        handle: str,
+        *,
+        max_posts: int | None = None,
+        include_reposts: bool = False,
+    ) -> list[IngestedContent]:
+        """指定ユーザーの BlueSky 投稿を一括取得する.
+
+        Args:
+            handle: BlueSky ハンドル（例: user.bsky.social）
+            max_posts: 取得する最大投稿数（None 時はコンストラクタの値を使用）
+            include_reposts: リポストを取得対象に含めるか
+
+        Returns:
+            IngestedContent のリスト
+
+        Raises:
+            ValueError: handle が不正な場合
+        """
+        handle = self._validate_handle(handle)
+
+        effective_max = self._max_posts
+        if max_posts is not None:
+            effective_max = _validate_max_posts(max_posts)
+
+        # source_id の重複チェック用セット
+        seen_source_ids: set[str] = set()
+        contents: list[IngestedContent] = []
+
+        # 1. オリジナル投稿の走査
+        post_records = await self._list_records(
+            handle, COLLECTION_POST, max_records=effective_max
+        )
+
+        for record in post_records:
+            content = await self._process_post_record(
+                record, handle, seen_source_ids, is_repost=False
+            )
+            if content is not None:
+                contents.append(content)
+
+        # 2. リポストの走査（オプション）
+        if include_reposts:
+            repost_records = await self._list_records(
+                handle, COLLECTION_REPOST, max_records=None
+            )
+            for repost_record in repost_records:
+                content = await self._process_repost_record(
+                    repost_record, handle, seen_source_ids
+                )
+                if content is not None:
+                    contents.append(content)
+
+        return contents
+
+    async def _process_post_record(
+        self,
+        record: dict[str, Any],
+        handle: str,
+        seen_source_ids: set[str],
+        *,
+        is_repost: bool,
+    ) -> IngestedContent | None:
+        """投稿レコードを処理して IngestedContent を構築する.
+
+        Args:
+            record: listRecords/getRecord のレコードオブジェクト
+            handle: ユーザーハンドル
+            seen_source_ids: 処理済み source_id のセット
+            is_repost: リポスト経由で取得した投稿かどうか
+
+        Returns:
+            IngestedContent、またはスキップ/失敗時は None
+        """
+        uri = record.get("uri", "")
+        parsed = _parse_at_uri(uri)
+        if parsed is None:
+            logger.warning("Invalid AT URI in record: %s", uri)
+            return None
+
+        did, _collection, rkey = parsed
+        source_id = f"at://{did}/{COLLECTION_POST}/{rkey}"
+
+        # 重複チェック
+        if source_id in seen_source_ids:
+            return None
+        seen_source_ids.add(source_id)
+
+        value = record.get("value")
+        if not isinstance(value, dict):
+            logger.warning("Unexpected record value type: %s", uri)
+            return None
+
+        # テキスト抽出
+        text = _extract_text_from_post(value)
+
+        # 引用元テキストの取得
+        quote_text = await self._fetch_quote_text(value)
+        if quote_text:
+            text = text + "\n[引用元]\n" + quote_text if text else "[引用元]\n" + quote_text
+
+        if not text.strip():
+            logger.debug("Skipping empty post: %s", uri)
+            return None
+
+        return self._build_content(
+            did=did,
+            rkey=rkey,
+            value=value,
+            text=text,
+            handle=handle,
+            is_repost=is_repost,
+        )
+
+    async def _process_repost_record(
+        self,
+        repost_record: dict[str, Any],
+        handle: str,
+        seen_source_ids: set[str],
+    ) -> IngestedContent | None:
+        """リポストレコードを処理し、元投稿を取得する.
+
+        Args:
+            repost_record: リポストレコード
+            handle: リポスト元ユーザーハンドル
+            seen_source_ids: 処理済み source_id のセット
+
+        Returns:
+            IngestedContent、またはスキップ/失敗時は None
+        """
+        value = repost_record.get("value")
+        if not isinstance(value, dict):
+            return None
+
+        subject = value.get("subject")
+        if not isinstance(subject, dict):
+            return None
+
+        subject_uri = subject.get("uri", "")
+        parsed = _parse_at_uri(subject_uri)
+        if parsed is None:
+            logger.warning("Invalid subject URI in repost: %s", subject_uri)
+            return None
+
+        did, collection, rkey = parsed
+        source_id = f"at://{did}/{COLLECTION_POST}/{rkey}"
+
+        # 重複チェック
+        if source_id in seen_source_ids:
+            return None
+
+        # 元投稿を取得
+        original_record = await self._get_record(did, collection, rkey)
+        if original_record is None:
+            return None
+
+        # 元投稿をポストレコードとして処理
+        return await self._process_post_record(
+            original_record, handle, seen_source_ids, is_repost=True
+        )
+
+    async def _fetch_quote_text(self, value: dict[str, Any]) -> str | None:
+        """引用元投稿のテキストを取得する.
+
+        embed.$type が app.bsky.embed.record または app.bsky.embed.recordWithMedia の
+        場合に引用元の AT URI を取得し、getRecord で引用元投稿のテキストを取得する。
+
+        Args:
+            value: 投稿レコードの value オブジェクト
+
+        Returns:
+            引用元テキスト、または引用なし/取得失敗時は None
+        """
+        embed = value.get("embed")
+        if not isinstance(embed, dict):
+            return None
+
+        embed_type = embed.get("$type", "")
+
+        quote_uri: str | None = None
+        if embed_type == "app.bsky.embed.record":
+            record_ref = embed.get("record")
+            if isinstance(record_ref, dict):
+                quote_uri = record_ref.get("uri")
+        elif embed_type == "app.bsky.embed.recordWithMedia":
+            record_ref = embed.get("record")
+            if isinstance(record_ref, dict):
+                inner_record = record_ref.get("record")
+                if isinstance(inner_record, dict):
+                    quote_uri = inner_record.get("uri")
+
+        if not quote_uri:
+            return None
+
+        parsed = _parse_at_uri(quote_uri)
+        if parsed is None:
+            logger.warning("Invalid quote URI: %s", quote_uri)
+            return None
+
+        did, collection, rkey = parsed
+        quote_record = await self._get_record(did, collection, rkey)
+        if quote_record is None:
+            return None
+
+        quote_value = quote_record.get("value")
+        if not isinstance(quote_value, dict):
+            return None
+
+        return _extract_text_from_post(quote_value) or None
+
+    async def _list_records(
+        self,
+        repo: str,
+        collection: str,
+        *,
+        max_records: int | None,
+    ) -> list[dict[str, Any]]:
+        """listRecords API をページネーション走査する.
+
+        Args:
+            repo: DID またはハンドル
+            collection: レコードコレクション
+            max_records: 取得上限（None で無制限、バジェット上限まで）
+
+        Returns:
+            レコードオブジェクトのリスト
+        """
+        records: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        while True:
+            query_params: dict[str, str | int] = {
+                "repo": repo,
+                "collection": collection,
+                "limit": LISTRECORDS_PAGE_SIZE,
+            }
+            if cursor is not None:
+                query_params["cursor"] = cursor
+
+            url = f"{self._pds_url}/xrpc/com.atproto.repo.listRecords?{urlencode(query_params)}"
+
+            try:
+                resp = await self._client.get(url)
+            except Exception:
+                logger.exception(
+                    "Failed to fetch %s records for %s", collection, repo
+                )
+                break
+
+            if resp.status_code != 200:
+                logger.error(
+                    "listRecords returned status %d for %s (repo: %s)",
+                    resp.status_code,
+                    collection,
+                    repo,
+                )
+                break
+
+            try:
+                data: dict[str, Any] = resp.json()
+            except Exception:
+                logger.exception(
+                    "Failed to parse listRecords JSON for %s (repo: %s)",
+                    collection,
+                    repo,
+                )
+                break
+
+            page_records = data.get("records")
+            if not isinstance(page_records, list):
+                logger.error(
+                    "Unexpected records format in listRecords response (repo: %s)",
+                    repo,
+                )
+                break
+
+            if not page_records:
+                break
+
+            for rec in page_records:
+                if max_records is not None and len(records) >= max_records:
+                    break
+                if isinstance(rec, dict):
+                    records.append(rec)
+
+            if max_records is not None and len(records) >= max_records:
+                if len(records) > max_records:
+                    records = records[:max_records]
+                logger.info(
+                    "Reached max_records limit (%d) for %s (repo: %s)",
+                    max_records,
+                    collection,
+                    repo,
+                )
+                break
+
+            next_cursor = data.get("cursor")
+            if next_cursor is None:
+                break
+
+            cursor = str(next_cursor)
+
+        logger.info(
+            "Listed %d %s records for %s",
+            len(records),
+            collection,
+            repo,
+        )
+        return records
+
+    async def _get_record(
+        self,
+        repo: str,
+        collection: str,
+        rkey: str,
+    ) -> dict[str, Any] | None:
+        """getRecord API で個別レコードを取得する.
+
+        Args:
+            repo: DID またはハンドル
+            collection: レコードコレクション
+            rkey: レコードキー
+
+        Returns:
+            レコードオブジェクト、または取得失敗時は None
+        """
+        query_params = urlencode({
+            "repo": repo,
+            "collection": collection,
+            "rkey": rkey,
+        })
+        url = f"{self._pds_url}/xrpc/com.atproto.repo.getRecord?{query_params}"
+
+        try:
+            resp = await self._client.get(url)
+        except Exception:
+            logger.exception(
+                "Failed to get record: %s/%s/%s", repo, collection, rkey
+            )
+            return None
+
+        if resp.status_code != 200:
+            log_fn = logger.warning if resp.status_code == 404 else logger.error
+            log_fn(
+                "getRecord returned status %d for %s/%s/%s",
+                resp.status_code,
+                repo,
+                collection,
+                rkey,
+            )
+            return None
+
+        try:
+            data: dict[str, Any] = resp.json()
+            return data
+        except Exception:
+            logger.exception(
+                "Failed to parse getRecord JSON for %s/%s/%s",
+                repo,
+                collection,
+                rkey,
+            )
+            return None
+
+    def _build_content(
+        self,
+        *,
+        did: str,
+        rkey: str,
+        value: dict[str, Any],
+        text: str,
+        handle: str,
+        is_repost: bool,
+    ) -> IngestedContent:
+        """IngestedContent を構築する.
+
+        Args:
+            did: DID
+            rkey: レコードキー
+            value: レコードの value オブジェクト
+            text: 抽出済みテキスト
+            handle: ユーザーハンドル
+            is_repost: リポスト経由の投稿か
+
+        Returns:
+            IngestedContent
+        """
+        source_id = f"at://{did}/{COLLECTION_POST}/{rkey}"
+        title = _make_title(text)
+        created_at = value.get("createdAt", "")
+
+        embed = value.get("embed")
+        has_images = False
+        has_video = False
+        has_external_link = False
+
+        if isinstance(embed, dict):
+            embed_type = embed.get("$type", "")
+            media_obj = embed
+
+            if embed_type == "app.bsky.embed.recordWithMedia":
+                media_obj = embed.get("media", {})
+
+            has_images = isinstance(media_obj.get("images"), list) and len(
+                media_obj.get("images", [])
+            ) > 0
+            has_video = media_obj.get("$type", "") == "app.bsky.embed.video"
+            has_external_link = isinstance(media_obj.get("external"), dict)
+
+        is_reply = isinstance(value.get("reply"), dict)
+
+        metadata: dict[str, object] = {
+            "handle": handle,
+            "did": did,
+            "rkey": rkey,
+            "url": f"https://bsky.app/profile/{handle}/post/{rkey}",
+            "createdAt": created_at,
+            "has_images": has_images,
+            "has_video": has_video,
+            "has_external_link": has_external_link,
+            "is_reply": is_reply,
+            "is_repost": is_repost,
+        }
+
+        return IngestedContent(
+            source_id=source_id,
+            title=title,
+            text=text,
+            ingested_at=IngestedContent.now_iso(),
+            source_type="bluesky",
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _validate_handle(handle: str) -> str:
+        """ハンドルを検証する.
+
+        Args:
+            handle: BlueSky ハンドル
+
+        Returns:
+            正規化済みハンドル
+
+        Raises:
+            ValueError: ハンドルが不正な場合
+        """
+        if not handle or not handle.strip():
+            raise ValueError("handle must not be empty")
+        handle = handle.strip()
+        if handle.startswith("did:"):
+            raise ValueError(
+                f"DID format is not accepted as handle: {handle!r}. "
+                "Please specify a handle (e.g., user.bsky.social)"
+            )
+        return handle

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -197,6 +197,28 @@ def _make_title(text: str) -> str:
     return flat
 
 
+def _validate_pds_url(url: str) -> str:
+    """PDS URL をバリデーションし、正規化する.
+
+    Args:
+        url: PDS URL 文字列
+
+    Returns:
+        正規化済み PDS URL（末尾スラッシュ除去済み）
+
+    Raises:
+        ValueError: URL が空または HTTPS スキームでない場合
+    """
+    url = url.strip()
+    if not url:
+        raise ValueError("pds_url must not be empty")
+    if not url.startswith("https://"):
+        raise ValueError(
+            f"pds_url must use HTTPS scheme, got: {url!r}"
+        )
+    return url.rstrip("/")
+
+
 class BlueskyIngester(BaseIngester):
     """BlueSky 投稿取り込み用インジェスター.
 
@@ -221,11 +243,11 @@ class BlueskyIngester(BaseIngester):
             max_posts: 取得する最大投稿数（デフォルト: 200、許容範囲: 1〜1000）
 
         Raises:
-            ValueError: max_posts が 0 または負数の場合
+            ValueError: max_posts が 0 または負数の場合、pds_url が空または非 HTTPS の場合
             TypeError: max_posts が整数でない場合
         """
         self._client = client
-        self._pds_url = pds_url.rstrip("/")
+        self._pds_url = _validate_pds_url(pds_url)
         self._max_posts = _validate_max_posts(max_posts)
 
     def validate_identifier(self, identifier: str) -> str:

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -851,6 +851,20 @@ class RAGKnowledgeService:
             bm25_results=bm25_items,
         )
 
+    async def source_exists(self, source_url: str) -> bool:
+        """ソースURLに対応するチャンクが存在するか確認する（軽量版）.
+
+        本文を読み出さず IDs の有無のみで判定するため、
+        get_full_page_text よりも低コストで存在確認できる。
+
+        Args:
+            source_url: 確認するソースURL
+
+        Returns:
+            チャンクが 1 件以上存在すれば True
+        """
+        return await self._vector_store.source_exists(source_url)
+
     async def get_full_page_text(self, source_url: str) -> str:
         """ソースURLのページ全文を返す.
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -458,7 +458,8 @@ async def rag_crawl_bluesky(
 
     Args:
         handle: BlueSky ハンドル（例: user.bsky.social）。DID 形式は不可
-        max_posts: 取得する最大投稿数（未指定時は設定値を使用、許容範囲: 1〜1000）
+        max_posts: 取得する最大オリジナル投稿数（未指定時は設定値を使用、許容範囲: 1〜1000）。
+            リポストには適用されない（リポストは独立して走査され、バジェット上限で制限される）
         include_reposts: リポストを取得対象に含めるか（未指定時は設定値を使用）
 
     Returns:
@@ -520,8 +521,7 @@ async def rag_crawl_bluesky(
             for content in contents:
                 # 既存 source_id チェック（スキップ判定）
                 # BlueSky は投稿編集不可のため、既存投稿はスキップする
-                existing = await service.get_full_page_text(content.source_id)
-                if existing:
+                if await service.source_exists(content.source_id):
                     skipped += 1
                     continue
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,12 +3,13 @@
 仕様: docs/specs/rag-knowledge.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 9 つの RAG ツールを公開する:
+FastMCP を使用して 10 個の RAG ツールを公開する:
 - rag_search: ナレッジベースから関連情報を検索
 - rag_add: 単一ページをナレッジベースに取り込み
 - rag_crawl: リンク集ページからクロール＆一括取り込み
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_crawl_zenn: Zenn 記事の一括取り込み
+- rag_crawl_bluesky: BlueSky 投稿の一括取り込み
 - rag_add_local: ローカルファイルをナレッジベースに取り込み
 - rag_crawl_local: ディレクトリ内ファイルを一括取り込み
 - rag_delete: ソースURL指定でナレッジから削除
@@ -38,6 +39,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
     from .config import get_settings
     from .embedding.factory import get_embedding_provider
+    from .ingesters.bluesky import BlueskyIngester
     from .ingesters.local_file import LocalFileIngester
     from .ingesters.web import WebIngester
     from .ingesters.zenn import ZennIngester
@@ -440,6 +442,116 @@ async def rag_crawl_zenn(username: str, max_articles: int | None = None) -> str:
     except Exception:
         logger.exception("Failed to crawl Zenn articles for user: %s", username)
         return f"エラー: Zenn 記事の取り込みに失敗しました（ユーザー: {username}）"
+
+
+@mcp.tool()
+async def rag_crawl_bluesky(
+    handle: str,
+    max_posts: int | None = None,
+    include_reposts: bool | None = None,
+) -> str:
+    """[rag-knowledge] RAG crawl BlueSky - BlueSky 投稿を AT Protocol API 経由で取得し一括取り込み.
+
+    knowledge base, BlueSky, Bluesky, ingest, posts, AT Protocol.
+    指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。
+    BlueSky は投稿編集不可のため、既存の投稿はスキップする（上書き不要）。
+
+    Args:
+        handle: BlueSky ハンドル（例: user.bsky.social）。DID 形式は不可
+        max_posts: 取得する最大投稿数（未指定時は設定値を使用、許容範囲: 1〜1000）
+        include_reposts: リポストを取得対象に含めるか（未指定時は設定値を使用）
+
+    Returns:
+        取り込み結果のサマリーテキスト（取得投稿数、スキップ数、チャンク数、エラー数）
+    """
+    service = await _get_rag_service()
+    settings = get_settings()
+
+    # max_posts のデフォルト解決: 未指定時は設定値を使用
+    if max_posts is None:
+        max_posts = settings.rag_bluesky_max_posts
+
+    # include_reposts のデフォルト解決
+    if include_reposts is None:
+        include_reposts = settings.rag_bluesky_include_reposts
+
+    # max_posts のバリデーション（MCP ツール入力として）
+    if not isinstance(max_posts, int) or isinstance(max_posts, bool):
+        return f"エラー: max_posts は整数で指定してください（入力値: {max_posts!r}）"
+    if max_posts <= 0:
+        return f"エラー: max_posts は正の整数で指定してください（入力値: {max_posts}）"
+
+    if not handle or not handle.strip():
+        return "エラー: handle を指定してください"
+
+    handle = handle.strip()
+    if handle.startswith("did:"):
+        return (
+            f"エラー: DID 形式は使用できません: {handle!r}。"
+            "ハンドル（例: user.bsky.social）を指定してください"
+        )
+
+    try:
+        async with ConstrainedClient(
+            request_timeout=settings.rag_bluesky_request_timeout,
+            request_interval=settings.rag_bluesky_request_interval,
+        ) as client:
+            ingester = BlueskyIngester(
+                client=client,
+                pds_url=settings.rag_bluesky_pds_url,
+                max_posts=max_posts,
+            )
+
+            # 投稿を一括取得
+            contents = await ingester.crawl(
+                handle,
+                include_reposts=include_reposts,
+            )
+
+            if not contents:
+                return f"投稿が見つかりませんでした（ハンドル: {handle}）"
+
+            # 各投稿をナレッジベースに取り込む
+            total_chunks = 0
+            errors = 0
+            skipped = 0
+            ingested_count = 0
+
+            for content in contents:
+                # 既存 source_id チェック（スキップ判定）
+                # BlueSky は投稿編集不可のため、既存投稿はスキップする
+                existing = await service.get_full_page_text(content.source_id)
+                if existing:
+                    skipped += 1
+                    continue
+
+                try:
+                    chunks = await service.ingest_content(content)
+                    total_chunks += chunks
+                    ingested_count += 1
+                except Exception:
+                    logger.exception(
+                        "Failed to ingest BlueSky post: %s", content.source_id
+                    )
+                    errors += 1
+
+            parts = [
+                f"完了: {ingested_count}投稿 / {total_chunks}チャンク",
+            ]
+            if skipped > 0:
+                parts.append(f"スキップ: {skipped}件")
+            if errors > 0:
+                parts.append(f"エラー: {errors}件")
+            parts.append(f"（ハンドル: {handle}）")
+
+            return " / ".join(parts)
+    except (ValueError, TypeError) as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception(
+            "Failed to crawl BlueSky posts for handle: %s", handle
+        )
+        return f"エラー: BlueSky 投稿の取り込みに失敗しました（ハンドル: {handle}）"
 
 
 def _create_local_ingester() -> LocalFileIngester:

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -245,6 +245,24 @@ class VectorStore:
         chunks.sort(key=lambda c: int(c.metadata.get("chunk_index", 0)))
         return chunks
 
+    async def source_exists(self, source_url: str) -> bool:
+        """ソースURLに対応するチャンクが存在するか確認する（軽量版）.
+
+        documents / metadatas を取得せず、IDs の有無のみで判定する。
+
+        Args:
+            source_url: 確認するソースURL
+
+        Returns:
+            チャンクが 1 件以上存在すれば True
+        """
+        results = await asyncio.to_thread(
+            self._collection.get,
+            where={"source_url": source_url},
+            include=[],
+        )
+        return bool(results["ids"])
+
     async def delete_by_source(self, source_url: str) -> int:
         """ソースURL指定でチャンクを削除.
 

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -1,0 +1,917 @@
+"""BlueSky インジェスターのテスト
+
+仕様: docs/specs/bluesky-ingester.md
+Issue: #185
+
+テスト方針:
+- 単体テスト: BlueskyIngester のメソッド（テキスト抽出、バリデーション、source_id 生成）
+- API レスポンスモック: listRecords・getRecord のレスポンスを fixture として定義
+- 正常系: 投稿取得・テキスト抽出・引用リポスト・リポスト走査・ページネーション
+- 異常系: 存在しないハンドル、空投稿、DID 形式の拒否、API エラー応答
+- バリデーション・クランプ: max_posts の 0/負数/上限超過
+- 既存 source_id スキップの動作確認
+- テスト時は投稿取得上限 3 件で実行
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rag.ingesters.bluesky import (
+    MAX_POSTS_HARD_LIMIT,
+    BlueskyIngester,
+    _extract_text_from_post,
+    _make_title,
+    _parse_at_uri,
+    _validate_max_posts,
+)
+
+
+# --- ヘルパー ---
+
+
+def _make_mock_client() -> MagicMock:
+    """モック ConstrainedClient を作成する."""
+    mock = MagicMock()
+    mock.get = AsyncMock()
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+def _make_list_records_response(
+    records: list[dict],
+    cursor: str | None = None,
+) -> MagicMock:
+    """listRecords API のモックレスポンスを作成する."""
+    resp = MagicMock()
+    resp.status_code = 200
+    data: dict = {"records": records}
+    if cursor is not None:
+        data["cursor"] = cursor
+    resp.json.return_value = data
+    return resp
+
+
+def _make_get_record_response(
+    uri: str = "at://did:plc:test123/app.bsky.feed.post/abc123",
+    value: dict | None = None,
+) -> MagicMock:
+    """getRecord API のモックレスポンスを作成する."""
+    resp = MagicMock()
+    resp.status_code = 200
+    if value is None:
+        value = {"text": "Test post", "createdAt": "2024-01-01T00:00:00Z"}
+    resp.json.return_value = {
+        "uri": uri,
+        "cid": "bafytest",
+        "value": value,
+    }
+    return resp
+
+
+def _make_post_record(
+    did: str = "did:plc:test123",
+    rkey: str = "abc123",
+    text: str = "Hello BlueSky!",
+    embed: dict | None = None,
+    reply: dict | None = None,
+    created_at: str = "2024-01-01T00:00:00Z",
+) -> dict:
+    """投稿レコードオブジェクトを作成する."""
+    value: dict = {
+        "text": text,
+        "createdAt": created_at,
+    }
+    if embed is not None:
+        value["embed"] = embed
+    if reply is not None:
+        value["reply"] = reply
+    return {
+        "uri": f"at://{did}/app.bsky.feed.post/{rkey}",
+        "cid": "bafytest",
+        "value": value,
+    }
+
+
+def _make_repost_record(
+    subject_uri: str = "at://did:plc:other/app.bsky.feed.post/xyz789",
+    subject_cid: str = "bafyother",
+    created_at: str = "2024-01-02T00:00:00Z",
+) -> dict:
+    """リポストレコードオブジェクトを作成する."""
+    return {
+        "uri": "at://did:plc:test123/app.bsky.feed.repost/repost1",
+        "cid": "bafyrepost",
+        "value": {
+            "subject": {
+                "uri": subject_uri,
+                "cid": subject_cid,
+            },
+            "createdAt": created_at,
+        },
+    }
+
+
+def _make_error_response(status_code: int = 404) -> MagicMock:
+    """エラーレスポンスを作成する."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    return resp
+
+
+# --- _validate_max_posts テスト ---
+
+
+class TestValidateMaxPosts:
+    """max_posts のバリデーション・クランプテスト."""
+
+    def test_valid_value(self) -> None:
+        """許容範囲内の値がそのまま返ること."""
+        assert _validate_max_posts(200) == 200
+        assert _validate_max_posts(1) == 1
+        assert _validate_max_posts(1000) == 1000
+
+    def test_clamp_exceeds_hard_limit(self) -> None:
+        """ハードリミット超過の正の整数がクランプされること."""
+        assert _validate_max_posts(2000) == MAX_POSTS_HARD_LIMIT
+        assert _validate_max_posts(1001) == MAX_POSTS_HARD_LIMIT
+        assert _validate_max_posts(9999) == MAX_POSTS_HARD_LIMIT
+
+    def test_reject_zero(self) -> None:
+        """0 がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="positive integer"):
+            _validate_max_posts(0)
+
+    def test_reject_negative(self) -> None:
+        """負数がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="positive integer"):
+            _validate_max_posts(-1)
+        with pytest.raises(ValueError, match="positive integer"):
+            _validate_max_posts(-100)
+
+    def test_reject_non_integer(self) -> None:
+        """非整数がバリデーションエラーになること."""
+        with pytest.raises(TypeError, match="must be an integer"):
+            _validate_max_posts(50.5)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="must be an integer"):
+            _validate_max_posts("50")  # type: ignore[arg-type]
+
+    def test_reject_bool(self) -> None:
+        """bool がバリデーションエラーになること（bool は int のサブクラス）."""
+        with pytest.raises(TypeError, match="must be an integer"):
+            _validate_max_posts(True)  # type: ignore[arg-type]
+
+
+# --- _parse_at_uri テスト ---
+
+
+class TestParseAtUri:
+    """AT URI パーサーのテスト."""
+
+    def test_valid_uri(self) -> None:
+        """正しい AT URI がパースされること."""
+        result = _parse_at_uri("at://did:plc:test123/app.bsky.feed.post/abc123")
+        assert result is not None
+        assert result == ("did:plc:test123", "app.bsky.feed.post", "abc123")
+
+    def test_valid_uri_with_web_did(self) -> None:
+        """did:web 形式の AT URI がパースされること."""
+        result = _parse_at_uri("at://did:web:example.com/app.bsky.feed.post/xyz")
+        assert result is not None
+        assert result[0] == "did:web:example.com"
+
+    def test_invalid_uri(self) -> None:
+        """不正な AT URI で None が返ること."""
+        assert _parse_at_uri("https://example.com") is None
+        assert _parse_at_uri("at://invalid") is None
+        assert _parse_at_uri("") is None
+
+
+# --- _extract_text_from_post テスト ---
+
+
+class TestExtractTextFromPost:
+    """テキスト抽出のテスト."""
+
+    def test_text_only(self) -> None:
+        """投稿テキストのみ抽出されること."""
+        value = {"text": "Hello World"}
+        assert _extract_text_from_post(value) == "Hello World"
+
+    def test_empty_text(self) -> None:
+        """空テキストが空文字列として返ること."""
+        value = {"text": ""}
+        assert _extract_text_from_post(value) == ""
+
+    def test_image_alt_text(self) -> None:
+        """画像 ALT テキストが抽出されること."""
+        value = {
+            "text": "Photo post",
+            "embed": {
+                "$type": "app.bsky.embed.images",
+                "images": [
+                    {"alt": "A beautiful sunset"},
+                    {"alt": "Mountain view"},
+                ],
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Photo post" in result
+        assert "A beautiful sunset" in result
+        assert "Mountain view" in result
+
+    def test_image_empty_alt(self) -> None:
+        """空の ALT テキストは無視されること."""
+        value = {
+            "text": "Photo",
+            "embed": {
+                "$type": "app.bsky.embed.images",
+                "images": [{"alt": ""}, {"alt": "Good alt"}],
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Good alt" in result
+
+    def test_video_alt_text(self) -> None:
+        """動画 ALT テキストが抽出されること."""
+        value = {
+            "text": "Video post",
+            "embed": {
+                "$type": "app.bsky.embed.video",
+                "alt": "Video description",
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Video post" in result
+        assert "Video description" in result
+
+    def test_external_link(self) -> None:
+        """リンクカードのタイトルと説明が抽出されること."""
+        value = {
+            "text": "Check this out",
+            "embed": {
+                "$type": "app.bsky.embed.external",
+                "external": {
+                    "title": "Example Article",
+                    "description": "Article description",
+                    "uri": "https://example.com",
+                },
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Check this out" in result
+        assert "Example Article" in result
+        assert "Article description" in result
+
+    def test_record_with_media_images(self) -> None:
+        """recordWithMedia 型のメディア配下画像 ALT が抽出されること."""
+        value = {
+            "text": "Quote with images",
+            "embed": {
+                "$type": "app.bsky.embed.recordWithMedia",
+                "record": {
+                    "record": {
+                        "uri": "at://did:plc:other/app.bsky.feed.post/xyz",
+                        "cid": "bafyother",
+                    },
+                },
+                "media": {
+                    "$type": "app.bsky.embed.images",
+                    "images": [{"alt": "Media image alt"}],
+                },
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Quote with images" in result
+        assert "Media image alt" in result
+
+    def test_record_with_media_external(self) -> None:
+        """recordWithMedia 型の media.external が抽出されること."""
+        value = {
+            "text": "Quote with link",
+            "embed": {
+                "$type": "app.bsky.embed.recordWithMedia",
+                "record": {
+                    "record": {
+                        "uri": "at://did:plc:other/app.bsky.feed.post/xyz",
+                        "cid": "bafyother",
+                    },
+                },
+                "media": {
+                    "$type": "app.bsky.embed.external",
+                    "external": {
+                        "title": "Link Title",
+                        "description": "Link Desc",
+                        "uri": "https://example.com",
+                    },
+                },
+            },
+        }
+        result = _extract_text_from_post(value)
+        assert "Link Title" in result
+        assert "Link Desc" in result
+
+    def test_no_embed(self) -> None:
+        """embed なしでテキストのみ返ること."""
+        value = {"text": "Just text"}
+        assert _extract_text_from_post(value) == "Just text"
+
+
+# --- _make_title テスト ---
+
+
+class TestMakeTitle:
+    """タイトル生成のテスト."""
+
+    def test_short_text(self) -> None:
+        """50 文字以下のテキストがそのまま返ること."""
+        assert _make_title("Hello") == "Hello"
+
+    def test_long_text(self) -> None:
+        """50 文字超のテキストが切り詰められること."""
+        text = "A" * 100
+        result = _make_title(text)
+        assert len(result) == 53  # 50 + "..."
+        assert result.endswith("...")
+
+    def test_multiline_text(self) -> None:
+        """改行が空白に置換されること."""
+        text = "Line 1\nLine 2\nLine 3"
+        assert _make_title(text) == "Line 1 Line 2 Line 3"
+
+    def test_exact_50_chars(self) -> None:
+        """ちょうど 50 文字でも「...」が付かないこと."""
+        text = "A" * 50
+        assert _make_title(text) == text
+
+
+# --- BlueskyIngester.validate_identifier テスト ---
+
+
+class TestBlueskyIngesterValidate:
+    """BlueskyIngester.validate_identifier のテスト."""
+
+    @pytest.fixture()
+    def ingester(self) -> BlueskyIngester:
+        return BlueskyIngester(client=_make_mock_client(), max_posts=3)
+
+    def test_valid_at_uri(self, ingester: BlueskyIngester) -> None:
+        """正しい AT URI がそのまま返ること."""
+        uri = "at://did:plc:test123/app.bsky.feed.post/abc123"
+        assert ingester.validate_identifier(uri) == uri
+
+    def test_at_uri_with_whitespace(self, ingester: BlueskyIngester) -> None:
+        """前後の空白がトリムされること."""
+        uri = "  at://did:plc:test123/app.bsky.feed.post/abc123  "
+        assert ingester.validate_identifier(uri) == uri.strip()
+
+    def test_empty_identifier(self, ingester: BlueskyIngester) -> None:
+        """空文字列がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            ingester.validate_identifier("")
+        with pytest.raises(ValueError, match="must not be empty"):
+            ingester.validate_identifier("   ")
+
+    def test_invalid_at_uri(self, ingester: BlueskyIngester) -> None:
+        """不正な AT URI がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="Invalid AT URI format"):
+            ingester.validate_identifier("https://example.com")
+        with pytest.raises(ValueError, match="Invalid AT URI format"):
+            ingester.validate_identifier("at://invalid")
+
+
+# --- BlueskyIngester._validate_handle テスト ---
+
+
+class TestBlueskyIngesterValidateHandle:
+    """BlueskyIngester._validate_handle のテスト."""
+
+    def test_valid_handle(self) -> None:
+        """正しいハンドルがそのまま返ること."""
+        assert BlueskyIngester._validate_handle("user.bsky.social") == "user.bsky.social"
+
+    def test_handle_with_whitespace(self) -> None:
+        """前後の空白がトリムされること."""
+        assert BlueskyIngester._validate_handle("  user.bsky.social  ") == "user.bsky.social"
+
+    def test_empty_handle(self) -> None:
+        """空文字列がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            BlueskyIngester._validate_handle("")
+        with pytest.raises(ValueError, match="must not be empty"):
+            BlueskyIngester._validate_handle("   ")
+
+    def test_did_format_rejected(self) -> None:
+        """DID 形式がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="DID format is not accepted"):
+            BlueskyIngester._validate_handle("did:plc:test123")
+
+
+# --- BlueskyIngester.fetch_single テスト ---
+
+
+class TestBlueskyIngesterFetchSingle:
+    """BlueskyIngester.fetch_single のテスト."""
+
+    @pytest.fixture()
+    def mock_client(self) -> MagicMock:
+        return _make_mock_client()
+
+    @pytest.fixture()
+    def ingester(self, mock_client: MagicMock) -> BlueskyIngester:
+        return BlueskyIngester(client=mock_client, max_posts=3)
+
+    async def test_fetch_single_success(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """正常に投稿を取得して IngestedContent を返すこと."""
+        mock_client.get.return_value = _make_get_record_response(
+            uri="at://did:plc:test123/app.bsky.feed.post/abc123",
+            value={
+                "text": "Hello BlueSky!",
+                "createdAt": "2024-01-01T00:00:00Z",
+            },
+        )
+
+        result = await ingester.fetch_single(
+            "at://did:plc:test123/app.bsky.feed.post/abc123"
+        )
+
+        assert result is not None
+        assert result.source_id == "at://did:plc:test123/app.bsky.feed.post/abc123"
+        assert result.title == "Hello BlueSky!"
+        assert result.text == "Hello BlueSky!"
+        assert result.source_type == "bluesky"
+        assert result.metadata["did"] == "did:plc:test123"
+        assert result.metadata["rkey"] == "abc123"
+        assert result.metadata["handle"] == "did:plc:test123"
+        assert result.metadata["url"] == "https://bsky.app/profile/did:plc:test123/post/abc123"
+        assert result.metadata["is_repost"] is False
+
+    async def test_fetch_single_404(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """404 エラーで None を返すこと."""
+        mock_client.get.return_value = _make_error_response(404)
+
+        result = await ingester.fetch_single(
+            "at://did:plc:test123/app.bsky.feed.post/abc123"
+        )
+
+        assert result is None
+
+    async def test_fetch_single_empty_text(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """空テキスト投稿で None を返すこと."""
+        mock_client.get.return_value = _make_get_record_response(
+            value={"text": "", "createdAt": "2024-01-01T00:00:00Z"},
+        )
+
+        result = await ingester.fetch_single(
+            "at://did:plc:test123/app.bsky.feed.post/abc123"
+        )
+
+        assert result is None
+
+    async def test_fetch_single_request_exception(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """リクエスト例外で None を返すこと."""
+        mock_client.get.side_effect = Exception("Connection error")
+
+        result = await ingester.fetch_single(
+            "at://did:plc:test123/app.bsky.feed.post/abc123"
+        )
+
+        assert result is None
+
+    async def test_fetch_single_invalid_uri(
+        self, ingester: BlueskyIngester
+    ) -> None:
+        """不正な AT URI でバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            await ingester.fetch_single("")
+
+
+# --- BlueskyIngester.crawl テスト ---
+
+
+class TestBlueskyIngesterCrawl:
+    """BlueskyIngester.crawl のテスト."""
+
+    @pytest.fixture()
+    def mock_client(self) -> MagicMock:
+        return _make_mock_client()
+
+    @pytest.fixture()
+    def ingester(self, mock_client: MagicMock) -> BlueskyIngester:
+        return BlueskyIngester(client=mock_client, max_posts=3)
+
+    async def test_crawl_basic(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """基本的な投稿取得が正常に動作すること."""
+        mock_client.get.return_value = _make_list_records_response(
+            records=[
+                _make_post_record(rkey="post1", text="First post"),
+                _make_post_record(rkey="post2", text="Second post"),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 2
+        assert contents[0].text == "First post"
+        assert contents[1].text == "Second post"
+
+    async def test_crawl_respects_max_posts(
+        self, mock_client: MagicMock
+    ) -> None:
+        """max_posts を超える投稿が返らないこと."""
+        ingester = BlueskyIngester(client=mock_client, max_posts=2)
+        mock_client.get.return_value = _make_list_records_response(
+            records=[
+                _make_post_record(rkey="post1", text="Post 1"),
+                _make_post_record(rkey="post2", text="Post 2"),
+                _make_post_record(rkey="post3", text="Post 3"),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 2
+
+    async def test_crawl_pagination(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """ページネーションが正常に動作すること."""
+        mock_client.get.side_effect = [
+            _make_list_records_response(
+                records=[
+                    _make_post_record(rkey="post1", text="Page 1 Post 1"),
+                    _make_post_record(rkey="post2", text="Page 1 Post 2"),
+                ],
+                cursor="cursor_2",
+            ),
+            _make_list_records_response(
+                records=[
+                    _make_post_record(rkey="post3", text="Page 2 Post 1"),
+                ],
+                cursor=None,
+            ),
+        ]
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 3
+        assert mock_client.get.call_count == 2
+
+    async def test_crawl_empty_posts(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """投稿が 0 件の場合、空リストを返すこと."""
+        mock_client.get.return_value = _make_list_records_response(
+            records=[], cursor=None
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert contents == []
+
+    async def test_crawl_api_error(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """API エラー時に空リストを返すこと."""
+        mock_client.get.return_value = _make_error_response(500)
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert contents == []
+
+    async def test_crawl_empty_handle(
+        self, ingester: BlueskyIngester
+    ) -> None:
+        """空のハンドルでバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            await ingester.crawl("")
+
+    async def test_crawl_did_handle_rejected(
+        self, ingester: BlueskyIngester
+    ) -> None:
+        """DID 形式のハンドルでバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="DID format is not accepted"):
+            await ingester.crawl("did:plc:test123")
+
+    async def test_crawl_with_quote_repost(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """引用リポスト投稿の引用元テキストが取得されること."""
+        # 投稿一覧: 引用リポスト
+        list_response = _make_list_records_response(
+            records=[
+                _make_post_record(
+                    rkey="quote1",
+                    text="My comment on this",
+                    embed={
+                        "$type": "app.bsky.embed.record",
+                        "record": {
+                            "uri": "at://did:plc:other/app.bsky.feed.post/original1",
+                            "cid": "bafyother",
+                        },
+                    },
+                ),
+            ],
+            cursor=None,
+        )
+
+        # 引用元投稿の getRecord レスポンス
+        quote_response = _make_get_record_response(
+            uri="at://did:plc:other/app.bsky.feed.post/original1",
+            value={"text": "Original post text", "createdAt": "2024-01-01T00:00:00Z"},
+        )
+
+        mock_client.get.side_effect = [list_response, quote_response]
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
+        assert "My comment on this" in contents[0].text
+        assert "[引用元]" in contents[0].text
+        assert "Original post text" in contents[0].text
+
+    async def test_crawl_quote_fetch_failure(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """引用元取得失敗時、投稿本文のみで取り込まれること."""
+        list_response = _make_list_records_response(
+            records=[
+                _make_post_record(
+                    rkey="quote1",
+                    text="My comment",
+                    embed={
+                        "$type": "app.bsky.embed.record",
+                        "record": {
+                            "uri": "at://did:plc:other/app.bsky.feed.post/deleted",
+                            "cid": "bafydeleted",
+                        },
+                    },
+                ),
+            ],
+            cursor=None,
+        )
+
+        mock_client.get.side_effect = [list_response, _make_error_response(404)]
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
+        assert contents[0].text == "My comment"
+        assert "[引用元]" not in contents[0].text
+
+    async def test_crawl_with_reposts(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """include_reposts=True でリポスト走査が行われること."""
+        # オリジナル投稿一覧
+        post_list = _make_list_records_response(
+            records=[
+                _make_post_record(rkey="post1", text="My post"),
+            ],
+            cursor=None,
+        )
+
+        # リポスト一覧
+        repost_list = _make_list_records_response(
+            records=[
+                _make_repost_record(
+                    subject_uri="at://did:plc:other/app.bsky.feed.post/reposted1",
+                ),
+            ],
+            cursor=None,
+        )
+
+        # リポスト元投稿
+        original_post = _make_get_record_response(
+            uri="at://did:plc:other/app.bsky.feed.post/reposted1",
+            value={"text": "Reposted content", "createdAt": "2024-01-01T00:00:00Z"},
+        )
+
+        mock_client.get.side_effect = [post_list, repost_list, original_post]
+
+        contents = await ingester.crawl(
+            "user.bsky.social", include_reposts=True
+        )
+
+        assert len(contents) == 2
+        texts = [c.text for c in contents]
+        assert "My post" in texts
+        assert "Reposted content" in texts
+
+    async def test_crawl_repost_duplicate_skipped(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """オリジナル投稿と重複するリポストがスキップされること."""
+        # オリジナル投稿: post1
+        post_list = _make_list_records_response(
+            records=[
+                _make_post_record(
+                    did="did:plc:test123", rkey="post1", text="My post"
+                ),
+            ],
+            cursor=None,
+        )
+
+        # リポスト: 同じ投稿を参照
+        repost_list = _make_list_records_response(
+            records=[
+                _make_repost_record(
+                    subject_uri="at://did:plc:test123/app.bsky.feed.post/post1",
+                ),
+            ],
+            cursor=None,
+        )
+
+        mock_client.get.side_effect = [post_list, repost_list]
+
+        contents = await ingester.crawl(
+            "user.bsky.social", include_reposts=True
+        )
+
+        # 重複が除外されるため 1 件のみ
+        assert len(contents) == 1
+
+    async def test_crawl_repost_fetch_failure(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """リポスト元取得失敗時、該当リポストがスキップされること."""
+        post_list = _make_list_records_response(
+            records=[
+                _make_post_record(rkey="post1", text="My post"),
+            ],
+            cursor=None,
+        )
+
+        repost_list = _make_list_records_response(
+            records=[
+                _make_repost_record(
+                    subject_uri="at://did:plc:other/app.bsky.feed.post/deleted",
+                ),
+            ],
+            cursor=None,
+        )
+
+        mock_client.get.side_effect = [
+            post_list,
+            repost_list,
+            _make_error_response(404),
+        ]
+
+        contents = await ingester.crawl(
+            "user.bsky.social", include_reposts=True
+        )
+
+        assert len(contents) == 1
+        assert contents[0].text == "My post"
+
+    async def test_crawl_skips_empty_text_posts(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """テキストが空の投稿がスキップされること."""
+        mock_client.get.return_value = _make_list_records_response(
+            records=[
+                _make_post_record(rkey="post1", text=""),
+                _make_post_record(rkey="post2", text="Valid post"),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
+        assert contents[0].text == "Valid post"
+
+    async def test_crawl_metadata_fields(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """メタデータフィールドが正しく設定されること."""
+        mock_client.get.return_value = _make_list_records_response(
+            records=[
+                _make_post_record(
+                    rkey="post1",
+                    text="Test metadata",
+                    created_at="2024-06-15T12:00:00Z",
+                    reply={"parent": {"uri": "at://did:plc:other/app.bsky.feed.post/parent"}},
+                    embed={
+                        "$type": "app.bsky.embed.images",
+                        "images": [{"alt": "test image"}],
+                    },
+                ),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
+        meta = contents[0].metadata
+        assert meta["handle"] == "user.bsky.social"
+        assert meta["did"] == "did:plc:test123"
+        assert meta["rkey"] == "post1"
+        assert meta["url"] == "https://bsky.app/profile/user.bsky.social/post/post1"
+        assert meta["createdAt"] == "2024-06-15T12:00:00Z"
+        assert meta["has_images"] is True
+        assert meta["is_reply"] is True
+        assert meta["is_repost"] is False
+
+    async def test_crawl_source_id_format(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """source_id が AT URI 形式であること."""
+        mock_client.get.return_value = _make_list_records_response(
+            records=[
+                _make_post_record(
+                    did="did:plc:abc123", rkey="post1", text="Test"
+                ),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
+        assert contents[0].source_id == "at://did:plc:abc123/app.bsky.feed.post/post1"
+
+    async def test_crawl_request_exception(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """リクエスト例外時に空リストを返すこと."""
+        mock_client.get.side_effect = Exception("Connection error")
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert contents == []
+
+
+# --- BlueskyIngester コンストラクタテスト ---
+
+
+class TestBlueskyIngesterInit:
+    """BlueskyIngester コンストラクタのテスト."""
+
+    def test_default_max_posts(self) -> None:
+        """デフォルト max_posts が 200 であること."""
+        ingester = BlueskyIngester(client=_make_mock_client())
+        assert ingester._max_posts == 200
+
+    def test_custom_max_posts(self) -> None:
+        """カスタム max_posts が設定できること."""
+        ingester = BlueskyIngester(client=_make_mock_client(), max_posts=10)
+        assert ingester._max_posts == 10
+
+    def test_clamp_max_posts(self) -> None:
+        """ハードリミット超過時にクランプされること."""
+        ingester = BlueskyIngester(client=_make_mock_client(), max_posts=2000)
+        assert ingester._max_posts == MAX_POSTS_HARD_LIMIT
+
+    def test_reject_zero_max_posts(self) -> None:
+        """max_posts=0 でバリデーションエラーになること."""
+        with pytest.raises(ValueError):
+            BlueskyIngester(client=_make_mock_client(), max_posts=0)
+
+    def test_reject_negative_max_posts(self) -> None:
+        """負の max_posts でバリデーションエラーになること."""
+        with pytest.raises(ValueError):
+            BlueskyIngester(client=_make_mock_client(), max_posts=-5)
+
+    def test_custom_pds_url(self) -> None:
+        """カスタム PDS URL が設定できること."""
+        ingester = BlueskyIngester(
+            client=_make_mock_client(),
+            pds_url="https://custom.pds.example.com",
+        )
+        assert ingester._pds_url == "https://custom.pds.example.com"
+
+    def test_pds_url_trailing_slash_stripped(self) -> None:
+        """PDS URL の末尾スラッシュが除去されること."""
+        ingester = BlueskyIngester(
+            client=_make_mock_client(),
+            pds_url="https://bsky.social/",
+        )
+        assert ingester._pds_url == "https://bsky.social"
+
+
+# --- ハードリミット定数テスト ---
+
+
+class TestHardLimits:
+    """ハードリミット定数の値テスト."""
+
+    def test_max_posts_hard_limit(self) -> None:
+        """投稿取得上限が仕様通りであること."""
+        assert MAX_POSTS_HARD_LIMIT == 1000

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -26,6 +26,7 @@ from rag.ingesters.bluesky import (
     _make_title,
     _parse_at_uri,
     _validate_max_posts,
+    _validate_pds_url,
 )
 
 
@@ -904,6 +905,62 @@ class TestBlueskyIngesterInit:
             pds_url="https://bsky.social/",
         )
         assert ingester._pds_url == "https://bsky.social"
+
+    def test_pds_url_whitespace_stripped(self) -> None:
+        """PDS URL の前後空白がトリムされること."""
+        ingester = BlueskyIngester(
+            client=_make_mock_client(),
+            pds_url="  https://bsky.social  ",
+        )
+        assert ingester._pds_url == "https://bsky.social"
+
+    def test_reject_empty_pds_url(self) -> None:
+        """空の PDS URL でバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            BlueskyIngester(client=_make_mock_client(), pds_url="")
+        with pytest.raises(ValueError, match="must not be empty"):
+            BlueskyIngester(client=_make_mock_client(), pds_url="   ")
+
+    def test_reject_non_https_pds_url(self) -> None:
+        """非 HTTPS の PDS URL でバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="HTTPS"):
+            BlueskyIngester(client=_make_mock_client(), pds_url="http://bsky.social")
+
+
+# --- _validate_pds_url テスト ---
+
+
+class TestValidatePdsUrl:
+    """PDS URL のバリデーションテスト."""
+
+    def test_valid_https_url(self) -> None:
+        """正しい HTTPS URL がそのまま返ること."""
+        assert _validate_pds_url("https://bsky.social") == "https://bsky.social"
+
+    def test_trailing_slash_stripped(self) -> None:
+        """末尾スラッシュが除去されること."""
+        assert _validate_pds_url("https://bsky.social/") == "https://bsky.social"
+
+    def test_whitespace_stripped(self) -> None:
+        """前後の空白がトリムされること."""
+        assert _validate_pds_url("  https://bsky.social  ") == "https://bsky.social"
+
+    def test_reject_empty(self) -> None:
+        """空文字列がバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_pds_url("")
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_pds_url("   ")
+
+    def test_reject_http(self) -> None:
+        """HTTP スキームがバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="HTTPS"):
+            _validate_pds_url("http://bsky.social")
+
+    def test_reject_no_scheme(self) -> None:
+        """スキームなしがバリデーションエラーになること."""
+        with pytest.raises(ValueError, match="HTTPS"):
+            _validate_pds_url("bsky.social")
 
 
 # --- ハードリミット定数テスト ---

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -29,8 +29,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_nine_tools() -> None:
-    """RAG MCPサーバーが9つのツールを公開すること."""
+async def test_rag_server_exposes_ten_tools() -> None:
+    """RAG MCPサーバーが10個のツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -39,20 +39,20 @@ async def test_rag_server_exposes_nine_tools() -> None:
 
     expected = {
         "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_crawl_zenn", "rag_add_local", "rag_crawl_local",
-        "rag_delete", "rag_stats",
+        "rag_crawl_zenn", "rag_crawl_bluesky", "rag_add_local",
+        "rag_crawl_local", "rag_delete", "rag_stats",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に9であること."""
+    """RAG MCPサーバーのツール数が正確に10であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 9
+    assert len(tools) == 10
 
 
 class TestRagSearchOutput:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `BlueskyIngester` クラスの実装（`BaseIngester` 継承、AT Protocol API 連携）
- `rag_crawl_bluesky` MCP ツールの登録（`server.py`）
- AT Protocol API 連携（`listRecords` / `getRecord` ページネーション走査）
- テキスト抽出（投稿本文、画像/動画 ALT、リンクカード、引用元テキスト取得）
- リポスト走査（`include_reposts` オプション）
- `ConstrainedClient` 経由の安全なリクエスト
- 設定項目追加（PDS URL、max_posts、タイムアウト、間隔、リポスト）
- ハードリミット・バリデーション・クランプの実装
- `docs/specs/rag-knowledge.md` のツール数・一覧更新
- `README.md` に BlueSky インジェスター追加
- `bluesky-ingester.md` の pre-impl Note 削除

## Test plan

- [x] 59 件の単体テスト（`tests/test_bluesky_ingester.py`）全通過
- [x] 既存テスト 602 件全通過
- [x] ruff チェック通過
- [x] mypy チェック通過

## Related issues

Closes #185

Generated with [Claude Code](https://claude.ai/code)