### PR TITLE
docs: 結合レビュー指摘対応 (#277)

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -115,7 +115,7 @@ source_store のディレクトリ構成をミラーする。source_store 内の
 |--------------------|----------------------|
 | `web/https/example.com/docs/guide.html` | `web/https/example.com/docs/guide.md` |
 | `web/https/example.com/docs/report.pdf` | `web/https/example.com/docs/report.md` |
-| `bluesky/did:plc:xxx/2026/03/rkey.json` | `bluesky/did:plc:xxx/2026/03/rkey.md` |
+| `bluesky/did：plc：xxx/2026/03/rkey.json` | `bluesky/did：plc：xxx/2026/03/rkey.md` |
 | `zenn/alice/articles/slug.html` | `zenn/alice/articles/slug.md` |
 | `local/my-notes/memo.md` | `local/my-notes/memo.md` |
 | `local/my-notes/note.txt` | `local/my-notes/note.txt` |

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -8,12 +8,12 @@
 
 本仕様書はインジェスター共通の設計・制約を定義する。各媒体固有の仕様は媒体別仕様書を参照。
 
-| 媒体 | 仕様書 | 状態 |
-|------|--------|------|
-| Web | [web.md](web.md) | 作成済み |
-| BlueSky | bluesky.md | 作成予定（#266） |
-| Zenn | zenn.md | 作成予定（#268） |
-| Local | local.md | 作成予定（#267） |
+| 媒体 | 仕様書 |
+|------|--------|
+| Web | [web.md](web.md) |
+| BlueSky | [bluesky.md](bluesky.md) |
+| Zenn | [zenn.md](zenn.md) |
+| Local | [local.md](local.md) |
 
 スコープ:
 
@@ -88,7 +88,7 @@
 | 一括クロール | web | `rag_crawl` | リンク集から一括取得して配置 |
 | クロールプレビュー | web | `rag_crawl_preview` | クロール対象のタイトル・URL 一覧を返す（配置なし） |
 | BlueSky 投稿取り込み | bluesky | `rag_crawl_bluesky` | タイムラインから投稿を取得して配置 |
-| Zenn 記事取り込み | zenn | `rag_crawl_zenn` | Zenn API から記事を取得して配置 |
+| Zenn コンテンツ取り込み | zenn | `rag_crawl_zenn` | Zenn API から記事・スクラップを取得して配置 |
 | 単一ドキュメント取り込み | local | `rag_add_document` | 指定ファイルを local/ にコピー |
 | ディレクトリ一括取り込み | local | `rag_crawl_documents` | glob パターンで検索してコピー |
 

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -16,16 +16,20 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 6 | 評価 CLI | 検索精度の評価パイプライン | [rag-knowledge.md](rag-knowledge.md) |
 | 7 | URL 安全性チェック | Google Safe Browsing API による URL 検証 | [rag-knowledge.md](rag-knowledge.md) |
 | 8 | クロールプレビュー | クロール対象ページのタイトル・URL 一覧を事前確認 | [rag-knowledge.md](rag-knowledge.md) |
-| 9 | Zenn インジェスター | Zenn 記事を API 経由で取得・ナレッジベースに取り込み（新アーキテクチャ移行後は [ingester.md](ingester.md) に統合予定） | [zenn-ingester.md](zenn-ingester.md) |
-| 10 | BlueSky インジェスター | BlueSky 投稿を AT Protocol API 経由で取得・ナレッジベースに取り込み（新アーキテクチャ移行後は [ingester.md](ingester.md) に統合予定） | [bluesky-ingester.md](bluesky-ingester.md) |
-| 11 | ドキュメントインジェスター | テキストドキュメントをナレッジベースに取り込み（新アーキテクチャ移行後は [ingester.md](ingester.md) に統合予定） | [document-ingester.md](document-ingester.md) |
+| 9 | Zenn インジェスター（旧） | Zenn 記事取り込み（旧アーキテクチャ。新: [ingesters/zenn.md](ingesters/zenn.md)） | [zenn-ingester.md](zenn-ingester.md) |
+| 10 | BlueSky インジェスター（旧） | BlueSky 投稿取り込み（旧アーキテクチャ。新: [ingesters/bluesky.md](ingesters/bluesky.md)） | [bluesky-ingester.md](bluesky-ingester.md) |
+| 11 | ドキュメントインジェスター（旧） | テキストドキュメント取り込み（旧アーキテクチャ。新: [ingesters/local.md](ingesters/local.md)） | [document-ingester.md](document-ingester.md) |
 | 12 | source_store | 全データの根源ストレージ（git 管理、.meta サイドカー） | [source-store.md](source-store.md) |
 | 13 | パイプライン制御 | 3段パイプラインのステージ間連携・差分更新制御 | [pipeline-controller.md](pipeline-controller.md) |
 | 14 | コンバーター | source_store のファイルを converted_store のテキストに変換 | [converter.md](converter.md) |
 | 15 | インデクサー | converted_store からチャンキング・Embedding・インデックス構築 | [indexer.md](indexer.md) |
 | 16 | インジェスター共通仕様 | インジェスターの共通制約・重複検出・パイプライン通知 | [ingesters/common.md](ingesters/common.md) |
-| 17 | 検索レスポンス + 全文取得 | チャンク単位検索レスポンスと全文取得ツール | [search-response.md](search-response.md) |
-| 18 | 再構築・統計・バックアップ | パイプライン再構築の MCP/CLI 公開・統計拡張・バックアップ手順 | [rebuild-stats.md](rebuild-stats.md) |
+| 17 | Web インジェスター | Web ページ取得・URL 安全性チェック・robots.txt 遵守 | [ingesters/web.md](ingesters/web.md) |
+| 18 | BlueSky インジェスター | AT Protocol API 経由の投稿取得 | [ingesters/bluesky.md](ingesters/bluesky.md) |
+| 19 | Zenn インジェスター | Zenn API 経由の記事・スクラップ取得 | [ingesters/zenn.md](ingesters/zenn.md) |
+| 20 | Local インジェスター | ローカルファイルの配置 | [ingesters/local.md](ingesters/local.md) |
+| 21 | 検索レスポンス + 全文取得 | チャンク単位検索レスポンスと全文取得ツール | [search-response.md](search-response.md) |
+| 22 | 再構築・統計・バックアップ | パイプライン再構築の MCP/CLI 公開・統計拡張・バックアップ手順 | [rebuild-stats.md](rebuild-stats.md) |
 
 ## 3. 技術スタック
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

#245（結合レビュー）で検出された6件の不整合を修正:

- common.md: 媒体別仕様書のリンクテーブルを「作成予定」→ 実リンクに更新
- common.md: Zenn の操作説明を「記事・スクラップ」に更新（scrap 対応反映）
- overview.md: 旧仕様書の `ingester.md` リンク切れを修正、各媒体仕様書（web/bluesky/zenn/local）を機能一覧に追加
- converter.md: bluesky パス例の DID を全角コロンに修正（source-store.md の禁止文字変換規則と整合）

## Test plan

- [x] 修正箇所のリンク先ファイルが全て存在することを確認

## Related issues

Closes #277
Closes #245