### PR TITLE
chore: .gitignore から不要な tests/fixtures/ エントリを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,9 +216,6 @@ bm25_index/
 # Evaluation reports
 reports/
 
-# Test fixtures (copyrighted content)
-tests/fixtures/
-
 # Claude Code local settings
 .claude/settings.local.json
 .claude/*.lock


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- fixtures ファイルをプロジェクト外に移動したため、`.gitignore` の `tests/fixtures/` エントリを削除

## Test plan

- [x] .gitignore の変更のみ、テスト影響なし

## Related issues

N/A