### PR TITLE
fix(rag-knowledge): ハイブリッド検索の min_combined_score フィルタを無効化 (#217)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ rag_hybrid_search_enabled = true
 rag_vector_weight = 0.90
 rag_bm25_k1 = 2.5
 rag_bm25_b = 0.50
-rag_min_combined_score = 0.75
+# rag_min_combined_score = (未設定時は None)
 
 # クロール
 rag_max_crawl_pages = 50


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正

## Summary

- `config.toml` の `rag_min_combined_score = 0.75` をコメントアウトし、コードデフォルトの `None`（フィルタなし）を適用
- 広いキーワードクエリ（例:「セキュリティ」）で BM25 が正しくヒットさせた結果がハイブリッド検索の閾値フィルタで除外される問題を解消
- 「足切りせず全結果を返却し LLM に判断させる」方針に合致

## Test plan

- [x] テスト用 DB で「セキュリティ」クエリの検索結果が 1件 → 4ソースに改善を確認
- [x] 具体的なクエリ（「ConstrainedClient の移行」等）の精度が維持されていることを確認
- [x] config.toml のみの変更のため、コードテスト不要

## Related issues

Closes #217