### PR TITLE
feat(search-response): 検索レスポンスをチャンク単位返却に変更、全文取得ツール追加 (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 | **チャンキング** | テキストを適切なサイズに分割（見出し・テーブル対応） |
 | **ベクトル検索** | ChromaDB による類似度検索 |
 | **ハイブリッド検索** | ベクトル検索 + BM25 のスコア統合 |
+| **全文取得** | ソースドキュメントの全文取得（変換済みテキスト/オリジナル） |
 | **MCP サーバー** | FastMCP による stdio/HTTP インターフェース |
 | **評価 CLI** | 検索精度の評価パイプライン |
 | **URL 安全性チェック** | Google Safe Browsing API による URL 検証 |
@@ -131,6 +132,7 @@ git-flow ベースのブランチ戦略を採用。詳細は `~/.claude/docs/spe
 ### 基盤仕様
 
 - [RAG ナレッジ](docs/specs/rag-knowledge.md)
+- [検索レスポンス + 全文取得](docs/specs/search-response.md)
 - [Zenn インジェスター](docs/specs/zenn-ingester.md)
 - [BlueSky インジェスター](docs/specs/bluesky-ingester.md)
 - [ドキュメントインジェスター](docs/specs/document-ingester.md)

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -5,7 +5,7 @@
 外部 Web ページから収集した知識をベクトル DB に蓄積し、
 MCP クライアントからのクエリに対して関連情報を検索・提供する
 RAG（Retrieval-Augmented Generation）基盤。
-MCP サーバーとして独立動作し、10 個のツールを提供する。
+MCP サーバーとして独立動作し、11 個のツールを提供する。
 
 スコープ:
 
@@ -55,7 +55,7 @@ MCP サーバーとして独立動作し、10 個のツールを提供する。
 | クロール | `rag_max_crawl_pages`, `rag_crawl_delay_sec` |
 | robots.txt | `rag_respect_robots_txt`, `rag_robots_txt_cache_ttl` |
 | URL 安全性 | `rag_url_safety_check`, `rag_url_safety_cache_ttl`, `rag_url_safety_fail_open`, `rag_url_safety_timeout` |
-| レスポンス制御 | `rag_max_response_chars`, `rag_stats_max_sources` |
+| レスポンス制御 | `rag_max_response_chars`（rag_get_document のトランケーション）, `rag_stats_max_sources` |
 | Zenn インジェスター | `rag_zenn_max_articles`, `rag_zenn_request_timeout`, `rag_zenn_request_interval` |
 | BlueSky インジェスター | `rag_bluesky_appview_url`, `rag_bluesky_max_posts`, `rag_bluesky_request_timeout`, `rag_bluesky_request_interval`, `rag_bluesky_include_reposts` |
 | ドキュメントインジェスター | `rag_document_supported_extensions` |
@@ -116,11 +116,12 @@ MCP サーバーとして独立動作し、10 個のツールを提供する。
 
 ### MCP ツール
 
-MCP サーバーが公開する 10 個のツール。
+MCP サーバーが公開する 11 個のツール。
 
 | ツール | 入力 | 振る舞い |
 | --- | --- | --- |
-| rag_search | クエリ、件数、source_type（任意） | ベクトル検索と BM25 の生結果を個別に返す。ページ全文を返却し、同一 URL は省略する。`source_type` 指定時はそのソース種別のチャンクのみを検索対象とする。レスポンス文字数上限（`RAG_MAX_RESPONSE_CHARS`）設定時は累積文字数を追跡し、上限到達後はページ全文取得を早期打ち切りして末尾に通知を付記する |
+| rag_search | クエリ、件数、source_type（任意） | ベクトル検索と BM25 の生結果をチャンク単位で返す。各結果にスコア・Source・Title・Chunk位置・Typeのメタデータを含める。`source_type` 指定時はそのソース種別のチャンクのみを検索対象とする。詳細は [search-response.md](search-response.md) を参照 |
+| rag_get_document | source_id、format（任意） | ソース全文を取得する。`format=text` で変換済みテキスト（converted_store）、`format=original` でオリジナル（source_store）を返す。MCP 経由では `rag_max_response_chars` でトランケーションを行う。詳細は [search-response.md](search-response.md) を参照 |
 | rag_add | URL | 単一ページをクロールして取り込む。同一 URL の再取り込み時は既存の知識を最新に置き換える |
 | rag_crawl | URL、パターン | リンク集ページから一括クロールして取り込む。同一ドメインのみ対象 |
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
@@ -133,7 +134,7 @@ MCP サーバーが公開する 10 個のツール。
 
 ### 検索結果の設計
 
-rag_search はベクトル検索と BM25 検索の生結果を個別に返す。
+rag_search はベクトル検索と BM25 検索の生結果をチャンク単位で個別に返す。全文が必要な場合は rag_get_document で取得する。詳細は [search-response.md](search-response.md) を参照。
 
 <!-- How追加理由: 統合パイプライン(CC)を迂回する設計判断の根拠 -->
 統合パイプライン（正規化・スコア結合）を迂回し、
@@ -151,6 +152,7 @@ rag_search はベクトル検索と BM25 検索の生結果を個別に返す。
 | evaluate | 評価データセットで検索精度を計測しレポートを出力する。ベースライン比較でリグレッションを検出できる |
 | init-test-db | テスト用のベクトル DB と BM25 インデックスを初期化する |
 | crawl-preview | 指定 URL からクロール対象ページのタイトルと URL の一覧を表示する。`--format json` で JSON 出力に対応 |
+| get-document | ソース全文を取得する。`--format text\|original`、`--output` でファイル出力（トランケーションなし） |
 
 評価指標: Precision、Recall、F1、NDCG@K、MRR
 
@@ -308,11 +310,13 @@ flowchart LR
     Q["ユーザー質問"] --> LLM["LLM が検索要否を判断"]
     LLM -->|検索必要| SEARCH["rag_search"]
     LLM -->|検索不要| ANS
-    SEARCH --> VR["ベクトル検索の生結果"]
-    SEARCH --> BR["BM25 検索の生結果"]
+    SEARCH --> VR["ベクトル検索: チャンク単位結果"]
+    SEARCH --> BR["BM25 検索: チャンク単位結果"]
     VR --> JUDGE["LLM が両結果を総合判断"]
     BR --> JUDGE
-    JUDGE --> ANS["応答生成"]
+    JUDGE -->|詳細が必要| GET["rag_get_document"]
+    JUDGE -->|十分| ANS["応答生成"]
+    GET --> ANS
 ```
 
 ### クロールプレビューフロー
@@ -375,7 +379,7 @@ flowchart LR
 | `OPENAI_API_KEY` が未登録 | オンライン Embedding プロバイダーの初期化に失敗し、エラーを返す |
 | `GOOGLE_SAFE_BROWSING_API_KEY` が未登録 | URL 安全性チェックを無効化し、警告ログを出力して処理を続行する |
 | クロールプレビュー時のタイトル取得失敗 | タイトルを空文字列とし、URL のみ返す。他のページの処理は続行する |
-| rag_search レスポンスサイズ超過 | `RAG_MAX_RESPONSE_CHARS` 超過時はレスポンス構築中に累積文字数を追跡し、上限到達後は以降のページ全文取得を打ち切る（早期打ち切り）。末尾にトランケート通知を付記する。未設定時はトランケーションなし（検索結果をそのまま返す） |
+| rag_get_document レスポンスサイズ超過 | MCP 経由で `RAG_MAX_RESPONSE_CHARS` 超過時はトランケーションし、末尾に CLI `--output` オプションでの全文取得を案内する。CLI の `--output` 指定時はトランケーションなし |
 | バジェット上限到達 | 取得済みデータを返し、上限到達の旨をログ出力する |
 | サーキットブレーカー発動 | 操作を中断し、取得済みデータを返す。エラーの詳細をログ出力する |
 | 操作全体タイムアウト | 操作を中断し、取得済みデータを返す |

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -251,6 +251,17 @@ class BM25Index:
         """
         return self._doc_source_map.get(doc_id)
 
+    def get_source_type(self, doc_id: str) -> str | None:
+        """ドキュメントIDからソース種別を取得する.
+
+        Args:
+            doc_id: ドキュメントID
+
+        Returns:
+            ソース種別、見つからない場合はNone
+        """
+        return self._doc_source_type_map.get(doc_id)
+
     def _rebuild_index(self) -> None:
         """BM25インデックスを再構築する."""
         try:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -250,6 +250,24 @@ def main() -> None:
         help="出力フォーマット（text/json）",
     )
 
+    # get-document サブコマンド
+    doc_parser = subparsers.add_parser("get-document", help="ソースの全文を取得")
+    doc_parser.add_argument(
+        "source_id",
+        help="ソース識別子（rag_search の Source 値）",
+    )
+    doc_parser.add_argument(
+        "--format",
+        choices=["text", "original"],
+        default="text",
+        help="取得形式（text: 変換済みテキスト、original: オリジナル、デフォルト: text）",
+    )
+    doc_parser.add_argument(
+        "--output",
+        default=None,
+        help="出力先ファイルパス（未指定時は標準出力）",
+    )
+
     args = parser.parse_args()
 
     if args.command == "evaluate":
@@ -258,6 +276,8 @@ def main() -> None:
         asyncio.run(init_test_db(args))
     elif args.command == "crawl-preview":
         asyncio.run(run_crawl_preview(args))
+    elif args.command == "get-document":
+        run_get_document(args)
 
 
 async def create_rag_service(
@@ -786,6 +806,39 @@ async def run_crawl_preview(args: argparse.Namespace) -> None:
             title = page.title or "(タイトル取得不可)"
             print(f"{i}. {title}")
             print(f"   {page.url}")
+
+
+def run_get_document(args: argparse.Namespace) -> None:
+    """ドキュメント全文を取得して出力する.
+
+    Args:
+        args: コマンドライン引数
+    """
+    from .config import get_settings
+    from .rag_knowledge import format_document_response, get_document
+
+    settings = get_settings()
+
+    result = get_document(
+        source_id=args.source_id,
+        format=args.format,
+        source_store_dir=settings.source_store_dir,
+        converted_store_dir=settings.converted_store_dir,
+    )
+
+    if result.error:
+        print(f"エラー: {result.error}", file=sys.stderr)
+        sys.exit(1)
+
+    response = format_document_response(result)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(response, encoding="utf-8")
+        print(f"出力しました: {args.output}")
+    else:
+        print(response)
 
 
 if __name__ == "__main__":

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -1054,6 +1054,9 @@ class DocumentResult:
     error: str | None = None
 
 
+_VALID_FORMATS: frozenset[str] = frozenset({"text", "original"})
+
+
 def get_document(
     source_id: str,
     format: str,
@@ -1073,60 +1076,85 @@ def get_document(
     Returns:
         DocumentResult
     """
-    from .store.source_store import SourceStore
-
-    with SourceStore(root_dir=Path(source_store_dir)) as store:
-        file_data = store.get_file(source_id)
-
-    if file_data is None:
+    # format バリデーション
+    if format not in _VALID_FORMATS:
+        valid = ", ".join(sorted(_VALID_FORMATS))
         return DocumentResult(
             source_id=source_id,
             title="",
             source_type="",
             format=format,
             content="",
-            error=f"ソースが見つかりません: {source_id}",
+            error=f"無効な format: {format!r}（有効値: {valid}）",
         )
 
-    meta = file_data.metadata
-    title = meta.title
-    source_type = meta.source_type
+    from .store.source_store import SourceStore
 
-    if format == "original":
-        # バイナリ判定: テキスト拡張子以外はバイナリとして扱う
-        ext = PurePosixPath(file_data.file_path).suffix.lower()
-        if ext not in _TEXT_EXTENSIONS:
-            mime_type = mimetypes.guess_type(file_data.file_path)[0] or "application/octet-stream"
-            file_size = len(file_data.content)
-            info = (
-                f"バイナリファイルです（MIME: {mime_type}, サイズ: {file_size:,} bytes）。\n"
-                "テキスト形式で取得するには format=text を指定してください。"
+    with SourceStore(root_dir=Path(source_store_dir)) as store:
+        # まずメタデータのみ取得（ファイル読み込みなし）
+        record = store.db.get_source(source_id)
+
+        if record is None:
+            return DocumentResult(
+                source_id=source_id,
+                title="",
+                source_type="",
+                format=format,
+                content="",
+                error=f"ソースが見つかりません: {source_id}",
             )
+
+        title = record.title
+        source_type = record.source_type
+        file_path = record.file_path
+
+        if format == "original":
+            # バイナリ判定: テキスト拡張子以外はバイナリとして扱う
+            ext = PurePosixPath(file_path).suffix.lower()
+            if ext not in _TEXT_EXTENSIONS:
+                # バイナリの場合はファイルを読み込まず、DB の file_size と stat で対応
+                mime_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+                file_size = record.file_size
+                info = (
+                    f"バイナリファイルです（MIME: {mime_type}, サイズ: {file_size:,} bytes）。\n"
+                    "テキスト形式で取得するには format=text を指定してください。"
+                )
+                return DocumentResult(
+                    source_id=source_id,
+                    title=title,
+                    source_type=source_type,
+                    format=format,
+                    content=info,
+                    is_binary=True,
+                )
+
+            # テキストファイル: source_store から読み取り
+            file_data = store.get_file(source_id)
+            if file_data is None:
+                return DocumentResult(
+                    source_id=source_id,
+                    title=title,
+                    source_type=source_type,
+                    format=format,
+                    content="",
+                    error=f"ファイルが見つかりません: {file_path}",
+                )
+
+            try:
+                content = file_data.content.decode("utf-8")
+            except UnicodeDecodeError:
+                content = file_data.content.decode("utf-8", errors="replace")
+
             return DocumentResult(
                 source_id=source_id,
                 title=title,
                 source_type=source_type,
                 format=format,
-                content=info,
-                is_binary=True,
+                content=content,
             )
 
-        # テキストとして読み取り
-        try:
-            content = file_data.content.decode("utf-8")
-        except UnicodeDecodeError:
-            content = file_data.content.decode("utf-8", errors="replace")
-
-        return DocumentResult(
-            source_id=source_id,
-            title=title,
-            source_type=source_type,
-            format=format,
-            content=content,
-        )
-
     # format == "text": converted_store から読み取り
-    converted_rel = _get_converted_rel_path(file_data.file_path)
+    converted_rel = _get_converted_rel_path(file_path)
     converted_path = Path(converted_store_dir) / converted_rel
 
     if not converted_path.exists():

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 from urllib.parse import urldefrag
 
@@ -88,38 +90,52 @@ class RAGRetrievalResult:
 class VectorSearchItem:
     """ベクトル検索の生結果アイテム.
 
-    仕様: docs/specs/rag-knowledge.md
+    仕様: docs/specs/search-response.md
 
     Attributes:
         text: チャンクテキスト
-        source_url: ソースURL
+        source_url: ソースURL（source_id）
         distance: cosine距離（0に近いほど類似）
-        chunk_index: チャンクインデックス
+        chunk_index: チャンクインデックス（0始まり）
+        title: コンテンツのタイトル
+        source_type: ソース種別
+        total_chunks: 当該ソースのチャンク総数（0はレガシーデータ）
     """
 
     text: str
     source_url: str
     distance: float
     chunk_index: int
+    title: str = ""
+    source_type: str = ""
+    total_chunks: int = 0
 
 
 @dataclass
 class BM25SearchItem:
     """BM25検索の生結果アイテム.
 
-    仕様: docs/specs/rag-knowledge.md
+    仕様: docs/specs/search-response.md
 
     Attributes:
         text: チャンクテキスト
-        source_url: ソースURL
+        source_url: ソースURL（source_id）
         score: BM25スコア（高いほどキーワード一致）
         doc_id: ドキュメントID
+        chunk_index: チャンクインデックス（0始まり）
+        title: コンテンツのタイトル
+        source_type: ソース種別
+        total_chunks: 当該ソースのチャンク総数（0はレガシーデータ）
     """
 
     text: str
     source_url: str
     score: float
     doc_id: str
+    chunk_index: int = 0
+    title: str = ""
+    source_type: str = ""
+    total_chunks: int = 0
 
 
 @dataclass
@@ -834,12 +850,18 @@ class RAGKnowledgeService:
         for result in vector_results_raw:
             source_url = str(result.metadata.get("source_url", ""))
             chunk_index = int(result.metadata.get("chunk_index", 0))
+            title = str(result.metadata.get("title", ""))
+            source_type_val = str(result.metadata.get("source_type", ""))
+            total_chunks = int(result.metadata.get("total_chunks", 0))
             vector_items.append(
                 VectorSearchItem(
                     text=result.text,
                     source_url=source_url,
                     distance=result.distance,
                     chunk_index=chunk_index,
+                    title=title,
+                    source_type=source_type_val,
+                    total_chunks=total_chunks,
                 )
             )
 
@@ -849,14 +871,33 @@ class RAGKnowledgeService:
             bm25_results_raw = self._bm25_index.search(
                 query, n_results=n_results, source_type=source_type,
             )
+
+            # BM25結果のメタデータをChromaDBから一括取得
+            bm25_doc_ids = [r.doc_id for r in bm25_results_raw]
+            bm25_meta_map = await self._vector_store.get_metadata_by_ids(
+                bm25_doc_ids
+            )
+
             for bm25_result in bm25_results_raw:
                 source_url = self._bm25_index.get_source_url(bm25_result.doc_id) or ""
+                meta = bm25_meta_map.get(bm25_result.doc_id, {})
+                title = str(meta.get("title", ""))
+                bm25_source_type = (
+                    self._bm25_index.get_source_type(bm25_result.doc_id)
+                    or str(meta.get("source_type", ""))
+                )
+                total_chunks = int(meta.get("total_chunks", 0))
+                chunk_index = int(meta.get("chunk_index", 0))
                 bm25_items.append(
                     BM25SearchItem(
                         text=bm25_result.text,
                         source_url=source_url,
                         score=bm25_result.score,
                         doc_id=bm25_result.doc_id,
+                        chunk_index=chunk_index,
+                        title=title,
+                        source_type=bm25_source_type,
+                        total_chunks=total_chunks,
                     )
                 )
 
@@ -960,3 +1001,180 @@ class RAGKnowledgeService:
         """
         # VectorStore.get_stats()は同期APIを呼ぶため、to_threadでラップ
         return await asyncio.to_thread(self._vector_store.get_stats)
+
+
+# --- ドキュメント全文取得（rag_get_document 共通ロジック） ---
+
+# converted_store 出力拡張子マッピング
+# converter/converter.py の _EXTENSION_OUTPUT_MAP と同期が必要
+_CONVERTED_EXT_MAP: dict[str, str] = {
+    ".html": ".md",
+    ".pdf": ".md",
+    ".json": ".md",
+}
+
+# テキストファイルとして扱う拡張子
+_TEXT_EXTENSIONS: frozenset[str] = frozenset(
+    {".md", ".txt", ".adoc", ".html", ".json"}
+)
+
+
+def _get_converted_rel_path(file_path: str) -> str:
+    """source_store 相対パスから converted_store の相対パスを算出する."""
+    p = PurePosixPath(file_path)
+    ext = p.suffix.lower()
+    new_ext = _CONVERTED_EXT_MAP.get(ext)
+    if new_ext is not None:
+        return str(p.with_suffix(new_ext))
+    return file_path
+
+
+@dataclass
+class DocumentResult:
+    """ドキュメント全文取得の結果.
+
+    仕様: docs/specs/search-response.md
+
+    Attributes:
+        source_id: ソース識別子
+        title: コンテンツのタイトル
+        source_type: ソース種別
+        format: 取得形式（"text" または "original"）
+        content: ドキュメントテキスト（バイナリの場合は情報文字列）
+        is_binary: バイナリファイルか否か
+        error: エラーメッセージ（エラー時のみ）
+    """
+
+    source_id: str
+    title: str
+    source_type: str
+    format: str
+    content: str
+    is_binary: bool = False
+    error: str | None = None
+
+
+def get_document(
+    source_id: str,
+    format: str,
+    source_store_dir: str,
+    converted_store_dir: str,
+) -> DocumentResult:
+    """ドキュメント全文を取得する（MCP/CLI 共通ロジック）.
+
+    仕様: docs/specs/search-response.md
+
+    Args:
+        source_id: ソース識別子
+        format: 取得形式（"text" または "original"）
+        source_store_dir: source_store のルートディレクトリパス
+        converted_store_dir: converted_store のルートディレクトリパス
+
+    Returns:
+        DocumentResult
+    """
+    from .store.source_store import SourceStore
+
+    with SourceStore(root_dir=Path(source_store_dir)) as store:
+        file_data = store.get_file(source_id)
+
+    if file_data is None:
+        return DocumentResult(
+            source_id=source_id,
+            title="",
+            source_type="",
+            format=format,
+            content="",
+            error=f"ソースが見つかりません: {source_id}",
+        )
+
+    meta = file_data.metadata
+    title = meta.title
+    source_type = meta.source_type
+
+    if format == "original":
+        # バイナリ判定: テキスト拡張子以外はバイナリとして扱う
+        ext = PurePosixPath(file_data.file_path).suffix.lower()
+        if ext not in _TEXT_EXTENSIONS:
+            mime_type = mimetypes.guess_type(file_data.file_path)[0] or "application/octet-stream"
+            file_size = len(file_data.content)
+            info = (
+                f"バイナリファイルです（MIME: {mime_type}, サイズ: {file_size:,} bytes）。\n"
+                "テキスト形式で取得するには format=text を指定してください。"
+            )
+            return DocumentResult(
+                source_id=source_id,
+                title=title,
+                source_type=source_type,
+                format=format,
+                content=info,
+                is_binary=True,
+            )
+
+        # テキストとして読み取り
+        try:
+            content = file_data.content.decode("utf-8")
+        except UnicodeDecodeError:
+            content = file_data.content.decode("utf-8", errors="replace")
+
+        return DocumentResult(
+            source_id=source_id,
+            title=title,
+            source_type=source_type,
+            format=format,
+            content=content,
+        )
+
+    # format == "text": converted_store から読み取り
+    converted_rel = _get_converted_rel_path(file_data.file_path)
+    converted_path = Path(converted_store_dir) / converted_rel
+
+    if not converted_path.exists():
+        return DocumentResult(
+            source_id=source_id,
+            title=title,
+            source_type=source_type,
+            format=format,
+            content="",
+            error=(
+                f"変換済みファイルが見つかりません: {converted_rel}\n"
+                "source_store にオリジナルが存在します。"
+                "format=original で取得できます。"
+            ),
+        )
+
+    try:
+        content = converted_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        content = converted_path.read_bytes().decode("utf-8", errors="replace")
+
+    return DocumentResult(
+        source_id=source_id,
+        title=title,
+        source_type=source_type,
+        format=format,
+        content=content,
+    )
+
+
+def format_document_response(result: DocumentResult) -> str:
+    """DocumentResult をプレーンテキストレスポンスにフォーマットする.
+
+    Args:
+        result: ドキュメント取得結果
+
+    Returns:
+        フォーマット済みレスポンステキスト
+    """
+    if result.error:
+        return f"エラー: {result.error}"
+
+    lines = [
+        f"Source: {result.source_id}",
+        f"Title: {result.title}",
+        f"Type: {result.source_type}",
+        f"Format: {result.format}",
+        "",
+        result.content,
+    ]
+    return "\n".join(lines)

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -280,14 +280,15 @@ async def rag_get_document(
 
     response = format_document_response(result)
 
-    # MCP 経由の場合、rag_max_response_chars でトランケーション
+    # MCP 経由の場合、rag_max_response_chars でトランケーション（通知文込みで上限内に収める）
     max_chars = settings.rag_max_response_chars
     if max_chars is not None and not result.error and len(response) > max_chars:
-        response = response[:max_chars]
-        response += (
+        truncation_notice = (
             "\n\n…（レスポンスが上限の{:,}文字を超えたためトランケートされました。"
             "CLI の --output オプションで全文取得できます）"
         ).format(max_chars)
+        truncate_at = max(0, max_chars - len(truncation_notice))
+        response = response[:truncate_at] + truncation_notice
 
     return response
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1,10 +1,11 @@
 """RAG MCP サーバー
 
-仕様: docs/specs/rag-knowledge.md
+仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 10 個の RAG ツールを公開する:
-- rag_search: ナレッジベースから関連情報を検索
+FastMCP を使用して 11 個の RAG ツールを公開する:
+- rag_search: ナレッジベース検索（チャンク単位返却）
+- rag_get_document: ソース全文取得
 - rag_add: 単一ページをナレッジベースに取り込み
 - rag_crawl: リンク集ページからクロール＆一括取り込み
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
@@ -43,7 +44,11 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .ingesters.document_ingester import DocumentIngester
     from .ingesters.web_ingester import WebIngester
     from .ingesters.zenn_ingester import ZennIngester
-    from .rag_knowledge import RAGKnowledgeService
+    from .rag_knowledge import (
+        RAGKnowledgeService,
+        format_document_response,
+        get_document,
+    )
     from .safe_browsing import create_safe_browsing_client
     from .vector_store import VectorStore
     from .web_crawler import WebCrawler
@@ -148,6 +153,22 @@ def _build_rag_service() -> RAGKnowledgeService:
 _VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "document"})
 
 
