### PR TITLE
docs(rag-knowledge): README の keyring 登録手順を簡潔化 (#209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ uv sync
 cp .env.example .env  # Embedding 設定等を編集
 ```
 
-API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `rag-knowledge`、キー名: `OPENAI_API_KEY` / `GOOGLE_SAFE_BROWSING_API_KEY`）。登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
+API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `rag-knowledge`）。登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
 ## 起動
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,7 @@ uv sync
 cp .env.example .env  # Embedding 設定等を編集
 ```
 
-API キーは OS セキュアストレージに登録する（サービス名: `rag-knowledge`）:
-
-```bash
-uv run python -c "import keyring, getpass; keyring.set_password('rag-knowledge', 'OPENAI_API_KEY', getpass.getpass('Value: '))"
-uv run python -c "import keyring, getpass; keyring.set_password('rag-knowledge', 'GOOGLE_SAFE_BROWSING_API_KEY', getpass.getpass('Value: '))"
-```
+API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する。登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
 ## 起動
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ uv sync
 cp .env.example .env  # Embedding 設定等を編集
 ```
 
-API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する。登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
+API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `rag-knowledge`、キー名: `OPENAI_API_KEY` / `GOOGLE_SAFE_BROWSING_API_KEY`）。登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
 ## 起動
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- README セットアップセクションの keyring 登録コマンドを削除
- py-common-lib の仕様書へのリンクに差し替え

## Test plan

- [x] ドキュメントのみの変更

## Related issues

Closes #209