### PR TITLE
feat(converter): コンバーターモジュール実装 (#249)

### DIFF
--- a/src/rag/converter/__init__.py
+++ b/src/rag/converter/__init__.py
@@ -1,0 +1,19 @@
+"""コンバーター: source_store → converted_store のテキスト変換.
+
+仕様: docs/specs/converter.md
+Issue: #249
+"""
+
+from rag.converter.converter import (
+    ConversionSkippedError,
+    ConvertBatchResult,
+    Converter,
+    RegenOption,
+)
+
+__all__ = [
+    "ConversionSkippedError",
+    "ConvertBatchResult",
+    "Converter",
+    "RegenOption",
+]

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -117,8 +117,13 @@ class Converter:
         source_path = source_store_dir / file_path
         ext = PurePosixPath(file_path).suffix.lower()
 
+        # ソースファイル存在チェック
+        if not source_path.exists():
+            logger.warning("Source file not found: %s", file_path)
+            raise ConversionSkippedError(f"Source not found: {file_path}")
+
         # 0 バイトチェック
-        if source_path.exists() and source_path.stat().st_size == 0:
+        if source_path.stat().st_size == 0:
             logger.warning("Skipping 0-byte file: %s", file_path)
             raise ConversionSkippedError(f"0-byte file: {file_path}")
 
@@ -307,10 +312,20 @@ class Converter:
 
         try:
             raw = source_path.read_text(encoding="utf-8")
-            data: dict[str, object] = json.loads(raw)
-        except (json.JSONDecodeError, OSError):
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             logger.exception("Failed to read JSON: %s", file_path)
             return None
+
+        if not isinstance(parsed, dict):
+            logger.warning(
+                "JSON root is not an object: %s (%s)",
+                type(parsed).__name__,
+                file_path,
+            )
+            return None
+
+        data: dict[str, object] = parsed
 
         if source_type == "bluesky":
             return convert_json_bluesky(data)

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -1,0 +1,344 @@
+"""コンバーター: source_store → converted_store のテキスト変換.
+
+仕様: docs/specs/converter.md
+Issue: #249
+
+ConverterProtocol を実装し、パイプライン制御から呼び出される。
+ファイル拡張子に応じた変換方式を選択し、
+インデクサーが処理可能な統一テキスト形式を出力する。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from rag.converter.handlers import (
+    convert_html,
+    convert_json_bluesky,
+    convert_json_zenn_scrap,
+    convert_pdf,
+    passthrough_copy,
+)
+from rag.converter.normalize import normalize_text
+from rag.ingesters.document_ingester import DocumentIngester, PdfBackendConfig
+from rag.pipeline.models import detect_source_type
+from rag.store.models import SourceType
+
+logger = logging.getLogger(__name__)
+
+RegenOption = Literal["skip", "if_modified", "force"]
+
+# 拡張子 → 出力拡張子のマッピング（変換対象）
+_EXTENSION_OUTPUT_MAP: dict[str, str] = {
+    ".html": ".md",
+    ".pdf": ".md",
+    ".json": ".md",
+}
+
+# パススルー対象の拡張子
+_PASSTHROUGH_EXTENSIONS: frozenset[str] = frozenset({".md", ".txt", ".adoc"})
+
+# 変換対象外のファイル名
+_EXCLUDED_FILES: frozenset[str] = frozenset({"metadata.db"})
+
+
+class ConversionSkippedError(Exception):
+    """変換がスキップされた場合の例外."""
+
+
+@dataclass
+class ConvertBatchResult:
+    """一括変換の結果サマリ."""
+
+    success: int = 0
+    skipped: int = 0
+    errors: int = 0
+    error_files: list[str] = field(default_factory=list)
+
+
+class Converter:
+    """コンバーター: source_store → converted_store のテキスト変換.
+
+    ConverterProtocol を満たす実装。
+    ファイル拡張子に応じた変換方式を選択し、
+    インデクサーが処理可能な統一テキスト形式を出力する。
+    """
+
+    def __init__(
+        self,
+        *,
+        regen_option: RegenOption = "skip",
+        pdf_config: PdfBackendConfig | None = None,
+    ) -> None:
+        """Converter を初期化する.
+
+        Args:
+            regen_option: 再生成オプション（デフォルト: skip）
+            pdf_config: PDF バックエンド設定
+        """
+        self._regen_option = regen_option
+        self._doc_ingester = DocumentIngester(
+            pdf_config=pdf_config or PdfBackendConfig(),
+        )
+
+    # --- ConverterProtocol 実装 ---
+
+    def convert(
+        self,
+        file_path: str,
+        source_store_dir: Path,
+        converted_store_dir: Path,
+    ) -> Path:
+        """ソースファイルをテキストに変換する.
+
+        Args:
+            file_path: source_store 内の相対パス
+            source_store_dir: source_store のルートディレクトリ
+            converted_store_dir: converted_store のルートディレクトリ
+
+        Returns:
+            converted_store 内の変換済みファイルの絶対パス
+
+        Raises:
+            ConversionSkippedError: 変換がスキップされた場合
+        """
+        # 変換対象外チェック
+        file_name = PurePosixPath(file_path).name
+        if file_name in _EXCLUDED_FILES:
+            raise ConversionSkippedError(f"Excluded file: {file_name}")
+        if file_path.endswith(".meta"):
+            raise ConversionSkippedError(f"Meta file excluded: {file_path}")
+
+        source_path = source_store_dir / file_path
+        ext = PurePosixPath(file_path).suffix.lower()
+
+        # 0 バイトチェック
+        if source_path.exists() and source_path.stat().st_size == 0:
+            logger.warning("Skipping 0-byte file: %s", file_path)
+            raise ConversionSkippedError(f"0-byte file: {file_path}")
+
+        # サポートされている拡張子かチェック
+        if ext not in _EXTENSION_OUTPUT_MAP and ext not in _PASSTHROUGH_EXTENSIONS:
+            logger.warning("Unsupported extension: %s (%s)", ext, file_path)
+            raise ConversionSkippedError(f"Unsupported extension: {ext}")
+
+        # 出力パス算出
+        converted_rel_path = _get_converted_rel_path(file_path)
+        converted_path = converted_store_dir / converted_rel_path
+
+        # パススルー判定
+        is_passthrough = ext in _PASSTHROUGH_EXTENSIONS
+
+        # 再生成オプションのチェック
+        if converted_path.exists():
+            if self._regen_option == "skip":
+                return converted_path
+            if self._regen_option == "if_modified":
+                source_mtime = source_path.stat().st_mtime
+                converted_mtime = converted_path.stat().st_mtime
+                if source_mtime <= converted_mtime:
+                    return converted_path
+
+        # パススルー
+        if is_passthrough:
+            try:
+                passthrough_copy(source_path, converted_path)
+                return converted_path
+            except OSError:
+                logger.exception("Passthrough copy failed: %s", file_path)
+                raise ConversionSkippedError(
+                    f"Copy failed: {file_path}",
+                ) from None
+
+        # 変換処理
+        text = self._dispatch_conversion(ext, source_path, file_path)
+
+        if text is None or not text.strip():
+            # 空結果: 既存ファイルを削除（Zenn スクラップ空コメント等）
+            if converted_path.exists():
+                converted_path.unlink()
+            logger.warning("No text extracted: %s", file_path)
+            raise ConversionSkippedError(
+                f"Empty conversion result: {file_path}",
+            )
+
+        # テキスト正規化
+        normalized = normalize_text(text)
+
+        # 出力
+        converted_path.parent.mkdir(parents=True, exist_ok=True)
+        converted_path.write_text(normalized, encoding="utf-8")
+        return converted_path
+
+    def delete(
+        self,
+        file_path: str,
+        converted_store_dir: Path,
+    ) -> None:
+        """converted_store から変換済みファイルを削除する.
+
+        Args:
+            file_path: source_store 内の相対パス
+            converted_store_dir: converted_store のルートディレクトリ
+        """
+        converted_rel_path = _get_converted_rel_path(file_path)
+        converted_path = converted_store_dir / converted_rel_path
+        if converted_path.exists():
+            converted_path.unlink()
+            logger.debug("Deleted converted file: %s", converted_path)
+
+    def clear(
+        self,
+        converted_store_dir: Path,
+        source_type: SourceType | None = None,
+    ) -> None:
+        """converted_store をクリアする.
+
+        Args:
+            converted_store_dir: converted_store のルートディレクトリ
+            source_type: 指定時はその媒体のディレクトリのみクリア
+        """
+        if source_type is not None:
+            target_dir = converted_store_dir / source_type
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+                logger.info("Cleared converted_store: %s", target_dir)
+        else:
+            if converted_store_dir.exists():
+                shutil.rmtree(converted_store_dir)
+                logger.info(
+                    "Cleared entire converted_store: %s",
+                    converted_store_dir,
+                )
+
+    # --- 一括変換（プロトコル外） ---
+
+    def convert_batch(
+        self,
+        file_paths: list[str],
+        source_store_dir: Path,
+        converted_store_dir: Path,
+        *,
+        regen_option: RegenOption | None = None,
+    ) -> ConvertBatchResult:
+        """複数ファイルを一括変換する.
+
+        Args:
+            file_paths: source_store 内の相対パスのリスト
+            source_store_dir: source_store のルートディレクトリ
+            converted_store_dir: converted_store のルートディレクトリ
+            regen_option: 再生成オプション（None 時はインスタンスのデフォルトを使用）
+
+        Returns:
+            変換結果サマリ
+        """
+        saved_option = self._regen_option
+        if regen_option is not None:
+            self._regen_option = regen_option
+
+        result = ConvertBatchResult()
+        try:
+            for file_path in file_paths:
+                try:
+                    self.convert(
+                        file_path, source_store_dir, converted_store_dir,
+                    )
+                    result.success += 1
+                except ConversionSkippedError:
+                    result.skipped += 1
+                except Exception:
+                    logger.exception("Conversion error: %s", file_path)
+                    result.errors += 1
+                    result.error_files.append(file_path)
+        finally:
+            self._regen_option = saved_option
+
+        return result
+
+    # --- 内部メソッド ---
+
+    def _dispatch_conversion(
+        self,
+        ext: str,
+        source_path: Path,
+        file_path: str,
+    ) -> str | None:
+        """拡張子に応じた変換処理を実行する.
+
+        Args:
+            ext: ファイル拡張子（小文字、ドット付き）
+            source_path: ソースファイルの絶対パス
+            file_path: source_store 内の相対パス
+
+        Returns:
+            変換後テキスト、または失敗時は None
+        """
+        if ext == ".html":
+            return convert_html(source_path)
+
+        if ext == ".pdf":
+            return convert_pdf(source_path, self._doc_ingester)
+
+        if ext == ".json":
+            return self._convert_json(source_path, file_path)
+
+        return None
+
+    def _convert_json(
+        self,
+        source_path: Path,
+        file_path: str,
+    ) -> str | None:
+        """JSON ファイルを source_type に応じて変換する.
+
+        Args:
+            source_path: JSON ファイルの絶対パス
+            file_path: source_store 内の相対パス
+
+        Returns:
+            抽出テキスト、または変換不可時は None
+        """
+        source_type = detect_source_type(file_path)
+
+        try:
+            raw = source_path.read_text(encoding="utf-8")
+            data: dict[str, object] = json.loads(raw)
+        except (json.JSONDecodeError, OSError):
+            logger.exception("Failed to read JSON: %s", file_path)
+            return None
+
+        if source_type == "bluesky":
+            return convert_json_bluesky(data)
+
+        if source_type == "zenn" and "/scraps/" in file_path:
+            return convert_json_zenn_scrap(data)
+
+        # 不明な JSON source_type
+        logger.warning(
+            "Unknown JSON source_type for conversion: %s (%s)",
+            source_type,
+            file_path,
+        )
+        return None
+
+
+def _get_converted_rel_path(file_path: str) -> str:
+    """source_store 相対パスから converted_store の相対パスを算出する.
+
+    Args:
+        file_path: source_store 内の相対パス
+
+    Returns:
+        converted_store 内の相対パス
+    """
+    p = PurePosixPath(file_path)
+    ext = p.suffix.lower()
+    new_ext = _EXTENSION_OUTPUT_MAP.get(ext)
+    if new_ext is not None:
+        return str(p.with_suffix(new_ext))
+    return file_path

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -1,0 +1,215 @@
+"""コンバーター変換ハンドラ.
+
+仕様: docs/specs/converter.md
+
+各ファイル形式に対応する変換ハンドラをモジュールレベル関数として提供する。
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+from charset_normalizer import from_bytes
+
+from rag.ingesters.bluesky_ingester import (
+    REASON_REPOST,
+    _extract_quote_text_from_view_embed,
+    _extract_text_from_post,
+)
+from rag.ingesters.document_ingester import DocumentIngester
+from rag.markdown import RagMarkdownConverter
+
+logger = logging.getLogger(__name__)
+
+# 非コンテンツタグ（HTML 変換時に除去）
+_NON_CONTENT_TAGS = (
+    "script", "style", "nav", "header", "footer", "aside", "noscript",
+)
+
+
+def _create_md_converter() -> RagMarkdownConverter:
+    """共通の Markdown コンバーターを生成する."""
+    return RagMarkdownConverter(
+        heading_style="ATX",
+        table_infer_header=True,
+        escape_underscores=False,
+        escape_asterisks=False,
+    )
+
+
+def convert_html(source_path: Path) -> str | None:
+    """HTML ファイルを Markdown に変換する.
+
+    仕様: docs/specs/converter.md「HTML → Markdown 変換」
+
+    - コンテンツエリア優先抽出（article > main > body）
+    - 非コンテンツタグ除去
+    - markdownify ベースの変換（ATX見出し、テーブル保持、リンクURL除去）
+    - 非 UTF-8 エンコーディング自動推定（charset_normalizer）
+
+    Args:
+        source_path: HTML ファイルの絶対パス
+
+    Returns:
+        Markdown テキスト、または変換失敗時は None
+    """
+    try:
+        raw_bytes = source_path.read_bytes()
+    except OSError:
+        logger.exception("Failed to read HTML file: %s", source_path)
+        return None
+
+    # エンコーディング自動推定（charset_normalizer）
+    detection = from_bytes(raw_bytes).best()
+    if detection is None:
+        logger.warning("Failed to detect encoding: %s", source_path)
+        return None
+    html_text = str(detection)
+
+    soup = BeautifulSoup(html_text, "html.parser")
+
+    # コンテンツエリア優先抽出（article > main > body）
+    content_area: Tag | BeautifulSoup = soup
+    for tag_name in ("article", "main", "body"):
+        found = soup.find(tag_name)
+        if isinstance(found, Tag):
+            content_area = found
+            break
+
+    # 非コンテンツタグ除去
+    for tag_name in _NON_CONTENT_TAGS:
+        for tag in content_area.find_all(tag_name):
+            tag.decompose()
+
+    # HTML → Markdown 変換
+    md_converter = _create_md_converter()
+    result: str = md_converter.convert_soup(content_area)
+    return result
+
+
+def convert_pdf(
+    source_path: Path,
+    doc_ingester: DocumentIngester,
+) -> str | None:
+    """PDF ファイルからテキストを抽出する.
+
+    既存の DocumentIngester の PDF 抽出ロジックを再利用する。
+
+    Args:
+        source_path: PDF ファイルの絶対パス
+        doc_ingester: DocumentIngester インスタンス（PDF設定を保持）
+
+    Returns:
+        Markdown テキスト、または抽出失敗/空の場合は None
+    """
+    return doc_ingester._extract_pdf(source_path)  # noqa: SLF001
+
+
+def convert_json_bluesky(data: dict[str, Any]) -> str | None:
+    """BlueSky 投稿 JSON からテキストを抽出する.
+
+    仕様: docs/specs/converter.md「BlueSky 投稿」
+
+    AT Protocol の投稿 JSON（getAuthorFeed レスポンスのフィードアイテム）から
+    テキストを構造化して抽出する。
+
+    Args:
+        data: フィードアイテム JSON（getAuthorFeed レスポンスの1アイテム）
+
+    Returns:
+        構造化プレーンテキスト、または抽出不可時は None
+    """
+    post = data.get("post")
+    if not isinstance(post, dict):
+        return None
+
+    record = post.get("record")
+    if not isinstance(record, dict):
+        return None
+
+    # テキスト抽出（post.record = raw record）
+    text = _extract_text_from_post(record)
+
+    # 引用元テキストの取得（post.embed = view版）
+    view_embed = post.get("embed")
+    quote_text = _extract_quote_text_from_view_embed(view_embed)
+    if quote_text:
+        quote_section = "[Quote]\n" + quote_text
+        text = text + "\n\n" + quote_section if text else quote_section
+
+    # リポスト検出
+    reason = data.get("reason")
+    is_repost = (
+        isinstance(reason, dict)
+        and reason.get("$type") == REASON_REPOST
+    )
+    if is_repost:
+        author = post.get("author")
+        author_handle = (
+            author.get("handle", "") if isinstance(author, dict) else ""
+        )
+        if author_handle:
+            text = f"[Repost: @{author_handle}]\n{text}"
+
+    return text if text and text.strip() else None
+
+
+def convert_json_zenn_scrap(data: dict[str, Any]) -> str | None:
+    """Zenn スクラップ JSON からテキストを抽出する.
+
+    仕様: docs/specs/converter.md「Zenn スクラップ」
+
+    comments 配列の各コメントの body_html を順序保持で結合し、
+    HTML → Markdown 変換して水平線で区切る。
+
+    Args:
+        data: スクラップ JSON
+
+    Returns:
+        Markdown テキスト（水平線区切り）、
+        またはコメント 0 件/全空の場合は None
+    """
+    # scrap オブジェクトの取得
+    scrap = data.get("scrap", data)
+    comments = scrap.get("comments")
+    if not isinstance(comments, list) or not comments:
+        return None
+
+    md_converter = _create_md_converter()
+    converted_parts: list[str] = []
+
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        body_html = comment.get("body_html", "")
+        if not isinstance(body_html, str) or not body_html.strip():
+            continue
+
+        soup = BeautifulSoup(body_html, "html.parser")
+        for tag_name in ("script", "style"):
+            for tag in soup.find_all(tag_name):
+                tag.decompose()
+
+        md_text: str = md_converter.convert_soup(soup)
+        if md_text and md_text.strip():
+            converted_parts.append(md_text.strip())
+
+    if not converted_parts:
+        return None
+
+    return "\n\n---\n\n".join(converted_parts)
+
+
+def passthrough_copy(source_path: Path, dest_path: Path) -> None:
+    """ファイルをそのままコピーする（パススルー）.
+
+    Args:
+        source_path: コピー元ファイルパス
+        dest_path: コピー先ファイルパス
+    """
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, dest_path)

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -175,6 +175,8 @@ def convert_json_zenn_scrap(data: dict[str, Any]) -> str | None:
     """
     # scrap オブジェクトの取得
     scrap = data.get("scrap", data)
+    if not isinstance(scrap, dict):
+        return None
     comments = scrap.get("comments")
     if not isinstance(comments, list) or not comments:
         return None

--- a/src/rag/converter/normalize.py
+++ b/src/rag/converter/normalize.py
@@ -1,0 +1,30 @@
+"""テキスト正規化.
+
+仕様: docs/specs/converter.md「テキスト正規化」
+
+変換処理（HTML → Markdown、PDF テキスト抽出、JSON → テキスト）の後に
+共通の正規化処理を適用する。パススルーファイルには適用しない。
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def normalize_text(text: str) -> str:
+    """変換後テキストの正規化を行う.
+
+    - 各行の末尾にある空白文字を除去
+    - 連続する空行を最大1行に圧縮
+
+    Args:
+        text: 変換後テキスト
+
+    Returns:
+        正規化済みテキスト
+    """
+    # 各行の末尾にある空白文字を除去
+    text = re.sub(r"[ \t]+$", "", text, flags=re.MULTILINE)
+    # 連続する空行を最大1行に圧縮
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -428,6 +428,11 @@ class TestConvertJsonZennScrap:
         result = convert_json_zenn_scrap(data)
         assert result is None
 