+def _format_chunk_position(chunk_index: int, total_chunks: int) -> str:
+    """チャンク位置を表示用文字列にフォーマットする.
+
+    Args:
+        chunk_index: 0始まりチャンクインデックス
+        total_chunks: チャンク総数（0はレガシーデータ＝不明）
+
+    Returns:
+        "3/15" 形式、total_chunks 不明時は "3/?"
+    """
+    pos = chunk_index + 1
+    if total_chunks > 0:
+        return f"{pos}/{total_chunks}"
+    return f"{pos}/?"
+
+
 @mcp.tool()
 async def rag_search(
     query: str,
@@ -169,11 +190,9 @@ async def rag_search(
 
     Returns:
         検索結果テキスト。ベクトル検索結果とBM25検索結果をセクション分けして返す。
-        ヒットしたチャンクのページ全文を返却し、同一URLの重複は参照テキストで省略する。
+        各結果はチャンク単位で返却される。
+        詳細が必要な場合は rag_get_document でソースの全文を取得できる。
         結果が0件の場合は「該当する情報が見つかりませんでした」を返す。
-        RAG_MAX_RESPONSE_CHARS 設定時、累積文字数を追跡し上限到達後はページ全文取得を
-        早期打ち切りする。末尾にトランケート通知が付記される。
-        未設定時はトランケーションなし（検索結果をそのまま返す）。
     """
     if source_type is not None and source_type not in _VALID_SOURCE_TYPES:
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
@@ -190,103 +209,85 @@ async def rag_search(
     if not raw.vector_results and not raw.bm25_results:
         return "該当する情報が見つかりませんでした"
 
-    max_chars = get_settings().rag_max_response_chars
-
-    # ページ全文キャッシュ（同一URLの多重DB問い合わせ防止）
-    page_cache: dict[str, str] = {}
-    # URL初出記録: url -> (セクション名, Result番号)
-    url_first_seen: dict[str, tuple[str, int]] = {}
-
-    async def _get_page_text(url: str) -> str:
-        if url not in page_cache:
-            page_cache[url] = await service.get_full_page_text(url)
-        return page_cache[url]
-
     parts: list[str] = []
-    # 累積文字数を追跡（改行セパレータ分も含む）
-    current_chars = 0
-    budget_exceeded = False
-
-    def _append_part(text: str) -> None:
-        """parts にテキストを追加し、累積文字数を更新する."""
-        nonlocal current_chars, budget_exceeded
-        # 改行セパレータ分を加算（最初の要素以外）
-        sep_len = 1 if parts else 0
-        new_chars = sep_len + len(text)
-
-        if max_chars is not None and current_chars + new_chars > max_chars:
-            # 空セパレータは装飾目的なので、超過しても打ち切りとみなさずスキップ
-            if not text:
-                return
-            # 残り文字数分だけ追加してトランケート
-            remaining = max_chars - current_chars - sep_len
-            if remaining > 0:
-                parts.append(text[:remaining])
-                current_chars = max_chars
-            budget_exceeded = True
-            return
-
-        parts.append(text)
-        current_chars += new_chars
 
     # ベクトル検索結果
     if raw.vector_results:
-        _append_part("## ベクトル検索結果 (意味的類似度)\n")
-        for i, vec_item in enumerate(raw.vector_results, start=1):
-            if budget_exceeded:
-                break
-            _append_part(f"### Result {i} [distance={vec_item.distance:.3f}]")
-            if budget_exceeded:
-                break
-            _append_part(f"Source: {vec_item.source_url}")
-            if budget_exceeded:
-                break
-
-            if vec_item.source_url not in url_first_seen:
-                url_first_seen[vec_item.source_url] = ("ベクトル検索結果", i)
-                full_text = await _get_page_text(vec_item.source_url)
-                _append_part(full_text)
-            else:
-                section, num = url_first_seen[vec_item.source_url]
-                _append_part(
-                    f"（この URL のページ全文は{section} Result {num} に掲載済み）"
-                )
-            if budget_exceeded:
-                break
-            _append_part("")
+        parts.append("## ベクトル検索結果 (意味的類似度)\n")
+        for i, item in enumerate(raw.vector_results, start=1):
+            chunk_pos = _format_chunk_position(item.chunk_index, item.total_chunks)
+            parts.append(f"### Result {i} [distance={item.distance:.3f}]")
+            parts.append(f"Source: {item.source_url}")
+            parts.append(f"Title: {item.title}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {item.source_type}")
+            parts.append("")
+            parts.append(item.text)
+            parts.append("")
 
     # BM25検索結果
-    if raw.bm25_results and not budget_exceeded:
-        _append_part("## BM25検索結果 (キーワード一致)\n")
+    if raw.bm25_results:
+        parts.append("## BM25 検索結果 (キーワード一致)\n")
         for i, bm25_item in enumerate(raw.bm25_results, start=1):
-            if budget_exceeded:
-                break
-            _append_part(f"### Result {i} [score={bm25_item.score:.3f}]")
-            if budget_exceeded:
-                break
-            _append_part(f"Source: {bm25_item.source_url}")
-            if budget_exceeded:
-                break
+            chunk_pos = _format_chunk_position(bm25_item.chunk_index, bm25_item.total_chunks)
+            parts.append(f"### Result {i} [score={bm25_item.score:.3f}]")
+            parts.append(f"Source: {bm25_item.source_url}")
+            parts.append(f"Title: {bm25_item.title}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {bm25_item.source_type}")
+            parts.append("")
+            parts.append(bm25_item.text)
+            parts.append("")
 
-            if bm25_item.source_url not in url_first_seen:
-                url_first_seen[bm25_item.source_url] = ("BM25検索結果", i)
-                full_text = await _get_page_text(bm25_item.source_url)
-                _append_part(full_text)
-            else:
-                section, num = url_first_seen[bm25_item.source_url]
-                _append_part(
-                    f"（この URL のページ全文は{section} Result {num} に掲載済み）"
-                )
-            if budget_exceeded:
-                break
-            _append_part("")
+    return "\n".join(parts).rstrip()
 
-    response = "\n".join(parts).rstrip()
 
-    if budget_exceeded:
-        response += "\n\n…（レスポンスが上限の{:,}文字を超えたため切り詰めました）".format(
-            max_chars
-        )
+_VALID_DOCUMENT_FORMATS: frozenset[str] = frozenset({"text", "original"})
+
+
+@mcp.tool()
+async def rag_get_document(
+    source_id: str,
+    format: str = "text",
+) -> str:
+    """[rag-knowledge] RAG get document - ソース全文取得。rag_search で見つけたソースの全文を取得する。
+
+    knowledge base, full text, document retrieval, get source.
+    rag_search の結果に含まれる Source 値をそのまま source_id に指定する。
+    format=text で変換済みテキスト、format=original でオリジナルデータを取得できる。
+
+    Args:
+        source_id: ソース識別子（rag_search の Source 値）
+        format: 取得形式。"text"（変換済みテキスト、デフォルト）または "original"（オリジナル）
+
+    Returns:
+        メタデータヘッダー + ドキュメント全文。
+        大規模ドキュメントはトランケーションされる場合がある。
+        その場合は CLI の --output オプションで全文取得可能。
+    """
+    if format not in _VALID_DOCUMENT_FORMATS:
+        valid = ", ".join(sorted(_VALID_DOCUMENT_FORMATS))
+        return f"無効な format: {format!r}（有効値: {valid}）"
+
+    settings = get_settings()
+    result = await asyncio.to_thread(
+        get_document,
+        source_id=source_id,
+        format=format,
+        source_store_dir=settings.source_store_dir,
+        converted_store_dir=settings.converted_store_dir,
+    )
+
+    response = format_document_response(result)
+
+    # MCP 経由の場合、rag_max_response_chars でトランケーション
+    max_chars = settings.rag_max_response_chars
+    if max_chars is not None and not result.error and len(response) > max_chars:
+        response = response[:max_chars]
+        response += (
+            "\n\n…（レスポンスが上限の{:,}文字を超えたためトランケートされました。"
+            "CLI の --output オプションで全文取得できます）"
+        ).format(max_chars)
 
     return response
 

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -253,6 +253,34 @@ class VectorStore:
         chunks.sort(key=lambda c: int(c.metadata.get("chunk_index", 0)))
         return chunks
 
+    async def get_metadata_by_ids(
+        self,
+        ids: list[str],
+    ) -> dict[str, dict[str, str | int | float | bool]]:
+        """チャンクIDのリストからメタデータを一括取得する.
+
+        Args:
+            ids: チャンクIDのリスト
+
+        Returns:
+            チャンクID → メタデータ辞書のマッピング
+        """
+        if not ids:
+            return {}
+
+        results = await asyncio.to_thread(
+            self._collection.get,
+            ids=ids,
+            include=["metadatas"],
+        )
+
+        meta_map: dict[str, dict[str, str | int | float | bool]] = {}
+        metadatas = results["metadatas"] or []
+        for chunk_id, meta in zip(results["ids"], metadatas):
+            meta_map[chunk_id] = meta or {}  # type: ignore[assignment]
+
+        return meta_map
+
     async def source_exists(self, source_url: str) -> bool:
         """ソースURLに対応するチャンクが存在するか確認する（軽量版）.
 

--- a/tests/test_get_document.py
+++ b/tests/test_get_document.py
@@ -152,6 +152,22 @@ class TestGetDocumentFormatOriginal:
 class TestGetDocumentEdgeCases:
     """エッジケースのテスト."""
 
+    def test_invalid_format_returns_error(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """無効な format でエラーを返すこと."""
+        source_dir, converted_dir = stores
+
+        result = get_document(
+            source_id="any",
+            format="invalid",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is not None
+        assert "無効な format" in result.error
+
     def test_nonexistent_source_returns_error(
         self, stores: tuple[Path, Path],
     ) -> None:

--- a/tests/test_get_document.py
+++ b/tests/test_get_document.py
@@ -1,0 +1,283 @@
+"""get_document 共通ロジックのテスト.
+
+仕様: docs/specs/search-response.md
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.rag_knowledge import (
+    DocumentResult,
+    format_document_response,
+    get_document,
+)
+
+
+@pytest.fixture
+def stores(tmp_path: Path) -> tuple[Path, Path]:
+    """テスト用 source_store と converted_store を作成する."""
+    source = tmp_path / "source_store"
+    converted = tmp_path / "converted_store"
+    source.mkdir()
+    converted.mkdir()
+    return source, converted
+
+
+class TestGetDocumentFormatText:
+    """format=text のテスト."""
+
+    def test_text_format_reads_from_converted_store(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """format=text で converted_store からテキストを読み取ること."""
+        source_dir, converted_dir = stores
+
+        # source_store にファイルを配置
+        _setup_source_with_db(
+            source_dir,
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="Test Page",
+            content=b"<html>original</html>",
+        )
+
+        # converted_store に変換済みファイルを配置
+        conv_file = converted_dir / "web/https/example.com/page.md"
+        conv_file.parent.mkdir(parents=True, exist_ok=True)
+        conv_file.write_text("# Converted content", encoding="utf-8")
+
+        result = get_document(
+            source_id="https://example.com/page",
+            format="text",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is None
+        assert result.source_id == "https://example.com/page"
+        assert result.title == "Test Page"
+        assert result.source_type == "web"
+        assert result.format == "text"
+        assert result.content == "# Converted content"
+        assert not result.is_binary
+
+    def test_text_format_missing_converted_file(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """format=text で converted_store にファイルがない場合、エラーを返すこと."""
+        source_dir, converted_dir = stores
+
+        _setup_source_with_db(
+            source_dir,
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="Test Page",
+            content=b"<html>original</html>",
+        )
+
+        result = get_document(
+            source_id="https://example.com/page",
+            format="text",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is not None
+        assert "変換済みファイルが見つかりません" in result.error
+        assert "format=original" in result.error
+
+
+class TestGetDocumentFormatOriginal:
+    """format=original のテスト."""
+
+    def test_original_format_reads_text_file(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """format=original でテキストファイルの内容を返すこと."""
+        source_dir, converted_dir = stores
+
+        _setup_source_with_db(
+            source_dir,
+            source_id="local/notes/memo.md",
+            source_type="local",
+            file_path="local/notes/memo.md",
+            title="memo",
+            content=b"# My Memo\nHello World",
+        )
+
+        result = get_document(
+            source_id="local/notes/memo.md",
+            format="original",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is None
+        assert result.content == "# My Memo\nHello World"
+        assert not result.is_binary
+
+    def test_original_format_binary_returns_info(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """format=original でバイナリファイルのとき、MIME情報を返すこと."""
+        source_dir, converted_dir = stores
+
+        _setup_source_with_db(
+            source_dir,
+            source_id="https://example.com/doc.pdf",
+            source_type="web",
+            file_path="web/https/example.com/doc.pdf",
+            title="PDF Document",
+            content=b"%PDF-1.4 fake content",
+        )
+
+        result = get_document(
+            source_id="https://example.com/doc.pdf",
+            format="original",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is None
+        assert result.is_binary
+        assert "application/pdf" in result.content
+        assert "format=text" in result.content
+
+
+class TestGetDocumentEdgeCases:
+    """エッジケースのテスト."""
+
+    def test_nonexistent_source_returns_error(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """存在しない source_id でエラーを返すこと."""
+        source_dir, converted_dir = stores
+
+        # metadata.db を初期化（空）
+        from rag.store.source_store import SourceStore
+        with SourceStore(root_dir=source_dir) as store:
+            store.initialize()
+
+        result = get_document(
+            source_id="nonexistent",
+            format="text",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is not None
+        assert "ソースが見つかりません" in result.error
+
+    def test_deleted_source_still_accessible(
+        self, stores: tuple[Path, Path],
+    ) -> None:
+        """論理削除済みのソースも取得できること."""
+        source_dir, converted_dir = stores
+
+        _setup_source_with_db(
+            source_dir,
+            source_id="local/old/doc.txt",
+            source_type="local",
+            file_path="local/old/doc.txt",
+            title="Old Doc",
+            content=b"Old content",
+        )
+
+        # 論理削除
+        from rag.store.source_store import SourceStore
+        with SourceStore(root_dir=source_dir) as store:
+            store.soft_delete("local/old/doc.txt")
+
+        result = get_document(
+            source_id="local/old/doc.txt",
+            format="original",
+            source_store_dir=str(source_dir),
+            converted_store_dir=str(converted_dir),
+        )
+
+        assert result.error is None
+        assert result.content == "Old content"
+
+
+class TestFormatDocumentResponse:
+    """format_document_response のテスト."""
+
+    def test_formats_successful_result(self) -> None:
+        """正常な結果をフォーマットできること."""
+        result = DocumentResult(
+            source_id="https://example.com/page",
+            title="Test Page",
+            source_type="web",
+            format="text",
+            content="Document content here.",
+        )
+
+        response = format_document_response(result)
+
+        assert "Source: https://example.com/page" in response
+        assert "Title: Test Page" in response
+        assert "Type: web" in response
+        assert "Format: text" in response
+        assert "Document content here." in response
+
+    def test_formats_error_result(self) -> None:
+        """エラー結果をフォーマットできること."""
+        result = DocumentResult(
+            source_id="missing",
+            title="",
+            source_type="",
+            format="text",
+            content="",
+            error="ソースが見つかりません: missing",
+        )
+
+        response = format_document_response(result)
+
+        assert response.startswith("エラー:")
+        assert "ソースが見つかりません" in response
+
+
+# --- ヘルパー関数 ---
+
+
+def _setup_source_with_db(
+    source_dir: Path,
+    *,
+    source_id: str,
+    source_type: str,
+    file_path: str,
+    title: str,
+    content: bytes,
+) -> None:
+    """source_store にファイルと metadata.db レコードをセットアップする."""
+    from rag.store.source_store import SourceStore
+
+    with SourceStore(root_dir=source_dir) as store:
+        store.initialize()
+
+        # ファイルを直接配置
+        full_path = source_dir / file_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_bytes(content)
+
+        # metadata.db に登録
+        import hashlib
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).isoformat()
+        content_hash = hashlib.sha256(content).hexdigest()
+        store.db.register_source(
+            source_id=source_id,
+            source_type=source_type,
+            file_path=file_path,
+            title=title,
+            content_hash=content_hash,
+            file_size=len(content),
+            created_at=now,
+            updated_at=now,
+        )

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -41,6 +41,7 @@ def mock_vector_store(mock_embedding_provider: MagicMock) -> MagicMock:
     mock.search = AsyncMock(return_value=[])
     mock.delete_by_source = AsyncMock(return_value=0)
     mock.delete_stale_chunks = AsyncMock(return_value=0)
+    mock.get_metadata_by_ids = AsyncMock(return_value={})
     mock.get_stats = MagicMock(return_value={
         "total_chunks": 10,
         "source_count": 2,

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1,7 +1,7 @@
 """RAG MCPサーバーのテスト.
 
-仕様: docs/specs/rag-knowledge.md
-10個のRAGツール（rag_search, rag_add, rag_crawl, rag_crawl_preview,
+仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md
+11個のRAGツール（rag_search, rag_get_document, rag_add, rag_crawl, rag_crawl_preview,
 rag_crawl_zenn, rag_crawl_bluesky, rag_add_document, rag_crawl_documents, rag_delete, rag_stats）が
 MCPサーバーとして公開されていることを検証する。
 """
@@ -29,8 +29,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_ten_tools() -> None:
-    """RAG MCPサーバーが10個のツールを公開すること."""
+async def test_rag_server_exposes_eleven_tools() -> None:
+    """RAG MCPサーバーが11個のツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -38,39 +38,35 @@ async def test_rag_server_exposes_ten_tools() -> None:
     tool_names = {t.name for t in tools}
 
     expected = {
-        "rag_search", "rag_add", "rag_crawl", "rag_crawl_preview",
-        "rag_crawl_zenn", "rag_crawl_bluesky", "rag_add_document",
-        "rag_crawl_documents", "rag_delete", "rag_stats",
+        "rag_search", "rag_get_document", "rag_add", "rag_crawl",
+        "rag_crawl_preview", "rag_crawl_zenn", "rag_crawl_bluesky",
+        "rag_add_document", "rag_crawl_documents", "rag_delete", "rag_stats",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に10であること."""
+    """RAG MCPサーバーのツール数が正確に11であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 10
+    assert len(tools) == 11
 
 
 class TestRagSearchOutput:
-    """rag_search ツールの出力フォーマットテスト（準Agentic Search, Issue #548）."""
+    """rag_search ツールのチャンク単位出力フォーマットテスト（#251）."""
 
     @pytest.fixture(autouse=True)
     def _patch_rag_service(self) -> None:
         """rag_search のテスト用に RAGKnowledgeService をモックする."""
         self.mock_service = AsyncMock()
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="ページ全文テキスト"
-        )
         self.mock_settings = MagicMock()
         self.mock_settings.rag_retrieval_count = 3
-        self.mock_settings.rag_max_response_chars = None
 
     async def test_output_contains_vector_and_bm25_sections(self) -> None:
-        """出力にベクトル検索結果とBM25検索結果のセクションが含まれること（#548）."""
+        """出力にベクトル検索結果とBM25検索結果のセクションが含まれること."""
         mod = import_module("rag.server")
 
         self.mock_service.retrieve_raw_results = AsyncMock(
@@ -80,7 +76,10 @@ class TestRagSearchOutput:
                         text="ベクトルの結果テキスト",
                         source_url="https://example.com/vec1",
                         distance=0.234,
-                        chunk_index=0,
+                        chunk_index=2,
+                        title="ガイドページ",
+                        source_type="web",
+                        total_chunks=15,
                     ),
                 ],
                 bm25_results=[
@@ -89,12 +88,13 @@ class TestRagSearchOutput:
                         source_url="https://example.com/bm25_1",
                         score=4.521,
                         doc_id="doc1",
+                        chunk_index=4,
+                        title="サンプル記事",
+                        source_type="zenn",
+                        total_chunks=20,
                     ),
                 ],
             )
-        )
-        self.mock_service.get_full_page_text = AsyncMock(
-            side_effect=lambda url: f"{url} のページ全文"
         )
 
         with (
@@ -104,20 +104,23 @@ class TestRagSearchOutput:
             result = await mod.rag_search("テストクエリ")
 
         assert "## ベクトル検索結果 (意味的類似度)" in result
-        assert "## BM25検索結果 (キーワード一致)" in result
+        assert "## BM25 検索結果 (キーワード一致)" in result
 
-    async def test_output_contains_source_urls(self) -> None:
-        """出力に Source: URL 行が含まれること（#548）."""
+    async def test_output_contains_chunk_metadata(self) -> None:
+        """各結果にSource/Title/Chunk/Typeメタデータが含まれること."""
         mod = import_module("rag.server")
 
         self.mock_service.retrieve_raw_results = AsyncMock(
             return_value=RawSearchResults(
                 vector_results=[
                     VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
+                        text="チャンクテキスト",
+                        source_url="https://example.com/docs/guide",
+                        distance=0.234,
+                        chunk_index=2,
+                        title="ガイドページ",
+                        source_type="web",
+                        total_chunks=15,
                     ),
                 ],
                 bm25_results=[],
@@ -130,10 +133,41 @@ class TestRagSearchOutput:
         ):
             result = await mod.rag_search("テスト")
 
-        assert "Source: https://example.com/page1" in result
+        assert "Source: https://example.com/docs/guide" in result
+        assert "Title: ガイドページ" in result
+        assert "Chunk: 3/15" in result
+        assert "Type: web" in result
+        assert "チャンクテキスト" in result
+
+    async def test_chunk_position_with_unknown_total(self) -> None:
+        """total_chunks=0（レガシーデータ）のとき Chunk: N/? と表示されること."""
+        mod = import_module("rag.server")
+
+        self.mock_service.retrieve_raw_results = AsyncMock(
+            return_value=RawSearchResults(
+                vector_results=[
+                    VectorSearchItem(
+                        text="テキスト",
+                        source_url="https://example.com/page1",
+                        distance=0.1,
+                        chunk_index=4,
+                        total_chunks=0,
+                    ),
+                ],
+                bm25_results=[],
+            )
+        )
+
+        with (
+            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
+            patch.object(mod, "get_settings", return_value=self.mock_settings),
+        ):
+            result = await mod.rag_search("テスト")
+
+        assert "Chunk: 5/?" in result
 
     async def test_output_contains_raw_scores(self) -> None:
-        """出力に生スコアが含まれること（#548）."""
+        """出力に生スコアが含まれること."""
         mod = import_module("rag.server")
 
         self.mock_service.retrieve_raw_results = AsyncMock(
@@ -185,26 +219,26 @@ class TestRagSearchOutput:
 
         assert result == "該当する情報が見つかりませんでした"
 
-    async def test_output_contains_full_page_text(self) -> None:
-        """チャンクテキストの代わりにページ全文が返ること（#575）."""
+    async def test_chunk_text_returned_directly(self) -> None:
+        """チャンクテキストがそのまま返却されること（ページ全文ではない）."""
         mod = import_module("rag.server")
 
         self.mock_service.retrieve_raw_results = AsyncMock(
             return_value=RawSearchResults(
                 vector_results=[
                     VectorSearchItem(
-                        text="チャンク断片",
+                        text="これはチャンクテキストです",
                         source_url="https://example.com/page1",
                         distance=0.1,
                         chunk_index=0,
+                        title="ページ1",
+                        source_type="web",
+                        total_chunks=5,
                     ),
                 ],
                 bm25_results=[],
             )
         )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="これはページ全文のテキストです。複数チャンクが結合されています。"
-        )
 
         with (
             patch.object(mod, "_get_rag_service", return_value=self.mock_service),
@@ -212,75 +246,36 @@ class TestRagSearchOutput:
         ):
             result = await mod.rag_search("テスト")
 
-        assert "これはページ全文のテキストです。複数チャンクが結合されています。" in result
-        assert "チャンク断片" not in result
+        assert "これはチャンクテキストです" in result
 
-    async def test_duplicate_url_cross_engine_shows_reference(self) -> None:
-        """ベクトル→BM25で同一URLが重複した場合、参照テキストが出ること（#575）."""
+    async def test_same_source_different_chunks_shown_individually(self) -> None:
+        """同一ソースの異なるチャンクが個別に表示されること."""
         mod = import_module("rag.server")
 
-        same_url = "https://example.com/same-page"
         self.mock_service.retrieve_raw_results = AsyncMock(
             return_value=RawSearchResults(
                 vector_results=[
                     VectorSearchItem(
-                        text="ベクトルチャンク",
-                        source_url=same_url,
+                        text="チャンク1のテキスト",
+                        source_url="https://example.com/page",
                         distance=0.1,
                         chunk_index=0,
-                    ),
-                ],
-                bm25_results=[
-                    BM25SearchItem(
-                        text="BM25チャンク",
-                        source_url=same_url,
-                        score=5.0,
-                        doc_id="doc1",
-                    ),
-                ],
-            )
-        )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="ページ全文テキスト"
-        )
-
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
-
-        # ベクトル検索結果にはページ全文が出る
-        assert "ページ全文テキスト" in result
-        # BM25検索結果には参照テキストが出る
-        assert "ベクトル検索結果 Result 1 に掲載済み" in result
-
-    async def test_duplicate_url_within_same_engine(self) -> None:
-        """同一エンジン内で同一URLが重複した場合、2回目以降は参照テキストが出ること（#575）."""
-        mod = import_module("rag.server")
-
-        same_url = "https://example.com/same-page"
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="チャンク1",
-                        source_url=same_url,
-                        distance=0.1,
-                        chunk_index=0,
+                        title="ページ",
+                        source_type="web",
+                        total_chunks=3,
                     ),
                     VectorSearchItem(
-                        text="チャンク2",
-                        source_url=same_url,
+                        text="チャンク2のテキスト",
+                        source_url="https://example.com/page",
                         distance=0.2,
-                        chunk_index=1,
+                        chunk_index=2,
+                        title="ページ",
+                        source_type="web",
+                        total_chunks=3,
                     ),
                 ],
                 bm25_results=[],
             )
