### PR TITLE
fix(local-file-ingester): Windows で Unix 形式絶対パスパターンを検出できない問題を修正

### DIFF
--- a/src/rag/ingesters/local_file.py
+++ b/src/rag/ingesters/local_file.py
@@ -196,7 +196,7 @@ class LocalFileIngester(BaseIngester):
             raise ValueError(
                 f"Pattern must not contain '..': {pattern!r}"
             )
-        if Path(pattern).is_absolute():
+        if pattern.startswith("/") or Path(pattern).is_absolute():
             raise ValueError(
                 f"Pattern must not be an absolute path: {pattern!r}"
             )


### PR DESCRIPTION
## Summary
- `validate_pattern()` で `pattern.startswith("/")` チェックを追加
- Windows の `Path.is_absolute()` は `/` 始まりを絶対パスと判定しないため、仕様書の要件を満たしていなかった

## Change type
- [x] `fix` — バグ修正

## Test plan
- [x] `tests/test_local_file_ingester.py` 全 43 テスト通過
- [x] 全テストスイート 611 テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)