### PR TITLE
docs(architecture): ARCHITECTURE.md に BlueskyIngester を追記

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@
 | ディレクトリ | 責務 |
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
-| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・LocalFileIngester） |
+| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・LocalFileIngester・BlueskyIngester） |
 
 ### ルートレベルファイル
 
@@ -50,6 +50,7 @@
 | `rag-knowledge.md` | `src/rag/` 全体 |
 | `zenn-ingester.md` | `src/rag/ingesters/zenn.py` |
 | `local-file-ingester.md` | `src/rag/ingesters/local_file.py` |
+| `bluesky-ingester.md` | `src/rag/ingesters/bluesky.py` |
 
 ### Claude Code 拡張
 


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md に BlueskyIngester を追記
- 仕様書対応表に bluesky-ingester.md を追加

## Change type
- [x] `docs` — ドキュメントのみの変更

## Test plan
- [ ] ドキュメントのみの変更のため、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)