-        )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="全文テキスト"
         )
 
         with (
@@ -289,10 +284,10 @@ class TestRagSearchOutput:
         ):
             result = await mod.rag_search("テスト")
 
-        # Result 1 にはページ全文が出る
-        assert "全文テキスト" in result
-        # Result 2 には参照テキストが出る
-        assert "ベクトル検索結果 Result 1 に掲載済み" in result
+        assert "チャンク1のテキスト" in result
+        assert "チャンク2のテキスト" in result
+        assert "Chunk: 1/3" in result
+        assert "Chunk: 3/3" in result
 
 
 class TestConfigureAndRun:
@@ -386,343 +381,171 @@ class TestConfigureAndRun:
         mock_log.assert_called_once_with("MCP server shut down")
 
 
-class TestRagSearchResponseTruncation:
-    """rag_search レスポンスサイズ上限ガードのテスト（#26）."""
+class TestRagGetDocumentTool:
+    """rag_get_document ツールのテスト（#251）."""
 
     @pytest.fixture(autouse=True)
-    def _patch_rag_service(self) -> None:
-        """rag_search のテスト用に RAGKnowledgeService をモックする."""
-        self.mock_service = AsyncMock()
+    def _patch_settings(self) -> None:
+        """テスト用の設定をモックする."""
         self.mock_settings = MagicMock()