+    def test_scrap_value_not_dict(self) -> None:
+        data = {"scrap": "not a dict"}
+        result = convert_json_zenn_scrap(data)
+        assert result is None
+
     def test_html_tags_removed_in_comments(self) -> None:
         data = {
             "comments": [
@@ -734,6 +739,22 @@ class TestConverterClear:
 
 class TestConverterEdgeCases:
     """Converter のエッジケーステスト."""
+
+    def test_source_file_not_found(self, tmp_path: Path) -> None:
+        source_dir = tmp_path / "source_store"
+        source_dir.mkdir()
+        converted_dir = tmp_path / "converted_store"
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Source not found"):
+            converter.convert("web/missing.html", source_dir, converted_dir)
+
+    def test_json_root_is_array(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "bluesky/did/post.json", json.dumps([1, 2, 3]),
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Empty conversion"):
+            converter.convert("bluesky/did/post.json", source_dir, converted_dir)
 
     def test_zero_byte_file(self, tmp_path: Path) -> None:
         source_dir, converted_dir = _setup_source(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,957 @@
+"""コンバーターのテスト.
+
+仕様: docs/specs/converter.md
+Issue: #249
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from rag.converter.converter import (
+    ConversionSkippedError,
+    Converter,
+    _get_converted_rel_path,
+)
+from rag.converter.handlers import (
+    convert_html,
+    convert_json_bluesky,
+    convert_json_zenn_scrap,
+    passthrough_copy,
+)
+from rag.converter.normalize import normalize_text
+
+
+# ============================================================
+# テキスト正規化
+# ============================================================
+
+
+class TestNormalizeText:
+    """normalize_text のテスト."""
+
+    def test_trailing_whitespace_removal(self) -> None:
+        text = "hello   \nworld\t\n"
+        result = normalize_text(text)
+        assert result == "hello\nworld"
+
+    def test_consecutive_blank_lines_compression(self) -> None:
+        text = "line1\n\n\n\nline2\n\n\n\n\nline3"
+        result = normalize_text(text)
+        assert result == "line1\n\nline2\n\nline3"
+
+    def test_already_clean_text(self) -> None:
+        text = "line1\n\nline2\nline3"
+        result = normalize_text(text)
+        assert result == text
+
+    def test_mixed_normalization(self) -> None:
+        text = "hello   \n\n\n\nworld  \t\n\nfoo\n\n\nbar"
+        result = normalize_text(text)
+        assert result == "hello\n\nworld\n\nfoo\n\nbar"
+
+    def test_empty_string(self) -> None:
+        assert normalize_text("") == ""
+
+    def test_whitespace_only(self) -> None:
+        assert normalize_text("   \n\n  \n") == ""
+
+
+# ============================================================
+# HTML → Markdown 変換ハンドラ
+# ============================================================
+
+
+class TestConvertHtml:
+    """convert_html のテスト."""
+
+    def test_basic_html_to_markdown(self, tmp_path: Path) -> None:
+        html = "<html><body><h1>Title</h1><p>Content here.</p></body></html>"
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Title" in result
+        assert "Content here." in result
+
+    def test_content_area_article(self, tmp_path: Path) -> None:
+        html = (
+            "<html><body>"
+            "<nav>Navigation</nav>"
+            "<article><h1>Article</h1><p>Article body.</p></article>"
+            "<footer>Footer</footer>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Article body." in result
+        assert "Navigation" not in result
+        assert "Footer" not in result
+
+    def test_content_area_main(self, tmp_path: Path) -> None:
+        html = (
+            "<html><body>"
+            "<nav>Navigation</nav>"
+            "<main><h1>Main</h1><p>Main body.</p></main>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Main body." in result
+        assert "Navigation" not in result
+
+    def test_non_content_tags_removed(self, tmp_path: Path) -> None:
+        html = (
+            "<html><body>"
+            "<script>alert('x')</script>"
+            "<style>.red{color:red}</style>"
+            "<nav>Nav</nav>"
+            "<header>Header</header>"
+            "<p>Content</p>"
+            "<footer>Footer</footer>"
+            "<aside>Sidebar</aside>"
+            "<noscript>NoScript</noscript>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Content" in result
+        assert "alert" not in result
+        assert "Nav" not in result
+        assert "Header" not in result
+        assert "Footer" not in result
+        assert "Sidebar" not in result
+        assert "NoScript" not in result
+
+    def test_atx_headings(self, tmp_path: Path) -> None:
+        html = "<html><body><h1>H1</h1><h2>H2</h2><h3>H3</h3></body></html>"
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "# H1" in result
+        assert "## H2" in result
+        assert "### H3" in result
+
+    def test_link_url_removed(self, tmp_path: Path) -> None:
+        html = '<html><body><a href="https://example.com">Link Text</a></body></html>'
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Link Text" in result
+        assert "https://example.com" not in result
+
+    def test_image_alt_only(self, tmp_path: Path) -> None:
+        html = '<html><body><img src="img.png" alt="Photo description"></body></html>'
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Photo description" in result
+        assert "img.png" not in result
+
+    def test_non_utf8_encoding(self, tmp_path: Path) -> None:
+        html = "<html><body><p>日本語テスト</p></body></html>"
+        html_file = tmp_path / "test.html"
+        html_file.write_bytes(html.encode("shift_jis"))
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "日本語テスト" in result
+
+    def test_table_conversion(self, tmp_path: Path) -> None:
+        html = (
+            "<html><body>"
+            "<table><tr><th>Name</th><th>Value</th></tr>"
+            "<tr><td>A</td><td>1</td></tr></table>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file)
+        assert result is not None
+        assert "Name" in result
+        assert "Value" in result
+        assert "|" in result
+
+
+# ============================================================
+# BlueSky JSON テキスト抽出ハンドラ
+# ============================================================
+
+
+class TestConvertJsonBluesky:
+    """convert_json_bluesky のテスト."""
+
+    def test_basic_post(self) -> None:
+        data = {
+            "post": {
+                "record": {"text": "Sample post text"},
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result == "Sample post text"
+
+    def test_image_alt(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Post with image",
+                    "embed": {
+                        "$type": "app.bsky.embed.images",
+                        "images": [
+                            {"alt": "A sunset photo"},
+                            {"alt": "A mountain view"},
+                        ],
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "Post with image" in result
+        assert "[Image ALT]" in result
+        assert "A sunset photo" in result
+        assert "A mountain view" in result
+
+    def test_video_alt(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Post with video",
+                    "embed": {
+                        "$type": "app.bsky.embed.video",
+                        "alt": "Video description",
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "[Video ALT] Video description" in result
+
+    def test_link_card(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Check this out",
+                    "embed": {
+                        "$type": "app.bsky.embed.external",
+                        "external": {
+                            "title": "Sample Article",
+                            "uri": "https://example.com/article",
+                            "description": "An article about something",
+                        },
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "[Link Card]" in result
+        assert "Title: Sample Article" in result
+        assert "URL: https://example.com/article" in result
+        assert "Description: An article about something" in result
+
+    def test_record_with_media(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Post with quote and media",
+                    "embed": {
+                        "$type": "app.bsky.embed.recordWithMedia",
+                        "media": {
+                            "$type": "app.bsky.embed.images",
+                            "images": [{"alt": "Media image"}],
+                        },
+                        "record": {"uri": "at://did:plc:xxx/app.bsky.feed.post/yyy"},
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "Post with quote and media" in result
+        assert "[Image ALT] Media image" in result
+
+    def test_quote_embed_record(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Quoting this",
+                    "embed": {
+                        "$type": "app.bsky.embed.record",
+                        "record": {"uri": "at://did:plc:xxx/app.bsky.feed.post/yyy"},
+                    },
+                },
+                "embed": {
+                    "$type": "app.bsky.embed.record#view",
+                    "record": {
+                        "value": {"text": "Original quoted text"},
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "Quoting this" in result
+        assert "[Quote]" in result
+        assert "Original quoted text" in result
+
+    def test_quote_embed_record_with_media(self) -> None:
+        data = {
+            "post": {
+                "record": {
+                    "text": "Quote with media",
+                    "embed": {
+                        "$type": "app.bsky.embed.recordWithMedia",
+                        "media": {"$type": "app.bsky.embed.images", "images": []},
+                        "record": {"uri": "at://did:plc:xxx/app.bsky.feed.post/yyy"},
+                    },
+                },
+                "embed": {
+                    "$type": "app.bsky.embed.recordWithMedia#view",
+                    "record": {
+                        "record": {
+                            "value": {"text": "Quoted via recordWithMedia"},
+                        },
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "Quote with media" in result
+        assert "[Quote]" in result
+        assert "Quoted via recordWithMedia" in result
+
+    def test_repost(self) -> None:
+        data = {
+            "post": {
+                "author": {"handle": "original.bsky.social"},
+                "record": {"text": "Reposted content"},
+            },
+            "reason": {
+                "$type": "app.bsky.feed.defs#reasonRepost",
+                "by": {"handle": "reposter.bsky.social"},
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "[Repost: @original.bsky.social]" in result
+        assert "Reposted content" in result
+
+    def test_empty_post(self) -> None:
+        data = {"post": {"record": {"text": ""}}}
+        result = convert_json_bluesky(data)
+        assert result is None
+
+    def test_missing_post(self) -> None:
+        data = {"something": "else"}
+        result = convert_json_bluesky(data)
+        assert result is None
+
+
+# ============================================================
+# Zenn スクラップ JSON テキスト抽出ハンドラ
+# ============================================================
+
+
+class TestConvertJsonZennScrap:
+    """convert_json_zenn_scrap のテスト."""
+
+    def test_multiple_comments(self) -> None:
+        data = {
+            "comments": [
+                {"body_html": "<p>First comment</p>"},
+                {"body_html": "<p>Second comment</p>"},
+                {"body_html": "<p>Third comment</p>"},
+            ],
+        }
+        result = convert_json_zenn_scrap(data)
+        assert result is not None
+        assert "First comment" in result
+        assert "Second comment" in result
+        assert "Third comment" in result
+        assert "---" in result
+
+    def test_scrap_key_wrapping(self) -> None:
+        data = {
+            "scrap": {
+                "comments": [
+                    {"body_html": "<p>Comment in scrap</p>"},
+                ],
+            },
+        }
+        result = convert_json_zenn_scrap(data)
+        assert result is not None
+        assert "Comment in scrap" in result
+
+    def test_empty_comments_list(self) -> None:
+        data = {"comments": []}
+        result = convert_json_zenn_scrap(data)
+        assert result is None
+
+    def test_zero_comments_key(self) -> None:
+        data = {"title": "No comments scrap"}
+        result = convert_json_zenn_scrap(data)
+        assert result is None
+
+    def test_all_empty_body_html(self) -> None:
+        data = {
+            "comments": [
+                {"body_html": ""},
+                {"body_html": "  "},
+            ],
+        }
+        result = convert_json_zenn_scrap(data)
+        assert result is None
+
+    def test_html_tags_removed_in_comments(self) -> None:
+        data = {
+            "comments": [
+                {"body_html": "<p>Clean text</p><script>evil()</script>"},
+            ],
+        }
+        result = convert_json_zenn_scrap(data)
+        assert result is not None
+        assert "Clean text" in result
+        assert "evil" not in result
+
+
+# ============================================================
+# パススルー
+# ============================================================
+
+
+class TestPassthrough:
+    """passthrough_copy のテスト."""
+
+    def test_md_copy(self, tmp_path: Path) -> None:
+        src = tmp_path / "source" / "doc.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("# Markdown content", encoding="utf-8")
+
+        dest = tmp_path / "dest" / "doc.md"
+        passthrough_copy(src, dest)
+        assert dest.read_text(encoding="utf-8") == "# Markdown content"
+
+    def test_txt_copy(self, tmp_path: Path) -> None:
+        src = tmp_path / "source" / "note.txt"
+        src.parent.mkdir(parents=True)
+        src.write_text("Plain text", encoding="utf-8")
+
+        dest = tmp_path / "dest" / "note.txt"
+        passthrough_copy(src, dest)
+        assert dest.read_text(encoding="utf-8") == "Plain text"
+
+    def test_adoc_copy(self, tmp_path: Path) -> None:
+        src = tmp_path / "source" / "guide.adoc"
+        src.parent.mkdir(parents=True)
+        src.write_text("= AsciiDoc Title", encoding="utf-8")
+
+        dest = tmp_path / "dest" / "guide.adoc"
+        passthrough_copy(src, dest)
+        assert dest.read_text(encoding="utf-8") == "= AsciiDoc Title"
+
+    def test_creates_directories(self, tmp_path: Path) -> None:
+        src = tmp_path / "source" / "doc.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("content", encoding="utf-8")
+
+        dest = tmp_path / "deep" / "nested" / "dir" / "doc.md"
+        passthrough_copy(src, dest)
+        assert dest.exists()
+
+
+# ============================================================
+# 相対パス変換ユーティリティ
+# ============================================================
+
+
+class TestGetConvertedRelPath:
+    """_get_converted_rel_path のテスト."""
+
+    def test_html_to_md(self) -> None:
+        assert _get_converted_rel_path("web/example/page.html") == "web/example/page.md"
+
+    def test_pdf_to_md(self) -> None:
+        assert _get_converted_rel_path("web/doc/report.pdf") == "web/doc/report.md"
+
+    def test_json_to_md(self) -> None:
+        assert _get_converted_rel_path("bluesky/did/post.json") == "bluesky/did/post.md"
+
+    def test_md_passthrough(self) -> None:
+        assert _get_converted_rel_path("local/notes/memo.md") == "local/notes/memo.md"
+
+    def test_txt_passthrough(self) -> None:
+        assert _get_converted_rel_path("local/note.txt") == "local/note.txt"
+
+    def test_adoc_passthrough(self) -> None:
+        assert _get_converted_rel_path("local/guide.adoc") == "local/guide.adoc"
+
+    def test_unknown_extension(self) -> None:
+        assert _get_converted_rel_path("local/file.xyz") == "local/file.xyz"
+
+
+# ============================================================
+# Converter 統合テスト
+# ============================================================
+
+
+def _setup_source(
+    tmp_path: Path,
+    rel_path: str,
+    content: str | bytes,
+) -> tuple[Path, Path]:
+    """テスト用のソースファイルを配置し、ディレクトリを返す."""
+    source_dir = tmp_path / "source_store"
+    converted_dir = tmp_path / "converted_store"
+    file_path = source_dir / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        file_path.write_bytes(content)
+    else:
+        file_path.write_text(content, encoding="utf-8")
+    return source_dir, converted_dir
+
+
+class TestConverterConvert:
+    """Converter.convert のテスト."""
+
+    def test_convert_html(self, tmp_path: Path) -> None:
+        html = "<html><body><h1>Title</h1><p>Content.</p></body></html>"
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/example/page.html", html,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "web/example/page.html", source_dir, converted_dir,
+        )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "Title" in text
+        assert "Content." in text
+        # 出力拡張子が .md
+        assert result.name == "page.md"
+
+    def test_convert_passthrough_md(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/notes/memo.md", "# Memo\nContent here.",
+        )
+        converter = Converter()
+        result = converter.convert(
+            "local/notes/memo.md", source_dir, converted_dir,
+        )
+        assert result.exists()
+        assert result.read_text(encoding="utf-8") == "# Memo\nContent here."
+
+    def test_convert_passthrough_txt(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/note.txt", "Plain text content",
+        )
+        converter = Converter()
+        result = converter.convert("local/note.txt", source_dir, converted_dir)
+        assert result.exists()
+        assert result.read_text(encoding="utf-8") == "Plain text content"
+
+    def test_convert_passthrough_adoc(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/guide.adoc", "= AsciiDoc Title",
+        )
+        converter = Converter()
+        result = converter.convert("local/guide.adoc", source_dir, converted_dir)
+        assert result.exists()
+        assert result.read_text(encoding="utf-8") == "= AsciiDoc Title"
+
+    def test_convert_json_bluesky(self, tmp_path: Path) -> None:
+        post_data = json.dumps({
+            "post": {
+                "record": {"text": "Sample BlueSky post"},
+            },
+        })
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "bluesky/did/2026/03/rkey.json", post_data,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "bluesky/did/2026/03/rkey.json", source_dir, converted_dir,
+        )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "Sample BlueSky post" in text
+        assert result.name == "rkey.md"
+
+    def test_convert_json_zenn_scrap(self, tmp_path: Path) -> None:
+        scrap_data = json.dumps({
+            "comments": [
+                {"body_html": "<p>Comment 1</p>"},
+                {"body_html": "<p>Comment 2</p>"},
+            ],
+        })
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "zenn/user/scraps/slug.json", scrap_data,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "zenn/user/scraps/slug.json", source_dir, converted_dir,
+        )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "Comment 1" in text
+        assert "Comment 2" in text
+        assert "---" in text
+
+    def test_convert_pdf(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/doc/report.pdf", b"%PDF-1.4 dummy",
+        )
+        converter = Converter()
+        with patch.object(
+            converter._doc_ingester,
+            "_extract_pdf",
+            return_value="# PDF Content\n\nExtracted text.",
+        ):
+            result = converter.convert(
+                "web/doc/report.pdf", source_dir, converted_dir,
+            )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "PDF Content" in text
+        assert result.name == "report.md"
+
+    def test_text_normalization_applied(self, tmp_path: Path) -> None:
+        html = "<html><body><p>line1   </p><p></p><p></p><p></p><p>line2</p></body></html>"
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/page.html", html,
+        )
+        converter = Converter()
+        result = converter.convert("web/page.html", source_dir, converted_dir)
+        text = result.read_text(encoding="utf-8")
+        # 連続空行が圧縮されていること
+        assert "\n\n\n" not in text
+
+    def test_converted_store_dir_auto_created(self, tmp_path: Path) -> None:
+        html = "<html><body><p>Content</p></body></html>"
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/deep/nested/page.html", html,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "web/deep/nested/page.html", source_dir, converted_dir,
+        )
+        assert result.exists()
+        assert "nested" in str(result)
+
+
+# ============================================================
+# Converter.delete
+# ============================================================
+
+
+class TestConverterDelete:
+    """Converter.delete のテスト."""
+
+    def test_delete_existing(self, tmp_path: Path) -> None:
+        converted_dir = tmp_path / "converted"
+        converted_file = converted_dir / "web" / "page.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("content", encoding="utf-8")
+
+        converter = Converter()
+        converter.delete("web/page.html", converted_dir)
+        assert not converted_file.exists()
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        converted_dir = tmp_path / "converted"
+        converter = Converter()
+        # Should not raise
+        converter.delete("web/page.html", converted_dir)
+
+
+# ============================================================
+# Converter.clear
+# ============================================================
+
+
+class TestConverterClear:
+    """Converter.clear のテスト."""
+
+    def test_clear_all(self, tmp_path: Path) -> None:
+        converted_dir = tmp_path / "converted"
+        (converted_dir / "web" / "page.md").parent.mkdir(parents=True)
+        (converted_dir / "web" / "page.md").write_text("x", encoding="utf-8")
+        (converted_dir / "local" / "doc.md").parent.mkdir(parents=True)
+        (converted_dir / "local" / "doc.md").write_text("y", encoding="utf-8")
+
+        converter = Converter()
+        converter.clear(converted_dir)
+        assert not converted_dir.exists()
+
+    def test_clear_source_type(self, tmp_path: Path) -> None:
+        converted_dir = tmp_path / "converted"
+        (converted_dir / "web" / "page.md").parent.mkdir(parents=True)
+        (converted_dir / "web" / "page.md").write_text("x", encoding="utf-8")
+        (converted_dir / "local" / "doc.md").parent.mkdir(parents=True)
+        (converted_dir / "local" / "doc.md").write_text("y", encoding="utf-8")
+
+        converter = Converter()
+        converter.clear(converted_dir, source_type="web")
+        assert not (converted_dir / "web").exists()
+        assert (converted_dir / "local" / "doc.md").exists()
+
+    def test_clear_nonexistent_dir(self, tmp_path: Path) -> None:
+        converter = Converter()
+        # Should not raise
+        converter.clear(tmp_path / "nonexistent")
+
+
+# ============================================================
+# エッジケース
+# ============================================================
+
+
+class TestConverterEdgeCases:
+    """Converter のエッジケーステスト."""
+
+    def test_zero_byte_file(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/empty.html", "",
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="0-byte"):
+            converter.convert("web/empty.html", source_dir, converted_dir)
+
+    def test_unsupported_extension(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/file.xyz", "content",
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Unsupported extension"):
+            converter.convert("web/file.xyz", source_dir, converted_dir)
+
+    def test_meta_file_excluded(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/page.html.meta", "meta content",
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Meta file"):
+            converter.convert("web/page.html.meta", source_dir, converted_dir)
+
+    def test_metadata_db_excluded(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "metadata.db", b"sqlite3",
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Excluded file"):
+            converter.convert("metadata.db", source_dir, converted_dir)
+
+    def test_empty_html_extraction(self, tmp_path: Path) -> None:
+        html = "<html><body><script>only script</script></body></html>"
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/empty-content.html", html,
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Empty conversion"):
+            converter.convert("web/empty-content.html", source_dir, converted_dir)
+
+    def test_empty_pdf_extraction(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/empty.pdf", b"%PDF-1.4",
+        )
+        converter = Converter()
+        with patch.object(
+            converter._doc_ingester, "_extract_pdf", return_value=None,
+        ):
+            with pytest.raises(ConversionSkippedError, match="Empty conversion"):
+                converter.convert("web/empty.pdf", source_dir, converted_dir)
+
+    def test_unknown_json_source_type(self, tmp_path: Path) -> None:
+        data = json.dumps({"key": "value"})
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/data.json", data,
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Empty conversion"):
+            converter.convert("local/data.json", source_dir, converted_dir)
+
+    def test_zenn_scrap_empty_comments_deletes_existing(
+        self, tmp_path: Path,
+    ) -> None:
+        scrap_data = json.dumps({"comments": []})
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "zenn/user/scraps/slug.json", scrap_data,
+        )
+        # Pre-create converted file
+        converted_file = converted_dir / "zenn" / "user" / "scraps" / "slug.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("old content", encoding="utf-8")
+
+        converter = Converter(regen_option="force")
+        with pytest.raises(ConversionSkippedError):
+            converter.convert(
+                "zenn/user/scraps/slug.json", source_dir, converted_dir,
+            )
+        # Existing file should be deleted
+        assert not converted_file.exists()
+
+
+# ============================================================
+# 再生成オプション
+# ============================================================
+
+
+class TestRegenOptions:
+    """再生成オプションのテスト."""
+
+    def test_skip_existing(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/doc.md", "new content",
+        )
+        # Pre-create converted file with different content
+        converted_file = converted_dir / "local" / "doc.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("old content", encoding="utf-8")
+
+        converter = Converter(regen_option="skip")
+        result = converter.convert("local/doc.md", source_dir, converted_dir)
+        # Should return existing, not overwrite
+        assert result.read_text(encoding="utf-8") == "old content"
+
+    def test_if_modified_not_newer(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/doc.md", "source content",
+        )
+        converted_file = converted_dir / "local" / "doc.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("converted content", encoding="utf-8")
+
+        # Make converted file newer than source
+        source_file = source_dir / "local" / "doc.md"
+        old_time = time.time() - 100
+        os.utime(source_file, (old_time, old_time))
+
+        converter = Converter(regen_option="if_modified")
+        result = converter.convert("local/doc.md", source_dir, converted_dir)
+        assert result.read_text(encoding="utf-8") == "converted content"
+
+    def test_if_modified_newer(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/doc.md", "updated content",
+        )
+        converted_file = converted_dir / "local" / "doc.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("old content", encoding="utf-8")
+
+        # Make source newer than converted
+        old_time = time.time() - 100
+        os.utime(converted_file, (old_time, old_time))
+
+        converter = Converter(regen_option="if_modified")
+        result = converter.convert("local/doc.md", source_dir, converted_dir)
+        assert result.read_text(encoding="utf-8") == "updated content"
+
+    def test_force_overwrites(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/doc.md", "new content",
+        )
+        converted_file = converted_dir / "local" / "doc.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("old content", encoding="utf-8")
+
+        converter = Converter(regen_option="force")
+        result = converter.convert("local/doc.md", source_dir, converted_dir)
+        assert result.read_text(encoding="utf-8") == "new content"
+
+
+# ============================================================
+# 一括変換
+# ============================================================
+
+
+class TestConvertBatch:
+    """Converter.convert_batch のテスト."""
+
+    def test_batch_success(self, tmp_path: Path) -> None:
+        source_dir = tmp_path / "source_store"
+        converted_dir = tmp_path / "converted_store"
+
+        for name in ("a.md", "b.md", "c.txt"):
+            f = source_dir / "local" / name
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(f"content of {name}", encoding="utf-8")
+
+        converter = Converter()
+        result = converter.convert_batch(
+            ["local/a.md", "local/b.md", "local/c.txt"],
+            source_dir,
+            converted_dir,
+        )
+        assert result.success == 3
+        assert result.skipped == 0
+        assert result.errors == 0
+
+    def test_batch_mixed_results(self, tmp_path: Path) -> None:
+        source_dir = tmp_path / "source_store"
+        converted_dir = tmp_path / "converted_store"
+
+        # One valid file
+        valid = source_dir / "local" / "doc.md"
+        valid.parent.mkdir(parents=True, exist_ok=True)
+        valid.write_text("valid content", encoding="utf-8")
+
+        # One 0-byte file (will be skipped)
+        empty = source_dir / "web" / "empty.html"
+        empty.parent.mkdir(parents=True, exist_ok=True)
+        empty.write_text("", encoding="utf-8")
+
+        converter = Converter()
+        result = converter.convert_batch(
+            ["local/doc.md", "web/empty.html"],
+            source_dir,
+            converted_dir,
+        )
+        assert result.success == 1
+        assert result.skipped == 1
+
+    def test_batch_regen_option_override(self, tmp_path: Path) -> None:
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "local/doc.md", "new content",
+        )
+        converted_file = converted_dir / "local" / "doc.md"
+        converted_file.parent.mkdir(parents=True)
+        converted_file.write_text("old content", encoding="utf-8")
+
+        converter = Converter(regen_option="skip")
+        result = converter.convert_batch(
+            ["local/doc.md"],
+            source_dir,
+            converted_dir,
+            regen_option="force",
+        )
+        assert result.success == 1
+        assert converted_file.read_text(encoding="utf-8") == "new content"
+
+        # Verify original regen_option restored
+        assert converter._regen_option == "skip"


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- `src/rag/converter/` パッケージ（4ファイル）を新規実装: `__init__.py`, `converter.py`, `handlers.py`, `normalize.py`
- ConverterProtocol（`pipeline/protocols.py`）を満たす Converter クラスを実装
- ファイル拡張子ベースの変換方式選択: HTML→Markdown, PDF→Markdown, JSON→テキスト, パススルー（md/txt/adoc）
- HTML 変換: コンテンツエリア優先抽出（article > main > body）、非コンテンツタグ除去、charset_normalizer によるエンコーディング自動推定
- PDF 変換: 既存の DocumentIngester の PDF 抽出ロジックを再利用（auto/pymupdf4llm/mineru バックエンド選択）
- JSON 変換: BlueSky 投稿テキスト抽出（recordWithMedia・引用・リポスト対応）、Zenn スクラップ（コメント結合→Markdown→水平線区切り）
- テキスト正規化: 末尾空白除去、連続空行圧縮（パススルーには適用しない）
- 再生成オプション: skip（デフォルト）/ if_modified / force
- 一括変換（convert_batch）: プロトコル外のユーティリティメソッド
- エッジケース対応: 0バイトファイル、未対応拡張子、.meta/metadata.db 除外、空テキスト抽出結果
- テスト 71件、全 967 テスト通過、ruff/mypy clean

## Test plan

- [x] pytest: 全 967 テスト通過（新規 71 テスト含む）
- [x] ruff check: All checks passed
- [x] mypy: clean
- [x] ConverterProtocol 準拠確認（ランタイムチェック通過）

## Related issues

Closes #249