### PR TITLE
feat(source-store): source_store + metadata.db 基盤モジュール実装 (#246)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ LMSTUDIO_BASE_URL=http://localhost:1234
 # ストレージ
 CHROMADB_PERSIST_DIR=./chroma_db
 BM25_PERSIST_DIR=./bm25_index
+SOURCE_STORE_DIR=./source_store
 
 # トランスポート (stdio or http)
 RAG_TRANSPORT=stdio

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,7 @@
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
 | `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・DocumentIngester・BlueskyIngester） |
+| `src/rag/store/` | source_store 管理（ファイル配置・.meta 読み書き・metadata.db 操作・URL パス変換） |
 
 ### ルートレベルファイル
 
@@ -51,6 +52,7 @@
 | `zenn-ingester.md` | `src/rag/ingesters/zenn_ingester.py` |
 | `document-ingester.md` | `src/rag/ingesters/document_ingester.py` |
 | `bluesky-ingester.md` | `src/rag/ingesters/bluesky_ingester.py` |
+| `source-store.md` | `src/rag/store/` |
 
 ### Claude Code 拡張
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
 | PDF テキスト抽出 | pymupdf4llm / MinerU (optional, PyTorch CUDA 推奨) |
+| YAML パーサー | PyYAML |
 
 ## セットアップ
 
@@ -133,6 +134,7 @@ git-flow ベースのブランチ戦略を採用。詳細は `~/.claude/docs/spe
 - [Zenn インジェスター](docs/specs/zenn-ingester.md)
 - [BlueSky インジェスター](docs/specs/bluesky-ingester.md)
 - [ドキュメントインジェスター](docs/specs/document-ingester.md)
+- [source_store](docs/specs/source-store.md)
 
 ### Claude Code 拡張（agentic）
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -40,7 +40,7 @@ MCP サーバーとして独立動作し、10 個のツールを提供する。
 | カテゴリ | 設定項目 |
 |---------|---------|
 | Embedding 接続 | `EMBEDDING_PROVIDER`, `LMSTUDIO_BASE_URL` |
-| ストレージ | `CHROMADB_PERSIST_DIR`, `BM25_PERSIST_DIR` |
+| ストレージ | `CHROMADB_PERSIST_DIR`, `BM25_PERSIST_DIR`, `SOURCE_STORE_DIR` |
 | トランスポート | `RAG_TRANSPORT`, `RAG_HTTP_HOST`, `RAG_HTTP_PORT`, `RAG_DNS_REBINDING_PROTECTION` |
 | デバッグ | `RAG_DEBUG_LOG_ENABLED` |
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -366,8 +366,6 @@ source_store 内の全ファイルのメタデータ索引。
 |---------|-----|--------|------|-----------|
 | `SOURCE_STORE_DIR` | str | `.env` | source_store のディレクトリパス | なし（必須） |
 
-> **TODO:#239** 実装時に `rag-knowledge.md` の `.env`（環境依存値）一覧にも `SOURCE_STORE_DIR` を追記すること。
-
 ## エッジケース
 
 | ケース | 振る舞い |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "bm25s>=0.3,<1",
     "fugashi>=1.3,<2",
     "unidic-lite>=1.0,<2",
+    "pyyaml>=6.0,<7",
     "tzdata>=2024.1",
     "pymupdf4llm>=0.0.17",
     "py-common-lib",
@@ -76,4 +77,5 @@ dev = [
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=5.0",
     "ruff>=0.14.14",
+    "types-PyYAML>=6.0",
 ]

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -60,6 +60,7 @@ class _EnvLoader(BaseSettings):
     # ストレージ（MCP サーバー起動 cwd からの相対パス）
     chromadb_persist_dir: str
     bm25_persist_dir: str
+    source_store_dir: str
 
     # トランスポート
     rag_transport: Literal["stdio", "http"]
@@ -93,6 +94,7 @@ class RAGSettings(BaseModel):
     lmstudio_base_url: str
     chromadb_persist_dir: str
     bm25_persist_dir: str
+    source_store_dir: str
     rag_transport: Literal["stdio", "http"]
     rag_http_host: str
     rag_http_port: int = Field(ge=1, le=65535)

--- a/src/rag/store/__init__.py
+++ b/src/rag/store/__init__.py
@@ -1,0 +1,7 @@
+"""source_store パッケージ.
+
+仕様: docs/specs/source-store.md
+
+RAG Knowledge の全データの根源（Single Source of Truth）となるストレージ。
+各媒体から取得したオリジナルデータを無加工で保存し、git リポジトリとして管理する。
+"""

--- a/src/rag/store/meta.py
+++ b/src/rag/store/meta.py
@@ -43,9 +43,12 @@ def read_meta(file_path: Path) -> dict[str, Any]:
     """
     mp = meta_path_for(file_path)
     with open(mp, encoding="utf-8") as f:
-        data: dict[str, Any] = yaml.safe_load(f)
+        data = yaml.safe_load(f)
     if data is None:
         return {}
+    if not isinstance(data, dict):
+        msg = f".meta ファイルの内容が辞書ではありません: {mp}"
+        raise ValueError(msg)
     return data
 
 
@@ -58,7 +61,7 @@ def write_meta(file_path: Path, metadata: dict[str, Any]) -> None:
     """
     mp = meta_path_for(file_path)
     with open(mp, "w", encoding="utf-8") as f:
-        yaml.dump(
+        yaml.safe_dump(
             metadata,
             f,
             default_flow_style=False,

--- a/src/rag/store/meta.py
+++ b/src/rag/store/meta.py
@@ -8,6 +8,7 @@ local 媒体は .meta を持たない。
 
 from __future__ import annotations
 
+import datetime
 import logging
 from pathlib import Path
 from typing import Any
@@ -49,7 +50,8 @@ def read_meta(file_path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         msg = f".meta ファイルの内容が辞書ではありません: {mp}"
         raise ValueError(msg)
-    return data
+    # PyYAML が datetime/date に暗黙変換した値を ISO 8601 文字列に正規化
+    return _normalize_timestamps(data)
 
 
 def write_meta(file_path: Path, metadata: dict[str, Any]) -> None:
@@ -68,3 +70,13 @@ def write_meta(file_path: Path, metadata: dict[str, Any]) -> None:
             allow_unicode=True,
             sort_keys=False,
         )
+
+
+def _normalize_timestamps(data: dict[str, Any]) -> dict[str, Any]:
+    """PyYAML が暗黙変換した datetime/date 値を ISO 8601 文字列に戻す."""
+    for key, value in data.items():
+        if isinstance(value, datetime.datetime):
+            data[key] = value.isoformat()
+        elif isinstance(value, datetime.date):
+            data[key] = value.isoformat()
+    return data

--- a/src/rag/store/meta.py
+++ b/src/rag/store/meta.py
@@ -1,0 +1,67 @@
+""".meta サイドカーファイルの読み書き.
+
+仕様: docs/specs/source-store.md
+
+オリジナルデータファイルと同階層に配置する YAML 形式のメタデータファイル。
+local 媒体は .meta を持たない。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def meta_path_for(file_path: Path) -> Path:
+    """データファイルに対応する .meta ファイルのパスを返す.
+
+    Args:
+        file_path: データファイルのパス
+
+    Returns:
+        .meta ファイルのパス（同階層、ファイル名 + ``.meta``）
+    """
+    return file_path.with_name(file_path.name + ".meta")
+
+
+def read_meta(file_path: Path) -> dict[str, Any]:
+    """.meta ファイルを読み取る.
+
+    Args:
+        file_path: データファイルのパス（.meta ファイル自体ではない）
+
+    Returns:
+        メタデータの辞書
+
+    Raises:
+        FileNotFoundError: .meta ファイルが存在しない場合
+    """
+    mp = meta_path_for(file_path)
+    with open(mp, encoding="utf-8") as f:
+        data: dict[str, Any] = yaml.safe_load(f)
+    if data is None:
+        return {}
+    return data
+
+
+def write_meta(file_path: Path, metadata: dict[str, Any]) -> None:
+    """.meta ファイルを書き込む.
+
+    Args:
+        file_path: データファイルのパス（.meta ファイル自体ではない）
+        metadata: 書き込むメタデータの辞書
+    """
+    mp = meta_path_for(file_path)
+    with open(mp, "w", encoding="utf-8") as f:
+        yaml.dump(
+            metadata,
+            f,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -1,0 +1,310 @@
+"""metadata.db — ソースメタデータの SQLite 索引.
+
+仕様: docs/specs/source-store.md
+
+sources テーブル + pipeline_history テーブルを管理する。
+WAL モードで運用し、source_store のファイルと .meta から再構築可能。
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from rag.store.models import (
+    NULL_COMMIT_HASH,
+    PipelineHistoryRecord,
+    SourceRecord,
+    SourceStatus,
+    SourceType,
+)
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS sources (
+    source_id    TEXT PRIMARY KEY,
+    source_type  TEXT NOT NULL,
+    file_path    TEXT NOT NULL UNIQUE,
+    title        TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'active',
+    content_hash TEXT NOT NULL,
+    file_size    INTEGER NOT NULL,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_history (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_commit_id TEXT NOT NULL,
+    to_commit_id   TEXT NOT NULL,
+    processed_at   TEXT NOT NULL
+);
+"""
+
+
+class MetadataDB:
+    """metadata.db の操作クラス."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+
+    @property
+    def _connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(str(self._db_path))
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA foreign_keys=ON")
+        return self._conn
+
+    def initialize(self) -> None:
+        """スキーマを初期化する."""
+        self._connection.executescript(_SCHEMA_SQL)
+
+    def close(self) -> None:
+        """接続を閉じる."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def __enter__(self) -> MetadataDB:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # --- sources CRUD ---
+
+    def register_source(
+        self,
+        *,
+        source_id: str,
+        source_type: SourceType,
+        file_path: str,
+        title: str,
+        content_hash: str,
+        file_size: int,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        """ソースを登録する.
+
+        同一 source_id が既に存在する場合は上書きする
+        （再取り込み時の更新動作。deleted → active への復帰を含む）。
+        """
+        self._connection.execute(
+            """\
+            INSERT INTO sources
+                (source_id, source_type, file_path, title, status,
+                 content_hash, file_size, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)
+            ON CONFLICT(source_id) DO UPDATE SET
+                source_type = excluded.source_type,
+                file_path = excluded.file_path,
+                title = excluded.title,
+                status = 'active',
+                content_hash = excluded.content_hash,
+                file_size = excluded.file_size,
+                updated_at = excluded.updated_at
+            """,
+            (
+                source_id,
+                source_type,
+                file_path,
+                title,
+                content_hash,
+                file_size,
+                created_at,
+                updated_at,
+            ),
+        )
+        self._connection.commit()
+
+    def update_source(self, source_id: str, **fields: Any) -> None:
+        """ソースの指定フィールドを更新する.
+
+        Args:
+            source_id: 対象ソースの識別子
+            **fields: 更新するフィールド名と値
+
+        Raises:
+            ValueError: 更新フィールドが空の場合
+            KeyError: source_id が存在しない場合
+        """
+        if not fields:
+            msg = "更新フィールドが指定されていません"
+            raise ValueError(msg)
+
+        allowed = {
+            "source_type",
+            "file_path",
+            "title",
+            "status",
+            "content_hash",
+            "file_size",
+            "updated_at",
+        }
+        invalid = set(fields.keys()) - allowed
+        if invalid:
+            msg = f"不正なフィールド: {invalid}"
+            raise ValueError(msg)
+
+        set_clause = ", ".join(f"{k} = ?" for k in fields)
+        values = list(fields.values())
+        values.append(source_id)
+
+        cursor = self._connection.execute(
+            f"UPDATE sources SET {set_clause} WHERE source_id = ?",  # noqa: S608
+            values,
+        )
+        if cursor.rowcount == 0:
+            msg = f"source_id が見つかりません: {source_id}"
+            raise KeyError(msg)
+        self._connection.commit()
+
+    def get_source(self, source_id: str) -> SourceRecord | None:
+        """source_id でソースを取得する."""
+        row = self._connection.execute(
+            "SELECT * FROM sources WHERE source_id = ?",
+            (source_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_source_record(row)
+
+    def get_source_by_path(self, file_path: str) -> SourceRecord | None:
+        """file_path でソースを取得する."""
+        row = self._connection.execute(
+            "SELECT * FROM sources WHERE file_path = ?",
+            (file_path,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_source_record(row)
+
+    def search_sources(
+        self,
+        *,
+        source_type: SourceType | None = None,
+        status: SourceStatus | None = None,
+    ) -> list[SourceRecord]:
+        """条件に合致するソースを検索する."""
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if source_type is not None:
+            conditions.append("source_type = ?")
+            params.append(source_type)
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        rows = self._connection.execute(
+            f"SELECT * FROM sources WHERE {where} ORDER BY created_at",  # noqa: S608
+            params,
+        ).fetchall()
+        return [_row_to_source_record(r) for r in rows]
+
+    def set_status(self, source_id: str, status: SourceStatus) -> None:
+        """ソースのステータスを変更する.
+
+        Raises:
+            KeyError: source_id が存在しない場合
+        """
+        cursor = self._connection.execute(
+            "UPDATE sources SET status = ? WHERE source_id = ?",
+            (status, source_id),
+        )
+        if cursor.rowcount == 0:
+            msg = f"source_id が見つかりません: {source_id}"
+            raise KeyError(msg)
+        self._connection.commit()
+
+    def delete_all_sources(self) -> None:
+        """全ソースレコードを削除する（DB 再構築用）."""
+        self._connection.execute("DELETE FROM sources")
+        self._connection.commit()
+
+    # --- pipeline_history ---
+
+    def add_pipeline_history(
+        self,
+        *,
+        from_commit_id: str,
+        to_commit_id: str,
+        processed_at: str,
+    ) -> None:
+        """パイプライン実行履歴を追加する."""
+        self._connection.execute(
+            """\
+            INSERT INTO pipeline_history (from_commit_id, to_commit_id, processed_at)
+            VALUES (?, ?, ?)
+            """,
+            (from_commit_id, to_commit_id, processed_at),
+        )
+        self._connection.commit()
+
+    def get_last_commit_id(self) -> str:
+        """最終コミット ID を取得する.
+
+        Returns:
+            最新の to_commit_id。履歴がない場合は null commit hash。
+        """
+        row = self._connection.execute(
+            "SELECT to_commit_id FROM pipeline_history ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            return NULL_COMMIT_HASH
+        return str(row["to_commit_id"])
+
+    def get_pipeline_history(self) -> list[PipelineHistoryRecord]:
+        """パイプライン実行履歴を取得する."""
+        rows = self._connection.execute(
+            "SELECT * FROM pipeline_history ORDER BY id"
+        ).fetchall()
+        return [
+            PipelineHistoryRecord(
+                id=row["id"],
+                from_commit_id=row["from_commit_id"],
+                to_commit_id=row["to_commit_id"],
+                processed_at=row["processed_at"],
+            )
+            for row in rows
+        ]
+
+    def checkpoint(self) -> None:
+        """WAL をフラッシュする（バックアップ前に実行）."""
+        self._connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    def source_count(self, *, status: SourceStatus | None = None) -> int:
+        """ソース件数を返す."""
+        if status is not None:
+            row = self._connection.execute(
+                "SELECT COUNT(*) as cnt FROM sources WHERE status = ?",
+                (status,),
+            ).fetchone()
+        else:
+            row = self._connection.execute(
+                "SELECT COUNT(*) as cnt FROM sources"
+            ).fetchone()
+        return int(row["cnt"]) if row else 0
+
+
+def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
+    """sqlite3.Row を SourceRecord に変換する."""
+    return SourceRecord(
+        source_id=row["source_id"],
+        source_type=row["source_type"],
+        file_path=row["file_path"],
+        title=row["title"],
+        status=row["status"],
+        content_hash=row["content_hash"],
+        file_size=row["file_size"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -153,6 +153,7 @@ class MetadataDB:
             "status",
             "content_hash",
             "file_size",
+            "created_at",
             "updated_at",
         }
         invalid = set(fields.keys()) - allowed

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -95,7 +95,14 @@ class MetadataDB:
 
         同一 source_id が既に存在する場合は上書きする
         （再取り込み時の更新動作。deleted → active への復帰を含む）。
+        異なる source_id で同一 file_path のレコードが存在する場合は
+        旧レコードを削除してから登録する。
         """
+        # file_path UNIQUE 競合の防止: 異なる source_id で同じ file_path を持つ旧レコードを削除
+        self._connection.execute(
+            "DELETE FROM sources WHERE file_path = ? AND source_id != ?",
+            (file_path, source_id),
+        )
         self._connection.execute(
             """\
             INSERT INTO sources
@@ -279,6 +286,7 @@ class MetadataDB:
 
     def checkpoint(self) -> None:
         """WAL をフラッシュする（バックアップ前に実行）."""
+        self._connection.commit()
         self._connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
     def source_count(self, *, status: SourceStatus | None = None) -> int:

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -97,6 +97,12 @@ class MetadataDB:
         （再取り込み時の更新動作。deleted → active への復帰を含む）。
         異なる source_id で同一 file_path のレコードが存在する場合は
         旧レコードを削除してから登録する。
+
+        Note:
+            created_at は新規 INSERT 時のみ使用される。既存レコードの
+            更新時は元の created_at が保持される（ON CONFLICT で更新対象外）。
+            local 媒体の git 由来時刻への補正は、パイプライン制御層が
+            update_source() で後から実施する。
         """
         # file_path UNIQUE 競合の防止: 異なる source_id で同じ file_path を持つ旧レコードを削除
         self._connection.execute(

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -1,0 +1,60 @@
+"""source_store データモデル.
+
+仕様: docs/specs/source-store.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+SourceType = Literal["web", "bluesky", "zenn", "local"]
+SourceStatus = Literal["active", "deleted"]
+
+# git null commit hash（初回パイプライン実行時の from_commit_id）
+NULL_COMMIT_HASH = "0" * 40
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    """sources テーブルのレコード."""
+
+    source_id: str
+    source_type: SourceType
+    file_path: str
+    title: str
+    status: SourceStatus
+    content_hash: str
+    file_size: int
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class PipelineHistoryRecord:
+    """pipeline_history テーブルのレコード."""
+
+    id: int
+    from_commit_id: str
+    to_commit_id: str
+    processed_at: str
+
+
+@dataclass
+class SourceMetadata:
+    """ソースのメタデータ（.meta + DB 共通）."""
+
+    source_id: str
+    source_type: SourceType
+    title: str
+    collected_at: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FileData:
+    """ファイル取得結果."""
+
+    content: bytes
+    file_path: str
+    metadata: SourceMetadata

--- a/src/rag/store/path_converter.py
+++ b/src/rag/store/path_converter.py
@@ -60,10 +60,12 @@ def url_to_path(url: str) -> str:
         msg = f"サポートされていない URL スキーム: {scheme}"
         raise ValueError(msg)
 
-    # ホスト名 + ポート（ポートありの場合 : を全角に）
-    host = parsed.hostname or ""
-    if parsed.port:
-        host = f"{host}{_HALF_TO_FULL[':']}{parsed.port}"
+    # ホスト名 + ポート（netloc でケースを保持。urlparse.hostname は小文字化するため使用しない）
+    netloc = parsed.netloc
+    # netloc からユーザー情報を除去（user:pass@host の場合）
+    if "@" in netloc:
+        netloc = netloc.split("@", 1)[1]
+    host = _escape_path(netloc)
 
     # パス部分（先頭の / を除去）
     path = parsed.path.lstrip("/")
@@ -75,9 +77,8 @@ def url_to_path(url: str) -> str:
 
     # フラグメントは除去（仕様: フラグメント違いは同一ファイル）
 
-    # Windows 禁止文字をエスケープ
+    # Windows 禁止文字をエスケープ（host は既にエスケープ済み）
     path = _escape_path(path)
-    host = _escape_path(host)
 
     # web/{scheme}/{host}/{path}
     parts = [p for p in [host, path] if p]

--- a/src/rag/store/path_converter.py
+++ b/src/rag/store/path_converter.py
@@ -1,0 +1,120 @@
+"""URL ↔ source_store パス変換.
+
+仕様: docs/specs/source-store.md
+
+Web URL を source_store のファイルパスに変換する。
+Windows のファイルパス禁止文字は全角文字で代替する。
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+# Windows ファイルパス禁止文字 → 全角代替（半角→全角）
+_HALF_TO_FULL: dict[str, str] = {
+    ":": "\uff1a",  # ：
+    "?": "\uff1f",  # ？
+    "*": "\uff0a",  # ＊
+    "<": "\uff1c",  # ＜
+    ">": "\uff1e",  # ＞
+    "|": "\uff5c",  # ｜
+    '"': "\uff02",  # ＂
+}
+
+# 逆変換テーブル（全角→半角）
+_FULL_TO_HALF: dict[str, str] = {v: k for k, v in _HALF_TO_FULL.items()}
+
+
+def _escape_path(raw: str) -> str:
+    """パス文字列内の Windows 禁止文字を全角に置換する."""
+    result = raw
+    for half, full in _HALF_TO_FULL.items():
+        result = result.replace(half, full)
+    return result
+
+
+def _unescape_path(escaped: str) -> str:
+    """パス文字列内の全角文字を半角に戻す."""
+    result = escaped
+    for full, half in _FULL_TO_HALF.items():
+        result = result.replace(full, half)
+    return result
+
+
+def url_to_path(url: str) -> str:
+    """URL を source_store 内の相対パスに変換する.
+
+    Args:
+        url: 変換元の URL
+
+    Returns:
+        source_store 内の相対パス（例: ``web/https/example.com/docs/guide``）
+
+    Raises:
+        ValueError: サポートされていない URL スキームの場合
+    """
+    parsed = urlparse(url)
+
+    scheme = parsed.scheme.lower()
+    if scheme not in ("http", "https"):
+        msg = f"サポートされていない URL スキーム: {scheme}"
+        raise ValueError(msg)
+
+    # ホスト名 + ポート（ポートありの場合 : を全角に）
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}{_HALF_TO_FULL[':']}{parsed.port}"
+
+    # パス部分（先頭の / を除去）
+    path = parsed.path.lstrip("/")
+
+    # クエリパラメータ（? を全角に置換して結合）
+    query = parsed.query
+    if query:
+        path = f"{path}{_HALF_TO_FULL['?']}{query}"
+
+    # フラグメントは除去（仕様: フラグメント違いは同一ファイル）
+
+    # Windows 禁止文字をエスケープ
+    path = _escape_path(path)
+    host = _escape_path(host)
+
+    # web/{scheme}/{host}/{path}
+    parts = [p for p in [host, path] if p]
+    return "web/" + scheme + "/" + "/".join(parts)
+
+
+def path_to_url(rel_path: str) -> str:
+    """source_store 内の相対パスを URL に逆変換する.
+
+    Args:
+        rel_path: source_store 内の相対パス（例: ``web/https/example.com/docs/guide``）
+
+    Returns:
+        復元した URL 文字列
+
+    Raises:
+        ValueError: web/ プレフィックスでない、またはスキームが不正な場合
+    """
+    if not rel_path.startswith("web/"):
+        msg = f"web/ プレフィックスではありません: {rel_path}"
+        raise ValueError(msg)
+
+    # web/ を除去
+    remainder = rel_path[4:]
+
+    # スキーム部分を抽出
+    if remainder.startswith("https/"):
+        scheme = "https"
+        rest = remainder[6:]
+    elif remainder.startswith("http/"):
+        scheme = "http"
+        rest = remainder[5:]
+    else:
+        msg = f"不正なスキーム: {remainder}"
+        raise ValueError(msg)
+
+    # 全角文字を半角に戻す
+    rest = _unescape_path(rest)
+
+    return f"{scheme}://{rest}"

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -91,6 +91,15 @@ class SourceStore:
         # パストラバーサル防止
         self._validate_rel_path(rel_path)
 
+        # source_type と rel_path プレフィックスの整合性チェック
+        expected_prefix = f"{source_type}/"
+        if not rel_path.startswith(expected_prefix):
+            msg = (
+                f"source_type '{source_type}' と rel_path '{rel_path}' の"
+                f"プレフィックスが一致しません（期待: '{expected_prefix}'）"
+            )
+            raise ValueError(msg)
+
         # 非 local 媒体は metadata 必須
         if source_type not in _NO_META_TYPES and metadata is None:
             msg = f"metadata は {source_type} 媒体で必須です (rel_path={rel_path})"
@@ -238,20 +247,22 @@ class SourceStore:
         if not search_dir.exists():
             return []
 
+        import os
+
         result: list[Path] = []
-        for p in search_dir.rglob("*"):
-            if not p.is_file():
-                continue
-            rel = p.relative_to(self._root)
-            rel_str = rel.as_posix()
-            # 除外: .meta, metadata.db, .git/
-            if rel_str.endswith(".meta"):
-                continue
-            if rel_str == "metadata.db" or rel_str.startswith("metadata.db"):
-                continue
-            if rel_str.startswith(".git"):
-                continue
-            result.append(rel)
+        for dirpath, dirnames, filenames in os.walk(search_dir):
+            # .git ディレクトリを走査段階で除外（性能最適化）
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            for fname in filenames:
+                full = Path(dirpath) / fname
+                rel = full.relative_to(self._root)
+                rel_str = rel.as_posix()
+                # 除外: .meta, metadata.db 関連
+                if rel_str.endswith(".meta"):
+                    continue
+                if rel_str == "metadata.db" or rel_str.startswith("metadata.db"):
+                    continue
+                result.append(rel)
 
         return sorted(result)
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -1,0 +1,358 @@
+"""SourceStore — source_store の統合管理.
+
+仕様: docs/specs/source-store.md
+
+ファイル配置、.meta 読み書き、metadata.db 操作、URL↔パス変換を統合する。
+git 操作はパイプライン制御層の責務であり、このモジュールでは行わない。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from rag.store.meta import meta_path_for, read_meta, write_meta
+from rag.store.metadata_db import MetadataDB
+from rag.store.models import (
+    FileData,
+    SourceMetadata,
+    SourceType,
+)
+from rag.store.path_converter import url_to_path
+
+logger = logging.getLogger(__name__)
+
+# .meta を持たない媒体
+_NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})
+
+
+class SourceStore:
+    """source_store の統合管理クラス."""
+
+    def __init__(self, root_dir: Path) -> None:
+        """初期化.
+
+        Args:
+            root_dir: source_store のルートディレクトリパス
+        """
+        self._root = root_dir
+        self._db = MetadataDB(root_dir / "metadata.db")
+
+    @property
+    def root_dir(self) -> Path:
+        """source_store のルートディレクトリ."""
+        return self._root
+
+    @property
+    def db(self) -> MetadataDB:
+        """metadata.db への直接アクセス."""
+        return self._db
+
+    def initialize(self) -> None:
+        """source_store を初期化する.
+
+        ルートディレクトリと metadata.db スキーマを作成する。
+        """
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._db.initialize()
+
+    def close(self) -> None:
+        """リソースを解放する."""
+        self._db.close()
+
+    # --- ファイル配置 ---
+
+    def place_file(
+        self,
+        *,
+        source_type: SourceType,
+        data: bytes,
+        rel_path: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> Path:
+        """ファイルを source_store に配置する.
+
+        Args:
+            source_type: 媒体種別
+            data: ファイルデータ
+            rel_path: source_store 内の相対パス
+            metadata: .meta に書き込むメタデータ（local 以外で必須）
+
+        Returns:
+            配置先のフルパス
+        """
+        dest = self._root / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+
+        # .meta 生成（local 以外）
+        if source_type not in _NO_META_TYPES:
+            if metadata is not None:
+                write_meta(dest, metadata)
+            else:
+                logger.warning(
+                    "metadata が指定されていません (source_type=%s, rel_path=%s)",
+                    source_type,
+                    rel_path,
+                )
+
+        # metadata.db 登録
+        content_hash = hashlib.sha256(data).hexdigest()
+        now = datetime.now(timezone.utc).isoformat()
+
+        source_id = self._resolve_source_id(source_type, rel_path, metadata)
+        title = self._resolve_title(source_type, rel_path, metadata)
+
+        existing = self._db.get_source(source_id)
+        self._db.register_source(
+            source_id=source_id,
+            source_type=source_type,
+            file_path=rel_path,
+            title=title,
+            content_hash=content_hash,
+            file_size=len(data),
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+
+        return dest
+
+    def place_file_from_url(
+        self,
+        *,
+        url: str,
+        data: bytes,
+        metadata: dict[str, Any],
+        extension: str = "",
+    ) -> Path:
+        """URL ベースでファイルを配置する（web 媒体用）.
+
+        Args:
+            url: 元の URL
+            data: ファイルデータ
+            metadata: .meta に書き込むメタデータ
+            extension: ファイル拡張子（例: ``.html``）
+
+        Returns:
+            配置先のフルパス
+        """
+        rel_path = url_to_path(url)
+        if extension and not rel_path.endswith(extension):
+            rel_path += extension
+        return self.place_file(
+            source_type="web",
+            data=data,
+            rel_path=rel_path,
+            metadata=metadata,
+        )
+
+    # --- ファイル取得 ---
+
+    def get_file(self, source_id: str) -> FileData | None:
+        """source_id でファイルを取得する.
+
+        論理削除済みのファイルも取得可能。
+
+        Args:
+            source_id: ソース識別子
+
+        Returns:
+            ファイルデータとメタデータ。存在しない場合は None。
+        """
+        record = self._db.get_source(source_id)
+        if record is None:
+            return None
+
+        file_path = self._root / record.file_path
+        if not file_path.exists():
+            logger.warning("DB にレコードがあるがファイルが見つかりません: %s", file_path)
+            return None
+
+        content = file_path.read_bytes()
+
+        # メタデータ構築
+        extra: dict[str, Any] = {}
+        if record.source_type not in _NO_META_TYPES:
+            meta_file = meta_path_for(file_path)
+            if meta_file.exists():
+                meta_data = read_meta(file_path)
+                # 共通フィールドを除いた残りが extra
+                for key in ("source_id", "source_type", "title", "collected_at"):
+                    meta_data.pop(key, None)
+                extra = meta_data
+
+        source_meta = SourceMetadata(
+            source_id=record.source_id,
+            source_type=record.source_type,
+            title=record.title,
+            collected_at=record.created_at,
+            extra=extra,
+        )
+
+        return FileData(
+            content=content,
+            file_path=record.file_path,
+            metadata=source_meta,
+        )
+
+    # --- ファイル一覧 ---
+
+    def list_files(
+        self,
+        *,
+        source_type: SourceType | None = None,
+    ) -> list[Path]:
+        """source_store 内のファイルを列挙する.
+
+        .meta ファイル、metadata.db、.git 配下は除外する。
+
+        Args:
+            source_type: 指定時はそのディレクトリのみ
+
+        Returns:
+            ファイルパスのリスト（source_store ルートからの相対パス）
+        """
+        if source_type:
+            search_dir = self._root / source_type
+        else:
+            search_dir = self._root
+
+        if not search_dir.exists():
+            return []
+
+        result: list[Path] = []
+        for p in search_dir.rglob("*"):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(self._root)
+            rel_str = rel.as_posix()
+            # 除外: .meta, metadata.db, .git/
+            if rel_str.endswith(".meta"):
+                continue
+            if rel_str == "metadata.db" or rel_str.startswith("metadata.db"):
+                continue
+            if rel_str.startswith(".git"):
+                continue
+            result.append(rel)
+
+        return sorted(result)
+
+    # --- 論理削除 ---
+
+    def soft_delete(self, source_id: str) -> None:
+        """ソースを論理削除する.
+
+        Raises:
+            KeyError: source_id が存在しない場合
+        """
+        self._db.set_status(source_id, "deleted")
+
+    def restore(self, source_id: str) -> None:
+        """論理削除を解除する.
+
+        Raises:
+            KeyError: source_id が存在しない場合
+        """
+        self._db.set_status(source_id, "active")
+
+    # --- DB 再構築 ---
+
+    def rebuild_db(self) -> int:
+        """source_store のファイルと .meta から metadata.db を再構築する.
+
+        Returns:
+            登録されたソース数
+        """
+        self._db.delete_all_sources()
+
+        files = self.list_files()
+        count = 0
+        now = datetime.now(timezone.utc).isoformat()
+
+        for rel_path in files:
+            full_path = self._root / rel_path
+            rel_str = rel_path.as_posix()
+            data = full_path.read_bytes()
+            content_hash = hashlib.sha256(data).hexdigest()
+
+            source_type = self._detect_source_type(rel_str)
+            meta_dict: dict[str, Any] = {}
+
+            if source_type not in _NO_META_TYPES:
+                meta_file = meta_path_for(full_path)
+                if meta_file.exists():
+                    meta_dict = read_meta(full_path)
+                else:
+                    logger.warning(
+                        ".meta ファイルが欠落しています: %s", full_path
+                    )
+
+            source_id = self._resolve_source_id(source_type, rel_str, meta_dict or None)
+            title = self._resolve_title(source_type, rel_str, meta_dict or None)
+            collected_at = meta_dict.get("collected_at", now)
+
+            self._db.register_source(
+                source_id=source_id,
+                source_type=source_type,
+                file_path=rel_str,
+                title=title,
+                content_hash=content_hash,
+                file_size=len(data),
+                created_at=collected_at,
+                updated_at=now,
+            )
+            count += 1
+
+        logger.info("metadata.db 再構築完了: %d 件", count)
+        return count
+
+    # --- 内部ユーティリティ ---
+
+    @staticmethod
+    def _detect_source_type(rel_path: str) -> SourceType:
+        """相対パスから source_type を判定する."""
+        if rel_path.startswith("web/"):
+            return "web"
+        if rel_path.startswith("bluesky/"):
+            return "bluesky"
+        if rel_path.startswith("zenn/"):
+            return "zenn"
+        return "local"
+
+    @staticmethod
+    def _resolve_source_id(
+        source_type: SourceType,
+        rel_path: str,
+        metadata: dict[str, Any] | None,
+    ) -> str:
+        """source_id を決定する."""
+        if metadata and "source_id" in metadata:
+            return str(metadata["source_id"])
+        # local 媒体: 相対パスが source_id
+        if source_type == "local":
+            return rel_path
+        # .meta がない場合のフォールバック: 相対パスを使用
+        return rel_path
+
+    @staticmethod
+    def _resolve_title(
+        source_type: SourceType,
+        rel_path: str,
+        metadata: dict[str, Any] | None,
+    ) -> str:
+        """タイトルを決定する."""
+        if metadata and "title" in metadata:
+            return str(metadata["title"])
+        # local 媒体: ファイル名（拡張子除去）
+        return Path(rel_path).stem
+
+    # --- コンテキストマネージャ ---
+
+    def __enter__(self) -> SourceStore:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -332,6 +332,11 @@ class SourceStore:
         Raises:
             ValueError: 絶対パス、パストラバーサル、source_store 外への脱出の場合
         """
+        # バックスラッシュを拒否（Windows パストラバーサル防止）
+        if "\\" in rel_path:
+            msg = f"バックスラッシュは許可されていません: {rel_path}"
+            raise ValueError(msg)
+
         from pathlib import PurePosixPath
 
         pure = PurePosixPath(rel_path)
@@ -344,7 +349,7 @@ class SourceStore:
         # resolve 後に root_dir 配下に収まることを確認
         resolved = (self._root / rel_path).resolve()
         root_resolved = self._root.resolve()
-        if not str(resolved).startswith(str(root_resolved)):
+        if not resolved.is_relative_to(root_resolved):
             msg = f"source_store 外へのパスは許可されていません: {rel_path}"
             raise ValueError(msg)
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -83,21 +83,26 @@ class SourceStore:
 
         Returns:
             配置先のフルパス
+
+        Raises:
+            ValueError: rel_path が不正（絶対パス、パストラバーサル等）、
+                        または非 local 媒体で metadata が未指定の場合
         """
+        # パストラバーサル防止
+        self._validate_rel_path(rel_path)
+
+        # 非 local 媒体は metadata 必須
+        if source_type not in _NO_META_TYPES and metadata is None:
+            msg = f"metadata は {source_type} 媒体で必須です (rel_path={rel_path})"
+            raise ValueError(msg)
+
         dest = self._root / rel_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
 
         # .meta 生成（local 以外）
-        if source_type not in _NO_META_TYPES:
-            if metadata is not None:
-                write_meta(dest, metadata)
-            else:
-                logger.warning(
-                    "metadata が指定されていません (source_type=%s, rel_path=%s)",
-                    source_type,
-                    rel_path,
-                )
+        if source_type not in _NO_META_TYPES and metadata is not None:
+            write_meta(dest, metadata)
 
         # metadata.db 登録
         content_hash = hashlib.sha256(data).hexdigest()
@@ -106,7 +111,15 @@ class SourceStore:
         source_id = self._resolve_source_id(source_type, rel_path, metadata)
         title = self._resolve_title(source_type, rel_path, metadata)
 
+        # created_at: 既存レコード > metadata['collected_at'] > now の優先順
         existing = self._db.get_source(source_id)
+        if existing:
+            created_at = existing.created_at
+        elif metadata and "collected_at" in metadata:
+            created_at = str(metadata["collected_at"])
+        else:
+            created_at = now
+
         self._db.register_source(
             source_id=source_id,
             source_type=source_type,
@@ -114,7 +127,7 @@ class SourceStore:
             title=title,
             content_hash=content_hash,
             file_size=len(data),
-            created_at=existing.created_at if existing else now,
+            created_at=created_at,
             updated_at=now,
         )
 
@@ -173,14 +186,16 @@ class SourceStore:
 
         content = file_path.read_bytes()
 
-        # メタデータ構築
+        # メタデータ構築: .meta の collected_at を優先、なければ DB の created_at
         extra: dict[str, Any] = {}
+        collected_at = record.created_at
         if record.source_type not in _NO_META_TYPES:
             meta_file = meta_path_for(file_path)
             if meta_file.exists():
                 meta_data = read_meta(file_path)
+                collected_at = str(meta_data.pop("collected_at", collected_at))
                 # 共通フィールドを除いた残りが extra
-                for key in ("source_id", "source_type", "title", "collected_at"):
+                for key in ("source_id", "source_type", "title"):
                     meta_data.pop(key, None)
                 extra = meta_data
 
@@ -188,7 +203,7 @@ class SourceStore:
             source_id=record.source_id,
             source_type=record.source_type,
             title=record.title,
-            collected_at=record.created_at,
+            collected_at=collected_at,
             extra=extra,
         )
 
@@ -310,6 +325,28 @@ class SourceStore:
         return count
 
     # --- 内部ユーティリティ ---
+
+    def _validate_rel_path(self, rel_path: str) -> None:
+        """相対パスの安全性を検証する.
+
+        Raises:
+            ValueError: 絶対パス、パストラバーサル、source_store 外への脱出の場合
+        """
+        from pathlib import PurePosixPath
+
+        pure = PurePosixPath(rel_path)
+        if pure.is_absolute():
+            msg = f"絶対パスは許可されていません: {rel_path}"
+            raise ValueError(msg)
+        if ".." in pure.parts:
+            msg = f"パストラバーサルは許可されていません: {rel_path}"
+            raise ValueError(msg)
+        # resolve 後に root_dir 配下に収まることを確認
+        resolved = (self._root / rel_path).resolve()
+        root_resolved = self._root.resolve()
+        if not str(resolved).startswith(str(root_resolved)):
+            msg = f"source_store 外へのパスは許可されていません: {rel_path}"
+            raise ValueError(msg)
 
     @staticmethod
     def _detect_source_type(rel_path: str) -> SourceType:

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -13,6 +13,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "lmstudio_base_url": "http://localhost:1234",
     "chromadb_persist_dir": "./chroma_db",
     "bm25_persist_dir": "./bm25_index",
+    "source_store_dir": "./source_store",
     "rag_transport": "stdio",
     "rag_http_host": "127.0.0.1",
     "rag_http_port": 8081,

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -209,6 +209,7 @@ rag_pdf_quality_sample_pages = 10
             "LMSTUDIO_BASE_URL": "http://localhost:1234",
             "CHROMADB_PERSIST_DIR": "./chroma_db",
             "BM25_PERSIST_DIR": "./bm25_index",
+            "SOURCE_STORE_DIR": "./source_store",
             "RAG_TRANSPORT": "stdio",
             "RAG_HTTP_HOST": "127.0.0.1",
             "RAG_HTTP_PORT": "8081",

--- a/tests/test_store_meta.py
+++ b/tests/test_store_meta.py
@@ -1,0 +1,144 @@
+"""meta モジュールのテスト.
+
+仕様: docs/specs/source-store.md — .meta サイドカーファイル
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.store.meta import meta_path_for, read_meta, write_meta
+
+
+class TestMetaPathFor:
+    """meta_path_for のテスト."""
+
+    def test_html_file(self) -> None:
+        result = meta_path_for(Path("guide.html"))
+        assert result == Path("guide.html.meta")
+
+    def test_json_file(self) -> None:
+        result = meta_path_for(Path("post_xyz.json"))
+        assert result == Path("post_xyz.json.meta")
+
+    def test_nested_path(self) -> None:
+        result = meta_path_for(Path("web/https/example.com/page.html"))
+        assert result == Path("web/https/example.com/page.html.meta")
+
+
+class TestWriteAndReadMeta:
+    """write_meta / read_meta のテスト."""
+
+    def test_write_and_read(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "test.html"
+        data_file.write_text("<html></html>")
+
+        metadata = {
+            "source_id": "https://example.com/test",
+            "source_type": "web",
+            "title": "Test Page",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "url": "https://example.com/test",
+        }
+
+        write_meta(data_file, metadata)
+        result = read_meta(data_file)
+
+        assert result["source_id"] == "https://example.com/test"
+        assert result["source_type"] == "web"
+        assert result["title"] == "Test Page"
+        assert result["url"] == "https://example.com/test"
+
+    def test_unicode_content(self, tmp_path: Path) -> None:
+        """日本語を含むメタデータの読み書き."""
+        data_file = tmp_path / "article.html"
+        data_file.write_text("<html></html>")
+
+        metadata = {
+            "source_id": "https://example.com/article",
+            "title": "テスト記事タイトル",
+            "source_type": "web",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+        }
+
+        write_meta(data_file, metadata)
+        result = read_meta(data_file)
+
+        assert result["title"] == "テスト記事タイトル"
+
+    def test_bluesky_meta(self, tmp_path: Path) -> None:
+        """BlueSky の .meta フィールド."""
+        data_file = tmp_path / "rkey.json"
+        data_file.write_text("{}")
+
+        metadata = {
+            "source_id": "at://did:plc:abc123/app.bsky.feed.post/xyz789",
+            "source_type": "bluesky",
+            "title": "Sample post text",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "handle": "alice.bsky.social",
+            "did": "did:plc:abc123",
+            "rkey": "xyz789",
+            "url": "https://bsky.app/profile/alice.bsky.social/post/xyz789",
+            "created_at": "2026-01-15T09:00:00Z",
+            "has_images": False,
+            "has_video": False,
+            "has_external_link": True,
+            "is_reply": False,
+            "is_repost": False,
+        }
+
+        write_meta(data_file, metadata)
+        result = read_meta(data_file)
+
+        assert result["handle"] == "alice.bsky.social"
+        assert result["has_external_link"] is True
+        assert result["is_reply"] is False
+
+    def test_zenn_meta_with_topics(self, tmp_path: Path) -> None:
+        """Zenn の topics リストの読み書き."""
+        data_file = tmp_path / "slug.html"
+        data_file.write_text("<html></html>")
+
+        metadata = {
+            "source_id": "https://zenn.dev/alice/articles/sample",
+            "source_type": "zenn",
+            "title": "Sample Article",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "slug": "sample",
+            "content_type": "article",
+            "article_type": "tech",
+            "published_at": "2026-01-10T12:00:00+09:00",
+            "liked_count": 42,
+            "topics": ["Python", "FastAPI"],
+            "comments_count": 0,
+            "closed": False,
+            "username": "alice",
+        }
+
+        write_meta(data_file, metadata)
+        result = read_meta(data_file)
+
+        assert result["topics"] == ["Python", "FastAPI"]
+        assert result["liked_count"] == 42
+
+    def test_read_missing_meta(self, tmp_path: Path) -> None:
+        """.meta ファイルが存在しない場合 FileNotFoundError."""
+        data_file = tmp_path / "no_meta.html"
+        data_file.write_text("<html></html>")
+
+        with pytest.raises(FileNotFoundError):
+            read_meta(data_file)
+
+    def test_meta_file_is_yaml(self, tmp_path: Path) -> None:
+        """.meta ファイルが YAML 形式で書かれていることを確認."""
+        data_file = tmp_path / "test.html"
+        data_file.write_text("<html></html>")
+
+        write_meta(data_file, {"key": "value"})
+
+        meta_file = tmp_path / "test.html.meta"
+        content = meta_file.read_text(encoding="utf-8")
+        assert "key: value" in content

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -160,7 +160,7 @@ class TestSourcesCRUD:
             updated_at="2026-01-01T00:00:00Z",
         )
         with pytest.raises(ValueError, match="不正なフィールド"):
-            db.update_source("test", created_at="2026-01-01T00:00:00Z")
+            db.update_source("test", id=999)
 
     def test_search_by_type(self, db: MetadataDB) -> None:
         db.register_source(

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -1,0 +1,359 @@
+"""metadata_db モジュールのテスト.
+
+仕様: docs/specs/source-store.md — metadata.db スキーマ
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.store.metadata_db import MetadataDB
+from rag.store.models import NULL_COMMIT_HASH
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> MetadataDB:
+    """テスト用 MetadataDB インスタンス."""
+    mdb = MetadataDB(tmp_path / "metadata.db")
+    mdb.initialize()
+    return mdb
+
+
+class TestSourcesCRUD:
+    """sources テーブルの CRUD テスト."""
+
+    def test_register_and_get(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="Test Page",
+            content_hash="abc123",
+            file_size=1024,
+            created_at="2026-01-15T10:00:00Z",
+            updated_at="2026-01-15T10:00:00Z",
+        )
+
+        record = db.get_source("https://example.com/page")
+        assert record is not None
+        assert record.source_id == "https://example.com/page"
+        assert record.source_type == "web"
+        assert record.title == "Test Page"
+        assert record.status == "active"
+        assert record.file_size == 1024
+
+    def test_register_upsert(self, db: MetadataDB) -> None:
+        """同一 source_id の再登録で上書きされる."""
+        db.register_source(
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="Old Title",
+            content_hash="old",
+            file_size=100,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="New Title",
+            content_hash="new",
+            file_size=200,
+            created_at="2026-01-02T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+        )
+
+        record = db.get_source("https://example.com/page")
+        assert record is not None
+        assert record.title == "New Title"
+        assert record.content_hash == "new"
+        assert record.status == "active"
+
+    def test_register_restores_deleted(self, db: MetadataDB) -> None:
+        """deleted 状態のソースへの再登録で active に復帰する."""
+        db.register_source(
+            source_id="test",
+            source_type="local",
+            file_path="local/test.md",
+            title="Test",
+            content_hash="hash1",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.set_status("test", "deleted")
+
+        db.register_source(
+            source_id="test",
+            source_type="local",
+            file_path="local/test.md",
+            title="Test Updated",
+            content_hash="hash2",
+            file_size=20,
+            created_at="2026-01-02T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+        )
+
+        record = db.get_source("test")
+        assert record is not None
+        assert record.status == "active"
+        assert record.title == "Test Updated"
+
+    def test_get_nonexistent(self, db: MetadataDB) -> None:
+        assert db.get_source("nonexistent") is None
+
+    def test_get_by_path(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="test-id",
+            source_type="local",
+            file_path="local/test.md",
+            title="Test",
+            content_hash="hash",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        record = db.get_source_by_path("local/test.md")
+        assert record is not None
+        assert record.source_id == "test-id"
+
+    def test_update_source(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="test",
+            source_type="local",
+            file_path="local/test.md",
+            title="Old",
+            content_hash="hash",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        db.update_source("test", title="New Title", file_size=20)
+        record = db.get_source("test")
+        assert record is not None
+        assert record.title == "New Title"
+        assert record.file_size == 20
+
+    def test_update_nonexistent(self, db: MetadataDB) -> None:
+        with pytest.raises(KeyError):
+            db.update_source("nonexistent", title="X")
+
+    def test_update_empty_fields(self, db: MetadataDB) -> None:
+        with pytest.raises(ValueError, match="更新フィールドが指定されていません"):
+            db.update_source("test")
+
+    def test_update_invalid_field(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="test",
+            source_type="local",
+            file_path="local/test.md",
+            title="Test",
+            content_hash="hash",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        with pytest.raises(ValueError, match="不正なフィールド"):
+            db.update_source("test", created_at="2026-01-01T00:00:00Z")
+
+    def test_search_by_type(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="web1",
+            source_type="web",
+            file_path="web/https/a.com/p.html",
+            title="Web1",
+            content_hash="h1",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="local1",
+            source_type="local",
+            file_path="local/test.md",
+            title="Local1",
+            content_hash="h2",
+            file_size=20,
+            created_at="2026-01-02T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+        )
+
+        web_results = db.search_sources(source_type="web")
+        assert len(web_results) == 1
+        assert web_results[0].source_id == "web1"
+
+    def test_search_by_status(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="active1",
+            source_type="local",
+            file_path="local/active.md",
+            title="Active",
+            content_hash="h1",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="deleted1",
+            source_type="local",
+            file_path="local/deleted.md",
+            title="Deleted",
+            content_hash="h2",
+            file_size=20,
+            created_at="2026-01-02T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+        )
+        db.set_status("deleted1", "deleted")
+
+        active = db.search_sources(status="active")
+        assert len(active) == 1
+        assert active[0].source_id == "active1"
+
+    def test_set_status(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="test",
+            source_type="local",
+            file_path="local/test.md",
+            title="Test",
+            content_hash="hash",
+            file_size=10,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        db.set_status("test", "deleted")
+        record = db.get_source("test")
+        assert record is not None
+        assert record.status == "deleted"
+
+        db.set_status("test", "active")
+        record = db.get_source("test")
+        assert record is not None
+        assert record.status == "active"
+
+    def test_set_status_nonexistent(self, db: MetadataDB) -> None:
+        with pytest.raises(KeyError):
+            db.set_status("nonexistent", "deleted")
+
+    def test_source_count(self, db: MetadataDB) -> None:
+        assert db.source_count() == 0
+
+        db.register_source(
+            source_id="s1",
+            source_type="local",
+            file_path="local/s1.md",
+            title="S1",
+            content_hash="h",
+            file_size=1,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="s2",
+            source_type="local",
+            file_path="local/s2.md",
+            title="S2",
+            content_hash="h",
+            file_size=1,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.set_status("s2", "deleted")
+
+        assert db.source_count() == 2
+        assert db.source_count(status="active") == 1
+        assert db.source_count(status="deleted") == 1
+
+
+class TestPipelineHistory:
+    """pipeline_history テーブルのテスト."""
+
+    def test_get_last_commit_id_empty(self, db: MetadataDB) -> None:
+        """履歴がない場合 null commit hash を返す."""
+        assert db.get_last_commit_id() == NULL_COMMIT_HASH
+
+    def test_add_and_get_last(self, db: MetadataDB) -> None:
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="abc123",
+            processed_at="2026-01-15T10:00:00Z",
+        )
+        assert db.get_last_commit_id() == "abc123"
+
+    def test_multiple_entries(self, db: MetadataDB) -> None:
+        """複数履歴追加で最新の to_commit_id を返す."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="commit1",
+            processed_at="2026-01-01T00:00:00Z",
+        )
+        db.add_pipeline_history(
+            from_commit_id="commit1",
+            to_commit_id="commit2",
+            processed_at="2026-01-02T00:00:00Z",
+        )
+        db.add_pipeline_history(
+            from_commit_id="commit2",
+            to_commit_id="commit3",
+            processed_at="2026-01-03T00:00:00Z",
+        )
+
+        assert db.get_last_commit_id() == "commit3"
+
+    def test_get_history(self, db: MetadataDB) -> None:
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+        )
+        db.add_pipeline_history(
+            from_commit_id="c1",
+            to_commit_id="c2",
+            processed_at="2026-01-02T00:00:00Z",
+        )
+
+        history = db.get_pipeline_history()
+        assert len(history) == 2
+        assert history[0].from_commit_id == NULL_COMMIT_HASH
+        assert history[0].to_commit_id == "c1"
+        assert history[1].from_commit_id == "c1"
+        assert history[1].to_commit_id == "c2"
+
+    def test_checkpoint(self, db: MetadataDB) -> None:
+        """checkpoint が例外なく実行できる."""
+        db.checkpoint()
+
+
+class TestDeleteAllSources:
+    """delete_all_sources のテスト."""
+
+    def test_delete_all(self, db: MetadataDB) -> None:
+        db.register_source(
+            source_id="s1",
+            source_type="local",
+            file_path="local/s1.md",
+            title="S1",
+            content_hash="h",
+            file_size=1,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="s2",
+            source_type="web",
+            file_path="web/https/s2.html",
+            title="S2",
+            content_hash="h",
+            file_size=1,
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        db.delete_all_sources()
+        assert db.source_count() == 0

--- a/tests/test_store_path_converter.py
+++ b/tests/test_store_path_converter.py
@@ -1,0 +1,115 @@
+"""path_converter モジュールのテスト.
+
+仕様: docs/specs/source-store.md — URL パス変換規則
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rag.store.path_converter import path_to_url, url_to_path
+
+
+class TestUrlToPath:
+    """URL → source_store 相対パス変換."""
+
+    def test_basic_https(self) -> None:
+        result = url_to_path("https://example.com/docs/guide")
+        assert result == "web/https/example.com/docs/guide"
+
+    def test_basic_http(self) -> None:
+        result = url_to_path("http://example.com/page")
+        assert result == "web/http/example.com/page"
+
+    def test_query_parameter(self) -> None:
+        """クエリパラメータの ? を全角に置換する."""
+        result = url_to_path("https://example.com/docs/guide?lang=ja")
+        assert result == "web/https/example.com/docs/guide\uff1flang=ja"
+
+    def test_port_number(self) -> None:
+        """ポート番号の : を全角に置換する."""
+        result = url_to_path("http://localhost:8080/api/docs")
+        assert result == "web/http/localhost\uff1a8080/api/docs"
+
+    def test_fragment_removed(self) -> None:
+        """フラグメントは除去される."""
+        result = url_to_path("https://example.com/page#section")
+        assert result == "web/https/example.com/page"
+
+    def test_fragment_same_as_no_fragment(self) -> None:
+        """フラグメント違いの URL は同一パスになる."""
+        assert url_to_path("https://example.com/page") == url_to_path(
+            "https://example.com/page#section"
+        )
+
+    def test_unsupported_scheme(self) -> None:
+        with pytest.raises(ValueError, match="サポートされていない URL スキーム"):
+            url_to_path("ftp://example.com/file")
+
+    def test_root_url(self) -> None:
+        result = url_to_path("https://example.com/")
+        assert result == "web/https/example.com"
+
+    def test_host_only(self) -> None:
+        result = url_to_path("https://example.com")
+        assert result == "web/https/example.com"
+
+    def test_multiple_query_params(self) -> None:
+        result = url_to_path("https://example.com/search?q=test&page=2")
+        assert result == "web/https/example.com/search\uff1fq=test&page=2"
+
+
+class TestPathToUrl:
+    """source_store 相対パス → URL 逆変換."""
+
+    def test_basic_https(self) -> None:
+        result = path_to_url("web/https/example.com/docs/guide")
+        assert result == "https://example.com/docs/guide"
+
+    def test_basic_http(self) -> None:
+        result = path_to_url("web/http/example.com/page")
+        assert result == "http://example.com/page"
+
+    def test_fullwidth_question_mark(self) -> None:
+        """全角？を半角に戻す."""
+        result = path_to_url("web/https/example.com/docs/guide\uff1flang=ja")
+        assert result == "https://example.com/docs/guide?lang=ja"
+
+    def test_fullwidth_colon(self) -> None:
+        """全角：を半角に戻す."""
+        result = path_to_url("web/http/localhost\uff1a8080/api/docs")
+        assert result == "http://localhost:8080/api/docs"
+
+    def test_not_web_prefix(self) -> None:
+        with pytest.raises(ValueError, match="web/ プレフィックスではありません"):
+            path_to_url("bluesky/did/post.json")
+
+    def test_invalid_scheme(self) -> None:
+        with pytest.raises(ValueError, match="不正なスキーム"):
+            path_to_url("web/ftp/example.com/file")
+
+
+class TestRoundTrip:
+    """URL → パス → URL の往復変換."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/docs/guide",
+            "http://localhost:8080/api/docs",
+            "https://example.com/search?q=test&page=2",
+            "https://example.com/path/to/page",
+        ],
+    )
+    def test_roundtrip(self, url: str) -> None:
+        """URL → パス → URL で元に戻る."""
+        path = url_to_path(url)
+        restored = path_to_url(path)
+        assert restored == url
+
+    def test_roundtrip_fragment_stripped(self) -> None:
+        """フラグメント付き URL は往復でフラグメントが消える."""
+        url = "https://example.com/page#section"
+        path = url_to_path(url)
+        restored = path_to_url(path)
+        assert restored == "https://example.com/page"

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -1,0 +1,352 @@
+"""source_store 統合テスト.
+
+仕様: docs/specs/source-store.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.store.source_store import SourceStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SourceStore:
+    """テスト用 SourceStore インスタンス."""
+    ss = SourceStore(tmp_path / "source_store")
+    ss.initialize()
+    return ss
+
+
+class TestPlaceFile:
+    """ファイル配置のテスト."""
+
+    def test_place_local_file(self, store: SourceStore) -> None:
+        data = b"# Test Document\n\nHello World"
+        dest = store.place_file(
+            source_type="local",
+            data=data,
+            rel_path="local/test.md",
+        )
+
+        assert dest.exists()
+        assert dest.read_bytes() == data
+        # .meta は local では生成されない
+        assert not dest.with_name(dest.name + ".meta").exists()
+
+        # DB に登録されている
+        record = store.db.get_source("local/test.md")
+        assert record is not None
+        assert record.source_type == "local"
+        assert record.title == "test"
+        assert record.status == "active"
+        assert record.file_size == len(data)
+
+    def test_place_web_file_with_meta(self, store: SourceStore) -> None:
+        data = b"<html><body>Test</body></html>"
+        metadata = {
+            "source_id": "https://example.com/page",
+            "source_type": "web",
+            "title": "Test Page",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "url": "https://example.com/page",
+        }
+
+        dest = store.place_file(
+            source_type="web",
+            data=data,
+            rel_path="web/https/example.com/page.html",
+            metadata=metadata,
+        )
+
+        assert dest.exists()
+        # .meta が生成される
+        meta_file = dest.with_name(dest.name + ".meta")
+        assert meta_file.exists()
+
+        record = store.db.get_source("https://example.com/page")
+        assert record is not None
+        assert record.title == "Test Page"
+
+    def test_place_overwrites_existing(self, store: SourceStore) -> None:
+        """既存ファイルを上書きする."""
+        store.place_file(
+            source_type="local",
+            data=b"old content",
+            rel_path="local/test.md",
+        )
+        store.place_file(
+            source_type="local",
+            data=b"new content",
+            rel_path="local/test.md",
+        )
+
+        dest = store.root_dir / "local" / "test.md"
+        assert dest.read_bytes() == b"new content"
+
+
+class TestPlaceFileFromUrl:
+    """URL ベースのファイル配置テスト."""
+
+    def test_place_from_url(self, store: SourceStore) -> None:
+        data = b"<html>page</html>"
+        metadata = {
+            "source_id": "https://example.com/docs/guide",
+            "source_type": "web",
+            "title": "Guide",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "url": "https://example.com/docs/guide",
+        }
+
+        dest = store.place_file_from_url(
+            url="https://example.com/docs/guide",
+            data=data,
+            metadata=metadata,
+            extension=".html",
+        )
+
+        assert dest.exists()
+        assert "web" in dest.as_posix()
+        assert "https" in dest.as_posix()
+        assert "example.com" in dest.as_posix()
+
+
+class TestGetFile:
+    """ファイル取得テスト."""
+
+    def test_get_existing_file(self, store: SourceStore) -> None:
+        metadata = {
+            "source_id": "https://example.com/page",
+            "source_type": "web",
+            "title": "Test Page",
+            "collected_at": "2026-01-15T10:30:00+09:00",
+            "url": "https://example.com/page",
+        }
+        store.place_file(
+            source_type="web",
+            data=b"<html>test</html>",
+            rel_path="web/https/example.com/page.html",
+            metadata=metadata,
+        )
+
+        result = store.get_file("https://example.com/page")
+        assert result is not None
+        assert result.content == b"<html>test</html>"
+        assert result.metadata.source_id == "https://example.com/page"
+        assert result.metadata.title == "Test Page"
+        assert result.metadata.extra.get("url") == "https://example.com/page"
+
+    def test_get_local_file(self, store: SourceStore) -> None:
+        store.place_file(
+            source_type="local",
+            data=b"hello",
+            rel_path="local/test.md",
+        )
+
+        result = store.get_file("local/test.md")
+        assert result is not None
+        assert result.content == b"hello"
+        assert result.metadata.source_type == "local"
+
+    def test_get_nonexistent(self, store: SourceStore) -> None:
+        assert store.get_file("nonexistent") is None
+
+    def test_get_file_with_missing_physical_file(self, store: SourceStore) -> None:
+        """DB レコードがあるが物理ファイルが削除されている場合 None を返す."""
+        store.place_file(source_type="local", data=b"data", rel_path="local/gone.md")
+        # 物理ファイルを手動削除
+        (store.root_dir / "local" / "gone.md").unlink()
+
+        result = store.get_file("local/gone.md")
+        assert result is None
+
+    def test_get_deleted_file(self, store: SourceStore) -> None:
+        """論理削除済みでも取得可能."""
+        store.place_file(
+            source_type="local",
+            data=b"content",
+            rel_path="local/test.md",
+        )
+        store.soft_delete("local/test.md")
+
+        result = store.get_file("local/test.md")
+        assert result is not None
+        assert result.content == b"content"
+
+
+class TestListFiles:
+    """ファイル一覧テスト."""
+
+    def test_list_all(self, store: SourceStore) -> None:
+        store.place_file(source_type="local", data=b"a", rel_path="local/a.md")
+        store.place_file(source_type="local", data=b"b", rel_path="local/b.md")
+        store.place_file(
+            source_type="web",
+            data=b"c",
+            rel_path="web/https/example.com/c.html",
+            metadata={
+                "source_id": "https://example.com/c",
+                "source_type": "web",
+                "title": "C",
+                "collected_at": "2026-01-01T00:00:00Z",
+            },
+        )
+
+        files = store.list_files()
+        paths = [f.as_posix() for f in files]
+
+        assert "local/a.md" in paths
+        assert "local/b.md" in paths
+        assert "web/https/example.com/c.html" in paths
+        # .meta は除外
+        assert not any(p.endswith(".meta") for p in paths)
+
+    def test_list_by_type(self, store: SourceStore) -> None:
+        store.place_file(source_type="local", data=b"a", rel_path="local/a.md")
+        store.place_file(
+            source_type="web",
+            data=b"b",
+            rel_path="web/https/example.com/b.html",
+            metadata={
+                "source_id": "https://example.com/b",
+                "source_type": "web",
+                "title": "B",
+                "collected_at": "2026-01-01T00:00:00Z",
+            },
+        )
+
+        local_files = store.list_files(source_type="local")
+        assert len(local_files) == 1
+        assert local_files[0].as_posix() == "local/a.md"
+
+    def test_list_empty(self, store: SourceStore) -> None:
+        assert store.list_files() == []
+
+    def test_excludes_metadata_db(self, store: SourceStore) -> None:
+        """metadata.db はリストに含まれない."""
+        store.place_file(source_type="local", data=b"a", rel_path="local/a.md")
+        files = store.list_files()
+        paths = [f.as_posix() for f in files]
+        assert "metadata.db" not in paths
+
+    def test_excludes_git_directory(self, store: SourceStore) -> None:
+        """.git/ 配下のファイルはリストに含まれない."""
+        git_dir = store.root_dir / ".git" / "objects"
+        git_dir.mkdir(parents=True)
+        (git_dir / "dummy").write_bytes(b"git object")
+        store.place_file(source_type="local", data=b"a", rel_path="local/a.md")
+
+        files = store.list_files()
+        paths = [f.as_posix() for f in files]
+        assert not any(p.startswith(".git") for p in paths)
+        assert "local/a.md" in paths
+
+
+class TestSoftDelete:
+    """論理削除テスト."""
+
+    def test_soft_delete_and_restore(self, store: SourceStore) -> None:
+        store.place_file(source_type="local", data=b"data", rel_path="local/test.md")
+
+        store.soft_delete("local/test.md")
+        record = store.db.get_source("local/test.md")
+        assert record is not None
+        assert record.status == "deleted"
+
+        # ファイルはまだ存在する
+        assert (store.root_dir / "local" / "test.md").exists()
+
+        store.restore("local/test.md")
+        record = store.db.get_source("local/test.md")
+        assert record is not None
+        assert record.status == "active"
+
+    def test_soft_delete_nonexistent(self, store: SourceStore) -> None:
+        with pytest.raises(KeyError):
+            store.soft_delete("nonexistent")
+
+
+class TestRebuildDb:
+    """DB 再構築テスト."""
+
+    def test_rebuild(self, store: SourceStore) -> None:
+        """ファイルと .meta から DB を再構築する."""
+        # ファイルを配置
+        store.place_file(source_type="local", data=b"local data", rel_path="local/doc.md")
+        store.place_file(
+            source_type="web",
+            data=b"<html>page</html>",
+            rel_path="web/https/example.com/page.html",
+            metadata={
+                "source_id": "https://example.com/page",
+                "source_type": "web",
+                "title": "Test Page",
+                "collected_at": "2026-01-15T10:30:00+09:00",
+            },
+        )
+
+        # DB をクリアして再構築
+        count = store.rebuild_db()
+        assert count == 2
+
+        # local ファイル
+        local_record = store.db.get_source("local/doc.md")
+        assert local_record is not None
+        assert local_record.source_type == "local"
+        assert local_record.title == "doc"
+
+        # web ファイル（.meta から source_id とタイトルを取得）
+        web_record = store.db.get_source("https://example.com/page")
+        assert web_record is not None
+        assert web_record.source_type == "web"
+        assert web_record.title == "Test Page"
+
+    def test_rebuild_with_missing_meta(self, store: SourceStore) -> None:
+        """非 local 媒体で .meta が欠落している場合、パスベースのフォールバックで登録される."""
+        # .meta なしで直接ファイルを配置
+        web_dir = store.root_dir / "web" / "https" / "example.com"
+        web_dir.mkdir(parents=True)
+        (web_dir / "page.html").write_bytes(b"<html>test</html>")
+
+        count = store.rebuild_db()
+        assert count == 1
+
+        # パスベースのフォールバックで登録
+        record = store.db.get_source("web/https/example.com/page.html")
+        assert record is not None
+        assert record.source_type == "web"
+        assert record.title == "page"  # ファイル名から導出
+
+
+class TestPlaceFileFromUrlExtension:
+    """place_file_from_url の拡張子処理テスト."""
+
+    def test_no_double_extension(self, store: SourceStore) -> None:
+        """URL パスが既に拡張子で終わる場合、二重付加しない."""
+        metadata = {
+            "source_id": "https://example.com/page.html",
+            "source_type": "web",
+            "title": "Page",
+            "collected_at": "2026-01-01T00:00:00Z",
+        }
+        dest = store.place_file_from_url(
+            url="https://example.com/page.html",
+            data=b"<html></html>",
+            metadata=metadata,
+            extension=".html",
+        )
+        assert dest.name == "page.html"
+        assert ".html.html" not in dest.name
+
+
+class TestContextManager:
+    """コンテキストマネージャテスト."""
+
+    def test_context_manager(self, tmp_path: Path) -> None:
+        with SourceStore(tmp_path / "store") as store:
+            store.initialize()
+            store.place_file(source_type="local", data=b"test", rel_path="local/t.md")
+            record = store.db.get_source("local/t.md")
+            assert record is not None

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -70,6 +70,29 @@ class TestPlaceFile:
         assert record is not None
         assert record.title == "Test Page"
 
+    def test_place_rejects_absolute_path(self, store: SourceStore) -> None:
+        """絶対パスは拒否される."""
+        with pytest.raises(ValueError, match="絶対パス"):
+            store.place_file(
+                source_type="local", data=b"x", rel_path="/etc/passwd"
+            )
+
+    def test_place_rejects_path_traversal(self, store: SourceStore) -> None:
+        """パストラバーサルは拒否される."""
+        with pytest.raises(ValueError, match="パストラバーサル"):
+            store.place_file(
+                source_type="local", data=b"x", rel_path="local/../../etc/passwd"
+            )
+
+    def test_place_web_without_metadata_raises(self, store: SourceStore) -> None:
+        """非 local 媒体で metadata=None は ValueError."""
+        with pytest.raises(ValueError, match="metadata は web 媒体で必須"):
+            store.place_file(
+                source_type="web",
+                data=b"<html></html>",
+                rel_path="web/https/example.com/page.html",
+            )
+
     def test_place_overwrites_existing(self, store: SourceStore) -> None:
         """既存ファイルを上書きする."""
         store.place_file(

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -84,6 +84,13 @@ class TestPlaceFile:
                 source_type="local", data=b"x", rel_path="local/../../etc/passwd"
             )
 
+    def test_place_rejects_backslash(self, store: SourceStore) -> None:
+        """バックスラッシュは拒否される."""
+        with pytest.raises(ValueError, match="バックスラッシュ"):
+            store.place_file(
+                source_type="local", data=b"x", rel_path="local\\..\\..\\etc\\passwd"
+            )
+
     def test_place_web_without_metadata_raises(self, store: SourceStore) -> None:
         """非 local 媒体で metadata=None は ValueError."""
         with pytest.raises(ValueError, match="metadata は web 媒体で必須"):

--- a/uv.lock
+++ b/uv.lock
@@ -3567,6 +3567,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymupdf4llm" },
+    { name = "pyyaml" },
     { name = "tzdata" },
     { name = "unidic-lite" },
 ]
@@ -3590,6 +3591,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -3609,6 +3611,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.6,<3" },
     { name = "pydantic-settings", specifier = ">=2.1,<3" },
     { name = "pymupdf4llm", specifier = ">=0.0.17" },
+    { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "torch", marker = "extra == 'mineru'", specifier = ">=2.6" },
     { name = "torch", marker = "extra == 'mineru-cuda'", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu124", conflict = { package = "rag-knowledge", extra = "mineru-cuda" } },
     { name = "torchvision", marker = "extra == 'mineru'", specifier = ">=0.21" },
@@ -3625,6 +3628,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.14.14" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -4636,6 +4640,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★

## Summary

- source_store パッケージ (`src/rag/store/`) を新規実装
  - `models.py`: SourceRecord, PipelineHistoryRecord, SourceMetadata, FileData データモデル
  - `path_converter.py`: URL ↔ source_store 相対パスの双方向変換（Windows 禁止文字の全角代替、フラグメント除去）
  - `meta.py`: .meta サイドカーファイルの YAML 読み書き
  - `metadata_db.py`: SQLite WAL モードの metadata.db（sources + pipeline_history テーブル CRUD）
  - `source_store.py`: 統合クラス（ファイル配置・取得・一覧・論理削除・DB 再構築）
- 設定: `SOURCE_STORE_DIR` を `.env` 環境依存値として追加
- 依存: `pyyaml` を追加、`types-PyYAML` を dev 依存に追加
- ドキュメント: ARCHITECTURE.md, README.md, rag-knowledge.md を更新。source-store.md の TODO を完了除去

## Test plan

- [x] pytest 715 passed
- [x] ruff check: All checks passed
- [x] mypy src: Success (33 source files)
- [x] コードレビュー: Warning 4件対応済み
- [x] ドキュメントレビュー: Warning 2件対応済み

## Related issues

Closes #246