### PR TITLE
refactor(document-ingester): LocalFileIngester を DocumentIngester にリネーム (#198)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@
 | ディレクトリ | 責務 |
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
-| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・LocalFileIngester・BlueskyIngester） |
+| `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・DocumentIngester・BlueskyIngester） |
 
 ### ルートレベルファイル
 
@@ -48,9 +48,9 @@
 | 仕様書 | 実装モジュール |
 |---|---|
 | `rag-knowledge.md` | `src/rag/` 全体 |
-| `zenn-ingester.md` | `src/rag/ingesters/zenn.py` |
-| `local-file-ingester.md` | `src/rag/ingesters/local_file.py` |
-| `bluesky-ingester.md` | `src/rag/ingesters/bluesky.py` |
+| `zenn-ingester.md` | `src/rag/ingesters/zenn_ingester.py` |
+| `document-ingester.md` | `src/rag/ingesters/document_ingester.py` |
+| `bluesky-ingester.md` | `src/rag/ingesters/bluesky_ingester.py` |
 
 ### Claude Code 拡張
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | **クロールプレビュー** | クロール対象ページのタイトル・URL 一覧を事前確認 |
 | **Zenn インジェスター** | Zenn 記事を API 経由で取得・ナレッジベースに取り込み |
 | **BlueSky インジェスター** | BlueSky 投稿を AT Protocol API 経由で取得・ナレッジベースに取り込み |
-| **ローカルファイルインジェスター** | ローカルファイル（Markdown、テキスト、PDF、AsciiDoc）をナレッジベースに取り込み |
+| **ドキュメントインジェスター** | テキストドキュメント（Markdown、テキスト、PDF、AsciiDoc）をナレッジベースに取り込み |
 | **制約付き HTTP クライアント** | バジェット・サーキットブレーカー・レート制限を統合した安全な HTTP アクセス（py-common-lib 提供） |
 
 ## 動作環境
@@ -117,7 +117,7 @@ git-flow ベースのブランチ戦略を採用。詳細は `~/.claude/docs/spe
 - [RAG ナレッジ](docs/specs/rag-knowledge.md)
 - [Zenn インジェスター](docs/specs/zenn-ingester.md)
 - [BlueSky インジェスター](docs/specs/bluesky-ingester.md)
-- [ローカルファイルインジェスター](docs/specs/local-file-ingester.md)
+- [ドキュメントインジェスター](docs/specs/document-ingester.md)
 
 ### Claude Code 拡張（agentic）
 

--- a/docs/specs/document-ingester.md
+++ b/docs/specs/document-ingester.md
@@ -1,8 +1,8 @@
-# ローカルファイルインジェスター
+# ドキュメントインジェスター
 
 ## 概要
 
-ローカルファイルシステム上のドキュメントを読み取り、ナレッジベースに取り込むインジェスター。
+テキストドキュメントを読み取り、ナレッジベースに取り込むインジェスター。
 単一ファイルの追加とディレクトリ一括取り込みの 2 つの操作を提供する。
 
 スコープ:
@@ -21,12 +21,12 @@
 
 ## 背景
 
-- 既存のインジェスター（WebIngester、ZennIngester）は外部 Web リソースからの取り込みに特化しており、ローカルファイル（職務経歴書、学習ノート等）を直接取り込む手段がない
+- 既存のインジェスター（WebIngester、ZennIngester）は外部 Web リソースからの取り込みに特化しており、テキストドキュメント（職務経歴書、学習ノート等）を直接取り込む手段がない
 - BaseIngester / IngestedContent の共通インターフェースに準拠し、プラグイン構造（#109）の一環として設計する
 
 ## 制約
 
-- ファイル読み取りはローカルファイルシステムのみ対象とする（外部 HTTP リクエストは発生しない）
+- 現時点ではローカルファイルシステムのみ対象とする（外部 HTTP リクエストは発生しない）
 - パストラバーサル対策: ファイルパスを `Path.resolve()` で正規化し、`..` を含むパスの解決後に実際のファイルシステムパスとして扱う
 - アクセス許可ディレクトリの制限は設けない（OS レベルのファイル権限に委ねる）
   - **前提**: 本機能は stdio モードでの信頼済みローカル環境での利用を想定する。HTTP モードで外部公開する場合は、認証・ネットワーク制御等の対策が必須である。HTTP モードでの本ツールの有効化は明示的な opt-in とし、デフォルトでは無効とする
@@ -50,16 +50,14 @@
 
 ### MCP ツール
 
-既存の `rag_add`（URL ベースの単一ページ追加）および `rag_crawl`（URL ベースの一括クロール）とは独立した新規ツールとして追加する。ローカルファイルはファイルシステムからの読み取りであり、Web クロールとは取得方式・制約が異なるため分離する。
-
-> **Note**: 本仕様書は設計先行（`docs(pre-impl)`）で作成している。後続の実装フェーズで `rag-knowledge.md` のツール数・ツール一覧も併せて更新する。
+既存の `rag_add`（URL ベースの単一ページ追加）および `rag_crawl`（URL ベースの一括クロール）とは独立した新規ツールとして追加する。ドキュメントファイルはファイルシステムからの読み取りであり、Web クロールとは取得方式・制約が異なるため分離する。
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| rag_add_local | file_path | 単一ローカルファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
-| rag_crawl_local | dir_path、pattern（任意） | 指定ディレクトリ内のファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
+| rag_add_document | file_path | 単一ドキュメントファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
+| rag_crawl_documents | dir_path、pattern（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 
-#### rag_add_local パラメータ
+#### rag_add_document パラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
@@ -67,7 +65,7 @@
 
 ツール出力: 取り込み結果のサマリーテキスト（ファイル名、チャンク数）
 
-#### rag_crawl_local パラメータ
+#### rag_crawl_documents パラメータ
 
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
@@ -87,7 +85,7 @@
 | `.pdf` | `pymupdf4llm` で Markdown に変換して取り込む |
 | `.adoc` | AsciiDoc としてそのまま取り込む |
 
-対応拡張子は環境変数 `RAG_LOCAL_SUPPORTED_EXTENSIONS` で追加可能（セクション「設定項目」参照）。追加した拡張子のファイルはプレーンテキストとして取り込む。
+対応拡張子は環境変数 `RAG_DOCUMENT_SUPPORTED_EXTENSIONS` で追加可能（セクション「設定項目」参照）。追加した拡張子のファイルはプレーンテキストとして取り込む。
 
 ### source_id
 
@@ -101,11 +99,11 @@
 
 | 環境変数 | 型 | デフォルト | 説明 |
 |---------|-----|-----------|------|
-| `RAG_LOCAL_SUPPORTED_EXTENSIONS` | 文字列 | `".md,.txt,.pdf,.adoc"` | 対応ファイル拡張子のカンマ区切りリスト。先頭にドット（`.`）を含める |
+| `RAG_DOCUMENT_SUPPORTED_EXTENSIONS` | 文字列 | `".md,.txt,.pdf,.adoc"` | 対応ファイル拡張子のカンマ区切りリスト。先頭にドット（`.`）を含める |
 
 ## コンポーネント構成
 
-### ローカルファイルインジェスターの位置付け
+### ドキュメントインジェスターの位置付け
 
 ```mermaid
 flowchart TB
@@ -121,28 +119,28 @@ flowchart TB
     subgraph Ingesters["インジェスター"]
         WING["WebIngester"]
         ZING["ZennIngester"]
-        LING["LocalFileIngester"]
+        DING["DocumentIngester"]
     end
 
-    FS["ローカルファイルシステム"]
+    FS["ファイルシステム"]
 
     CLIENT -->|stdio / http| TOOLS
     TOOLS --> Service
     Service --> Ingesters
-    LING --> FS
+    DING --> FS
 ```
 
 ### コンポーネント一覧
 
 | コンポーネント | 役割 |
 |--------------|------|
-| LocalFileIngester | ローカルファイル取り込み用インジェスター。BaseIngester を継承し、ファイルシステムからドキュメントを読み取る |
+| DocumentIngester | ドキュメント取り込み用インジェスター。BaseIngester を継承し、ファイルシステムからドキュメントを読み取る |
 
 ### 単一ファイル取り込みフロー
 
 ```mermaid
 flowchart TD
-    START["rag_add_local(file_path)"]
+    START["rag_add_document(file_path)"]
     VALIDATE["入力バリデーション"]
     RESOLVE["パス正規化（resolve）"]
     CHECK_EXT{"拡張子は対応済み?"}
@@ -164,7 +162,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    START["rag_crawl_local(dir_path, pattern)"]
+    START["rag_crawl_documents(dir_path, pattern)"]
     VALIDATE["入力バリデーション（パターン含む）"]
     RESOLVE["パス正規化（resolve）"]
     GLOB["glob パターンでファイル検索"]
@@ -209,7 +207,7 @@ flowchart TD
    - `source_id`: file URI（`Path.as_uri()` で生成）
    - `title`: ファイル名（拡張子なし）
    - `text`: 抽出済みテキスト
-   - `source_type`: `"local"`
+   - `source_type`: `"document"`
    - `metadata`: `file_extension`、`file_size_bytes`、`file_path`（元の指定パス）
 7. ナレッジサービス経由でチャンキング・ベクトル保存を行う
 
@@ -246,8 +244,8 @@ flowchart TD
 | glob パターンがファイル数上限を超過 | パスの辞書順でソートした上で先頭 100 件にクランプし、警告ログを出力する。超過分は処理しない |
 | glob パターンに一致するファイルが 0 件 | 0 件処理として正常終了する |
 | 同一ファイルの再取り込み | `source_id`（file URI）の一致で検出し、既存データを最新に置き換える |
-| ファイルが指定されたがディレクトリだった | バリデーションエラーとして拒否する（`rag_add_local` の場合） |
-| ディレクトリが指定されたがファイルだった | バリデーションエラーとして拒否する（`rag_crawl_local` の場合） |
+| ファイルが指定されたがディレクトリだった | バリデーションエラーとして拒否する（`rag_add_document` の場合） |
+| ディレクトリが指定されたがファイルだった | バリデーションエラーとして拒否する（`rag_crawl_documents` の場合） |
 | `pattern` に `..` が含まれる、または `Path(pattern).is_absolute()` が真 | バリデーションエラーとして拒否する |
 | glob マッチ結果が `dir_path` 配下でない | 該当ファイルを除外する |
 

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -18,7 +18,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 8 | クロールプレビュー | クロール対象ページのタイトル・URL 一覧を事前確認 | [rag-knowledge.md](rag-knowledge.md) |
 | 9 | Zenn インジェスター | Zenn 記事を API 経由で取得・ナレッジベースに取り込み | [zenn-ingester.md](zenn-ingester.md) |
 | 10 | BlueSky インジェスター | BlueSky 投稿を AT Protocol API 経由で取得・ナレッジベースに取り込み | [bluesky-ingester.md](bluesky-ingester.md) |
-| 11 | ローカルファイルインジェスター | ローカルファイルをナレッジベースに取り込み | [local-file-ingester.md](local-file-ingester.md) |
+| 11 | ドキュメントインジェスター | テキストドキュメントをナレッジベースに取り込み | [document-ingester.md](document-ingester.md) |
 
 ## 3. 技術スタック
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -9,7 +9,7 @@ MCP サーバーとして独立動作し、10 個のツールを提供する。
 
 スコープ:
 
-- 知識の取り込み（クロール・単一ページ追加・Zenn 記事取り込み・BlueSky 投稿取り込み・ローカルファイル取り込み）
+- 知識の取り込み（クロール・単一ページ追加・Zenn 記事取り込み・BlueSky 投稿取り込み・ドキュメントファイル取り込み）
 - 知識の検索（ベクトル検索・BM25 キーワード検索）
 - 知識の管理（統計表示・削除）
 - クロールプレビュー（対象ページの事前確認）
@@ -89,8 +89,8 @@ MCP サーバーが公開する 10 個のツール。
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_crawl_zenn | username、max_articles（任意） | 指定ユーザーの Zenn 記事を API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（記事の公開 URL）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。max_posts はタイムライン全体（リポスト含む）に適用。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
-| rag_add_local | file_path | 単一ローカルファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
-| rag_crawl_local | dir_path、pattern（任意） | 指定ディレクトリ内のファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
+| rag_add_document | file_path | 単一ドキュメントファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
+| rag_crawl_documents | dir_path、pattern（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_delete | URL | ソース URL 指定でナレッジを削除する |
 | rag_stats | なし | 統計情報（総チャンク数、ソース URL 数）と蓄積データ概要（ドメイン別ソース URL 一覧・タイトル）を返す。表示件数上限は `RAG_STATS_MAX_SOURCES` で制御する |
 
@@ -193,7 +193,7 @@ flowchart LR
 | `title` | str | コンテンツのタイトル |
 | `chunk_index` | int | チャンクの連番（0 始まり） |
 | `crawled_at` | str | 取り込みタイムスタンプ（ISO 8601） |
-| `source_type` | str | データソース種別（`"web"`, `"zenn"`, `"bluesky"`, `"local"`） |
+| `source_type` | str | データソース種別（`"web"`, `"zenn"`, `"bluesky"`, `"document"`） |
 
 #### カスタムフィールド
 
@@ -348,4 +348,4 @@ flowchart LR
 
 - [zenn-ingester.md](zenn-ingester.md) — Zenn インジェスター仕様
 - [bluesky-ingester.md](bluesky-ingester.md) — BlueSky インジェスター仕様
-- [local-file-ingester.md](local-file-ingester.md) — ローカルファイルインジェスター仕様
+- [document-ingester.md](document-ingester.md) — ドキュメントインジェスター仕様

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -100,8 +100,8 @@ class RAGSettings(BaseSettings):
     rag_zenn_request_timeout: int = Field(default=30, ge=1, le=120)
     rag_zenn_request_interval: float = Field(default=1.0, ge=0.1, le=60.0)
 
-    # ローカルファイルインジェスター
-    rag_local_supported_extensions: str = ".md,.txt,.pdf,.adoc"
+    # ドキュメントインジェスター
+    rag_document_supported_extensions: str = ".md,.txt,.pdf,.adoc"
 
     # BlueSky インジェスター
     rag_bluesky_appview_url: str = "https://public.api.bsky.app"

--- a/src/rag/ingesters/__init__.py
+++ b/src/rag/ingesters/__init__.py
@@ -4,17 +4,17 @@
 Issue: #62
 """
 
-from .base import BaseIngester, IngestedContent
-from .bluesky import BlueskyIngester
-from .local_file import LocalFileIngester
-from .web import WebIngester
-from .zenn import ZennIngester
+from .base_ingester import BaseIngester, IngestedContent
+from .bluesky_ingester import BlueskyIngester
+from .document_ingester import DocumentIngester
+from .web_ingester import WebIngester
+from .zenn_ingester import ZennIngester
 
 __all__ = [
     "BaseIngester",
     "BlueskyIngester",
+    "DocumentIngester",
     "IngestedContent",
-    "LocalFileIngester",
     "WebIngester",
     "ZennIngester",
 ]

--- a/src/rag/ingesters/base_ingester.py
+++ b/src/rag/ingesters/base_ingester.py
@@ -24,7 +24,7 @@ class IngestedContent:
         title: コンテンツのタイトル
         text: 抽出済みテキスト
         ingested_at: 取り込みタイムスタンプ（ISO 8601）
-        source_type: データソース種別（"web", "zenn", "bluesky", "local"）
+        source_type: データソース種別（"web", "zenn", "bluesky", "document"）
         metadata: ソース固有のメタデータ
         skip_chunking: True の場合、チャンキングをスキップし 1 チャンクで格納する
     """

--- a/src/rag/ingesters/bluesky_ingester.py
+++ b/src/rag/ingesters/bluesky_ingester.py
@@ -11,7 +11,7 @@ import re
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
-from .base import BaseIngester, IngestedContent
+from .base_ingester import BaseIngester, IngestedContent
 
 if TYPE_CHECKING:
     from py_common_lib.httpx import ConstrainedClient

--- a/src/rag/ingesters/document_ingester.py
+++ b/src/rag/ingesters/document_ingester.py
@@ -1,7 +1,7 @@
-"""ローカルファイルインジェスター: ローカルファイルを読み取りナレッジベースに取り込む
+"""ドキュメントインジェスター: テキストドキュメントを読み取りナレッジベースに取り込む
 
-仕様: docs/specs/local-file-ingester.md
-Issue: #184
+仕様: docs/specs/document-ingester.md
+Issue: #184, #198
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from .base import BaseIngester, IngestedContent
+from .base_ingester import BaseIngester, IngestedContent
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +18,13 @@ MAX_FILES_HARD_LIMIT = 100
 """ディレクトリ一括取り込み時のファイル数上限"""
 
 
-class LocalFileIngester(BaseIngester):
-    """ローカルファイル取り込み用インジェスター.
+class DocumentIngester(BaseIngester):
+    """ドキュメント取り込み用インジェスター.
 
-    仕様: docs/specs/local-file-ingester.md
+    仕様: docs/specs/document-ingester.md
 
-    ローカルファイルシステムからドキュメントを読み取り、
-    IngestedContent に変換する。BaseIngester を継承する。
+    テキストドキュメント（Markdown、プレーンテキスト、PDF、AsciiDoc）を
+    読み取り、IngestedContent に変換する。BaseIngester を継承する。
     """
 
     def __init__(
@@ -32,7 +32,7 @@ class LocalFileIngester(BaseIngester):
         *,
         supported_extensions: list[str] | None = None,
     ) -> None:
-        """LocalFileIngester を初期化する.
+        """DocumentIngester を初期化する.
 
         Args:
             supported_extensions: 対応ファイル拡張子のリスト
@@ -119,7 +119,7 @@ class LocalFileIngester(BaseIngester):
             title=path.stem,
             text=text,
             ingested_at=IngestedContent.now_iso(),
-            source_type="local",
+            source_type="document",
             metadata={
                 "file_extension": path.suffix.lower(),
                 "file_size_bytes": file_size,

--- a/src/rag/ingesters/web_ingester.py
+++ b/src/rag/ingesters/web_ingester.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-from .base import BaseIngester, IngestedContent
+from .base_ingester import BaseIngester, IngestedContent
 
 if TYPE_CHECKING:
     from ..safe_browsing import SafeBrowsingClient

--- a/src/rag/ingesters/zenn_ingester.py
+++ b/src/rag/ingesters/zenn_ingester.py
@@ -14,7 +14,7 @@ from urllib.parse import urlencode
 from bs4 import BeautifulSoup
 
 from ..markdown import RagMarkdownConverter
-from .base import BaseIngester, IngestedContent
+from .base_ingester import BaseIngester, IngestedContent
 
 if TYPE_CHECKING:
     from py_common_lib.httpx import ConstrainedClient

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -16,14 +16,14 @@ from urllib.parse import urldefrag
 from .chunker import chunk_text
 from .content_detector import ContentType, detect_content_type
 from .heading_chunker import chunk_by_headings
-from .ingesters.base import IngestedContent
+from .ingesters.base_ingester import IngestedContent
 from .table_chunker import chunk_table_data
 from .vector_store import DocumentChunk, VectorStore
 
 if TYPE_CHECKING:
     from .bm25_index import BM25Index
     from .hybrid_search import HybridSearchEngine
-    from .ingesters.web import WebIngester
+    from .ingesters.web_ingester import WebIngester
     from .safe_browsing import SafeBrowsingClient
     from py_common_lib.httpx import ConstrainedClient
     from .web_crawler import CrawlPreviewPage, CrawledPage, WebCrawler

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -10,8 +10,8 @@ FastMCP を使用して 10 個の RAG ツールを公開する:
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_crawl_zenn: Zenn 記事の一括取り込み
 - rag_crawl_bluesky: BlueSky 投稿の一括取り込み
-- rag_add_local: ローカルファイルをナレッジベースに取り込み
-- rag_crawl_local: ディレクトリ内ファイルを一括取り込み
+- rag_add_document: ドキュメントファイルをナレッジベースに取り込み
+- rag_crawl_documents: ディレクトリ内ドキュメントを一括取り込み
 - rag_delete: ソースURL指定でナレッジから削除
 - rag_stats: ナレッジベースの統計情報を表示
 """
@@ -39,10 +39,10 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
     from .config import get_settings
     from .embedding.factory import get_embedding_provider
-    from .ingesters.bluesky import BlueskyIngester
-    from .ingesters.local_file import LocalFileIngester
-    from .ingesters.web import WebIngester
-    from .ingesters.zenn import ZennIngester
+    from .ingesters.bluesky_ingester import BlueskyIngester
+    from .ingesters.document_ingester import DocumentIngester
+    from .ingesters.web_ingester import WebIngester
+    from .ingesters.zenn_ingester import ZennIngester
     from .rag_knowledge import RAGKnowledgeService
     from .safe_browsing import create_safe_browsing_client
     from .vector_store import VectorStore
@@ -145,7 +145,7 @@ def _build_rag_service() -> RAGKnowledgeService:
 
 # --- MCP ツール定義 ---
 
-_VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "local"})
+_VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "document"})
 
 
 @mcp.tool()
@@ -164,7 +164,7 @@ async def rag_search(
     Args:
         query: 検索クエリ（ユーザーの質問からキーワードを抽出して構成する）
         n_results: 各エンジンから取得する結果数（未指定時は設定値を使用）
-        source_type: ソース種別フィルタ（"web", "zenn", "bluesky", "local"）。
+        source_type: ソース種別フィルタ（"web", "zenn", "bluesky", "document"）。
             指定時はそのソース種別のチャンクのみを検索対象とする。未指定時は全種別を検索。
 
     Returns:
@@ -568,23 +568,23 @@ async def rag_crawl_bluesky(
         return f"エラー: BlueSky 投稿の取り込みに失敗しました（ハンドル: {handle}）"
 
 
-def _create_local_ingester() -> LocalFileIngester:
-    """設定に基づいて LocalFileIngester を生成する."""
+def _create_document_ingester() -> DocumentIngester:
+    """設定に基づいて DocumentIngester を生成する."""
     settings = get_settings()
     extensions = [
         ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
-        for ext in settings.rag_local_supported_extensions.split(",")
+        for ext in settings.rag_document_supported_extensions.split(",")
         if ext.strip()
     ]
-    return LocalFileIngester(supported_extensions=extensions)
+    return DocumentIngester(supported_extensions=extensions)
 
 
 @mcp.tool()
-async def rag_add_local(file_path: str) -> str:
-    """[rag-knowledge] RAG add local - ローカルファイルをナレッジベースに取り込む.
+async def rag_add_document(file_path: str) -> str:
+    """[rag-knowledge] RAG add document - ドキュメントファイルをナレッジベースに取り込む.
 
-    knowledge base, ingest, local file, document.
-    ローカルファイル（Markdown、テキスト、PDF、AsciiDoc）を読み取り、
+    knowledge base, ingest, document, file, text.
+    ドキュメントファイル（Markdown、テキスト、PDF、AsciiDoc）を読み取り、
     ナレッジベースに取り込む。同一ファイルの再取り込み時は既存の知識を最新に置き換える。
     stdio モード専用。HTTP モードでは無効。
 
@@ -595,10 +595,10 @@ async def rag_add_local(file_path: str) -> str:
         取り込み結果のメッセージ（ファイル名、チャンク数）
     """
     if get_settings().rag_transport == "http":
-        return "エラー: rag_add_local は HTTP モードでは無効です（セキュリティ上の制約）"
+        return "エラー: rag_add_document は HTTP モードでは無効です（セキュリティ上の制約）"
 
     service = await _get_rag_service()
-    ingester = _create_local_ingester()
+    ingester = _create_document_ingester()
 
     try:
         content = await ingester.fetch_single(file_path)
@@ -611,16 +611,16 @@ async def rag_add_local(file_path: str) -> str:
     except ValueError as e:
         return f"エラー: {e}"
     except Exception:
-        logger.exception("Failed to add local file: %s", file_path)
+        logger.exception("Failed to add document file: %s", file_path)
         return f"エラー: ファイルの取り込みに失敗しました。パス: {file_path}"
 
 
 @mcp.tool()
-async def rag_crawl_local(dir_path: str, pattern: str = "**/*") -> str:
-    """[rag-knowledge] RAG crawl local - ディレクトリ内のファイルを一括取り込み.
+async def rag_crawl_documents(dir_path: str, pattern: str = "**/*") -> str:
+    """[rag-knowledge] RAG crawl documents - ディレクトリ内のドキュメントを一括取り込み.
 
-    knowledge base, ingest, local directory, bulk import, glob.
-    指定ディレクトリ内のファイルを glob パターンで検索し、
+    knowledge base, ingest, document directory, bulk import, glob.
+    指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、
     一括でナレッジベースに取り込む。同一ファイルの再取り込み時は
     既存の知識を最新に置き換える。
     stdio モード専用。HTTP モードでは無効。
@@ -633,10 +633,10 @@ async def rag_crawl_local(dir_path: str, pattern: str = "**/*") -> str:
         取り込み結果のサマリーテキスト（処理ファイル数、総チャンク数、スキップ数、エラー数）
     """
     if get_settings().rag_transport == "http":
-        return "エラー: rag_crawl_local は HTTP モードでは無効です（セキュリティ上の制約）"
+        return "エラー: rag_crawl_documents は HTTP モードでは無効です（セキュリティ上の制約）"
 
     service = await _get_rag_service()
-    ingester = _create_local_ingester()
+    ingester = _create_document_ingester()
 
     try:
         files = ingester.collect_files(dir_path, pattern)
@@ -661,7 +661,7 @@ async def rag_crawl_local(dir_path: str, pattern: str = "**/*") -> str:
             total_chunks += chunks
             ingested_count += 1
         except Exception:
-            logger.exception("Failed to ingest local file: %s", file)
+            logger.exception("Failed to ingest document file: %s", file)
             errors += 1
 
     parts = [

--- a/tests/test_bluesky_ingester.py
+++ b/tests/test_bluesky_ingester.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from rag.ingesters.bluesky import (
+from rag.ingesters.bluesky_ingester import (
     MAX_POSTS_HARD_LIMIT,
     BlueskyIngester,
     _extract_quote_text_from_view_embed,

--- a/tests/test_document_ingester.py
+++ b/tests/test_document_ingester.py
@@ -1,10 +1,10 @@
-"""ローカルファイルインジェスターのテスト
+"""ドキュメントインジェスターのテスト
 
-仕様: docs/specs/local-file-ingester.md
-Issue: #184
+仕様: docs/specs/document-ingester.md
+Issue: #184, #198
 
 テスト方針:
-- 単体テスト: LocalFileIngester の fetch_single / validate_identifier / collect_files
+- 単体テスト: DocumentIngester の fetch_single / validate_identifier / collect_files
 - 正常系: .md / .txt / .adoc ファイルの取り込み、ディレクトリ一括取り込み
 - 異常系: 存在しないファイル、空パス、未対応拡張子、空ファイル（0バイト）、UTF-8以外
 - バリデーション: パストラバーサル対策、pattern の '..' / 絶対パス拒否
@@ -19,9 +19,9 @@ from unittest.mock import patch
 
 import pytest
 
-from rag.ingesters.local_file import (
+from rag.ingesters.document_ingester import (
     MAX_FILES_HARD_LIMIT,
-    LocalFileIngester,
+    DocumentIngester,
 )
 
 
@@ -60,54 +60,54 @@ class TestHardLimits:
         assert MAX_FILES_HARD_LIMIT == 100
 
 
-# --- LocalFileIngester.validate_identifier テスト ---
+# --- DocumentIngester.validate_identifier テスト ---
 
 
-class TestLocalFileIngesterValidate:
-    """LocalFileIngester.validate_identifier のテスト."""
+class TestDocumentIngesterValidate:
+    """DocumentIngester.validate_identifier のテスト."""
 
     @pytest.fixture()
-    def ingester(self) -> LocalFileIngester:
-        return LocalFileIngester()
+    def ingester(self) -> DocumentIngester:
+        return DocumentIngester()
 
-    def test_valid_md_file(self, ingester: LocalFileIngester, tmp_path: Path) -> None:
+    def test_valid_md_file(self, ingester: DocumentIngester, tmp_path: Path) -> None:
         """正しい .md ファイルのパスが正規化されて返ること."""
         f = _create_text_file(tmp_path, "test.md", "# Hello")
         result = ingester.validate_identifier(str(f))
         assert result == str(f.resolve())
 
-    def test_valid_txt_file(self, ingester: LocalFileIngester, tmp_path: Path) -> None:
+    def test_valid_txt_file(self, ingester: DocumentIngester, tmp_path: Path) -> None:
         """正しい .txt ファイルのパスが正規化されて返ること."""
         f = _create_text_file(tmp_path, "test.txt", "Hello")
         result = ingester.validate_identifier(str(f))
         assert result == str(f.resolve())
 
-    def test_valid_adoc_file(self, ingester: LocalFileIngester, tmp_path: Path) -> None:
+    def test_valid_adoc_file(self, ingester: DocumentIngester, tmp_path: Path) -> None:
         """正しい .adoc ファイルのパスが正規化されて返ること."""
         f = _create_text_file(tmp_path, "test.adoc", "= Hello")
         result = ingester.validate_identifier(str(f))
         assert result == str(f.resolve())
 
-    def test_valid_pdf_file(self, ingester: LocalFileIngester, tmp_path: Path) -> None:
+    def test_valid_pdf_file(self, ingester: DocumentIngester, tmp_path: Path) -> None:
         """正しい .pdf ファイルのパスが正規化されて返ること."""
         f = _create_binary_file(tmp_path, "test.pdf", b"%PDF-1.4 dummy")
         result = ingester.validate_identifier(str(f))
         assert result == str(f.resolve())
 
-    def test_empty_path(self, ingester: LocalFileIngester) -> None:
+    def test_empty_path(self, ingester: DocumentIngester) -> None:
         """空文字列がバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not be empty"):
             ingester.validate_identifier("")
         with pytest.raises(ValueError, match="must not be empty"):
             ingester.validate_identifier("   ")
 
-    def test_nonexistent_file(self, ingester: LocalFileIngester) -> None:
+    def test_nonexistent_file(self, ingester: DocumentIngester) -> None:
         """存在しないファイルがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="File not found"):
             ingester.validate_identifier("/nonexistent/path/file.md")
 
     def test_unsupported_extension(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """未対応拡張子がバリデーションエラーになること."""
         f = _create_text_file(tmp_path, "test.docx", "Hello")
@@ -115,14 +115,14 @@ class TestLocalFileIngesterValidate:
             ingester.validate_identifier(str(f))
 
     def test_directory_path(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ディレクトリパスがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="Path is a directory"):
             ingester.validate_identifier(str(tmp_path))
 
     def test_whitespace_trimmed(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """前後の空白がトリムされること."""
         f = _create_text_file(tmp_path, "test.md", "# Hello")
@@ -131,7 +131,7 @@ class TestLocalFileIngesterValidate:
 
     def test_custom_extensions(self, tmp_path: Path) -> None:
         """カスタム拡張子が受け入れられること."""
-        ingester = LocalFileIngester(supported_extensions=[".md", ".rst"])
+        ingester = DocumentIngester(supported_extensions=[".md", ".rst"])
         f = _create_text_file(tmp_path, "test.rst", "Hello")
         result = ingester.validate_identifier(str(f))
         assert result == str(f.resolve())
@@ -142,18 +142,18 @@ class TestLocalFileIngesterValidate:
             ingester.validate_identifier(str(f2))
 
 
-# --- LocalFileIngester.fetch_single テスト ---
+# --- DocumentIngester.fetch_single テスト ---
 
 
-class TestLocalFileIngesterFetchSingle:
-    """LocalFileIngester.fetch_single のテスト."""
+class TestDocumentIngesterFetchSingle:
+    """DocumentIngester.fetch_single のテスト."""
 
     @pytest.fixture()
-    def ingester(self) -> LocalFileIngester:
-        return LocalFileIngester()
+    def ingester(self) -> DocumentIngester:
+        return DocumentIngester()
 
     async def test_fetch_md_file(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """Markdown ファイルが正常に取り込まれること."""
         f = _create_text_file(tmp_path, "document.md", "# Hello World\n\nThis is content.")
@@ -163,13 +163,13 @@ class TestLocalFileIngesterFetchSingle:
         assert result.source_id == f.resolve().as_uri()
         assert result.title == "document"
         assert result.text == "# Hello World\n\nThis is content."
-        assert result.source_type == "local"
+        assert result.source_type == "document"
         assert result.metadata["file_extension"] == ".md"
         assert result.metadata["file_size_bytes"] > 0
         assert result.metadata["file_path"] == str(f)
 
     async def test_fetch_txt_file(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """テキストファイルが正常に取り込まれること."""
         f = _create_text_file(tmp_path, "notes.txt", "Some plain text notes.")
@@ -180,7 +180,7 @@ class TestLocalFileIngesterFetchSingle:
         assert result.text == "Some plain text notes."
 
     async def test_fetch_adoc_file(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """AsciiDoc ファイルが正常に取り込まれること."""
         f = _create_text_file(tmp_path, "guide.adoc", "= Guide Title\n\nContent here.")
@@ -191,7 +191,7 @@ class TestLocalFileIngesterFetchSingle:
         assert result.text == "= Guide Title\n\nContent here."
 
     async def test_fetch_empty_file(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """空ファイル（0バイト）がスキップされること."""
         f = _create_empty_file(tmp_path, "empty.md")
@@ -200,14 +200,14 @@ class TestLocalFileIngesterFetchSingle:
         assert result is None
 
     async def test_fetch_nonexistent_file(
-        self, ingester: LocalFileIngester
+        self, ingester: DocumentIngester
     ) -> None:
         """存在しないファイルで ValueError を送出すること."""
         with pytest.raises(ValueError, match="File not found"):
             await ingester.fetch_single("/nonexistent/file.md")
 
     async def test_fetch_unsupported_extension(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """未対応拡張子で ValueError を送出すること."""
         f = _create_text_file(tmp_path, "test.docx", "Hello")
@@ -215,7 +215,7 @@ class TestLocalFileIngesterFetchSingle:
             await ingester.fetch_single(str(f))
 
     async def test_fetch_non_utf8_file(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """UTF-8 以外のエンコーディングのファイルで None を返すこと."""
         f = tmp_path / "shift_jis.txt"
@@ -225,13 +225,13 @@ class TestLocalFileIngesterFetchSingle:
         assert result is None
 
     async def test_fetch_pdf_with_mock(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """PDF ファイルが pymupdf4llm 経由で取り込まれること（モック）."""
         f = _create_binary_file(tmp_path, "report.pdf", b"%PDF-1.4 dummy content")
 
         with patch(
-            "rag.ingesters.local_file.LocalFileIngester._extract_pdf",
+            "rag.ingesters.document_ingester.DocumentIngester._extract_pdf",
             return_value="# Extracted PDF Content\n\nParagraph from PDF.",
         ):
             result = await ingester.fetch_single(str(f))
@@ -242,13 +242,13 @@ class TestLocalFileIngesterFetchSingle:
         assert result.metadata["file_extension"] == ".pdf"
 
     async def test_fetch_pdf_extraction_failure(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """PDF 変換失敗時に None を返すこと."""
         f = _create_binary_file(tmp_path, "bad.pdf", b"%PDF-1.4 corrupted")
 
         with patch(
-            "rag.ingesters.local_file.LocalFileIngester._extract_pdf",
+            "rag.ingesters.document_ingester.DocumentIngester._extract_pdf",
             return_value=None,
         ):
             result = await ingester.fetch_single(str(f))
@@ -256,7 +256,7 @@ class TestLocalFileIngesterFetchSingle:
         assert result is None
 
     async def test_fetch_whitespace_only_content(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """空白のみのファイルで None を返すこと."""
         f = _create_text_file(tmp_path, "whitespace.md", "   \n\n   ")
@@ -265,7 +265,7 @@ class TestLocalFileIngesterFetchSingle:
         assert result is None
 
     async def test_source_id_is_file_uri(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """source_id が file URI であること."""
         f = _create_text_file(tmp_path, "doc.md", "Content")
@@ -275,7 +275,7 @@ class TestLocalFileIngesterFetchSingle:
         assert result.source_id.startswith("file:///")
 
     async def test_ingested_at_is_set(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ingested_at がセットされること."""
         f = _create_text_file(tmp_path, "doc.md", "Content")
@@ -285,47 +285,47 @@ class TestLocalFileIngesterFetchSingle:
         assert result.ingested_at  # 空でない
 
 
-# --- LocalFileIngester.validate_pattern テスト ---
+# --- DocumentIngester.validate_pattern テスト ---
 
 
-class TestLocalFileIngesterValidatePattern:
-    """LocalFileIngester.validate_pattern のテスト."""
+class TestDocumentIngesterValidatePattern:
+    """DocumentIngester.validate_pattern のテスト."""
 
     @pytest.fixture()
-    def ingester(self) -> LocalFileIngester:
-        return LocalFileIngester()
+    def ingester(self) -> DocumentIngester:
+        return DocumentIngester()
 
-    def test_valid_pattern(self, ingester: LocalFileIngester) -> None:
+    def test_valid_pattern(self, ingester: DocumentIngester) -> None:
         """正しいパターンがそのまま返ること."""
         assert ingester.validate_pattern("**/*.md") == "**/*.md"
         assert ingester.validate_pattern("*.txt") == "*.txt"
         assert ingester.validate_pattern("docs/**/*") == "docs/**/*"
 
-    def test_pattern_with_dotdot(self, ingester: LocalFileIngester) -> None:
+    def test_pattern_with_dotdot(self, ingester: DocumentIngester) -> None:
         """'..' を含むパターンがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not contain '..'"):
             ingester.validate_pattern("../**/*.md")
         with pytest.raises(ValueError, match="must not contain '..'"):
             ingester.validate_pattern("docs/../../etc/passwd")
 
-    def test_absolute_pattern(self, ingester: LocalFileIngester) -> None:
+    def test_absolute_pattern(self, ingester: DocumentIngester) -> None:
         """絶対パスのパターンがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not be an absolute path"):
             ingester.validate_pattern("/etc/**/*.md")
 
 
-# --- LocalFileIngester.collect_files テスト ---
+# --- DocumentIngester.collect_files テスト ---
 
 
-class TestLocalFileIngesterCollectFiles:
-    """LocalFileIngester.collect_files のテスト."""
+class TestDocumentIngesterCollectFiles:
+    """DocumentIngester.collect_files のテスト."""
 
     @pytest.fixture()
-    def ingester(self) -> LocalFileIngester:
-        return LocalFileIngester()
+    def ingester(self) -> DocumentIngester:
+        return DocumentIngester()
 
     def test_collect_from_directory(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ディレクトリからファイルが収集されること."""
         _create_text_file(tmp_path, "a.md", "Content A")
@@ -341,7 +341,7 @@ class TestLocalFileIngesterCollectFiles:
         assert "c.py" not in names
 
     def test_collect_recursive(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """サブディレクトリ内のファイルも再帰的に収集されること."""
         sub = tmp_path / "sub"
@@ -354,7 +354,7 @@ class TestLocalFileIngesterCollectFiles:
         assert len(files) == 2
 
     def test_collect_with_pattern(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """glob パターンでフィルタされること."""
         _create_text_file(tmp_path, "a.md", "Content A")
@@ -366,7 +366,7 @@ class TestLocalFileIngesterCollectFiles:
         assert files[0].name == "a.md"
 
     def test_collect_sorted(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ファイルがパスの辞書順でソートされること."""
         _create_text_file(tmp_path, "c.md", "C")
@@ -379,7 +379,7 @@ class TestLocalFileIngesterCollectFiles:
         assert names == sorted(names)
 
     def test_collect_empty_directory(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """空ディレクトリで空リストを返すこと."""
         files = ingester.collect_files(str(tmp_path))
@@ -387,7 +387,7 @@ class TestLocalFileIngesterCollectFiles:
         assert files == []
 
     def test_collect_no_matching_files(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """対応拡張子に一致するファイルがない場合に空リストを返すこと."""
         _create_text_file(tmp_path, "script.py", "print('hello')")
@@ -396,7 +396,7 @@ class TestLocalFileIngesterCollectFiles:
 
         assert files == []
 
-    def test_collect_empty_dir_path(self, ingester: LocalFileIngester) -> None:
+    def test_collect_empty_dir_path(self, ingester: DocumentIngester) -> None:
         """空の dir_path がバリデーションエラーになること."""
         with pytest.raises(ValueError, match="dir_path must not be empty"):
             ingester.collect_files("")
@@ -404,14 +404,14 @@ class TestLocalFileIngesterCollectFiles:
             ingester.collect_files("   ")
 
     def test_collect_nonexistent_directory(
-        self, ingester: LocalFileIngester
+        self, ingester: DocumentIngester
     ) -> None:
         """存在しないディレクトリがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="Directory not found"):
             ingester.collect_files("/nonexistent/directory")
 
     def test_collect_file_instead_of_directory(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ファイルパスがバリデーションエラーになること."""
         f = _create_text_file(tmp_path, "file.md", "Content")
@@ -419,21 +419,21 @@ class TestLocalFileIngesterCollectFiles:
             ingester.collect_files(str(f))
 
     def test_collect_pattern_with_dotdot(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """'..' を含むパターンがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not contain '..'"):
             ingester.collect_files(str(tmp_path), pattern="../**/*.md")
 
     def test_collect_absolute_pattern(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """絶対パスのパターンがバリデーションエラーになること."""
         with pytest.raises(ValueError, match="must not be an absolute path"):
             ingester.collect_files(str(tmp_path), pattern="/etc/**/*.md")
 
     def test_collect_clamp_at_limit(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ファイル数上限超過時にクランプされること（テスト安全値: 5件）."""
         for i in range(8):
@@ -447,7 +447,7 @@ class TestLocalFileIngesterCollectFiles:
         assert names == ["file_00.md", "file_01.md", "file_02.md", "file_03.md", "file_04.md"]
 
     def test_collect_within_limit(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """ファイル数上限以内の場合にクランプされないこと."""
         for i in range(3):
@@ -458,7 +458,7 @@ class TestLocalFileIngesterCollectFiles:
         assert len(files) == 3
 
     def test_collect_max_files_capped_by_hard_limit(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """max_files が MAX_FILES_HARD_LIMIT を超えないこと."""
         _create_text_file(tmp_path, "a.md", "Content")
@@ -471,15 +471,15 @@ class TestLocalFileIngesterCollectFiles:
 # --- PDF 抽出テスト（モック） ---
 
 
-class TestLocalFileIngesterPdf:
+class TestDocumentIngesterPdf:
     """PDF テキスト抽出のテスト（pymupdf4llm をモック）."""
 
     @pytest.fixture()
-    def ingester(self) -> LocalFileIngester:
-        return LocalFileIngester()
+    def ingester(self) -> DocumentIngester:
+        return DocumentIngester()
 
     def test_extract_pdf_success(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """pymupdf4llm で正常にテキスト抽出されること."""
         f = _create_binary_file(tmp_path, "doc.pdf", b"%PDF-1.4 dummy")
@@ -495,7 +495,7 @@ class TestLocalFileIngesterPdf:
         assert result == "# PDF Title\n\nPDF content here."
 
     def test_extract_pdf_import_error(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """pymupdf4llm が未インストールの場合に None を返すこと."""
         f = _create_binary_file(tmp_path, "doc.pdf", b"%PDF-1.4 dummy")
@@ -506,7 +506,7 @@ class TestLocalFileIngesterPdf:
         assert result is None
 
     def test_extract_pdf_conversion_error(
-        self, ingester: LocalFileIngester, tmp_path: Path
+        self, ingester: DocumentIngester, tmp_path: Path
     ) -> None:
         """PDF 変換エラー時に None を返すこと."""
         f = _create_binary_file(tmp_path, "doc.pdf", b"%PDF-1.4 dummy")

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -10,8 +10,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from rag.ingesters.base import BaseIngester, IngestedContent
-from rag.ingesters.web import WebIngester
+from rag.ingesters.base_ingester import BaseIngester, IngestedContent
+from rag.ingesters.web_ingester import WebIngester
 from rag.rag_knowledge import RAGKnowledgeService
 from rag.vector_store import VectorStore
 from rag.web_crawler import CrawledPage, WebCrawler

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1,8 +1,8 @@
 """RAG MCPサーバーのテスト.
 
 仕様: docs/specs/rag-knowledge.md
-9つのRAGツール（rag_search, rag_add, rag_crawl, rag_crawl_preview,
-rag_crawl_zenn, rag_add_local, rag_crawl_local, rag_delete, rag_stats）が
+10個のRAGツール（rag_search, rag_add, rag_crawl, rag_crawl_preview,
+rag_crawl_zenn, rag_crawl_bluesky, rag_add_document, rag_crawl_documents, rag_delete, rag_stats）が
 MCPサーバーとして公開されていることを検証する。
 """
 
@@ -39,8 +39,8 @@ async def test_rag_server_exposes_ten_tools() -> None:
 
     expected = {
         "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_crawl_zenn", "rag_crawl_bluesky", "rag_add_local",
-        "rag_crawl_local", "rag_delete", "rag_stats",
+        "rag_crawl_zenn", "rag_crawl_bluesky", "rag_add_document",
+        "rag_crawl_documents", "rag_delete", "rag_stats",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 

--- a/tests/test_zenn_ingester.py
+++ b/tests/test_zenn_ingester.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from rag.ingesters.zenn import (
+from rag.ingesters.zenn_ingester import (
     MAX_ARTICLES_HARD_LIMIT,
     MAX_PAGINATION_PAGES,
     ZennIngester,


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング ★
- [x] docs: ドキュメント更新

## Summary

- `LocalFileIngester` → `DocumentIngester` にリネーム（クラス名・MCP ツール名・source_type・環境変数名）
- 全インジェスターモジュールに `_ingester.py` サフィックスを付加（`base.py` → `base_ingester.py` 等）
- 仕様書を `local-file-ingester.md` → `document-ingester.md` にリネーム・内容更新
- 関連ドキュメント（README, ARCHITECTURE, overview, rag-knowledge.md）の参照更新
- MCP ツール名: `rag_add_local` → `rag_add_document`、`rag_crawl_local` → `rag_crawl_documents`
- `source_type`: `"local"` → `"document"`
- 環境変数: `RAG_LOCAL_SUPPORTED_EXTENSIONS` → `RAG_DOCUMENT_SUPPORTED_EXTENSIONS`

## Test plan

- [x] pytest 619件パス
- [x] ruff check クリア
- [x] mypy src クリア
- [x] コードレビュー実施（Warning 1件修正済み）
- [x] ドキュメントレビュー実施（指摘なし）

## Related issues

Closes #198