### PR TITLE
feat(bluesky-ingester): getAuthorFeed による統一タイムライン取得に切り替え (#194)

### DIFF
--- a/docs/specs/bluesky-ingester.md
+++ b/docs/specs/bluesky-ingester.md
@@ -427,7 +427,7 @@ BlueSky は投稿の編集が不可能なため、既存の `source_id` と一�
 | `title` | 投稿テキストの先頭 50 文字（50 文字を超える場合は末尾に `...` を付加） |
 | `text` | 抽出済みプレーンテキスト |
 | `source_type` | `"bluesky"` |
-| `metadata` | `handle`、`did`、`rkey`、`url`（`https://bsky.app/profile/{handle}/post/{rkey}`）、`createdAt`、`has_images`、`has_video`、`has_external_link`、`is_reply`、`is_repost` |
+| `metadata` | `handle`（元投稿者のハンドル。リポスト時は `post.author.handle`）、`did`、`rkey`、`url`（`https://bsky.app/profile/{handle}/post/{rkey}`）、`createdAt`、`has_images`、`has_video`、`has_external_link`、`is_reply`、`is_repost` |
 
 `is_repost` の判定: フィードアイテムに `reason` フィールドが存在し、`reason.$type` が `app.bsky.feed.defs#reasonRepost` の場合に `True`。
 

--- a/docs/specs/bluesky-ingester.md
+++ b/docs/specs/bluesky-ingester.md
@@ -3,17 +3,18 @@
 ## 概要
 
 BlueSky（AT Protocol）の投稿を API 経由で取得し、ナレッジベースに取り込むインジェスター。
-`com.atproto.repo.listRecords` API を使用し、指定ユーザーの公開投稿を一括取得する。
+`app.bsky.feed.getAuthorFeed` API を使用し、指定ユーザーの統一タイムライン（投稿・リポスト・リプライ混在）を一括取得する。
 
 スコープ:
 
-- 指定ユーザーの公開投稿の取得（オリジナル投稿 + 引用リポスト）
-- リポストの取得（オプション）
+- 指定ユーザーの統一タイムラインの取得（投稿・引用リポスト・リポスト・リプライ）
+- リポストのフィルタリング（`include_reposts` パラメータによる除外制御）
+- AT URI 指定による個別投稿の取得
 - MCP ツールとしての投稿取り込みインターフェースの提供
 
 スコープ外:
 
-- 他ユーザーの投稿の取得（リポスト元の取得を除く）
+- 他ユーザーの投稿の個別取得（タイムラインに含まれるリポスト・引用を除く）
 - 投稿の作成・編集・削除（読み取り専用）
 - DM（ダイレクトメッセージ）の取得
 - フォロー・いいね等のソーシャルデータの取得
@@ -29,9 +30,9 @@ BlueSky（AT Protocol）の投稿を API 経由で取得し、ナレッジベー
 - 外部 HTTP リクエストは ConstrainedClient（py-common-lib）経由で実行する
 - ハードリミット（コード内定数。設定・引数・環境変数で緩和不可。厳格化は可能）:
   - 操作あたりリクエスト総数上限: 500（ConstrainedClient 共通）
-  - 最低リクエスト間隔: 0.1 秒（ConstrainedClient 共通。ページネーション走査中の各リクエスト間、リポスト元投稿取得間を含む全外部リクエスト間に適用）
+  - 最低リクエスト間隔: 0.1 秒（ConstrainedClient 共通。ページネーション走査中の各リクエスト間を含む全外部リクエスト間に適用）
   - 操作全体タイムアウト: 600 秒（許容範囲 1〜600 秒、ConstrainedClient 共通）
-  - 投稿取得上限: 1000 件（BlueSky インジェスター固有。オリジナル投稿の取得数に適用。リポストは独立走査のため本上限の対象外）
+  - 投稿取得上限: 1000 件（BlueSky インジェスター固有。タイムライン全体に適用。リポストを含む全アイテムが対象）
 - サーキットブレーカー: 5 回連続失敗で操作全体を中断する（ConstrainedClient 共通）
 - バリデーションとクランプの使い分け:
   - **バリデーションエラー（拒否）**: 型不正（非整数など）、0、負数。これらは明らかな誤入力であり、クランプで救済しない
@@ -43,23 +44,21 @@ BlueSky（AT Protocol）の投稿を API 経由で取得し、ナレッジベー
 
 ### AT Protocol API
 
-AT Protocol は分散型プロトコルであり、ユーザーのデータは各 PDS（Personal Data Server）にホストされる。XRPC エンドポイントはユーザーが所属する PDS に対してリクエストを送信する必要がある。
+本インジェスターでは AppView（公開 API ゲートウェイ）経由で BlueSky のデータを取得する。AppView はユーザーのデータを集約して提供する公開 API であり、認証不要でアクセスできる。
 
-本インジェスターでは PDS のベース URL を設定可能とし、デフォルトは `https://bsky.social`（BlueSky 公式 PDS）とする。セルフホスト PDS や他の PDS を利用するユーザーの投稿を取得する場合は、環境変数 `RAG_BLUESKY_PDS_URL` で対象 PDS の URL を指定する。
-
-> **Note**: handle から PDS エンドポイントを自動解決する仕組み（DID Document の `#atproto_pds` サービスエンドポイント参照）は、初期リリースのスコープ外とする。必要に応じて後続フェーズで対応する。
+AppView のベース URL を設定可能とし、デフォルトは `https://public.api.bsky.app`（BlueSky 公式 AppView）とする。環境変数 `RAG_BLUESKY_APPVIEW_URL` で変更可能。
 
 | 連携先 | 用途 | 接続方式 |
 |--------|------|---------|
-| AT Protocol PDS（デフォルト: bsky.social） | 投稿の取得 | REST API（ConstrainedClient 経由） |
+| AT Protocol AppView（デフォルト: public.api.bsky.app） | 投稿の取得 | REST API（ConstrainedClient 経由） |
 
-#### listRecords エンドポイント（投稿取得）
+#### getAuthorFeed エンドポイント（タイムライン取得）
 
 | 項目 | 内容 |
 |------|------|
-| URL | `{PDS_URL}/xrpc/com.atproto.repo.listRecords`（デフォルト: `https://bsky.social/xrpc/com.atproto.repo.listRecords`） |
+| URL | `{APPVIEW_URL}/xrpc/app.bsky.feed.getAuthorFeed`（デフォルト: `https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed`） |
 | メソッド | GET |
-| 認証 | 不要（公開リポジトリ） |
+| 認証 | 不要（公開 API） |
 | ページサイズ | `limit` パラメータで指定（最大 100） |
 | ページネーション | レスポンスの `cursor` フィールド。存在しない場合は最終ページ |
 
@@ -67,45 +66,60 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
-| `repo` | 文字列 | はい | DID またはハンドル（例: `user.bsky.social`） |
-| `collection` | 文字列 | はい | レコードコレクション。投稿: `app.bsky.feed.post`、リポスト: `app.bsky.feed.repost` |
+| `actor` | 文字列 | はい | ハンドルまたは DID（例: `user.bsky.social`） |
 | `limit` | 整数 | いいえ | 1 ページあたりの取得件数（最大 100） |
 | `cursor` | 文字列 | いいえ | ページネーションカーソル |
-| `reverse` | 真偽値 | いいえ | `true` で古い順に取得 |
 
 レスポンス構造:
 
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
-| `records` | 配列 | レコードオブジェクトの配列 |
+| `feed` | 配列 | フィードアイテムの配列 |
 | `cursor` | 文字列 or 不在 | 次ページのカーソル。最終ページでは存在しない |
 
-レコードオブジェクトの主要フィールド:
+フィードアイテムの主要フィールド:
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `post` | オブジェクト | 投稿オブジェクト（投稿データ・投稿者情報を含む） |
+| `reason` | オブジェクト or 不在 | リポスト理由。リポストの場合のみ存在する |
+
+投稿オブジェクト（`post`）の主要フィールド:
 
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
 | `uri` | 文字列 | AT URI（例: `at://did:plc:xxx/app.bsky.feed.post/rkey`） |
 | `cid` | 文字列 | コンテンツ ID |
-| `value` | オブジェクト | レコード本体 |
+| `author` | オブジェクト | 投稿者情報（`did`、`handle`、`displayName` 等） |
+| `record` | オブジェクト | 投稿レコード本体（raw record） |
+| `embed` | オブジェクト or 不在 | 展開済み embed（view 版。`$type` に `#view` サフィックスが付く） |
 
-投稿レコード（`value`）の主要フィールド:
+投稿レコード（`record`）の主要フィールド:
 
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
 | `text` | 文字列 | 投稿テキスト（最大 300 grapheme） |
 | `createdAt` | 文字列 | 投稿日時（ISO 8601） |
-| `embed` | オブジェクト | 添付コンテンツ（画像・動画・リンクカード・引用等） |
+| `embed` | オブジェクト | 添付コンテンツ（raw 形式。`#view` サフィックスなし） |
 | `reply` | オブジェクト | リプライ先情報（リプライの場合） |
+
+リポスト理由（`reason`）:
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `$type` | 文字列 | `app.bsky.feed.defs#reasonRepost`（リポストの場合） |
+| `by` | オブジェクト | リポストしたユーザーの情報（`did`、`handle` 等） |
+| `indexedAt` | 文字列 | リポスト日時（ISO 8601） |
 
 #### getRecord エンドポイント（個別レコード取得）
 
-リポスト元投稿の取得に使用する。
+個別投稿取得（`fetch_single`）に使用する。タイムライン一括取得では使用しない。
 
 | 項目 | 内容 |
 |------|------|
-| URL | `{PDS_URL}/xrpc/com.atproto.repo.getRecord`（デフォルト: `https://bsky.social/xrpc/com.atproto.repo.getRecord`） |
+| URL | `{APPVIEW_URL}/xrpc/com.atproto.repo.getRecord`（デフォルト: `https://public.api.bsky.app/xrpc/com.atproto.repo.getRecord`） |
 | メソッド | GET |
-| 認証 | 不要（公開リポジトリ） |
+| 認証 | 不要（AppView がプロキシ） |
 
 クエリパラメータ:
 
@@ -128,51 +142,34 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 
 | HTTP ステータス | 意味 | 対応 |
 |----------------|------|------|
-| 400 | パラメータ不正 | 該当リポストをスキップ、エラーログ出力 |
-| 404（`RecordNotFound`） | レコードが存在しない（削除済み等） | 該当リポストをスキップ、警告ログ出力 |
-| 502 / 503 / 504 | サーバーエラー | 該当リポストをスキップ、サーキットブレーカーに計上 |
-
-#### リポスト取得
-
-リポストは `collection=app.bsky.feed.repost` で別途取得する。リポストレコードは元投稿への参照（`subject.uri` / `subject.cid`）のみを含み、テキストは含まれない。元投稿のテキストを取得するには上記 `com.atproto.repo.getRecord` での追加リクエストが必要。
-
-リポストレコード（`value`）の主要フィールド:
-
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `subject.uri` | 文字列 | 元投稿の AT URI（例: `at://did:plc:xxx/app.bsky.feed.post/rkey`） |
-| `subject.cid` | 文字列 | 元投稿のコンテンツ ID |
-| `createdAt` | 文字列 | リポスト日時（ISO 8601） |
-
-元投稿の取得時には、`subject.uri` を解析して `repo`（DID）、`collection`、`rkey` を抽出し、`getRecord` エンドポイントに渡す。
+| 400 | パラメータ不正 | エラーログ出力、None を返す |
+| 404（`RecordNotFound`） | レコードが存在しない（削除済み等） | 警告ログ出力、None を返す |
+| 502 / 503 / 504 | サーバーエラー | エラーログ出力、サーキットブレーカーに計上 |
 
 #### API 選定理由
 
-`getAuthorFeed` ではなく `listRecords` を採用する理由:
+`listRecords` ではなく `getAuthorFeed` を採用する理由:
 
-- `getAuthorFeed` は約 1,950 件でカーソルが消失するバグがあり、全件取得が保証できない
-- `listRecords` にはこの制限がなく、公開リポジトリの全レコードを取得可能
-- `listRecords` は raw record を返すため、テキスト抽出には十分な情報を含む
+- `getAuthorFeed` は投稿・リポスト・リプライを時系列の統一タイムラインとして返すため、`max_posts` をタイムライン全体に一貫して適用できる
+- リポストの元投稿データがレスポンスに含まれるため、`getRecord` による追加リクエストが不要
+- 引用リポストの引用元テキストもレスポンスに展開済みで含まれるため、追加リクエストが不要
+- `listRecords` では投稿とリポストが別系統のため `max_posts` の一貫した適用が困難だった
+
+`getAuthorFeed` の既知の制約:
+
+- 約 1,950 件でカーソルが消失するバグがある。ただし `max_posts` のハードリミットが 1000 件のため、本インジェスターの利用範囲では影響しない
 
 ## 想定プロファイル
 
-### rag_crawl_bluesky（BlueSky 投稿一括取り込み・リポストなし）
+### rag_crawl_bluesky（BlueSky 投稿一括取り込み）
+
+`max_posts` はタイムライン全体（リポスト含む）に適用される。
 
 | 項目 | 内容 |
 |------|------|
-| 最悪ケースリクエスト数 | 10（投稿走査: ceil(1000/100)）+ 1000（引用元投稿取得: 全投稿が引用リポストの場合）= 1010。ただしバジェットトラッカー上限 500 で打ち切り。引用のない一般的なケースでは 10 リクエスト程度 |
-| 最悪ケース所要時間 | 500 × 0.1 秒（ハードリミット最小間隔での理論最短）= 50 秒。引用のない一般的なケースではデフォルト設定（1.0 秒間隔）で 10 秒。操作全体タイムアウト 600 秒の範囲内 |
-| 想定エラー率 | AT Protocol API 依存。リトライ機構なし（失敗ページはエラーとして処理中断）。引用元取得失敗時は引用元テキストなしで続行。5 回連続失敗でサーキットブレーカーが発動し操作中断 |
-
-### rag_crawl_bluesky（BlueSky 投稿一括取り込み・リポストあり）
-
-`max_posts` はオリジナル投稿にのみ適用される。リポストは独立に走査し、件数上限は設けない（バジェット上限で制限）。
-
-| 項目 | 内容 |
-|------|------|
-| 最悪ケースリクエスト数 | 10（投稿走査）+ 引用元取得（投稿側）+ リポスト走査（ページ数はリポスト総数依存）+ リポスト元投稿取得（リポスト件数分）+ 引用元取得（リポスト側）。全て合算でバジェットトラッカー上限 500 で打ち切り |
-| 最悪ケース所要時間 | 500 × 0.1 秒（ハードリミット最小間隔での理論最短）= 50 秒。デフォルト設定（1.0 秒間隔）では 500 秒。操作全体タイムアウト 600 秒の範囲内 |
-| 想定エラー率 | リポスト元投稿・引用元投稿の取得失敗時は該当投稿をスキップし処理を続行。5 回連続失敗でサーキットブレーカーが発動し操作中断 |
+| 最悪ケースリクエスト数 | ceil(1000/100) = 10。引用元テキストは `getAuthorFeed` のレスポンスに展開済みのため追加リクエスト不要。バジェットトラッカー上限 500 の範囲内 |
+| 最悪ケース所要時間 | 10 × 0.1 秒（ハードリミット最小間隔での理論最短）= 1 秒。デフォルト設定（1.0 秒間隔）で 10 秒。操作全体タイムアウト 600 秒の範囲内 |
+| 想定エラー率 | AT Protocol API 依存。リトライ機構なし（失敗ページはエラーとして処理中断）。5 回連続失敗でサーキットブレーカーが発動し操作中断 |
 
 ## 安全制約
 
@@ -182,7 +179,7 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 | 最低リクエスト間隔 | ハードリミット | 0.1 秒 | 引き下げ不可（引き上げ可） |
 | 操作全体タイムアウト | ハードリミット | 600 秒、許容範囲 1〜600 秒 | 引き上げ不可（引き下げ可、下限 1 秒） |
 | サーキットブレーカー閾値 | ハードリミット | 5 回連続失敗 | 引き上げ不可（引き下げ可） |
-| 投稿取得上限 | ハードリミット | 1000 件（オリジナル投稿のみ。リポストは対象外） | 引き上げ不可（引き下げ可） |
+| 投稿取得上限 | ハードリミット | 1000 件（タイムライン全体。リポストを含む全アイテムが対象） | 引き上げ不可（引き下げ可） |
 | 取得投稿数 | 設定値 | 許容範囲 1〜1000、デフォルト 200 | 範囲内で変更可 |
 | リクエストタイムアウト | 設定値 | 許容範囲 1〜120 秒、デフォルト 30 秒 | 範囲内で変更可 |
 | リクエスト間隔 | 設定値 | 許容範囲 0.1〜60 秒、デフォルト 1.0 秒 | 範囲内で変更可 |
@@ -205,8 +202,8 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
 | `handle` | 文字列 | はい | BlueSky ハンドル（例: `user.bsky.social`）。DID 形式（`did:` 始まり）はバリデーションで拒否する |
-| `max_posts` | 整数 | いいえ | 取得する最大投稿数。デフォルト: 200、許容範囲: 1〜1000 |
-| `include_reposts` | 真偽値 | いいえ | リポストを取得対象に含めるか。デフォルト: `false` |
+| `max_posts` | 整数 | いいえ | 取得する最大投稿数（タイムライン全体に適用）。デフォルト: 200、許容範囲: 1〜1000 |
+| `include_reposts` | 真偽値 | いいえ | タイムラインにリポストを含めるか。`false` の場合、リポスト（`reason.$type` が `app.bsky.feed.defs#reasonRepost` のアイテム）を除外する。デフォルト: `true` |
 
 ツール出力: 取り込み結果のサマリーテキスト（取得投稿数、スキップ数、チャンク数、エラー数）
 
@@ -216,11 +213,11 @@ AT Protocol は分散型プロトコルであり、ユーザーのデータは�
 
 | 環境変数 | 型 | デフォルト | 許容範囲 | 説明 |
 |---------|-----|-----------|---------|------|
-| `RAG_BLUESKY_PDS_URL` | 文字列 | `https://bsky.social` | 有効な HTTPS URL | PDS のベース URL。セルフホスト PDS 等を利用する場合に変更する |
-| `RAG_BLUESKY_MAX_POSTS` | 整数 | 200 | 1〜1000 | 取得する最大投稿数 |
+| `RAG_BLUESKY_APPVIEW_URL` | 文字列 | `https://public.api.bsky.app` | 有効な HTTPS URL | AppView のベース URL |
+| `RAG_BLUESKY_MAX_POSTS` | 整数 | 200 | 1〜1000 | 取得する最大投稿数（タイムライン全体に適用） |
 | `RAG_BLUESKY_REQUEST_TIMEOUT` | 整数 | 30 | 1〜120 | リクエストタイムアウト（秒） |
 | `RAG_BLUESKY_REQUEST_INTERVAL` | 小数 | 1.0 | 0.1〜60 | リクエスト間の最低間隔（秒） |
-| `RAG_BLUESKY_INCLUDE_REPOSTS` | 真偽値 | false | true/false | リポストを取得対象に含めるか |
+| `RAG_BLUESKY_INCLUDE_REPOSTS` | 真偽値 | true | true/false | タイムラインにリポストを含めるか |
 
 ## コンポーネント構成
 
@@ -275,95 +272,91 @@ flowchart TB
 flowchart TD
     START["rag_crawl_bluesky(handle, max_posts, include_reposts)"]
     VALIDATE["入力バリデーション"]
-    DISCOVER["投稿一覧 API を走査"]
-    PAGE["ページ取得（listRecords）"]
+    FEED["タイムライン API を走査"]
+    PAGE["ページ取得（getAuthorFeed）"]
     CHECK_CURSOR{"cursor が存在する?"}
     CHECK_LIMIT{"投稿数上限到達?"}
-    REPOST_CHECK{"include_reposts?"}
-    REPOST_DISCOVER["リポスト一覧 API を走査"]
-    REPOST_FETCH["リポスト元投稿を取得"]
-    EACH_POST{"未処理の投稿がある?"}
+    EACH_ITEM{"未処理のアイテムがある?"}
+    REPOST_FILTER{"リポスト除外?"}
     EXTRACT["テキスト抽出"]
     SKIP_CHECK{"既存 source_id?"}
     INGEST["チャンキング・ベクトル保存"]
     RESULT["結果サマリーを返却"]
 
     START --> VALIDATE
-    VALIDATE --> DISCOVER
-    DISCOVER --> PAGE
+    VALIDATE --> FEED
+    FEED --> PAGE
     PAGE --> CHECK_CURSOR
-    CHECK_CURSOR -->|"いいえ（最終ページ）"| REPOST_CHECK
+    CHECK_CURSOR -->|"いいえ（最終ページ）"| EACH_ITEM
     CHECK_CURSOR -->|"はい"| CHECK_LIMIT
-    CHECK_LIMIT -->|"はい（上限到達）"| REPOST_CHECK
+    CHECK_LIMIT -->|"はい（上限到達）"| EACH_ITEM
     CHECK_LIMIT -->|"いいえ"| PAGE
-    REPOST_CHECK -->|"はい"| REPOST_DISCOVER
-    REPOST_CHECK -->|"いいえ"| EACH_POST
-    REPOST_DISCOVER --> REPOST_FETCH
-    REPOST_FETCH --> EACH_POST
-    EACH_POST -->|"はい"| EXTRACT
-    EACH_POST -->|"いいえ（全件処理済み）"| RESULT
+    EACH_ITEM -->|"はい"| REPOST_FILTER
+    EACH_ITEM -->|"いいえ（全件処理済み）"| RESULT
+    REPOST_FILTER -->|"はい（スキップ）"| EACH_ITEM
+    REPOST_FILTER -->|"いいえ（処理する）"| EXTRACT
     EXTRACT --> SKIP_CHECK
-    SKIP_CHECK -->|"はい（スキップ）"| EACH_POST
+    SKIP_CHECK -->|"はい（スキップ）"| EACH_ITEM
     SKIP_CHECK -->|"いいえ（新規）"| INGEST
-    INGEST --> EACH_POST
+    INGEST --> EACH_ITEM
 ```
 
-### 投稿一覧走査の処理手順
+### タイムライン走査の処理手順
 
-1. `listRecords` API に `collection=app.bsky.feed.post`、`repo={handle}`、`limit=100` でリクエストを送信する
-2. レスポンスから `records` 配列を取得し、各レコードの `uri` から `rkey` を抽出して投稿リストに追加する
-3. 終了判定（以下のいずれかで走査を終了する）:
+1. `getAuthorFeed` API に `actor={handle}`、`limit=100` でリクエストを送信する
+2. レスポンスから `feed` 配列を取得する
+3. 各フィードアイテムを処理する:
+   - `include_reposts` が `false` かつ `reason.$type` が `app.bsky.feed.defs#reasonRepost` の場合、スキップする
+   - `post.uri` から `did` と `rkey` を抽出する
+   - `post.record` からテキストを抽出する
+   - `post.embed`（view 版）から引用元テキストを取得する（引用リポストの場合）
+4. 終了判定（以下のいずれかで走査を終了する）:
    - `cursor` がレスポンスに存在しない（最終ページ）
    - 投稿数上限に到達
    - バジェット上限に到達（ConstrainedClient）
    - サーキットブレーカー発動（ConstrainedClient）
-4. 終了条件を満たさない場合、`cursor` の値でリクエストパラメータを更新し、手順 1 に戻る
-5. 収集した投稿レコードのリストを返す
-
-### リポスト取得の処理手順
-
-`include_reposts` が有効な場合のみ実行する。リポスト走査は `max_posts` の対象外であり、オリジナル投稿とは独立して走査する。リポスト走査の件数上限は設けず、ConstrainedClient のバジェット上限（500 リクエスト）で自然に制限される。
-
-1. `listRecords` API に `collection=app.bsky.feed.repost`、`repo={handle}`、`limit=100` でリクエストを送信する
-2. レスポンスから `records` 配列を取得し、各レコードの `value.subject.uri` を抽出する
-3. 終了判定（以下のいずれかで走査を終了する）:
-   - `cursor` がレスポンスに存在しない（最終ページ）
-   - バジェット上限に到達（ConstrainedClient）
-   - サーキットブレーカー発動（ConstrainedClient）
-4. 各リポストの元投稿を `com.atproto.repo.getRecord` で取得する
-   - 元投稿の取得に失敗した場合は該当リポストをスキップし、次のリポストの処理を続行する
-5. 取得した元投稿を投稿リストに追加する（重複する `source_id` は除外する）
+5. 終了条件を満たさない場合、`cursor` の値でリクエストパラメータを更新し、手順 1 に戻る
+6. 収集した投稿のリストを返す
 
 ### テキスト抽出
 
 投稿は最大 300 文字（grapheme 単位）の短文であり、Markdown 変換は不要。プレーンテキストとして取り込む。
 
+テキスト抽出は `post.record`（raw record）から行う。`post.record` の embed の `$type` に `#view` サフィックスは付かない。
+
 抽出対象フィールド:
 
 | フィールド | パス | 説明 |
 |-----------|------|------|
-| 投稿テキスト | `value.text` | 投稿本文 |
-| 画像 ALT テキスト | `value.embed.images[].alt` | 画像の代替テキスト |
-| 動画 ALT テキスト | `value.embed.alt` | 動画の代替テキスト |
-| リンクカードタイトル | `value.embed.external.title` | 外部リンクのタイトル |
-| リンクカード URL | `value.embed.external.uri` | 外部リンクの URL |
-| リンクカード説明 | `value.embed.external.description` | 外部リンクの説明文 |
+| 投稿テキスト | `record.text` | 投稿本文 |
+| 画像 ALT テキスト | `record.embed.images[].alt` | 画像の代替テキスト |
+| 動画 ALT テキスト | `record.embed.alt` | 動画の代替テキスト |
+| リンクカードタイトル | `record.embed.external.title` | 外部リンクのタイトル |
+| リンクカード URL | `record.embed.external.uri` | 外部リンクの URL |
+| リンクカード説明 | `record.embed.external.description` | 外部リンクの説明文 |
 
 embed の `$type` が `app.bsky.embed.recordWithMedia`（メディア + 引用の複合型）の場合、メディア部分は `embed.media` 配下にネストされる:
 
 | フィールド | パス（recordWithMedia 時） | 説明 |
 |-----------|--------------------------|------|
-| 画像 ALT テキスト | `value.embed.media.images[].alt` | recordWithMedia 時の画像 ALT |
-| 動画 ALT テキスト | `value.embed.media.alt` | recordWithMedia 時の動画 ALT |
-| リンクカードタイトル | `value.embed.media.external.title` | recordWithMedia 時のリンクタイトル |
-| リンクカード URL | `value.embed.media.external.uri` | recordWithMedia 時のリンク URL |
-| リンクカード説明 | `value.embed.media.external.description` | recordWithMedia 時のリンク説明 |
+| 画像 ALT テキスト | `record.embed.media.images[].alt` | recordWithMedia 時の画像 ALT |
+| 動画 ALT テキスト | `record.embed.media.alt` | recordWithMedia 時の動画 ALT |
+| リンクカードタイトル | `record.embed.media.external.title` | recordWithMedia 時のリンクタイトル |
+| リンクカード URL | `record.embed.media.external.uri` | recordWithMedia 時のリンク URL |
+| リンクカード説明 | `record.embed.media.external.description` | recordWithMedia 時のリンク説明 |
 
 #### 引用元投稿テキストの取得
 
-listRecords が返す raw record の `embed.record` は `strongRef`（`uri` + `cid`）のみを含み、引用元の投稿テキストは含まれない。引用元テキストを取得するには `getRecord` による追加リクエストが必要。
+`getAuthorFeed` のレスポンスでは、引用元投稿のテキストが `post.embed`（view 版）に展開済みで含まれる。`getRecord` による追加リクエストは不要。
 
-引用リポスト（`embed.$type` が `app.bsky.embed.record` または `app.bsky.embed.recordWithMedia`）を検出した場合、`embed.record.uri`（recordWithMedia 時は `embed.record.record.uri`）から引用元の AT URI を取得し、`getRecord` で引用元投稿のテキストを取得する。取得失敗時は引用元テキストなしで投稿本文のみを取り込む。
+引用リポスト（`record.embed.$type` が `app.bsky.embed.record` または `app.bsky.embed.recordWithMedia`）を検出した場合、引用元テキストを以下のパスから取得する:
+
+| embed の $type | 引用元テキストのパス |
+|----------------|-------------------|
+| `app.bsky.embed.record` | `post.embed.record.value.text` |
+| `app.bsky.embed.recordWithMedia` | `post.embed.record.record.value.text` |
+
+引用元が投稿以外（スターターパック、フィードジェネレーター等）の場合は `value` キーが存在しない。この場合は引用元テキストなしとして扱う。
 
 抽出対象外:
 
@@ -372,24 +365,27 @@ listRecords が返す raw record の `embed.record` は `strongRef`（`uri` + `c
 抽出したテキストは以下の構造で構築する。各セクションは空行で区切る。該当するセクションがない場合は省略する。
 
 ```
+[Repost: @元投稿者ハンドル]
 投稿テキスト
 
-[画像ALT] 画像の代替テキスト（複数ある場合は改行で連結）
-[動画ALT] 動画の代替テキスト
+[Image ALT] 画像の代替テキスト（複数ある場合は改行で連結）
+[Video ALT] 動画の代替テキスト
 
-[リンクカード]
-タイトル: 外部リンクのタイトル
+[Link Card]
+Title: 外部リンクのタイトル
 URL: 外部リンクの URL
-説明: 外部リンクの説明文
+Description: 外部リンクの説明文
 
-[引用元]
+[Quote]
 引用元の投稿テキスト
 ```
 
+- リポストの場合、先頭に `[Repost: @元投稿者ハンドル]` ヘッダーを付与する。元投稿者のハンドルは `post.author.handle` から取得する
 - 投稿テキストを先頭に配置する（検索ヒット時に最も重要な情報が先頭に来る）
-- 画像/動画 ALT テキストは `[画像ALT]` / `[動画ALT]` プレフィックスで区別する
-- リンクカードは `[リンクカード]` セクション内に構造化する。リンクカードの URL は `embed.external.uri` から取得する
-- 引用元テキストは `[引用元]` セクションに配置する
+- 画像/動画 ALT テキストは `[Image ALT]` / `[Video ALT]` プレフィックスで区別する
+- リンクカードは `[Link Card]` セクション内に構造化する。リンクカードの URL は `embed.external.uri` から取得する
+- 引用元テキストは `[Quote]` セクションに配置する
+- セクションラベルは英語表記とする（LLM による検索・解釈の精度向上のため）
 
 ### チャンキング
 
@@ -405,8 +401,8 @@ BlueSky の投稿は最大 300 文字の短文であり、1 投稿が意味の�
 
 AT URI 形式を使用する: `at://{did}/app.bsky.feed.post/{rkey}`
 
-- `did`: レコードの `uri` フィールドから抽出した DID（例: `did:plc:xxx`）
-- `rkey`: `uri` の末尾パス（`at://did:plc:xxx/app.bsky.feed.post/{rkey}` の `{rkey}` 部分）
+- `did`: `post.author.did` から取得した DID（例: `did:plc:xxx`）。リポストの場合は元投稿者の DID
+- `rkey`: `post.uri` の末尾パス（`at://did:plc:xxx/app.bsky.feed.post/{rkey}` の `{rkey}` 部分）
 
 AT URI を `source_id` に採用する理由:
 
@@ -433,17 +429,17 @@ BlueSky は投稿の編集が不可能なため、既存の `source_id` と一�
 | `source_type` | `"bluesky"` |
 | `metadata` | `handle`、`did`、`rkey`、`url`（`https://bsky.app/profile/{handle}/post/{rkey}`）、`createdAt`、`has_images`、`has_video`、`has_external_link`、`is_reply`、`is_repost` |
 
+`is_repost` の判定: フィードアイテムに `reason` フィールドが存在し、`reason.$type` が `app.bsky.feed.defs#reasonRepost` の場合に `True`。
+
 ## エッジケース
 
 | ケース | 振る舞い |
 |--------|---------|
 | ハンドルが存在しない | API がエラーを返す。エラーメッセージとして「指定されたハンドルが見つかりません」を返す |
-| ユーザーの投稿が 0 件 | 空の `records` 配列。0 件取得として正常終了する |
-| `listRecords` API のレスポンス形式変更 | JSON パースエラーまたは必須フィールド欠落として処理を中断する。エラーの詳細をログ出力する |
+| ユーザーの投稿が 0 件 | 空の `feed` 配列。0 件取得として正常終了する |
+| `getAuthorFeed` API のレスポンス形式変更 | JSON パースエラーまたは必須フィールド欠落として処理を中断する。エラーの詳細をログ出力する |
 | 投稿レコードの `text` フィールドが空 | 他の抽出対象フィールド（ALT テキスト等）がある場合は取り込む。全て空の場合は該当投稿をスキップする |
-| リポスト元投稿の取得失敗（404 等） | 該当リポストをスキップし、他のリポストの処理を続行する。エラーをログ出力する |
-| リポスト元投稿が非公開・削除済み | 取得失敗と同様にスキップする |
-| 同一投稿の重複（オリジナルとリポスト） | `source_id` の一致で重複を検出し、2 件目以降をスキップする |
+| 同一投稿の重複（タイムライン内） | `source_id` の一致で重複を検出し、2 件目以降をスキップする |
 | 既存 source_id との一致 | スキップする（BlueSky は投稿編集不可のため上書き不要） |
 | 取り込み済み投稿が BlueSky 上で削除された | ナレッジベースに残る。削除同期は行わない。ユーザーが `rag_delete` で手動削除する |
 | 大量投稿ユーザー（1000 件超） | 投稿取得上限（1000 件）で打ち切る。取得済み投稿を処理し、上限到達の旨を警告ログに出力する |
@@ -454,7 +450,7 @@ BlueSky は投稿の編集が不可能なため、既存の `source_id` と一�
 | `max_posts` に 0 や負数を指定 | バリデーションエラーとして拒否する（クランプ対象外。制約セクション参照） |
 | `handle` が空文字列 | バリデーションエラーとして拒否する |
 | `handle` に DID 形式（`did:` 始まり）が指定された | バリデーションエラーとして拒否する |
-| 引用元投稿の getRecord 取得失敗 | 引用元テキストなしで投稿本文のみ取り込む。エラーをログ出力する |
+| 引用元が投稿以外（スターターパック等） | 引用元テキストなしとして扱う。エラーにしない |
 | AT Protocol のレート制限（429） | ConstrainedClient のサーキットブレーカーで検出される。連続失敗として計上し、閾値超過で操作を中断する |
 
 ## 関連ドキュメント

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -88,7 +88,7 @@ MCP サーバーが公開する 10 個のツール。
 | rag_crawl | URL、パターン | リンク集ページから一括クロールして取り込む。同一ドメインのみ対象 |
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_crawl_zenn | username、max_articles（任意） | 指定ユーザーの Zenn 記事を API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（記事の公開 URL）の一致で検出し、既存の知識を最新に置き換える |
-| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。max_posts はオリジナル投稿のみに適用（リポストは独立走査、バジェット上限で制限）。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
+| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。max_posts はタイムライン全体（リポスト含む）に適用。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
 | rag_add_local | file_path | 単一ローカルファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_local | dir_path、pattern（任意） | 指定ディレクトリ内のファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_delete | URL | ソース URL 指定でナレッジを削除する |

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -104,11 +104,11 @@ class RAGSettings(BaseSettings):
     rag_local_supported_extensions: str = ".md,.txt,.pdf,.adoc"
 
     # BlueSky インジェスター
-    rag_bluesky_pds_url: str = "https://bsky.social"
+    rag_bluesky_appview_url: str = "https://public.api.bsky.app"
     rag_bluesky_max_posts: int = Field(default=200, ge=1, le=1000)
     rag_bluesky_request_timeout: int = Field(default=30, ge=1, le=120)
     rag_bluesky_request_interval: float = Field(default=1.0, ge=0.1, le=60.0)
-    rag_bluesky_include_reposts: bool = False
+    rag_bluesky_include_reposts: bool = True
 
     # デバッグ
     rag_debug_log_enabled: bool = False

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -1,7 +1,7 @@
 """BlueSky インジェスター: AT Protocol API 経由で BlueSky 投稿を取得しナレッジベースに取り込む
 
 仕様: docs/specs/bluesky-ingester.md
-Issue: #185
+Issue: #185, #194
 """
 
 from __future__ import annotations
@@ -20,17 +20,17 @@ logger = logging.getLogger(__name__)
 
 # --- ハードリミット（コード内定数。設定・引数・環境変数で緩和不可） ---
 MAX_POSTS_HARD_LIMIT = 1000
-"""投稿取得上限（オリジナル投稿のみ。リポストは対象外）"""
+"""投稿取得上限（タイムライン全体。リポストを含む全アイテムが対象）"""
 
 # --- AT Protocol ---
-LISTRECORDS_PAGE_SIZE = 100
-"""listRecords API の 1 ページあたり取得件数（API 上限）"""
+FEED_PAGE_SIZE = 100
+"""getAuthorFeed API の 1 ページあたり取得件数（API 上限）"""
 
 COLLECTION_POST = "app.bsky.feed.post"
 """オリジナル投稿のコレクション"""
 
-COLLECTION_REPOST = "app.bsky.feed.repost"
-"""リポストのコレクション"""
+REASON_REPOST = "app.bsky.feed.defs#reasonRepost"
+"""リポスト理由の $type"""
 
 # --- バリデーション ---
 _AT_URI_PATTERN = re.compile(
@@ -104,13 +104,13 @@ def _extract_text_from_post(value: dict[str, Any]) -> str:
 
     構造:
     1. 投稿テキスト（先頭）
-    2. 画像/動画 ALT テキスト（[画像ALT] / [動画ALT] プレフィックス）
-    3. リンクカード（[リンクカード] セクション）
+    2. 画像/動画 ALT テキスト（[Image ALT] / [Video ALT] プレフィックス）
+    3. リンクカード（[Link Card] セクション）
 
-    引用元テキストは呼び出し元で [引用元] セクションとして追加する。
+    引用元テキストは呼び出し元で [Quote] セクションとして追加する。
 
     Args:
-        value: 投稿レコードの value オブジェクト
+        value: 投稿レコードの value/record オブジェクト
 
     Returns:
         構造化されたプレーンテキスト
@@ -171,26 +171,26 @@ def _extract_media_sections(media: dict[str, Any]) -> list[str]:
             if isinstance(img, dict) and img.get("alt", "")
         ]
         if alt_texts:
-            sections.append("[画像ALT] " + "\n".join(alt_texts))
+            sections.append("[Image ALT] " + "\n".join(alt_texts))
 
     # 動画 ALT テキスト
     video_alt = media.get("alt", "")
     if video_alt:
-        sections.append(f"[動画ALT] {video_alt}")
+        sections.append(f"[Video ALT] {video_alt}")
 
     # リンクカード
     external = media.get("external")
     if isinstance(external, dict):
-        card_parts: list[str] = ["[リンクカード]"]
+        card_parts: list[str] = ["[Link Card]"]
         ext_title = external.get("title", "")
         if ext_title:
-            card_parts.append(f"タイトル: {ext_title}")
+            card_parts.append(f"Title: {ext_title}")
         ext_uri = external.get("uri", "")
         if ext_uri:
             card_parts.append(f"URL: {ext_uri}")
         ext_desc = external.get("description", "")
         if ext_desc:
-            card_parts.append(f"説明: {ext_desc}")
+            card_parts.append(f"Description: {ext_desc}")
         if len(card_parts) > 1:
             sections.append("\n".join(card_parts))
 
@@ -213,26 +213,68 @@ def _make_title(text: str) -> str:
     return flat
 
 
-def _validate_pds_url(url: str) -> str:
-    """PDS URL をバリデーションし、正規化する.
+def _validate_appview_url(url: str) -> str:
+    """AppView URL をバリデーションし、正規化する.
 
     Args:
-        url: PDS URL 文字列
+        url: AppView URL 文字列
 
     Returns:
-        正規化済み PDS URL（末尾スラッシュ除去済み）
+        正規化済み AppView URL（末尾スラッシュ除去済み）
 
     Raises:
         ValueError: URL が空または HTTPS スキームでない場合
     """
     url = url.strip()
     if not url:
-        raise ValueError("pds_url must not be empty")
+        raise ValueError("appview_url must not be empty")
     if not url.startswith("https://"):
         raise ValueError(
-            f"pds_url must use HTTPS scheme, got: {url!r}"
+            f"appview_url must use HTTPS scheme, got: {url!r}"
         )
     return url.rstrip("/")
+
+
+def _extract_quote_text_from_view_embed(
+    view_embed: dict[str, Any] | None,
+) -> str | None:
+    """view embed（post.embed）から引用元テキストを取得する.
+
+    getAuthorFeed のレスポンスでは引用元テキストが post.embed に展開済み。
+
+    パス:
+    - app.bsky.embed.record#view → post.embed.record.value.text
+    - app.bsky.embed.recordWithMedia#view → post.embed.record.record.value.text
+
+    Args:
+        view_embed: post.embed オブジェクト（view 版）
+
+    Returns:
+        引用元テキスト、または引用なし/非投稿引用時は None
+    """
+    if not isinstance(view_embed, dict):
+        return None
+
+    embed_type = view_embed.get("$type", "")
+
+    if embed_type == "app.bsky.embed.record#view":
+        record = view_embed.get("record")
+        if isinstance(record, dict):
+            value = record.get("value")
+            if isinstance(value, dict):
+                text = value.get("text", "")
+                return text if text else None
+    elif embed_type == "app.bsky.embed.recordWithMedia#view":
+        record = view_embed.get("record")
+        if isinstance(record, dict):
+            inner_record = record.get("record")
+            if isinstance(inner_record, dict):
+                value = inner_record.get("value")
+                if isinstance(value, dict):
+                    text = value.get("text", "")
+                    return text if text else None
+
+    return None
 
 
 class BlueskyIngester(BaseIngester):
@@ -240,7 +282,7 @@ class BlueskyIngester(BaseIngester):
 
     仕様: docs/specs/bluesky-ingester.md
 
-    AT Protocol API を使用して投稿一覧を走査し、テキストを抽出する。
+    getAuthorFeed API を使用してタイムラインを走査し、テキストを抽出する。
     全 HTTP リクエストは ConstrainedClient 経由で実行する。
     """
 
@@ -248,22 +290,22 @@ class BlueskyIngester(BaseIngester):
         self,
         client: ConstrainedClient,
         *,
-        pds_url: str = "https://bsky.social",
+        appview_url: str = "https://public.api.bsky.app",
         max_posts: int = 200,
     ) -> None:
         """BlueskyIngester を初期化する.
 
         Args:
             client: ConstrainedClient インスタンス
-            pds_url: PDS のベース URL（デフォルト: https://bsky.social）
+            appview_url: AppView のベース URL（デフォルト: https://public.api.bsky.app）
             max_posts: 取得する最大投稿数（デフォルト: 200、許容範囲: 1〜1000）
 
         Raises:
-            ValueError: max_posts が 0 または負数の場合、pds_url が空または非 HTTPS の場合
+            ValueError: max_posts が 0 または負数の場合、appview_url が空または非 HTTPS の場合
             TypeError: max_posts が整数でない場合
         """
         self._client = client
