### PR TITLE
feat(bluesky-ingester): 投稿テキストの構造化とチャンキングスキップ (#192)

### DIFF
--- a/docs/specs/bluesky-ingester.md
+++ b/docs/specs/bluesky-ingester.md
@@ -346,6 +346,7 @@ flowchart TD
 | 画像 ALT テキスト | `value.embed.images[].alt` | 画像の代替テキスト |
 | 動画 ALT テキスト | `value.embed.alt` | 動画の代替テキスト |
 | リンクカードタイトル | `value.embed.external.title` | 外部リンクのタイトル |
+| リンクカード URL | `value.embed.external.uri` | 外部リンクの URL |
 | リンクカード説明 | `value.embed.external.description` | 外部リンクの説明文 |
 
 embed の `$type` が `app.bsky.embed.recordWithMedia`（メディア + 引用の複合型）の場合、メディア部分は `embed.media` 配下にネストされる:
@@ -355,6 +356,7 @@ embed の `$type` が `app.bsky.embed.recordWithMedia`（メディア + 引用�
 | 画像 ALT テキスト | `value.embed.media.images[].alt` | recordWithMedia 時の画像 ALT |
 | 動画 ALT テキスト | `value.embed.media.alt` | recordWithMedia 時の動画 ALT |
 | リンクカードタイトル | `value.embed.media.external.title` | recordWithMedia 時のリンクタイトル |
+| リンクカード URL | `value.embed.media.external.uri` | recordWithMedia 時のリンク URL |
 | リンクカード説明 | `value.embed.media.external.description` | recordWithMedia 時のリンク説明 |
 
 #### 引用元投稿テキストの取得
@@ -367,7 +369,33 @@ listRecords が返す raw record の `embed.record` は `strongRef`（`uri` + `c
 
 - 動画キャプション（VTT）
 
-抽出したテキストはフィールド間を改行で連結し、1 つのプレーンテキストとして構築する。引用元テキストには `[引用元]` プレフィックスを付加し、投稿本文と区別できるようにする。
+抽出したテキストは以下の構造で構築する。各セクションは空行で区切る。該当するセクションがない場合は省略する。
+
+```
+投稿テキスト
+
+[画像ALT] 画像の代替テキスト（複数ある場合は改行で連結）
+[動画ALT] 動画の代替テキスト
+
+[リンクカード]
+タイトル: 外部リンクのタイトル
+URL: 外部リンクの URL
+説明: 外部リンクの説明文
+
+[引用元]
+引用元の投稿テキスト
+```
+
+- 投稿テキストを先頭に配置する（検索ヒット時に最も重要な情報が先頭に来る）
+- 画像/動画 ALT テキストは `[画像ALT]` / `[動画ALT]` プレフィックスで区別する
+- リンクカードは `[リンクカード]` セクション内に構造化する。リンクカードの URL は `embed.external.uri` から取得する
+- 引用元テキストは `[引用元]` セクションに配置する
+
+### チャンキング
+
+BlueSky の投稿は最大 300 文字の短文であり、1 投稿が意味の最小単位である。チャンカーによる文字数ベースの分割は URL の分断やコンテキストの喪失を招くため、チャンキングをスキップし 1 投稿 = 1 チャンクで格納する。
+
+`IngestedContent` の `skip_chunking` フラグを `True` に設定することで、`RAGKnowledgeService.ingest_content` はチャンキングをスキップし、テキスト全体を 1 チャンクとして保存する。
 
 ### スレッドの扱い
 

--- a/src/rag/ingesters/base.py
+++ b/src/rag/ingesters/base.py
@@ -26,6 +26,7 @@ class IngestedContent:
         ingested_at: 取り込みタイムスタンプ（ISO 8601）
         source_type: データソース種別（"web", "file" 等）
         metadata: ソース固有のメタデータ
+        skip_chunking: True の場合、チャンキングをスキップし 1 チャンクで格納する
     """
 
     source_id: str
@@ -34,6 +35,7 @@ class IngestedContent:
     ingested_at: str
     source_type: str
     metadata: dict[str, object] = field(default_factory=dict)
+    skip_chunking: bool = False
 
     @staticmethod
     def now_iso() -> str:

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -98,87 +98,103 @@ def _parse_at_uri(uri: str) -> tuple[str, str, str] | None:
 
 
 def _extract_text_from_post(value: dict[str, Any]) -> str:
-    """投稿レコードからテキストを抽出する.
+    """投稿レコードからテキストを構造化して抽出する.
 
     仕様: docs/specs/bluesky-ingester.md「テキスト抽出」
 
-    抽出対象:
-    - 投稿テキスト (value.text)
-    - 画像 ALT テキスト (value.embed.images[].alt)
-    - 動画 ALT テキスト (value.embed.alt)
-    - リンクカードタイトル (value.embed.external.title)
-    - リンクカード説明 (value.embed.external.description)
-    - recordWithMedia 時の media 配下も同様
+    構造:
+    1. 投稿テキスト（先頭）
+    2. 画像/動画 ALT テキスト（[画像ALT] / [動画ALT] プレフィックス）
+    3. リンクカード（[リンクカード] セクション）
+
+    引用元テキストは呼び出し元で [引用元] セクションとして追加する。
 
     Args:
         value: 投稿レコードの value オブジェクト
 
     Returns:
-        改行で連結されたプレーンテキスト
+        構造化されたプレーンテキスト
     """
-    parts: list[str] = []
+    sections: list[str] = []
 
-    # 投稿テキスト
+    # 1. 投稿テキスト（先頭）
     text = value.get("text", "")
     if text:
-        parts.append(text)
+        sections.append(text)
 
+    # 2-3. embed からメディア情報を抽出
     embed = value.get("embed")
     if isinstance(embed, dict):
-        _extract_embed_text(embed, parts)
+        media_sections = _extract_embed_sections(embed)
+        sections.extend(media_sections)
 
-    return "\n".join(parts)
+    return "\n\n".join(sections)
 
 
-def _extract_embed_text(embed: dict[str, Any], parts: list[str]) -> None:
-    """embed オブジェクトからテキストを抽出する.
+def _extract_embed_sections(embed: dict[str, Any]) -> list[str]:
+    """embed オブジェクトから構造化セクションを抽出する.
 
     Args:
         embed: embed オブジェクト
-        parts: テキストパーツのリスト（破壊的に追加）
+
+    Returns:
+        構造化セクションのリスト
     """
     embed_type = embed.get("$type", "")
 
     if embed_type == "app.bsky.embed.recordWithMedia":
-        # recordWithMedia: media 配下にメディア情報がネスト
         media = embed.get("media")
         if isinstance(media, dict):
-            _extract_media_text(media, parts)
-    else:
-        # 通常の embed
-        _extract_media_text(embed, parts)
+            return _extract_media_sections(media)
+        return []
+
+    return _extract_media_sections(embed)
 
 
-def _extract_media_text(media: dict[str, Any], parts: list[str]) -> None:
-    """メディアオブジェクトからテキストを抽出する.
+def _extract_media_sections(media: dict[str, Any]) -> list[str]:
+    """メディアオブジェクトから構造化セクションを抽出する.
 
     Args:
         media: メディアオブジェクト（embed または embed.media）
-        parts: テキストパーツのリスト（破壊的に追加）
+
+    Returns:
+        構造化セクションのリスト
     """
+    sections: list[str] = []
+
     # 画像 ALT テキスト
     images = media.get("images")
     if isinstance(images, list):
-        for img in images:
-            if isinstance(img, dict):
-                alt = img.get("alt", "")
-                if alt:
-                    parts.append(alt)
+        alt_texts = [
+            img.get("alt", "")
+            for img in images
+            if isinstance(img, dict) and img.get("alt", "")
+        ]
+        if alt_texts:
+            sections.append("[画像ALT] " + "\n".join(alt_texts))
 
     # 動画 ALT テキスト
     video_alt = media.get("alt", "")
     if video_alt:
-        parts.append(video_alt)
+        sections.append(f"[動画ALT] {video_alt}")
 
     # リンクカード
     external = media.get("external")
     if isinstance(external, dict):
+        card_parts: list[str] = ["[リンクカード]"]
         ext_title = external.get("title", "")
         if ext_title:
-            parts.append(ext_title)
+            card_parts.append(f"タイトル: {ext_title}")
+        ext_uri = external.get("uri", "")
+        if ext_uri:
+            card_parts.append(f"URL: {ext_uri}")
         ext_desc = external.get("description", "")
         if ext_desc:
-            parts.append(ext_desc)
+            card_parts.append(f"説明: {ext_desc}")
+        if len(card_parts) > 1:
+            sections.append("\n".join(card_parts))
+
+    return sections
 
 
 def _make_title(text: str) -> str:
@@ -413,7 +429,8 @@ class BlueskyIngester(BaseIngester):
         # 引用元テキストの取得
         quote_text = await self._fetch_quote_text(value)
         if quote_text:
-            text = text + "\n[引用元]\n" + quote_text if text else "[引用元]\n" + quote_text
+            quote_section = "[引用元]\n" + quote_text
+            text = text + "\n\n" + quote_section if text else quote_section
 
         if not text.strip():
             logger.debug("Skipping empty post: %s", uri)
@@ -745,6 +762,7 @@ class BlueskyIngester(BaseIngester):
             ingested_at=IngestedContent.now_iso(),
             source_type="bluesky",
             metadata=metadata,
+            skip_chunking=True,
         )
 
     @staticmethod

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -587,14 +587,20 @@ class RAGKnowledgeService:
     async def ingest_content(self, content: IngestedContent) -> int:
         """IngestedContent をチャンキングして保存する.
 
+        content.skip_chunking が True の場合、チャンキングをスキップし
+        テキスト全体を 1 チャンクとして保存する。
+
         Args:
             content: 取り込み済みコンテンツ
 
         Returns:
             保存されたチャンク数
         """
-        # テキストをスマートチャンキング
-        chunks = self._smart_chunk(content.text)
+        # テキストをスマートチャンキング（skip_chunking 時は 1 チャンクで格納）
+        if content.skip_chunking:
+            chunks = [content.text]
+        else:
+            chunks = self._smart_chunk(content.text)
 
         if not chunks:
             logger.info("No chunks generated for content: %s", content.source_id)

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -598,7 +598,7 @@ class RAGKnowledgeService:
         """
         # テキストをスマートチャンキング（skip_chunking 時は 1 チャンクで格納）
         if content.skip_chunking:
-            chunks = [content.text]
+            chunks = [content.text] if content.text.strip() else []
         else:
             chunks = self._smart_chunk(content.text)
 

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -208,7 +208,7 @@ class TestExtractTextFromPost:
         assert _extract_text_from_post(value) == ""
 
     def test_image_alt_text(self) -> None:
-        """画像 ALT テキストが抽出されること."""
+        """画像 ALT テキストが [画像ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Photo post",
             "embed": {
@@ -220,9 +220,12 @@ class TestExtractTextFromPost:
             },
         }
         result = _extract_text_from_post(value)
-        assert "Photo post" in result
+        assert result.startswith("Photo post")
+        assert "[画像ALT] " in result
         assert "A beautiful sunset" in result
         assert "Mountain view" in result
+        # セクション間は空行区切り
+        assert "\n\n" in result
 
     def test_image_empty_alt(self) -> None:
         """空の ALT テキストは無視されること."""
@@ -237,7 +240,7 @@ class TestExtractTextFromPost:
         assert "Good alt" in result
 
     def test_video_alt_text(self) -> None:
-        """動画 ALT テキストが抽出されること."""
+        """動画 ALT テキストが [動画ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Video post",
             "embed": {
@@ -246,11 +249,11 @@ class TestExtractTextFromPost:
             },
         }
         result = _extract_text_from_post(value)
-        assert "Video post" in result
-        assert "Video description" in result
+        assert result.startswith("Video post")
+        assert "[動画ALT] Video description" in result
 
     def test_external_link(self) -> None:
-        """リンクカードのタイトルと説明が抽出されること."""
+        """リンクカードが [リンクカード] セクション構造で抽出されること."""
         value = {
             "text": "Check this out",
             "embed": {
@@ -263,12 +266,14 @@ class TestExtractTextFromPost:
             },
         }
         result = _extract_text_from_post(value)
-        assert "Check this out" in result
-        assert "Example Article" in result
-        assert "Article description" in result
+        assert result.startswith("Check this out")
+        assert "[リンクカード]" in result
+        assert "タイトル: Example Article" in result
+        assert "URL: https://example.com" in result
+        assert "説明: Article description" in result
 
     def test_record_with_media_images(self) -> None:
-        """recordWithMedia 型のメディア配下画像 ALT が抽出されること."""
+        """recordWithMedia 型の画像 ALT が [画像ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Quote with images",
             "embed": {
@@ -286,11 +291,11 @@ class TestExtractTextFromPost:
             },
         }
         result = _extract_text_from_post(value)
-        assert "Quote with images" in result
-        assert "Media image alt" in result
+        assert result.startswith("Quote with images")
+        assert "[画像ALT] Media image alt" in result
 
     def test_record_with_media_external(self) -> None:
-        """recordWithMedia 型の media.external が抽出されること."""
+        """recordWithMedia 型の media.external が [リンクカード] セクションで抽出されること."""
         value = {
             "text": "Quote with link",
             "embed": {
@@ -312,8 +317,11 @@ class TestExtractTextFromPost:
             },
         }
         result = _extract_text_from_post(value)
-        assert "Link Title" in result
-        assert "Link Desc" in result
+        assert result.startswith("Quote with link")
+        assert "[リンクカード]" in result
+        assert "タイトル: Link Title" in result
+        assert "URL: https://example.com" in result
+        assert "説明: Link Desc" in result
 
     def test_no_embed(self) -> None:
         """embed なしでテキストのみ返ること."""
@@ -451,6 +459,7 @@ class TestBlueskyIngesterFetchSingle:
         assert result.metadata["handle"] == "did:plc:test123"
         assert result.metadata["url"] == "https://bsky.app/profile/did:plc:test123/post/abc123"
         assert result.metadata["is_repost"] is False
+        assert result.skip_chunking is True
 
     async def test_fetch_single_404(
         self, ingester: BlueskyIngester, mock_client: MagicMock
@@ -829,6 +838,7 @@ class TestBlueskyIngesterCrawl:
         assert meta["has_images"] is True
         assert meta["is_reply"] is True
         assert meta["is_repost"] is False
+        assert contents[0].skip_chunking is True
 
     async def test_crawl_source_id_format(
         self, ingester: BlueskyIngester, mock_client: MagicMock


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- BlueSky 投稿のテキスト抽出を構造化フォーマットに変更（投稿テキスト先頭、[画像ALT]/[動画ALT]/[リンクカード]/[引用元] セクション区切り）
- `IngestedContent` に `skip_chunking` フラグを追加。BlueSky 投稿は 1投稿=1チャンクで格納（URL 分断・コンテキスト喪失を防止）
- 仕様書（bluesky-ingester.md）のテキスト抽出・チャンキングセクションを更新
- テストの構造化フォーマット厳密検証と `skip_chunking` アサートを追加

## Test plan

- [x] pytest 611 passed
- [x] ruff check passed
- [x] mypy passed

## Related issues

Closes #192