### PR TITLE
feat(rag-knowledge): 設定値のデフォルト値を廃止し未設定時はエラーに (#212)

### DIFF
--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -10,7 +10,8 @@
 - 共通設定値: config.toml
 
 全設定値は明示的に .env / config.toml に記載する必要がある。
-未記載の場合はバリデーションエラーとなる。
+config.toml が存在しない場合は FileNotFoundError、
+設定値が不足している場合は pydantic の ValidationError となる。
 例外: rag_similarity_threshold, rag_max_response_chars, rag_min_combined_score
 （未設定 = 機能無効を意図する項目は None がデフォルト）
 """

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -8,6 +8,11 @@
 - シークレット: OS セキュアストレージ (keyring)
 - 環境依存値: .env（_EnvLoader）
 - 共通設定値: config.toml
+
+全設定値は明示的に .env / config.toml に記載する必要がある。
+未記載の場合はバリデーションエラーとなる。
+例外: rag_similarity_threshold, rag_max_response_chars, rag_min_combined_score
+（未設定 = 機能無効を意図する項目は None がデフォルト）
 """
 
 from __future__ import annotations
@@ -22,10 +27,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# LM Studio のデフォルトベースURL
+# LM Studio のデフォルトベースURL（LMStudioEmbedding コンストラクタ用）
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
 
-# デフォルトEmbeddingモデル名
+# デフォルトEmbeddingモデル名（LMStudioEmbedding コンストラクタ用）
 DEFAULT_EMBEDDING_MODEL_LOCAL = "nomic-embed-text"
 
 # プロジェクトルートのパス
@@ -38,6 +43,7 @@ class _EnvLoader(BaseSettings):
     """環境依存設定のローダー（内部用）.
 
     .env および環境変数から、デプロイ先・マシンごとに異なる値を取得する。
+    全フィールドは必須。未設定時はバリデーションエラーとなる。
     """
 
     model_config = SettingsConfigDict(
@@ -47,21 +53,21 @@ class _EnvLoader(BaseSettings):
     )
 
     # Embedding 接続
-    embedding_provider: Literal["local", "online"] = "local"
-    lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL
+    embedding_provider: Literal["local", "online"]
+    lmstudio_base_url: str
 
     # ストレージ（MCP サーバー起動 cwd からの相対パス）
-    chromadb_persist_dir: str = "./chroma_db"
-    bm25_persist_dir: str = "./bm25_index"
+    chromadb_persist_dir: str
+    bm25_persist_dir: str
 
     # トランスポート
-    rag_transport: Literal["stdio", "http"] = "stdio"
-    rag_http_host: str = "127.0.0.1"
-    rag_http_port: int = Field(default=8081, ge=1, le=65535)
-    rag_dns_rebinding_protection: bool = True
+    rag_transport: Literal["stdio", "http"]
+    rag_http_host: str
+    rag_http_port: int = Field(ge=1, le=65535)
+    rag_dns_rebinding_protection: bool
 
     # デバッグ
-    rag_debug_log_enabled: bool = False
+    rag_debug_log_enabled: bool
 
 
 # .env 管理フィールド名の集合（重複検出に使用）
@@ -76,79 +82,82 @@ class RAGSettings(BaseModel):
     各設定値の取得元は1つに固定されている（フォールバックなし）:
     - 環境依存値(.env): embedding_provider, lmstudio_base_url 等
     - 共通設定値(config.toml): rag_chunk_size, rag_retrieval_count 等
+
+    全フィールドは必須。例外: float | None / int | None 型のフィールドは
+    未設定時に None（機能無効）がデフォルト。
     """
 
     # --- .env から取得（環境依存値） ---
-    embedding_provider: Literal["local", "online"] = "local"
-    lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL
-    chromadb_persist_dir: str = "./chroma_db"
-    bm25_persist_dir: str = "./bm25_index"
-    rag_transport: Literal["stdio", "http"] = "stdio"
-    rag_http_host: str = "127.0.0.1"
-    rag_http_port: int = Field(default=8081, ge=1, le=65535)
-    rag_dns_rebinding_protection: bool = True
-    rag_debug_log_enabled: bool = False
+    embedding_provider: Literal["local", "online"]
+    lmstudio_base_url: str
+    chromadb_persist_dir: str
+    bm25_persist_dir: str
+    rag_transport: Literal["stdio", "http"]
+    rag_http_host: str
+    rag_http_port: int = Field(ge=1, le=65535)
+    rag_dns_rebinding_protection: bool
+    rag_debug_log_enabled: bool
 
     # --- config.toml から取得（共通設定値） ---
 
     # Embedding モデル
-    embedding_model_local: str = DEFAULT_EMBEDDING_MODEL_LOCAL
-    embedding_model_online: str = "text-embedding-3-small"
-    embedding_prefix_enabled: bool = True
+    embedding_model_local: str
+    embedding_model_online: str
+    embedding_prefix_enabled: bool
 
     # チャンキング
-    rag_chunk_size: int = Field(default=200, ge=1)
-    rag_chunk_overlap: int = Field(default=30, ge=0)
+    rag_chunk_size: int = Field(ge=1)
+    rag_chunk_overlap: int = Field(ge=0)
 
     # 検索
-    rag_retrieval_count: int = Field(default=3, ge=1)
+    rag_retrieval_count: int = Field(ge=1)
     rag_similarity_threshold: float | None = Field(
         default=None, ge=0.0, le=2.0
     )
 
     # ハイブリッド検索
-    rag_hybrid_search_enabled: bool = False
-    rag_vector_weight: float = Field(default=0.90, ge=0.0, le=1.0)
-    rag_bm25_k1: float = Field(default=2.5, gt=0.0)
-    rag_bm25_b: float = Field(default=0.50, ge=0.0, le=1.0)
+    rag_hybrid_search_enabled: bool
+    rag_vector_weight: float = Field(ge=0.0, le=1.0)
+    rag_bm25_k1: float = Field(gt=0.0)
+    rag_bm25_b: float = Field(ge=0.0, le=1.0)
     rag_min_combined_score: float | None = Field(
-        default=0.75, ge=0.0, le=1.0
+        default=None, ge=0.0, le=1.0
     )
 
     # クロール（範囲外の値は WebCrawler / ConstrainedClient が警告付きでクランプする）
-    rag_max_crawl_pages: int = Field(default=50, ge=1)
-    rag_crawl_delay_sec: float = Field(default=1.0, ge=0)
+    rag_max_crawl_pages: int = Field(ge=1)
+    rag_crawl_delay_sec: float = Field(ge=0)
 
     # robots.txt
-    rag_respect_robots_txt: bool = True
-    rag_robots_txt_cache_ttl: int = Field(default=3600, ge=0)
+    rag_respect_robots_txt: bool
+    rag_robots_txt_cache_ttl: int = Field(ge=0)
 
     # URL安全性チェック (Google Safe Browsing API)
-    rag_url_safety_check: bool = False
-    rag_url_safety_cache_ttl: int = Field(default=300, ge=0)
-    rag_url_safety_fail_open: bool = True
-    rag_url_safety_timeout: float = Field(default=5.0, gt=0)
+    rag_url_safety_check: bool
+    rag_url_safety_cache_ttl: int = Field(ge=0)
+    rag_url_safety_fail_open: bool
+    rag_url_safety_timeout: float = Field(gt=0)
 
     # レスポンスサイズ制限
     rag_max_response_chars: int | None = Field(default=None, ge=1)
 
     # rag_stats ソース一覧の最大表示件数
-    rag_stats_max_sources: int = Field(default=100, ge=1)
+    rag_stats_max_sources: int = Field(ge=1)
 
     # Zenn インジェスター
-    rag_zenn_max_articles: int = Field(default=50, ge=1, le=100)
-    rag_zenn_request_timeout: int = Field(default=30, ge=1, le=120)
-    rag_zenn_request_interval: float = Field(default=1.0, ge=0.1, le=60.0)
+    rag_zenn_max_articles: int = Field(ge=1, le=100)
+    rag_zenn_request_timeout: int = Field(ge=1, le=120)
+    rag_zenn_request_interval: float = Field(ge=0.1, le=60.0)
 
     # ドキュメントインジェスター
-    rag_document_supported_extensions: str = ".md,.txt,.pdf,.adoc"
+    rag_document_supported_extensions: str
 
     # BlueSky インジェスター
-    rag_bluesky_appview_url: str = "https://public.api.bsky.app"
-    rag_bluesky_max_posts: int = Field(default=200, ge=1, le=1000)
-    rag_bluesky_request_timeout: int = Field(default=30, ge=1, le=120)
-    rag_bluesky_request_interval: float = Field(default=1.0, ge=0.1, le=60.0)
-    rag_bluesky_include_reposts: bool = True
+    rag_bluesky_appview_url: str
+    rag_bluesky_max_posts: int = Field(ge=1, le=1000)
+    rag_bluesky_request_timeout: int = Field(ge=1, le=120)
+    rag_bluesky_request_interval: float = Field(ge=0.1, le=60.0)
+    rag_bluesky_include_reposts: bool
 
     @model_validator(mode="after")
     def validate_chunk_settings(self) -> RAGSettings:
@@ -164,7 +173,8 @@ class RAGSettings(BaseModel):
 def _load_toml_config() -> dict[str, Any]:
     """config.toml を読み込み、層の重複を検証する."""
     if not _TOML_FILE.exists():
-        return {}
+        msg = f"config.toml が見つかりません: {_TOML_FILE}"
+        raise FileNotFoundError(msg)
     with open(_TOML_FILE, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
     # config.toml に環境依存値が混入していないか検証
@@ -191,7 +201,7 @@ def get_settings() -> RAGSettings:
     .env から環境依存値、config.toml から共通設定値を取得し、
     統合した RAGSettings を返す。
     """
-    env_loader = _EnvLoader()
+    env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
     toml_data = _load_toml_config()
     return RAGSettings(**env_loader.model_dump(), **toml_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+"""テスト共通フィクスチャ."""
+
+from __future__ import annotations
+
+# RAGSettings の全必須フィールドのテスト用デフォルト値。
+# config.py のフィールドにデフォルト値がないため、テストで RAGSettings を
+# 直接生成する際にこの辞書を使用する。
+# Optional (None デフォルト) フィールドは含まない。
+# 注意: 本番 config.toml の値とは意図的に異なる場合がある（テスト用に安全・軽量な値を使用）。
+TEST_SETTINGS_DEFAULTS: dict[str, object] = {
+    # .env フィールド
+    "embedding_provider": "local",
+    "lmstudio_base_url": "http://localhost:1234",
+    "chromadb_persist_dir": "./chroma_db",
+    "bm25_persist_dir": "./bm25_index",
+    "rag_transport": "stdio",
+    "rag_http_host": "127.0.0.1",
+    "rag_http_port": 8081,
+    "rag_dns_rebinding_protection": True,
+    "rag_debug_log_enabled": False,
+    # config.toml フィールド
+    "embedding_model_local": "nomic-embed-text",
+    "embedding_model_online": "text-embedding-3-small",
+    "embedding_prefix_enabled": True,
+    "rag_chunk_size": 200,
+    "rag_chunk_overlap": 30,
+    "rag_retrieval_count": 3,
+    "rag_hybrid_search_enabled": False,
+    "rag_vector_weight": 0.90,
+    "rag_bm25_k1": 2.5,
+    "rag_bm25_b": 0.50,
+    "rag_max_crawl_pages": 50,
+    "rag_crawl_delay_sec": 1.0,
+    "rag_respect_robots_txt": True,
+    "rag_robots_txt_cache_ttl": 3600,
+    "rag_url_safety_check": False,
+    "rag_url_safety_cache_ttl": 300,
+    "rag_url_safety_fail_open": True,
+    "rag_url_safety_timeout": 5.0,
+    "rag_stats_max_sources": 100,
+    "rag_zenn_max_articles": 50,
+    "rag_zenn_request_timeout": 30,
+    "rag_zenn_request_interval": 1.0,
+    "rag_document_supported_extensions": ".md,.txt,.pdf,.adoc",
+    "rag_bluesky_appview_url": "https://public.api.bsky.app",
+    "rag_bluesky_max_posts": 200,
+    "rag_bluesky_request_timeout": 30,
+    "rag_bluesky_request_interval": 1.0,
+    "rag_bluesky_include_reposts": True,
+}

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -1,4 +1,4 @@
-"""テスト共通フィクスチャ."""
+"""テスト用設定デフォルト値."""
 
 from __future__ import annotations
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from py_common_lib.secrets import SecretNotFoundError
 
+from conftest import TEST_SETTINGS_DEFAULTS
 from rag.config import DEFAULT_LMSTUDIO_BASE_URL, RAGSettings as Settings
 from rag.embedding.base import EmbeddingProvider
 from rag.embedding.factory import get_embedding_provider
@@ -116,14 +117,14 @@ async def test_openai_embedding_is_available() -> None:
 
 def test_factory_returns_correct_provider_local() -> None:
     """AC4: get_embedding_provider() が 'local' 設定で LMStudioEmbedding を返すこと."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     provider = get_embedding_provider(settings, "local")
     assert isinstance(provider, LMStudioEmbedding)
 
 
 def test_factory_returns_correct_provider_online() -> None:
     """AC4: get_embedding_provider() が 'online' 設定で OpenAIEmbedding を返すこと."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     with patch("rag.embedding.factory.get_secret", return_value="sk-test"):
         provider = get_embedding_provider(settings, "online")
     assert isinstance(provider, OpenAIEmbedding)
@@ -131,7 +132,7 @@ def test_factory_returns_correct_provider_online() -> None:
 
 def test_factory_raises_on_missing_api_key() -> None:
     """OPENAI_API_KEY 未登録時に ValueError を送出すること."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     with patch(
         "rag.embedding.factory.get_secret",
         side_effect=SecretNotFoundError("not found"),
@@ -142,7 +143,7 @@ def test_factory_raises_on_missing_api_key() -> None:
 
 def test_factory_raises_on_empty_api_key() -> None:
     """OPENAI_API_KEY が空文字列の場合に ValueError を送出すること."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     with patch("rag.embedding.factory.get_secret", return_value=""):
         with pytest.raises(ValueError, match="empty"):
             get_embedding_provider(settings, "online")
@@ -150,7 +151,7 @@ def test_factory_raises_on_empty_api_key() -> None:
 
 def test_factory_uses_settings_model_local() -> None:
     """AC4: ファクトリが Settings の embedding_model_local を使用すること."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     provider = get_embedding_provider(settings, "local")
     assert isinstance(provider, LMStudioEmbedding)
     assert provider._model == settings.embedding_model_local
@@ -158,16 +159,16 @@ def test_factory_uses_settings_model_local() -> None:
 
 def test_factory_uses_settings_model_online() -> None:
     """AC4: ファクトリが Settings の embedding_model_online を使用すること."""
-    settings = Settings(embedding_model_online="text-embedding-3-large")
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "embedding_model_online": "text-embedding-3-large"})
     with patch("rag.embedding.factory.get_secret", return_value="sk-test"):
         provider = get_embedding_provider(settings, "online")
     assert isinstance(provider, OpenAIEmbedding)
     assert provider._model == "text-embedding-3-large"
 
 
-def test_embedding_settings_defaults() -> None:
-    """AC4: Embedding関連設定のデフォルト値が設定されていること."""
-    settings = Settings()
+def test_embedding_settings_accepted() -> None:
+    """AC4: Embedding関連設定が正しく受け入れられること."""
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     assert settings.embedding_provider == "local"
     assert settings.embedding_model_local  # デフォルト値が設定されていること
     assert settings.embedding_model_online  # デフォルト値が設定されていること
@@ -175,11 +176,12 @@ def test_embedding_settings_defaults() -> None:
 
 def test_embedding_settings_configurable() -> None:
     """AC4: Embedding関連設定が設定可能であること."""
-    settings = Settings(
-        embedding_provider="online",
-        embedding_model_local="custom-embed-model",
-        embedding_model_online="text-embedding-3-large",
-    )
+    settings = Settings(**{
+        **TEST_SETTINGS_DEFAULTS,
+        "embedding_provider": "online",
+        "embedding_model_local": "custom-embed-model",
+        "embedding_model_online": "text-embedding-3-large",
+    })
     assert settings.embedding_provider == "online"
     assert settings.embedding_model_local == "custom-embed-model"
     assert settings.embedding_model_online == "text-embedding-3-large"
@@ -336,21 +338,21 @@ async def test_openai_embed_query_delegates_to_embed() -> None:
     assert result == [1.0, 2.0, 3.0]
 
 
-def test_embedding_prefix_enabled_setting_default() -> None:
-    """embedding_prefix_enabled のデフォルト値が True であること."""
-    settings = Settings()
+def test_embedding_prefix_enabled_setting_accepted() -> None:
+    """embedding_prefix_enabled が正しく受け入れられること."""
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     assert settings.embedding_prefix_enabled is True
 
 
 def test_embedding_prefix_enabled_setting_configurable() -> None:
     """embedding_prefix_enabled が設定可能であること."""
-    settings = Settings(embedding_prefix_enabled=True)
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "embedding_prefix_enabled": True})
     assert settings.embedding_prefix_enabled is True
 
 
 def test_factory_passes_prefix_enabled() -> None:
     """ファクトリが prefix_enabled を LMStudioEmbedding に渡すこと."""
-    settings = Settings(embedding_prefix_enabled=True)
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "embedding_prefix_enabled": True})
     provider = get_embedding_provider(settings, "local")
     assert isinstance(provider, LMStudioEmbedding)
     assert provider._prefix_enabled is True
@@ -358,7 +360,7 @@ def test_factory_passes_prefix_enabled() -> None:
 
 def test_factory_passes_prefix_enabled_by_default() -> None:
     """ファクトリがデフォルトで prefix_enabled=True を渡すこと."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     provider = get_embedding_provider(settings, "local")
     assert isinstance(provider, LMStudioEmbedding)
     assert provider._prefix_enabled is True

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from py_common_lib.secrets import SecretNotFoundError
 
-from conftest import TEST_SETTINGS_DEFAULTS
+from settings_defaults import TEST_SETTINGS_DEFAULTS
 from rag.config import DEFAULT_LMSTUDIO_BASE_URL, RAGSettings as Settings
 from rag.embedding.base import EmbeddingProvider
 from rag.embedding.factory import get_embedding_provider

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -17,12 +17,13 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
+from conftest import TEST_SETTINGS_DEFAULTS
 from rag.config import RAGSettings, _ENV_FIELD_NAMES, _load_toml_config
 
 
 def _make_settings(**overrides: object) -> RAGSettings:
-    """テスト用 RAGSettings を生成する."""
-    return RAGSettings(**overrides)
+    """テスト用 RAGSettings を生成する（全必須フィールドをデフォルト値付きで提供）."""
+    return RAGSettings(**{**TEST_SETTINGS_DEFAULTS, **overrides})
 
 
 # --- Zenn インジェスター: rag_zenn_max_articles ---
@@ -32,7 +33,7 @@ class TestZennMaxArticles:
     """rag_zenn_max_articles のバリデーションテスト."""
 
     def test_default_value(self) -> None:
-        """デフォルト値が 50 であること."""
+        """テスト用デフォルト値が 50 であること."""
         settings = _make_settings()
         assert settings.rag_zenn_max_articles == 50
 
@@ -62,7 +63,7 @@ class TestZennRequestTimeout:
     """rag_zenn_request_timeout のバリデーションテスト."""
 
     def test_default_value(self) -> None:
-        """デフォルト値が 30 であること."""
+        """テスト用デフォルト値が 30 であること."""
         settings = _make_settings()
         assert settings.rag_zenn_request_timeout == 30
 
@@ -92,7 +93,7 @@ class TestZennRequestInterval:
     """rag_zenn_request_interval のバリデーションテスト."""
 
     def test_default_value(self) -> None:
-        """デフォルト値が 1.0 であること."""
+        """テスト用デフォルト値が 1.0 であること."""
         settings = _make_settings()
         assert settings.rag_zenn_request_interval == 1.0
 
@@ -145,12 +146,12 @@ class TestTomlConfigValidation:
             data = _load_toml_config()
         assert data["rag_chunk_size"] == 500
 
-    def test_missing_toml_returns_empty(self, tmp_path: Path) -> None:
-        """config.toml が存在しない場合は空辞書を返すこと."""
+    def test_missing_toml_raises_error(self, tmp_path: Path) -> None:
+        """config.toml が存在しない場合は FileNotFoundError."""
         toml_file = tmp_path / "nonexistent.toml"
         with patch("rag.config._TOML_FILE", toml_file):
-            data = _load_toml_config()
-        assert data == {}
+            with pytest.raises(FileNotFoundError, match="config.toml"):
+                _load_toml_config()
 
     def test_env_field_names_match_env_loader(self) -> None:
         """_ENV_FIELD_NAMES が _EnvLoader のフィールドと一致すること."""
@@ -162,32 +163,78 @@ class TestTomlConfigValidation:
 class TestGetSettingsIntegration:
     """get_settings() の統合テスト (#207)."""
 
+    # config.toml の全必須フィールド（TOML形式文字列）
+    _TOML_CONTENT = """\
+embedding_model_local = "nomic-embed-text"
+embedding_model_online = "text-embedding-3-small"
+embedding_prefix_enabled = true
+rag_chunk_size = 200
+rag_chunk_overlap = 30
+rag_retrieval_count = 3
+rag_hybrid_search_enabled = false
+rag_vector_weight = 0.90
+rag_bm25_k1 = 2.5
+rag_bm25_b = 0.50
+rag_max_crawl_pages = 50
+rag_crawl_delay_sec = 1.0
+rag_respect_robots_txt = true
+rag_robots_txt_cache_ttl = 3600
+rag_url_safety_check = false
+rag_url_safety_cache_ttl = 300
+rag_url_safety_fail_open = true
+rag_url_safety_timeout = 5.0
+rag_stats_max_sources = 100
+rag_zenn_max_articles = 50
+rag_zenn_request_timeout = 30
+rag_zenn_request_interval = 1.0
+rag_document_supported_extensions = ".md,.txt,.pdf,.adoc"
+rag_bluesky_appview_url = "https://public.api.bsky.app"
+rag_bluesky_max_posts = 200
+rag_bluesky_request_timeout = 30
+rag_bluesky_request_interval = 1.0
+rag_bluesky_include_reposts = true
+"""
+
+    def _set_all_env(self, monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+        """全必須 env フィールドを monkeypatch で設定する."""
+        defaults = {
+            "EMBEDDING_PROVIDER": "local",
+            "LMSTUDIO_BASE_URL": "http://localhost:1234",
+            "CHROMADB_PERSIST_DIR": "./chroma_db",
+            "BM25_PERSIST_DIR": "./bm25_index",
+            "RAG_TRANSPORT": "stdio",
+            "RAG_HTTP_HOST": "127.0.0.1",
+            "RAG_HTTP_PORT": "8081",
+            "RAG_DNS_REBINDING_PROTECTION": "true",
+            "RAG_DEBUG_LOG_ENABLED": "false",
+        }
+        defaults.update(overrides)
+        for key, value in defaults.items():
+            monkeypatch.setenv(key, value)
+
     def test_env_values_reflected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """.env の値が RAGSettings に反映されること."""
         from rag.config import get_settings
 
         get_settings.cache_clear()
-        env_file = tmp_path / ".env"
-        env_file.write_text("EMBEDDING_PROVIDER=online\n")
         toml_file = tmp_path / "config.toml"
-        toml_file.write_text("")
-        with patch("rag.config._ENV_FILE", str(env_file)), \
-             patch("rag.config._TOML_FILE", toml_file):
-            # _EnvLoader が新しい _ENV_FILE を使うよう再構成
-            from rag.config import _EnvLoader
-            monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
-            monkeypatch.setenv("EMBEDDING_PROVIDER", "online")
+        toml_file.write_text(self._TOML_CONTENT)
+        self._set_all_env(monkeypatch, EMBEDDING_PROVIDER="online")
+        with patch("rag.config._TOML_FILE", toml_file):
             settings = get_settings()
             assert settings.embedding_provider == "online"
         get_settings.cache_clear()
 
-    def test_toml_values_reflected(self, tmp_path: Path) -> None:
+    def test_toml_values_reflected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """config.toml の値が RAGSettings に反映されること."""
         from rag.config import get_settings
 
         get_settings.cache_clear()
         toml_file = tmp_path / "config.toml"
-        toml_file.write_text("rag_chunk_size = 999\n")
+        toml_file.write_text(self._TOML_CONTENT.replace(
+            "rag_chunk_size = 200", "rag_chunk_size = 999"
+        ))
+        self._set_all_env(monkeypatch)
         with patch("rag.config._TOML_FILE", toml_file):
             settings = get_settings()
             assert settings.rag_chunk_size == 999
@@ -199,8 +246,10 @@ class TestGetSettingsIntegration:
 
         get_settings.cache_clear()
         toml_file = tmp_path / "config.toml"
-        toml_file.write_text("rag_chunk_size = 300\n")
-        monkeypatch.setenv("RAG_TRANSPORT", "http")
+        toml_file.write_text(self._TOML_CONTENT.replace(
+            "rag_chunk_size = 200", "rag_chunk_size = 300"
+        ))
+        self._set_all_env(monkeypatch, RAG_TRANSPORT="http")
         with patch("rag.config._TOML_FILE", toml_file):
             settings = get_settings()
             assert settings.rag_chunk_size == 300

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from conftest import TEST_SETTINGS_DEFAULTS
+from settings_defaults import TEST_SETTINGS_DEFAULTS
 from rag.config import RAGSettings, _ENV_FIELD_NAMES, _load_toml_config
 
 

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -9,8 +9,11 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
+from conftest import TEST_SETTINGS_DEFAULTS
 from rag.bm25_index import BM25Index, BM25Result
+from rag.config import RAGSettings
 from rag.vector_store import RetrievalResult, VectorStore
 from rag.rag_knowledge import (
     BM25SearchItem,
@@ -369,52 +372,43 @@ class TestConfiguration:
 
     def test_embedding_provider_switch(self) -> None:
         """AC28: embedding_provider で local / online を切り替えられること."""
-        from rag.config import RAGSettings
-
-        settings = RAGSettings(embedding_provider="local")
+        settings = RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "embedding_provider": "local"})
         assert settings.embedding_provider == "local"
 
-        settings = RAGSettings(embedding_provider="online")
+        settings = RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "embedding_provider": "online"})
         assert settings.embedding_provider == "online"
 
     def test_configurable_parameters(self) -> None:
         """AC29: チャンクサイズ・オーバーラップ・検索件数が設定可能であること."""