-        self.mock_settings.rag_retrieval_count = 3
-
-    async def test_response_not_truncated_when_limit_is_none(self) -> None:
-        """上限未設定時はレスポンスがそのまま返ること（#26）."""
-        mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
-        )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="ページ全文テキスト"
-        )
+        self.mock_settings.source_store_dir = "/tmp/source_store"
+        self.mock_settings.converted_store_dir = "/tmp/converted_store"
         self.mock_settings.rag_max_response_chars = None
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+    async def test_format_text_returns_document(self) -> None:
+        """format=text でドキュメントが返ること."""
+        from rag.rag_knowledge import DocumentResult
 
-        assert "切り詰めました" not in result
-        assert "ページ全文テキスト" in result
-
-    async def test_response_not_truncated_when_within_limit(self) -> None:
-        """レスポンスが上限以下の場合はそのまま返ること（#26）."""
         mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        mock_result = DocumentResult(
+            source_id="https://example.com/docs/guide",
+            title="ガイドページ",
+            source_type="web",
+            format="text",
+            content="これはドキュメント全文です。",
         )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="短いテキスト"
-        )
-        self.mock_settings.rag_max_response_chars = 100000
 
         with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
             patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
         ):
-            result = await mod.rag_search("テスト")
+            result = await mod.rag_get_document("https://example.com/docs/guide")
 