-        self._pds_url = _validate_pds_url(pds_url)
+        self._appview_url = _validate_appview_url(appview_url)
         self._max_posts = _validate_max_posts(max_posts)
 
     def validate_identifier(self, identifier: str) -> str:
@@ -336,12 +378,12 @@ class BlueskyIngester(BaseIngester):
         max_posts: int | None = None,
         include_reposts: bool = False,
     ) -> list[IngestedContent]:
-        """指定ユーザーの BlueSky 投稿を一括取得する.
+        """指定ユーザーの BlueSky 投稿を統一タイムラインから一括取得する.
 
         Args:
             handle: BlueSky ハンドル（例: user.bsky.social）
             max_posts: 取得する最大投稿数（None 時はコンストラクタの値を使用）
-            include_reposts: リポストを取得対象に含めるか
+            include_reposts: タイムラインにリポストを含めるか
 
         Returns:
             IngestedContent のリスト
@@ -359,55 +401,59 @@ class BlueskyIngester(BaseIngester):
         seen_source_ids: set[str] = set()
         contents: list[IngestedContent] = []
 
-        # 1. オリジナル投稿の走査
-        post_records = await self._list_records(
-            handle, COLLECTION_POST, max_records=effective_max
+        # 統一タイムラインの走査
+        feed_items = await self._get_author_feed(
+            handle, max_items=effective_max
         )
 
-        for record in post_records:
-            content = await self._process_post_record(
-                record, handle, seen_source_ids, is_repost=False
+        for item in feed_items:
+            content = self._process_feed_item(
+                item, handle, seen_source_ids,
+                include_reposts=include_reposts,
             )
             if content is not None:
                 contents.append(content)
 
-        # 2. リポストの走査（オプション）
-        if include_reposts:
-            repost_records = await self._list_records(
-                handle, COLLECTION_REPOST, max_records=None
-            )
-            for repost_record in repost_records:
-                content = await self._process_repost_record(
-                    repost_record, handle, seen_source_ids
-                )
-                if content is not None:
-                    contents.append(content)
-
         return contents
 
-    async def _process_post_record(
+    def _process_feed_item(
         self,
-        record: dict[str, Any],
+        item: dict[str, Any],
         handle: str,
         seen_source_ids: set[str],
         *,
-        is_repost: bool,
+        include_reposts: bool,
     ) -> IngestedContent | None:
-        """投稿レコードを処理して IngestedContent を構築する.
+        """フィードアイテムを処理して IngestedContent を構築する.
 
         Args:
-            record: listRecords/getRecord のレコードオブジェクト
-            handle: ユーザーハンドル
+            item: getAuthorFeed のフィードアイテム
+            handle: ユーザーハンドル（ツール呼び出し元のハンドル）
             seen_source_ids: 処理済み source_id のセット
-            is_repost: リポスト経由で取得した投稿かどうか
+            include_reposts: リポストを含めるか
 
         Returns:
             IngestedContent、またはスキップ/失敗時は None
         """
-        uri = record.get("uri", "")
+        # リポスト判定
+        reason = item.get("reason")
+        is_repost = (
+            isinstance(reason, dict)
+            and reason.get("$type") == REASON_REPOST
+        )
+
+        # リポスト除外フィルタ
+        if is_repost and not include_reposts:
+            return None
+
+        post = item.get("post")
+        if not isinstance(post, dict):
+            return None
+
+        uri = post.get("uri", "")
         parsed = _parse_at_uri(uri)
         if parsed is None:
-            logger.warning("Invalid AT URI in record: %s", uri)
+            logger.warning("Invalid AT URI in feed item: %s", uri)
             return None
 
         did, _collection, rkey = parsed
@@ -418,19 +464,27 @@ class BlueskyIngester(BaseIngester):
             return None
         seen_source_ids.add(source_id)
 
-        value = record.get("value")
-        if not isinstance(value, dict):
-            logger.warning("Unexpected record value type: %s", uri)
+        record = post.get("record")
+        if not isinstance(record, dict):
+            logger.warning("Unexpected record type in feed item: %s", uri)
             return None
 
-        # テキスト抽出
-        text = _extract_text_from_post(value)
+        # テキスト抽出（post.record = raw record）
+        text = _extract_text_from_post(record)
 
-        # 引用元テキストの取得
-        quote_text = await self._fetch_quote_text(value)
+        # 引用元テキストの取得（post.embed = view 版）
+        view_embed = post.get("embed")
+        quote_text = _extract_quote_text_from_view_embed(view_embed)
         if quote_text:
-            quote_section = "[引用元]\n" + quote_text
+            quote_section = "[Quote]\n" + quote_text
             text = text + "\n\n" + quote_section if text else quote_section
+
+        # リポストヘッダーの付与
+        if is_repost:
+            author = post.get("author")
+            author_handle = author.get("handle", "") if isinstance(author, dict) else ""
+            if author_handle:
+                text = f"[Repost: @{author_handle}]\n{text}"
 
         if not text.strip():
             logger.debug("Skipping empty post: %s", uri)
@@ -439,153 +493,56 @@ class BlueskyIngester(BaseIngester):
         return self._build_content(
             did=did,
             rkey=rkey,
-            value=value,
+            value=record,
             text=text,
             handle=handle,
             is_repost=is_repost,
         )
 
-    async def _process_repost_record(
+    async def _get_author_feed(
         self,
-        repost_record: dict[str, Any],
-        handle: str,
-        seen_source_ids: set[str],
-    ) -> IngestedContent | None:
-        """リポストレコードを処理し、元投稿を取得する.
-
-        Args:
-            repost_record: リポストレコード
-            handle: リポスト元ユーザーハンドル
-            seen_source_ids: 処理済み source_id のセット
-
-        Returns:
-            IngestedContent、またはスキップ/失敗時は None
-        """
-        value = repost_record.get("value")
-        if not isinstance(value, dict):
-            return None
-
-        subject = value.get("subject")
-        if not isinstance(subject, dict):
-            return None
-
-        subject_uri = subject.get("uri", "")
-        parsed = _parse_at_uri(subject_uri)
-        if parsed is None:
-            logger.warning("Invalid subject URI in repost: %s", subject_uri)
-            return None
-
-        did, collection, rkey = parsed
-        source_id = f"at://{did}/{COLLECTION_POST}/{rkey}"
-
-        # 重複チェック
-        if source_id in seen_source_ids:
-            return None
-
-        # 元投稿を取得
-        original_record = await self._get_record(did, collection, rkey)
-        if original_record is None:
-            return None
-
-        # 元投稿をポストレコードとして処理
-        return await self._process_post_record(
-            original_record, handle, seen_source_ids, is_repost=True
-        )
-
-    async def _fetch_quote_text(self, value: dict[str, Any]) -> str | None:
-        """引用元投稿のテキストを取得する.
-
-        embed.$type が app.bsky.embed.record または app.bsky.embed.recordWithMedia の
-        場合に引用元の AT URI を取得し、getRecord で引用元投稿のテキストを取得する。
-
-        Args:
-            value: 投稿レコードの value オブジェクト
-
-        Returns:
-            引用元テキスト、または引用なし/取得失敗時は None
-        """
-        embed = value.get("embed")
-        if not isinstance(embed, dict):
-            return None
-
-        embed_type = embed.get("$type", "")
-
-        quote_uri: str | None = None
-        if embed_type == "app.bsky.embed.record":
-            record_ref = embed.get("record")
-            if isinstance(record_ref, dict):
-                quote_uri = record_ref.get("uri")
-        elif embed_type == "app.bsky.embed.recordWithMedia":
-            record_ref = embed.get("record")
-            if isinstance(record_ref, dict):
-                inner_record = record_ref.get("record")
-                if isinstance(inner_record, dict):
-                    quote_uri = inner_record.get("uri")
-
-        if not quote_uri:
-            return None
-
-        parsed = _parse_at_uri(quote_uri)
-        if parsed is None:
-            logger.warning("Invalid quote URI: %s", quote_uri)
-            return None
-
-        did, collection, rkey = parsed
-        quote_record = await self._get_record(did, collection, rkey)
-        if quote_record is None:
-            return None
-
-        quote_value = quote_record.get("value")
-        if not isinstance(quote_value, dict):
-            return None
-
-        return _extract_text_from_post(quote_value) or None
-
-    async def _list_records(
-        self,
-        repo: str,
-        collection: str,
+        actor: str,
         *,
-        max_records: int | None,
+        max_items: int,
     ) -> list[dict[str, Any]]:
-        """listRecords API をページネーション走査する.
+        """getAuthorFeed API をページネーション走査する.
 
         Args:
-            repo: DID またはハンドル
-            collection: レコードコレクション
-            max_records: 取得上限（None で無制限、バジェット上限まで）
+            actor: ハンドルまたは DID
+            max_items: 取得上限
 
         Returns:
-            レコードオブジェクトのリスト
+            フィードアイテムのリスト
         """
-        records: list[dict[str, Any]] = []
+        items: list[dict[str, Any]] = []
         cursor: str | None = None
 
         while True:
             query_params: dict[str, str | int] = {
-                "repo": repo,
-                "collection": collection,
-                "limit": LISTRECORDS_PAGE_SIZE,
+                "actor": actor,
+                "limit": FEED_PAGE_SIZE,
             }
             if cursor is not None:
                 query_params["cursor"] = cursor
 
-            url = f"{self._pds_url}/xrpc/com.atproto.repo.listRecords?{urlencode(query_params)}"
+            url = (
+                f"{self._appview_url}/xrpc/app.bsky.feed.getAuthorFeed"
+                f"?{urlencode(query_params)}"
+            )
 
             try:
                 resp = await self._client.get(url)
             except Exception:
                 logger.exception(
-                    "Failed to fetch %s records for %s", collection, repo
+                    "Failed to fetch feed for %s", actor
                 )
                 break
 
             if resp.status_code != 200:
                 logger.error(
-                    "listRecords returned status %d for %s (repo: %s)",
+                    "getAuthorFeed returned status %d for %s",
                     resp.status_code,
-                    collection,
-                    repo,
+                    actor,
                 )
                 break
 
@@ -593,37 +550,34 @@ class BlueskyIngester(BaseIngester):
                 data: dict[str, Any] = resp.json()
             except Exception:
                 logger.exception(
-                    "Failed to parse listRecords JSON for %s (repo: %s)",
-                    collection,
-                    repo,
+                    "Failed to parse getAuthorFeed JSON for %s", actor
                 )
                 break
 
-            page_records = data.get("records")
-            if not isinstance(page_records, list):
+            feed = data.get("feed")
+            if not isinstance(feed, list):
                 logger.error(
-                    "Unexpected records format in listRecords response (repo: %s)",
-                    repo,
+                    "Unexpected feed format in getAuthorFeed response (%s)",
+                    actor,
                 )
                 break
 
-            if not page_records:
+            if not feed:
                 break
 
-            for rec in page_records:
-                if max_records is not None and len(records) >= max_records:
+            for feed_item in feed:
+                if len(items) >= max_items:
                     break
-                if isinstance(rec, dict):
-                    records.append(rec)
+                if isinstance(feed_item, dict):
+                    items.append(feed_item)
 
-            if max_records is not None and len(records) >= max_records:
-                if len(records) > max_records:
-                    records = records[:max_records]
+            if len(items) >= max_items:
+                if len(items) > max_items:
+                    items = items[:max_items]
                 logger.info(
-                    "Reached max_records limit (%d) for %s (repo: %s)",
-                    max_records,
-                    collection,
-                    repo,
+                    "Reached max_items limit (%d) for %s",
+                    max_items,
+                    actor,
                 )
                 break
 
@@ -634,12 +588,11 @@ class BlueskyIngester(BaseIngester):
             cursor = str(next_cursor)
 
         logger.info(
-            "Listed %d %s records for %s",
-            len(records),
-            collection,
-            repo,
+            "Listed %d feed items for %s",
+            len(items),
+            actor,
         )
-        return records
+        return items
 
     async def _get_record(
         self,
@@ -648,6 +601,8 @@ class BlueskyIngester(BaseIngester):
         rkey: str,
     ) -> dict[str, Any] | None:
         """getRecord API で個別レコードを取得する.
+
+        fetch_single で使用。タイムライン一括取得では使用しない。
 
         Args:
             repo: DID またはハンドル
@@ -662,7 +617,10 @@ class BlueskyIngester(BaseIngester):
             "collection": collection,
             "rkey": rkey,
         })
-        url = f"{self._pds_url}/xrpc/com.atproto.repo.getRecord?{query_params}"
+        url = (
+            f"{self._appview_url}/xrpc/com.atproto.repo.getRecord"
+            f"?{query_params}"
+        )
 
         try:
             resp = await self._client.get(url)
@@ -710,7 +668,7 @@ class BlueskyIngester(BaseIngester):
         Args:
             did: DID
             rkey: レコードキー
-            value: レコードの value オブジェクト
+            value: レコードの value/record オブジェクト
             text: 抽出済みテキスト
             handle: ユーザーハンドル
             is_repost: リポスト経由の投稿か

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -376,7 +376,7 @@ class BlueskyIngester(BaseIngester):
         handle: str,
         *,
         max_posts: int | None = None,
-        include_reposts: bool = False,
+        include_reposts: bool = True,
     ) -> list[IngestedContent]:
         """指定ユーザーの BlueSky 投稿を統一タイムラインから一括取得する.
 

--- a/src/rag/ingesters/bluesky.py
+++ b/src/rag/ingesters/bluesky.py
@@ -479,11 +479,13 @@ class BlueskyIngester(BaseIngester):
             quote_section = "[Quote]\n" + quote_text
             text = text + "\n\n" + quote_section if text else quote_section
 
-        # リポストヘッダーの付与
+        # リポスト: 元投稿者のハンドルを使用（URL・メタデータの正確性のため）
+        effective_handle = handle
         if is_repost:
             author = post.get("author")
             author_handle = author.get("handle", "") if isinstance(author, dict) else ""
             if author_handle:
+                effective_handle = author_handle
                 text = f"[Repost: @{author_handle}]\n{text}"
 
         if not text.strip():
@@ -495,7 +497,7 @@ class BlueskyIngester(BaseIngester):
             rkey=rkey,
             value=record,
             text=text,
-            handle=handle,
+            handle=effective_handle,
             is_repost=is_repost,
         )
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -458,9 +458,8 @@ async def rag_crawl_bluesky(
 
     Args:
         handle: BlueSky ハンドル（例: user.bsky.social）。DID 形式は不可
-        max_posts: 取得する最大オリジナル投稿数（未指定時は設定値を使用、許容範囲: 1〜1000）。
-            リポストには適用されない（リポストは独立して走査され、バジェット上限で制限される）
-        include_reposts: リポストを取得対象に含めるか（未指定時は設定値を使用）
+        max_posts: 取得する最大投稿数（タイムライン全体に適用、未指定時は設定値を使用、許容範囲: 1〜1000）
+        include_reposts: タイムラインにリポストを含めるか（未指定時は設定値を使用）
 
     Returns:
         取り込み結果のサマリーテキスト（取得投稿数、スキップ数、チャンク数、エラー数）
@@ -499,7 +498,7 @@ async def rag_crawl_bluesky(
         ) as client:
             ingester = BlueskyIngester(
                 client=client,
-                pds_url=settings.rag_bluesky_pds_url,
+                appview_url=settings.rag_bluesky_appview_url,
                 max_posts=max_posts,
             )
 

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -818,6 +818,9 @@ class TestBlueskyIngesterCrawl:
         assert repost_content.text.startswith("[Repost: @other.bsky.social]")
         assert "Reposted content" in repost_content.text
         assert repost_content.metadata["is_repost"] is True
+        # リポストの handle・url は元投稿者のもの
+        assert repost_content.metadata["handle"] == "other.bsky.social"
+        assert repost_content.metadata["url"] == "https://bsky.app/profile/other.bsky.social/post/reposted1"
 
     async def test_crawl_repost_filtered_by_default(
         self, ingester: BlueskyIngester, mock_client: MagicMock

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -822,10 +822,10 @@ class TestBlueskyIngesterCrawl:
         assert repost_content.metadata["handle"] == "other.bsky.social"
         assert repost_content.metadata["url"] == "https://bsky.app/profile/other.bsky.social/post/reposted1"
 
-    async def test_crawl_repost_filtered_by_default(
+    async def test_crawl_repost_filtered_when_excluded(
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
-        """include_reposts=False（デフォルト）でリポストが除外されること."""
+        """include_reposts=False でリポストが除外されること."""
         mock_client.get.return_value = _make_feed_response(
             feed=[
                 _make_feed_item(rkey="post1", text="My post"),
@@ -839,7 +839,7 @@ class TestBlueskyIngesterCrawl:
             cursor=None,
         )
 
-        contents = await ingester.crawl("user.bsky.social")
+        contents = await ingester.crawl("user.bsky.social", include_reposts=False)
 
         assert len(contents) == 1
         assert contents[0].text == "My post"

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -1,12 +1,12 @@
 """BlueSky インジェスターのテスト
 
 仕様: docs/specs/bluesky-ingester.md
-Issue: #185
+Issue: #185, #194
 
 テスト方針:
 - 単体テスト: BlueskyIngester のメソッド（テキスト抽出、バリデーション、source_id 生成）
-- API レスポンスモック: listRecords・getRecord のレスポンスを fixture として定義
-- 正常系: 投稿取得・テキスト抽出・引用リポスト・リポスト走査・ページネーション
+- API レスポンスモック: getAuthorFeed・getRecord のレスポンスを fixture として定義
+- 正常系: 統一タイムライン取得・テキスト抽出・引用リポスト・リポストフィルタ・ページネーション
 - 異常系: 存在しないハンドル、空投稿、DID 形式の拒否、API エラー応答
 - バリデーション・クランプ: max_posts の 0/負数/上限超過
 - 既存 source_id スキップの動作確認
@@ -22,11 +22,12 @@ import pytest
 from rag.ingesters.bluesky import (
     MAX_POSTS_HARD_LIMIT,
     BlueskyIngester,
+    _extract_quote_text_from_view_embed,
     _extract_text_from_post,
     _make_title,
     _parse_at_uri,
+    _validate_appview_url,
     _validate_max_posts,
-    _validate_pds_url,
 )
 
 
@@ -42,14 +43,14 @@ def _make_mock_client() -> MagicMock:
     return mock
 
 
-def _make_list_records_response(
-    records: list[dict],
+def _make_feed_response(
+    feed: list[dict],
     cursor: str | None = None,
 ) -> MagicMock:
-    """listRecords API のモックレスポンスを作成する."""
+    """getAuthorFeed API のモックレスポンスを作成する."""
     resp = MagicMock()
     resp.status_code = 200
-    data: dict = {"records": records}
+    data: dict = {"feed": feed}
     if cursor is not None:
         data["cursor"] = cursor
     resp.json.return_value = data
@@ -73,46 +74,59 @@ def _make_get_record_response(
     return resp
 
 
-def _make_post_record(
+def _make_feed_item(
     did: str = "did:plc:test123",
+    handle: str = "user.bsky.social",
     rkey: str = "abc123",
     text: str = "Hello BlueSky!",
     embed: dict | None = None,
+    view_embed: dict | None = None,
     reply: dict | None = None,
     created_at: str = "2024-01-01T00:00:00Z",
+    reason: dict | None = None,
 ) -> dict:
-    """投稿レコードオブジェクトを作成する."""
-    value: dict = {
+    """フィードアイテムオブジェクトを作成する."""
+    record: dict = {
+        "$type": "app.bsky.feed.post",
         "text": text,
         "createdAt": created_at,
     }
     if embed is not None:
-        value["embed"] = embed
+        record["embed"] = embed
     if reply is not None:
-        value["reply"] = reply
-    return {
+        record["reply"] = reply
+
+    post: dict = {
         "uri": f"at://{did}/app.bsky.feed.post/{rkey}",
         "cid": "bafytest",
-        "value": value,
-    }
-
-
-def _make_repost_record(
-    subject_uri: str = "at://did:plc:other/app.bsky.feed.post/xyz789",
-    subject_cid: str = "bafyother",
-    created_at: str = "2024-01-02T00:00:00Z",
-) -> dict:
-    """リポストレコードオブジェクトを作成する."""
-    return {
-        "uri": "at://did:plc:test123/app.bsky.feed.repost/repost1",
-        "cid": "bafyrepost",
-        "value": {
-            "subject": {
-                "uri": subject_uri,
-                "cid": subject_cid,
-            },
-            "createdAt": created_at,
+        "author": {
+            "did": did,
+            "handle": handle,
         },
+        "record": record,
+    }
+    if view_embed is not None:
+        post["embed"] = view_embed
+
+    item: dict = {"post": post}
+    if reason is not None:
+        item["reason"] = reason
+
+    return item
+
+
+def _make_repost_reason(
+    by_did: str = "did:plc:reposter",
+    by_handle: str = "reposter.bsky.social",
+) -> dict:
+    """リポスト理由オブジェクトを作成する."""
+    return {
+        "$type": "app.bsky.feed.defs#reasonRepost",
+        "by": {
+            "did": by_did,
+            "handle": by_handle,
+        },
+        "indexedAt": "2024-01-02T00:00:00Z",
     }
 
 
@@ -208,7 +222,7 @@ class TestExtractTextFromPost:
         assert _extract_text_from_post(value) == ""
 
     def test_image_alt_text(self) -> None:
-        """画像 ALT テキストが [画像ALT] プレフィックス付きで抽出されること."""
+        """画像 ALT テキストが [Image ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Photo post",
             "embed": {
@@ -221,7 +235,7 @@ class TestExtractTextFromPost:
         }
         result = _extract_text_from_post(value)
         assert result.startswith("Photo post")
-        assert "[画像ALT] " in result
+        assert "[Image ALT] " in result
         assert "A beautiful sunset" in result
         assert "Mountain view" in result
         # セクション間は空行区切り
@@ -240,7 +254,7 @@ class TestExtractTextFromPost:
         assert "Good alt" in result
 
     def test_video_alt_text(self) -> None:
-        """動画 ALT テキストが [動画ALT] プレフィックス付きで抽出されること."""
+        """動画 ALT テキストが [Video ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Video post",
             "embed": {
@@ -250,10 +264,10 @@ class TestExtractTextFromPost:
         }
         result = _extract_text_from_post(value)
         assert result.startswith("Video post")
-        assert "[動画ALT] Video description" in result
+        assert "[Video ALT] Video description" in result
 
     def test_external_link(self) -> None:
-        """リンクカードが [リンクカード] セクション構造で抽出されること."""
+        """リンクカードが [Link Card] セクション構造で抽出されること."""
         value = {
             "text": "Check this out",
             "embed": {
@@ -267,13 +281,13 @@ class TestExtractTextFromPost:
         }
         result = _extract_text_from_post(value)
         assert result.startswith("Check this out")
-        assert "[リンクカード]" in result
-        assert "タイトル: Example Article" in result
+        assert "[Link Card]" in result
+        assert "Title: Example Article" in result
         assert "URL: https://example.com" in result
-        assert "説明: Article description" in result
+        assert "Description: Article description" in result
 
     def test_record_with_media_images(self) -> None:
-        """recordWithMedia 型の画像 ALT が [画像ALT] プレフィックス付きで抽出されること."""
+        """recordWithMedia 型の画像 ALT が [Image ALT] プレフィックス付きで抽出されること."""
         value = {
             "text": "Quote with images",
             "embed": {
@@ -292,10 +306,10 @@ class TestExtractTextFromPost:
         }
         result = _extract_text_from_post(value)
         assert result.startswith("Quote with images")
-        assert "[画像ALT] Media image alt" in result
+        assert "[Image ALT] Media image alt" in result
 
     def test_record_with_media_external(self) -> None:
-        """recordWithMedia 型の media.external が [リンクカード] セクションで抽出されること."""
+        """recordWithMedia 型の media.external が [Link Card] セクションで抽出されること."""
         value = {
             "text": "Quote with link",
             "embed": {
@@ -318,15 +332,95 @@ class TestExtractTextFromPost:
         }
         result = _extract_text_from_post(value)
         assert result.startswith("Quote with link")
-        assert "[リンクカード]" in result
-        assert "タイトル: Link Title" in result
+        assert "[Link Card]" in result
+        assert "Title: Link Title" in result
         assert "URL: https://example.com" in result
-        assert "説明: Link Desc" in result
+        assert "Description: Link Desc" in result
 
     def test_no_embed(self) -> None:
         """embed なしでテキストのみ返ること."""
         value = {"text": "Just text"}
         assert _extract_text_from_post(value) == "Just text"
+
+
+# --- _extract_quote_text_from_view_embed テスト ---
+
+
+class TestExtractQuoteTextFromViewEmbed:
+    """view embed からの引用元テキスト抽出テスト."""
+
+    def test_record_view_with_text(self) -> None:
+        """record#view から引用元テキストが取得できること."""
+        view_embed = {
+            "$type": "app.bsky.embed.record#view",
+            "record": {
+                "$type": "app.bsky.embed.record#viewRecord",
+                "uri": "at://did:plc:other/app.bsky.feed.post/xyz",
+                "value": {
+                    "text": "Original quoted post",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                },
+            },
+        }
+        assert _extract_quote_text_from_view_embed(view_embed) == "Original quoted post"
+
+    def test_record_with_media_view_with_text(self) -> None:
+        """recordWithMedia#view から引用元テキストが取得できること."""
+        view_embed = {
+            "$type": "app.bsky.embed.recordWithMedia#view",
+            "record": {
+                "record": {
+                    "$type": "app.bsky.embed.record#viewRecord",
+                    "uri": "at://did:plc:other/app.bsky.feed.post/xyz",
+                    "value": {
+                        "text": "Quoted with media",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                    },
+                },
+            },
+            "media": {
+                "$type": "app.bsky.embed.images#view",
+                "images": [],
+            },
+        }
+        assert _extract_quote_text_from_view_embed(view_embed) == "Quoted with media"
+
+    def test_non_post_quote_returns_none(self) -> None:
+        """投稿以外の引用（スターターパック等）で None が返ること."""
+        view_embed = {
+            "$type": "app.bsky.embed.record#view",
+            "record": {
+                "$type": "app.bsky.feed.defs#generatorView",
+                "uri": "at://did:plc:other/app.bsky.feed.generator/xyz",
+                "creator": {},
+            },
+        }
+        assert _extract_quote_text_from_view_embed(view_embed) is None
+
+    def test_no_embed_returns_none(self) -> None:
+        """embed なしで None が返ること."""
+        assert _extract_quote_text_from_view_embed(None) is None
+
+    def test_non_quote_embed_returns_none(self) -> None:
+        """引用以外の embed で None が返ること."""
+        view_embed = {
+            "$type": "app.bsky.embed.images#view",
+            "images": [],
+        }
+        assert _extract_quote_text_from_view_embed(view_embed) is None
+
+    def test_empty_quote_text_returns_none(self) -> None:
+        """引用元テキストが空で None が返ること."""
+        view_embed = {
+            "$type": "app.bsky.embed.record#view",
+            "record": {
+                "value": {
+                    "text": "",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                },
+            },
+        }
+        assert _extract_quote_text_from_view_embed(view_embed) is None
 
 
 # --- _make_title テスト ---
@@ -525,10 +619,10 @@ class TestBlueskyIngesterCrawl:
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
         """基本的な投稿取得が正常に動作すること."""
-        mock_client.get.return_value = _make_list_records_response(
-            records=[
-                _make_post_record(rkey="post1", text="First post"),
-                _make_post_record(rkey="post2", text="Second post"),
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(rkey="post1", text="First post"),
+                _make_feed_item(rkey="post2", text="Second post"),
             ],
             cursor=None,
         )
@@ -544,11 +638,11 @@ class TestBlueskyIngesterCrawl:
     ) -> None:
         """max_posts を超える投稿が返らないこと."""
         ingester = BlueskyIngester(client=mock_client, max_posts=2)
-        mock_client.get.return_value = _make_list_records_response(
-            records=[
-                _make_post_record(rkey="post1", text="Post 1"),
-                _make_post_record(rkey="post2", text="Post 2"),
-                _make_post_record(rkey="post3", text="Post 3"),
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(rkey="post1", text="Post 1"),
+                _make_feed_item(rkey="post2", text="Post 2"),
+                _make_feed_item(rkey="post3", text="Post 3"),
             ],
             cursor=None,
         )
@@ -562,16 +656,16 @@ class TestBlueskyIngesterCrawl:
     ) -> None:
         """ページネーションが正常に動作すること."""
         mock_client.get.side_effect = [
-            _make_list_records_response(
-                records=[
-                    _make_post_record(rkey="post1", text="Page 1 Post 1"),
-                    _make_post_record(rkey="post2", text="Page 1 Post 2"),
+            _make_feed_response(
+                feed=[
+                    _make_feed_item(rkey="post1", text="Page 1 Post 1"),
+                    _make_feed_item(rkey="post2", text="Page 1 Post 2"),
                 ],
                 cursor="cursor_2",
             ),
-            _make_list_records_response(
-                records=[
-                    _make_post_record(rkey="post3", text="Page 2 Post 1"),
+            _make_feed_response(
+                feed=[
+                    _make_feed_item(rkey="post3", text="Page 2 Post 1"),
                 ],
                 cursor=None,
             ),
@@ -586,8 +680,8 @@ class TestBlueskyIngesterCrawl:
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
         """投稿が 0 件の場合、空リストを返すこと."""
-        mock_client.get.return_value = _make_list_records_response(
-            records=[], cursor=None
+        mock_client.get.return_value = _make_feed_response(
+            feed=[], cursor=None
         )
 
         contents = await ingester.crawl("user.bsky.social")
@@ -618,14 +712,13 @@ class TestBlueskyIngesterCrawl:
         with pytest.raises(ValueError, match="DID format is not accepted"):
             await ingester.crawl("did:plc:test123")
 
-    async def test_crawl_with_quote_repost(
+    async def test_crawl_with_quote_from_view_embed(
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
-        """引用リポスト投稿の引用元テキストが取得されること."""
-        # 投稿一覧: 引用リポスト
-        list_response = _make_list_records_response(
-            records=[
-                _make_post_record(
+        """引用リポスト投稿の引用元テキストが view embed から取得されること."""
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(
                     rkey="quote1",
                     text="My comment on this",
                     embed={
@@ -635,40 +728,15 @@ class TestBlueskyIngesterCrawl:
                             "cid": "bafyother",
                         },
                     },
-                ),
-            ],
-            cursor=None,
-        )
-
-        # 引用元投稿の getRecord レスポンス
-        quote_response = _make_get_record_response(
-            uri="at://did:plc:other/app.bsky.feed.post/original1",
-            value={"text": "Original post text", "createdAt": "2024-01-01T00:00:00Z"},
-        )
-
-        mock_client.get.side_effect = [list_response, quote_response]
-
-        contents = await ingester.crawl("user.bsky.social")
-
-        assert len(contents) == 1
-        assert "My comment on this" in contents[0].text
-        assert "[引用元]" in contents[0].text
-        assert "Original post text" in contents[0].text
-
-    async def test_crawl_quote_fetch_failure(
-        self, ingester: BlueskyIngester, mock_client: MagicMock
-    ) -> None:
-        """引用元取得失敗時、投稿本文のみで取り込まれること."""
-        list_response = _make_list_records_response(
-            records=[
-                _make_post_record(
-                    rkey="quote1",
-                    text="My comment",
-                    embed={
-                        "$type": "app.bsky.embed.record",
+                    view_embed={
+                        "$type": "app.bsky.embed.record#view",
                         "record": {
-                            "uri": "at://did:plc:other/app.bsky.feed.post/deleted",
-                            "cid": "bafydeleted",
+                            "$type": "app.bsky.embed.record#viewRecord",
+                            "uri": "at://did:plc:other/app.bsky.feed.post/original1",
+                            "value": {
+                                "text": "Original post text",
+                                "createdAt": "2024-01-01T00:00:00Z",
+                            },
                         },
                     },
                 ),
@@ -676,43 +744,67 @@ class TestBlueskyIngesterCrawl:
             cursor=None,
         )
 
-        mock_client.get.side_effect = [list_response, _make_error_response(404)]
-
         contents = await ingester.crawl("user.bsky.social")
 
         assert len(contents) == 1
-        assert contents[0].text == "My comment"
-        assert "[引用元]" not in contents[0].text
+        assert "My comment on this" in contents[0].text
+        assert "[Quote]" in contents[0].text
+        assert "Original post text" in contents[0].text
+        # getRecord は呼ばれない（view embed から取得）
+        assert mock_client.get.call_count == 1
 
-    async def test_crawl_with_reposts(
+    async def test_crawl_quote_non_post(
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
-        """include_reposts=True でリポスト走査が行われること."""
-        # オリジナル投稿一覧
-        post_list = _make_list_records_response(
-            records=[
-                _make_post_record(rkey="post1", text="My post"),
-            ],
-            cursor=None,
-        )
-
-        # リポスト一覧
-        repost_list = _make_list_records_response(
-            records=[
-                _make_repost_record(
-                    subject_uri="at://did:plc:other/app.bsky.feed.post/reposted1",
+        """引用元が投稿以外の場合、引用元テキストなしで取り込まれること."""
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(
+                    rkey="quote1",
+                    text="Check this feed",
+                    embed={
+                        "$type": "app.bsky.embed.record",
+                        "record": {
+                            "uri": "at://did:plc:other/app.bsky.feed.generator/xyz",
+                            "cid": "bafyother",
+                        },
+                    },
+                    view_embed={
+                        "$type": "app.bsky.embed.record#view",
+                        "record": {
+                            "$type": "app.bsky.feed.defs#generatorView",
+                            "uri": "at://did:plc:other/app.bsky.feed.generator/xyz",
+                            "creator": {},
+                        },
+                    },
                 ),
             ],
             cursor=None,
         )
 
-        # リポスト元投稿
-        original_post = _make_get_record_response(
-            uri="at://did:plc:other/app.bsky.feed.post/reposted1",
-            value={"text": "Reposted content", "createdAt": "2024-01-01T00:00:00Z"},
-        )
+        contents = await ingester.crawl("user.bsky.social")
 
-        mock_client.get.side_effect = [post_list, repost_list, original_post]
+        assert len(contents) == 1
+        assert contents[0].text == "Check this feed"
+        assert "[Quote]" not in contents[0].text
+
+    async def test_crawl_repost_included(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """include_reposts=True でリポストが含まれること."""
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(rkey="post1", text="My post"),
+                _make_feed_item(
+                    did="did:plc:other",
+                    handle="other.bsky.social",
+                    rkey="reposted1",
+                    text="Reposted content",
+                    reason=_make_repost_reason(),
+                ),
+            ],
+            cursor=None,
+        )
 
         contents = await ingester.crawl(
             "user.bsky.social", include_reposts=True
@@ -721,82 +813,62 @@ class TestBlueskyIngesterCrawl:
         assert len(contents) == 2
         texts = [c.text for c in contents]
         assert "My post" in texts
-        assert "Reposted content" in texts
+        # リポストの [Repost: @handle] ヘッダー
+        repost_content = next(c for c in contents if "Reposted content" in c.text)
+        assert repost_content.text.startswith("[Repost: @other.bsky.social]")
+        assert "Reposted content" in repost_content.text
+        assert repost_content.metadata["is_repost"] is True
 
-    async def test_crawl_repost_duplicate_skipped(
+    async def test_crawl_repost_filtered_by_default(
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
-        """オリジナル投稿と重複するリポストがスキップされること."""
-        # オリジナル投稿: post1
-        post_list = _make_list_records_response(
-            records=[
-                _make_post_record(
-                    did="did:plc:test123", rkey="post1", text="My post"
+        """include_reposts=False（デフォルト）でリポストが除外されること."""
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(rkey="post1", text="My post"),
+                _make_feed_item(
+                    did="did:plc:other",
+                    rkey="reposted1",
+                    text="Reposted content",
+                    reason=_make_repost_reason(),
                 ),
             ],
             cursor=None,
         )
 
-        # リポスト: 同じ投稿を参照
-        repost_list = _make_list_records_response(
-            records=[
-                _make_repost_record(
-                    subject_uri="at://did:plc:test123/app.bsky.feed.post/post1",
-                ),
-            ],
-            cursor=None,
-        )
-
-        mock_client.get.side_effect = [post_list, repost_list]
-
-        contents = await ingester.crawl(
-            "user.bsky.social", include_reposts=True
-        )
-
-        # 重複が除外されるため 1 件のみ
-        assert len(contents) == 1
-
-    async def test_crawl_repost_fetch_failure(
-        self, ingester: BlueskyIngester, mock_client: MagicMock
-    ) -> None:
-        """リポスト元取得失敗時、該当リポストがスキップされること."""
-        post_list = _make_list_records_response(
-            records=[
-                _make_post_record(rkey="post1", text="My post"),
-            ],
-            cursor=None,
-        )
-
-        repost_list = _make_list_records_response(
-            records=[
-                _make_repost_record(
-                    subject_uri="at://did:plc:other/app.bsky.feed.post/deleted",
-                ),
-            ],
-            cursor=None,
-        )
-
-        mock_client.get.side_effect = [
-            post_list,
-            repost_list,
-            _make_error_response(404),
-        ]
-
-        contents = await ingester.crawl(
-            "user.bsky.social", include_reposts=True
-        )
+        contents = await ingester.crawl("user.bsky.social")
 
         assert len(contents) == 1
         assert contents[0].text == "My post"
+
+    async def test_crawl_duplicate_source_id_skipped(
+        self, ingester: BlueskyIngester, mock_client: MagicMock
+    ) -> None:
+        """同一 source_id の重複がスキップされること."""
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(
+                    did="did:plc:test123", rkey="post1", text="First"
+                ),
+                _make_feed_item(
+                    did="did:plc:test123", rkey="post1", text="Duplicate"
+                ),
+            ],
+            cursor=None,
+        )
+
+        contents = await ingester.crawl("user.bsky.social")
+
+        assert len(contents) == 1
 
     async def test_crawl_skips_empty_text_posts(
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
         """テキストが空の投稿がスキップされること."""
-        mock_client.get.return_value = _make_list_records_response(
-            records=[
-                _make_post_record(rkey="post1", text=""),
-                _make_post_record(rkey="post2", text="Valid post"),
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(rkey="post1", text=""),
+                _make_feed_item(rkey="post2", text="Valid post"),
             ],
             cursor=None,
         )
@@ -810,9 +882,9 @@ class TestBlueskyIngesterCrawl:
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
         """メタデータフィールドが正しく設定されること."""
-        mock_client.get.return_value = _make_list_records_response(
-            records=[
-                _make_post_record(
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(
                     rkey="post1",
                     text="Test metadata",
                     created_at="2024-06-15T12:00:00Z",
@@ -844,9 +916,9 @@ class TestBlueskyIngesterCrawl:
         self, ingester: BlueskyIngester, mock_client: MagicMock
     ) -> None:
         """source_id が AT URI 形式であること."""
-        mock_client.get.return_value = _make_list_records_response(
-            records=[
-                _make_post_record(
+        mock_client.get.return_value = _make_feed_response(
+            feed=[
+                _make_feed_item(
                     did="did:plc:abc123", rkey="post1", text="Test"
                 ),
             ],
@@ -900,77 +972,77 @@ class TestBlueskyIngesterInit:
         with pytest.raises(ValueError):
             BlueskyIngester(client=_make_mock_client(), max_posts=-5)
 
-    def test_custom_pds_url(self) -> None:
-        """カスタム PDS URL が設定できること."""
+    def test_custom_appview_url(self) -> None:
+        """カスタム AppView URL が設定できること."""
         ingester = BlueskyIngester(
             client=_make_mock_client(),
-            pds_url="https://custom.pds.example.com",
+            appview_url="https://custom.appview.example.com",
         )
-        assert ingester._pds_url == "https://custom.pds.example.com"
+        assert ingester._appview_url == "https://custom.appview.example.com"
 
-    def test_pds_url_trailing_slash_stripped(self) -> None:
-        """PDS URL の末尾スラッシュが除去されること."""
+    def test_appview_url_trailing_slash_stripped(self) -> None:
+        """AppView URL の末尾スラッシュが除去されること."""
         ingester = BlueskyIngester(
             client=_make_mock_client(),
-            pds_url="https://bsky.social/",
+            appview_url="https://public.api.bsky.app/",
         )
-        assert ingester._pds_url == "https://bsky.social"
+        assert ingester._appview_url == "https://public.api.bsky.app"
 
-    def test_pds_url_whitespace_stripped(self) -> None:
-        """PDS URL の前後空白がトリムされること."""
+    def test_appview_url_whitespace_stripped(self) -> None:
+        """AppView URL の前後空白がトリムされること."""
         ingester = BlueskyIngester(
             client=_make_mock_client(),
-            pds_url="  https://bsky.social  ",
+            appview_url="  https://public.api.bsky.app  ",
         )
-        assert ingester._pds_url == "https://bsky.social"
+        assert ingester._appview_url == "https://public.api.bsky.app"
 
-    def test_reject_empty_pds_url(self) -> None:
-        """空の PDS URL でバリデーションエラーになること."""
+    def test_reject_empty_appview_url(self) -> None:
+        """空の AppView URL でバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not be empty"):
-            BlueskyIngester(client=_make_mock_client(), pds_url="")
+            BlueskyIngester(client=_make_mock_client(), appview_url="")
         with pytest.raises(ValueError, match="must not be empty"):
-            BlueskyIngester(client=_make_mock_client(), pds_url="   ")
+            BlueskyIngester(client=_make_mock_client(), appview_url="   ")
 
-    def test_reject_non_https_pds_url(self) -> None:
-        """非 HTTPS の PDS URL でバリデーションエラーになること."""
+    def test_reject_non_https_appview_url(self) -> None:
+        """非 HTTPS の AppView URL でバリデーションエラーになること."""
         with pytest.raises(ValueError, match="HTTPS"):
-            BlueskyIngester(client=_make_mock_client(), pds_url="http://bsky.social")
+            BlueskyIngester(client=_make_mock_client(), appview_url="http://public.api.bsky.app")
 
 
-# --- _validate_pds_url テスト ---
+# --- _validate_appview_url テスト ---
 
 
-class TestValidatePdsUrl:
-    """PDS URL のバリデーションテスト."""
+class TestValidateAppviewUrl:
+    """AppView URL のバリデーションテスト."""
 
     def test_valid_https_url(self) -> None:
         """正しい HTTPS URL がそのまま返ること."""
-        assert _validate_pds_url("https://bsky.social") == "https://bsky.social"
+        assert _validate_appview_url("https://public.api.bsky.app") == "https://public.api.bsky.app"
 
     def test_trailing_slash_stripped(self) -> None:
         """末尾スラッシュが除去されること."""
-        assert _validate_pds_url("https://bsky.social/") == "https://bsky.social"
+        assert _validate_appview_url("https://public.api.bsky.app/") == "https://public.api.bsky.app"
 
     def test_whitespace_stripped(self) -> None:
         """前後の空白がトリムされること."""
-        assert _validate_pds_url("  https://bsky.social  ") == "https://bsky.social"
+        assert _validate_appview_url("  https://public.api.bsky.app  ") == "https://public.api.bsky.app"
 
     def test_reject_empty(self) -> None:
         """空文字列がバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not be empty"):
-            _validate_pds_url("")
+            _validate_appview_url("")
         with pytest.raises(ValueError, match="must not be empty"):
-            _validate_pds_url("   ")
+            _validate_appview_url("   ")
 
     def test_reject_http(self) -> None:
         """HTTP スキームがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="HTTPS"):
-            _validate_pds_url("http://bsky.social")
+            _validate_appview_url("http://public.api.bsky.app")
 
     def test_reject_no_scheme(self) -> None:
         """スキームなしがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="HTTPS"):
-            _validate_pds_url("bsky.social")
+            _validate_appview_url("public.api.bsky.app")
 
 
 # --- ハードリミット定数テスト ---


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- BlueSky インジェスターの投稿取得 API を `listRecords` (PDS) から `getAuthorFeed` (AppView) に切り替え
- 統一タイムライン取得により `max_posts` がタイムライン全体（リポスト含む）に適用
- リポスト独立走査を廃止し、タイムライン内フィルタリングに変更
- 引用元テキストを view embed から直接取得（`getRecord` 追加リクエスト不要に）
- 設定変更: `RAG_BLUESKY_PDS_URL` → `RAG_BLUESKY_APPVIEW_URL`（デフォルト: `https://public.api.bsky.app`）
- `include_reposts` のデフォルトを `true` に変更（フィルタなし = 全て取り込み）
- リポスト投稿に `[Repost: @元投稿者ハンドル]` ヘッダーを付与
- テキストラベルを英語化（`[Image ALT]`, `[Video ALT]`, `[Link Card]`, `[Quote]`）
- リポスト時の `metadata["handle"]` / `metadata["url"]` を元投稿者のものに修正
- 仕様書・関連仕様書（rag-knowledge.md）を全面更新

## Test plan

- [x] pytest 74 passed
- [x] ruff 違反なし
- [x] mypy 型エラーなし
- [x] markdownlint 違反なし
- [x] mermaid-lint 違反なし
- [x] 実データ動作確認（rhythmcan.bsky.social, 200件取得）
- [x] MCP HTTP 経由での取り込み・検索確認
- [x] RAG 検索ヒット確認

## Related issues

Closes #194
Closes #196