-        from rag.config import RAGSettings
-
-        settings = RAGSettings(
-            rag_chunk_size=1000,
-            rag_chunk_overlap=100,
-            rag_retrieval_count=10,
-        )
+        settings = RAGSettings(**{
+            **TEST_SETTINGS_DEFAULTS,
+            "rag_chunk_size": 1000,
+            "rag_chunk_overlap": 100,
+            "rag_retrieval_count": 10,
+        })
         assert settings.rag_chunk_size == 1000
         assert settings.rag_chunk_overlap == 100
         assert settings.rag_retrieval_count == 10
 
     def test_similarity_threshold_configurable(self) -> None:
         """類似度閾値が設定可能であること (Issue #190)."""
-        from rag.config import RAGSettings
-
         # 設定あり
-        settings = RAGSettings(rag_similarity_threshold=0.5)
+        settings = RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "rag_similarity_threshold": 0.5})
         assert settings.rag_similarity_threshold == 0.5
 
         # 設定なし（デフォルト: None）
-        settings = RAGSettings()
+        settings = RAGSettings(**TEST_SETTINGS_DEFAULTS)
         assert settings.rag_similarity_threshold is None
 
     def test_similarity_threshold_validation(self) -> None:
         """類似度閾値のバリデーション (Issue #190)."""