-        assert "切り詰めました" not in result
-        assert "短いテキスト" in result
+        assert "Source: https://example.com/docs/guide" in result
+        assert "Title: ガイドページ" in result
+        assert "Type: web" in result
+        assert "Format: text" in result
+        assert "これはドキュメント全文です。" in result
 
-    async def test_response_truncated_when_exceeds_limit(self) -> None:
-        """レスポンスが上限を超えた場合にトランケートされること（#26）."""
+    async def test_format_original_returns_document(self) -> None:
+        """format=original でドキュメントが返ること."""
+        from rag.rag_knowledge import DocumentResult
+
         mod = import_module("rag.server")
-
-        long_text = "あ" * 500
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        mock_result = DocumentResult(
+            source_id="https://example.com/page.html",
+            title="HTMLページ",
+            source_type="web",
+            format="original",
+            content="<html>...</html>",
         )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value=long_text
-        )
-        self.mock_settings.rag_max_response_chars = 100
 
         with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
             patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
         ):
-            result = await mod.rag_search("テスト")
-
-        assert "切り詰めました" in result
-        assert "100" in result
-
-    async def test_truncated_response_starts_with_original_content(self) -> None:
-        """トランケートされたレスポンスが元の内容の先頭部分を含むこと（#26）."""
-        mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
+            result = await mod.rag_get_document(
+                "https://example.com/page.html", format="original"
             )
+
+        assert "Format: original" in result
+        assert "<html>...</html>" in result
+
+    async def test_missing_source_returns_error(self) -> None:
+        """存在しない source_id でエラーが返ること."""
+        from rag.rag_knowledge import DocumentResult
+
+        mod = import_module("rag.server")
+        mock_result = DocumentResult(
+            source_id="nonexistent",
+            title="",
+            source_type="",
+            format="text",
+            content="",
+            error="ソースが見つかりません: nonexistent",
         )
-        self.mock_service.get_full_page_text = AsyncMock(
-            return_value="あ" * 1000
-        )
+
+        with (
+            patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
+        ):
+            result = await mod.rag_get_document("nonexistent")
+
+        assert "エラー:" in result
+        assert "ソースが見つかりません" in result
+
+    async def test_truncation_with_max_response_chars(self) -> None:
+        """rag_max_response_chars でトランケーションされること."""
+        from rag.rag_knowledge import DocumentResult
+
+        mod = import_module("rag.server")
         self.mock_settings.rag_max_response_chars = 50
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
-
-        # トランケート通知の前の部分が正確に50文字であること
-        truncation_marker = "\n\n…（レスポンスが上限の"
-        marker_pos = result.index(truncation_marker)
-        assert marker_pos == 50
-
-    async def test_early_termination_skips_later_page_fetches(self) -> None:
-        """上限到達後は後続Resultのページ全文取得が呼ばれないこと（#56）."""
-        mod = import_module("rag.server")
-
-        # 3つの結果を用意し、上限を小さく設定
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト1",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                    VectorSearchItem(
-                        text="テキスト2",
-                        source_url="https://example.com/page2",
-                        distance=0.2,
-                        chunk_index=0,
-                    ),
-                    VectorSearchItem(
-                        text="テキスト3",
-                        source_url="https://example.com/page3",
-                        distance=0.3,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        long_content = "あ" * 1000
+        mock_result = DocumentResult(
+            source_id="https://example.com/long",
+            title="Long Page",
+            source_type="web",
+            format="text",
+            content=long_content,
         )
-        call_log: list[str] = []
-
-        async def _mock_get_full_page_text(url: str) -> str:
-            call_log.append(url)
-            return "あ" * 500
-
-        self.mock_service.get_full_page_text = _mock_get_full_page_text
-        # 最初の Result のヘッダー + ページ全文で超過する程度の上限
-        self.mock_settings.rag_max_response_chars = 100
 
         with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
             patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
         ):