-        from pydantic import ValidationError
-
-        from rag.config import RAGSettings
-
         # 負の値は拒否
         with pytest.raises(ValidationError):
-            RAGSettings(rag_similarity_threshold=-0.1)
+            RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "rag_similarity_threshold": -0.1})
 
         # 2.0を超える値は拒否（cosine距離の最大値は2.0）
         with pytest.raises(ValidationError):
-            RAGSettings(rag_similarity_threshold=2.5)
+            RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "rag_similarity_threshold": 2.5})
 
 
 class TestRAGDebugLog:

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic import ValidationError
 
-from conftest import TEST_SETTINGS_DEFAULTS
+from settings_defaults import TEST_SETTINGS_DEFAULTS
 from rag.bm25_index import BM25Index, BM25Result
 from rag.config import RAGSettings
 from rag.vector_store import RetrievalResult, VectorStore


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装
- [ ] fix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- `src/rag/config.py`: `_EnvLoader` と `RAGSettings` の全フィールドからデフォルト値を除去（必須化）。例外: `rag_similarity_threshold`, `rag_max_response_chars`, `rag_min_combined_score`（None デフォルト維持 = 機能無効を意図）
- `src/rag/config.py`: `_load_toml_config()` で config.toml 不存在時に `FileNotFoundError` を送出（サイレント空辞書返却を廃止）
- `tests/conftest.py`: 新規作成。`TEST_SETTINGS_DEFAULTS` 辞書（全必須フィールドのテスト用デフォルト値）
- テスト3ファイル: `RAGSettings()` → `RAGSettings(**TEST_SETTINGS_DEFAULTS)` に変更。テスト名・docstring を「デフォルト値」→「テスト用デフォルト値」に修正

## Test plan

- [x] pytest 627件パス
- [x] ruff チェック通過
- [x] mypy 型チェック通過
- [x] コードレビュー実施済み

## Related issues

Closes #212