-            result = await mod.rag_search("テスト")
+            result = await mod.rag_get_document("https://example.com/long")
 
-        # page1 の全文は取得されるが、page2, page3 は取得されない
-        assert "https://example.com/page1" in call_log
-        assert "https://example.com/page2" not in call_log
-        assert "https://example.com/page3" not in call_log
-        assert "切り詰めました" in result
+        assert "トランケートされました" in result
+        assert "--output" in result
 
-    async def test_early_termination_skips_bm25_when_vector_exhausts_budget(
-        self,
-    ) -> None:
-        """ベクトル検索結果で上限到達時、BM25のページ全文取得が呼ばれないこと（#56）."""
+    async def test_no_truncation_when_limit_is_none(self) -> None:
+        """rag_max_response_chars=None のときトランケーションされないこと."""
+        from rag.rag_knowledge import DocumentResult
+
         mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/vec1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[
-                    BM25SearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/bm25_1",
-                        score=5.0,
-                        doc_id="doc1",
-                    ),
-                ],
-            )
-        )
-        call_log: list[str] = []
-
-        async def _mock_get_full_page_text(url: str) -> str:
-            call_log.append(url)
-            return "あ" * 500
-
-        self.mock_service.get_full_page_text = _mock_get_full_page_text
-        self.mock_settings.rag_max_response_chars = 100
-
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
-
-        # BM25側のページ全文は取得されない
-        assert "https://example.com/bm25_1" not in call_log
-        assert "切り詰めました" in result
-
-    async def test_no_early_termination_when_limit_is_none(self) -> None:
-        """上限未設定時は全Resultのページ全文が取得されること（#56）."""
-        mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト1",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                    VectorSearchItem(
-                        text="テキスト2",
-                        source_url="https://example.com/page2",
-                        distance=0.2,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
-        )
-        call_log: list[str] = []
-
-        async def _mock_get_full_page_text(url: str) -> str:
-            call_log.append(url)
-            return "あ" * 500
-
-        self.mock_service.get_full_page_text = _mock_get_full_page_text
         self.mock_settings.rag_max_response_chars = None
 
+        long_content = "あ" * 1000
+        mock_result = DocumentResult(
+            source_id="https://example.com/long",
+            title="Long Page",
+            source_type="web",
+            format="text",
+            content=long_content,
+        )
+
         with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
             patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
         ):
-            result = await mod.rag_search("テスト")
+            result = await mod.rag_get_document("https://example.com/long")
 
-        # 全てのページ全文が取得される
-        assert "https://example.com/page1" in call_log
-        assert "https://example.com/page2" in call_log
-        assert "切り詰めました" not in result
+        assert "トランケートされました" not in result
+        assert long_content in result
 
-    async def test_exact_fit_separator_does_not_trigger_truncation(self) -> None:
-        """内容が上限ちょうどに収まった時、空セパレータで誤って打ち切り通知が出ないこと."""
+    async def test_binary_file_returns_info(self) -> None:
+        """format=original でバイナリファイルの場合、MIME情報が返ること."""
+        from rag.rag_knowledge import DocumentResult
+
+        mod = import_module("rag.server")
+        mock_result = DocumentResult(
+            source_id="https://example.com/doc.pdf",
+            title="PDF Doc",
+            source_type="web",
+            format="original",
+            content="バイナリファイルです（MIME: application/pdf, サイズ: 1,234 bytes）。\nテキスト形式で取得するには format=text を指定してください。",
+            is_binary=True,
+        )
+
+        with (
+            patch.object(mod, "get_settings", return_value=self.mock_settings),
+            patch.object(mod, "get_document", return_value=mock_result),
+        ):
+            result = await mod.rag_get_document(
+                "https://example.com/doc.pdf", format="original"
+            )
+
+        assert "application/pdf" in result
+        assert "format=text" in result
+
+    async def test_invalid_format_returns_error(self) -> None:
+        """無効な format 値でエラーが返ること."""
         mod = import_module("rag.server")
 
-        page_text = "テスト内容"
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
-        )
-        self.mock_service.get_full_page_text = AsyncMock(return_value=page_text)
+        result = await mod.rag_get_document("source", format="invalid")
 
-        # まず上限なしで実行し、実際のレスポンス長を取得
-        self.mock_settings.rag_max_response_chars = None
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            unlimited_result = await mod.rag_search("テスト")
-
-        # rstrip 後のレスポンス長をちょうど上限に設定
-        # （空セパレータが上限超過の原因にならないことを確認）
-        exact_limit = len(unlimited_result.rstrip())
-        self.mock_settings.rag_max_response_chars = exact_limit
-
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
-
-        assert "切り詰めました" not in result
-
-    async def test_empty_results_not_affected_by_limit(self) -> None:
-        """0件結果は上限設定に影響されないこと（#26）."""
-        mod = import_module("rag.server")
-
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[],
-                bm25_results=[],
-            )
-        )
-        self.mock_settings.rag_max_response_chars = 10
-
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
-
-        assert result == "該当する情報が見つかりませんでした"
+        assert "無効な format" in result
 
 
 class TestRagCrawlPreviewTool:

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -465,11 +465,12 @@ class TestRagGetDocumentTool:
         assert "ソースが見つかりません" in result
 
     async def test_truncation_with_max_response_chars(self) -> None:
-        """rag_max_response_chars でトランケーションされること."""
+        """rag_max_response_chars でトランケーションされ、通知文込みで上限内に収まること."""
         from rag.rag_knowledge import DocumentResult
 
         mod = import_module("rag.server")
-        self.mock_settings.rag_max_response_chars = 50
+        max_chars = 200
+        self.mock_settings.rag_max_response_chars = max_chars
 
         long_content = "あ" * 1000
         mock_result = DocumentResult(
@@ -488,6 +489,8 @@ class TestRagGetDocumentTool:
 
         assert "トランケートされました" in result
         assert "--output" in result
+        # 通知文込みで上限以内に収まること
+        assert len(result) <= max_chars
 
     async def test_no_truncation_when_limit_is_none(self) -> None:
         """rag_max_response_chars=None のときトランケーションされないこと."""


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- rag_search: ページ全文返却→チャンク単位返却に変更（破壊的変更）
  - 各結果に Source / Title / Chunk位置 / Type メタデータを付与
  - ページ全文結合・同一URL重複省略・rag_max_response_chars トランケーションを廃止
- rag_get_document: MCP ツール + CLI サブコマンドとして新規追加
  - format=text: converted_store から変換済みテキスト取得
  - format=original: source_store からオリジナル取得（バイナリはMIME情報を返却）
  - MCP 経由で rag_max_response_chars トランケーション適用
  - CLI --output でファイル出力（トランケーションなし）
- VectorSearchItem / BM25SearchItem に title, source_type, total_chunks フィールド追加
- VectorStore.get_metadata_by_ids, BM25Index.get_source_type メソッド追加
- rag-knowledge.md のツール数（10→11）、rag_search 説明、検索フロー図、CLI テーブルを更新
- README.md に全文取得機能と search-response.md リンクを追加

## Test plan

- [x] rag_search チャンク単位レスポンス形式テスト（メタデータ、スコア、チャンク位置）
- [x] rag_get_document format=text / format=original テスト
- [x] トランケーションテスト（MCP 経由）
- [x] 存在しない source_id テスト
- [x] 論理削除済みソースの取得テスト
- [x] バイナリファイル情報返却テスト
- [x] 全 900 テスト通過、ruff clean、mypy clean

## Related issues

Closes #251