### PR TITLE
fix: 深掘りチェック指摘対応（パス拡張子変換・二重管理解消・Embedding疎通確認） (#286)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ reports/
 .claude/settings.local.json
 .claude/*.lock
 scheduled_tasks.lock
+.claude/scheduled_tasks.lock

--- a/src/rag/converter/__init__.py
+++ b/src/rag/converter/__init__.py
@@ -9,6 +9,7 @@ from rag.converter.converter import (
     ConvertBatchResult,
     Converter,
     RegenOption,
+    get_converted_rel_path,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "ConvertBatchResult",
     "Converter",
     "RegenOption",
+    "get_converted_rel_path",
 ]

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -133,7 +133,7 @@ class Converter:
             raise ConversionSkippedError(f"Unsupported extension: {ext}")
 
         # 出力パス算出
-        converted_rel_path = _get_converted_rel_path(file_path)
+        converted_rel_path = get_converted_rel_path(file_path)
         converted_path = converted_store_dir / converted_rel_path
 
         # パススルー判定
@@ -191,7 +191,7 @@ class Converter:
             file_path: source_store 内の相対パス
             converted_store_dir: converted_store のルートディレクトリ
         """
-        converted_rel_path = _get_converted_rel_path(file_path)
+        converted_rel_path = get_converted_rel_path(file_path)
         converted_path = converted_store_dir / converted_rel_path
         if converted_path.exists():
             converted_path.unlink()
@@ -342,8 +342,11 @@ class Converter:
         return None
 
 
-def _get_converted_rel_path(file_path: str) -> str:
+def get_converted_rel_path(file_path: str) -> str:
     """source_store 相対パスから converted_store の相対パスを算出する.
+
+    拡張子マッピング（_EXTENSION_OUTPUT_MAP）に基づいて、
+    source_store の拡張子を converted_store の拡張子に変換する。
 
     Args:
         file_path: source_store 内の相対パス

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -56,6 +56,7 @@ class Indexer:
         self._metadata_db = metadata_db
         self._chunk_size = chunk_size
         self._chunk_overlap = chunk_overlap
+        self._embedding_checked = False
 
     def add(
         self,
@@ -197,13 +198,19 @@ class Indexer:
     def _check_embedding_available(self) -> None:
         """Embedding プロバイダーの疎通を確認する.
 
+        初回呼び出し時のみ実際にチェックし、結果をキャッシュする。
+        バッチ処理（run_index_only 等）での重複チェックを回避する。
+
         Raises:
             ConnectionError: プロバイダーに接続できない場合
         """
+        if self._embedding_checked:
+            return
         available = _run_async(self._vector_store._embedding.is_available())
         if not available:
             msg = "Embedding プロバイダーに接続できません"
             raise ConnectionError(msg)
+        self._embedding_checked = True
 
     def _read_file(self, path: Path) -> str:
         """ファイルの内容を読み取る."""

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -72,8 +72,10 @@ class Indexer:
 
         Raises:
             ValueError: source_id と metadata.source_id が一致しない場合
+            ConnectionError: Embedding プロバイダーに接続できない場合
         """
         _validate_source_id(source_id, metadata)
+        self._check_embedding_available()
         text = self._read_file(converted_path)
         if not text.strip():
             logger.info("空ファイルのためスキップ: %s", converted_path)
@@ -106,8 +108,10 @@ class Indexer:
 
         Raises:
             ValueError: source_id と metadata.source_id が一致しない場合
+            ConnectionError: Embedding プロバイダーに接続できない場合
         """
         _validate_source_id(source_id, metadata)
+        self._check_embedding_available()
         text = self._read_file(converted_path)
 
         if not text.strip():
@@ -189,6 +193,17 @@ class Indexer:
             self._clear_by_source_type(source_type)
 
     # --- 内部メソッド ---
+
+    def _check_embedding_available(self) -> None:
+        """Embedding プロバイダーの疎通を確認する.
+
+        Raises:
+            ConnectionError: プロバイダーに接続できない場合
+        """
+        available = _run_async(self._vector_store._embedding.is_available())
+        if not available:
+            msg = "Embedding プロバイダーに接続できません"
+            raise ConnectionError(msg)
 
     def _read_file(self, path: Path) -> str:
         """ファイルの内容を読み取る."""

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from rag.converter.converter import get_converted_rel_path
 from rag.pipeline.git_ops import GitOperations
 from rag.pipeline.models import (
     ChangeEntry,
@@ -30,6 +31,7 @@ from rag.store.models import (
     SourceRecord,
     SourceType,
 )
+from rag.store.resolve import resolve_source_id, resolve_title
 from rag.store.source_store import SourceStore
 
 logger = logging.getLogger(__name__)
@@ -322,7 +324,8 @@ class PipelineController:
 
         for record in records:
             try:
-                converted_path = self._converted_store_dir / record.file_path
+                converted_rel = get_converted_rel_path(record.file_path)
+                converted_path = self._converted_store_dir / converted_rel
                 if not converted_path.exists():
                     logger.warning(
                         "converted_store にファイルがありません: %s",
@@ -589,10 +592,10 @@ class PipelineController:
         source_type = detect_source_type(file_path)
         meta_dict = self._read_meta_dict(file_path)
 
-        source_id = _resolve_source_id_from_meta(
+        source_id = resolve_source_id(
             source_type, file_path, meta_dict,
         )
-        title = _resolve_title_from_meta(
+        title = resolve_title(
             source_type, file_path, meta_dict,
         )
 
@@ -644,7 +647,7 @@ class PipelineController:
             return record.source_id
         source_type = detect_source_type(file_path)
         meta_dict = self._read_meta_dict(file_path)
-        return _resolve_source_id_from_meta(source_type, file_path, meta_dict)
+        return resolve_source_id(source_type, file_path, meta_dict)
 
     def _read_meta_dict(self, file_path: str) -> dict[str, str] | None:
         """ファイルの .meta を読み込む."""
@@ -666,10 +669,10 @@ class PipelineController:
         source_type = detect_source_type(file_path)
         meta_dict = self._read_meta_dict(file_path) or {}
 
-        source_id = _resolve_source_id_from_meta(
+        source_id = resolve_source_id(
             source_type, file_path, meta_dict,
         )
-        title = _resolve_title_from_meta(
+        title = resolve_title(
             source_type, file_path, meta_dict,
         )
         collected_at = str(meta_dict.get(
@@ -717,30 +720,4 @@ class PipelineController:
 
 
 # --- モジュールレベルユーティリティ ---
-
-
-def _resolve_source_id_from_meta(
-    source_type: SourceType,
-    rel_path: str,
-    meta: dict[str, str] | None,
-) -> str:
-    """source_id を決定する.
-
-    .meta に source_id があればそれを使用し、
-    なければ相対パスをフォールバックとして使用する。
-    SourceStore._resolve_source_id と同一ロジック。
-    """
-    if meta and "source_id" in meta:
-        return str(meta["source_id"])
-    return rel_path
-
-
-def _resolve_title_from_meta(
-    source_type: SourceType,
-    rel_path: str,
-    meta: dict[str, str] | None,
-) -> str:
-    """タイトルを決定する."""
-    if meta and "title" in meta:
-        return str(meta["title"])
-    return Path(rel_path).stem
+# resolve_source_id / resolve_title は rag.store.resolve に一元化

--- a/src/rag/pipeline/ingesters/web.py
+++ b/src/rag/pipeline/ingesters/web.py
@@ -287,6 +287,7 @@ class WebIngester:
             url=url,
             data=data,
             metadata=metadata,
+            extension=".html",
         )
         result.placed += 1
 
@@ -412,6 +413,7 @@ class WebIngester:
                     url=link,
                     data=page_data,
                     metadata=metadata,
+                    extension=".html",
                 )
                 result.placed += 1
 

--- a/src/rag/pipeline/ingesters/web.py
+++ b/src/rag/pipeline/ingesters/web.py
@@ -20,7 +20,15 @@ from typing import TYPE_CHECKING, Any
 
 from bs4 import BeautifulSoup
 
+from pathlib import PurePosixPath
+
 from rag.pipeline.ingesters._common import IngestResult, now_iso
+
+# converter が認識する拡張子（変換対象 + パススルー対象）
+# この拡張子を持つ URL は .html を付与しない
+_KNOWN_WEB_EXTENSIONS: frozenset[str] = frozenset(
+    {".html", ".htm", ".pdf", ".json", ".md", ".txt", ".adoc"},
+)
 
 if TYPE_CHECKING:
 
@@ -176,6 +184,17 @@ def _extract_links(html_text: str, base_url: str) -> list[str]:
     return links
 
 
+def _needs_html_extension(url: str) -> bool:
+    """URL パスが既知の拡張子を持たない場合に True を返す.
+
+    converter が認識する拡張子（.html, .pdf 等）を既に持つ URL には
+    .html を付与しない。拡張子がないか未知の場合のみ .html を付与する。
+    """
+    path = urlparse(url).path
+    ext = PurePosixPath(path).suffix.lower()
+    return ext not in _KNOWN_WEB_EXTENSIONS
+
+
 class WebIngester:
     """Web インジェスター.
 
@@ -283,11 +302,12 @@ class WebIngester:
             "url": url,
         }
 
+        ext = ".html" if _needs_html_extension(url) else ""
         self._store.place_file_from_url(
             url=url,
             data=data,
             metadata=metadata,
-            extension=".html",
+            extension=ext,
         )
         result.placed += 1
 
@@ -409,11 +429,12 @@ class WebIngester:
                     "url": link,
                 }
 
+                ext = ".html" if _needs_html_extension(link) else ""
                 self._store.place_file_from_url(
                     url=link,
                     data=page_data,
                     metadata=metadata,
-                    extension=".html",
+                    extension=ext,
                 )
                 result.placed += 1
 

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -17,6 +17,7 @@ from urllib.parse import urldefrag
 
 from .chunker import chunk_text
 from .content_detector import ContentType, detect_content_type
+from .converter.converter import get_converted_rel_path
 from .heading_chunker import chunk_by_headings
 from .ingesters.base_ingester import IngestedContent
 from .table_chunker import chunk_table_data
@@ -1005,28 +1006,10 @@ class RAGKnowledgeService:
 
 # --- ドキュメント全文取得（rag_get_document 共通ロジック） ---
 
-# converted_store 出力拡張子マッピング
-# converter/converter.py の _EXTENSION_OUTPUT_MAP と同期が必要
-_CONVERTED_EXT_MAP: dict[str, str] = {
-    ".html": ".md",
-    ".pdf": ".md",
-    ".json": ".md",
-}
-
 # テキストファイルとして扱う拡張子
 _TEXT_EXTENSIONS: frozenset[str] = frozenset(
     {".md", ".txt", ".adoc", ".html", ".json"}
 )
-
-
-def _get_converted_rel_path(file_path: str) -> str:
-    """source_store 相対パスから converted_store の相対パスを算出する."""
-    p = PurePosixPath(file_path)
-    ext = p.suffix.lower()
-    new_ext = _CONVERTED_EXT_MAP.get(ext)
-    if new_ext is not None:
-        return str(p.with_suffix(new_ext))
-    return file_path
 
 
 @dataclass
@@ -1154,7 +1137,7 @@ def get_document(
             )
 
     # format == "text": converted_store から読み取り
-    converted_rel = _get_converted_rel_path(file_path)
+    converted_rel = get_converted_rel_path(file_path)
     converted_path = Path(converted_store_dir) / converted_rel
 
     if not converted_path.exists():

--- a/src/rag/store/resolve.py
+++ b/src/rag/store/resolve.py
@@ -1,0 +1,56 @@
+"""ソース識別・タイトル解決の共通ユーティリティ.
+
+source_id / title の解決ロジックを一元化する。
+SourceStore と PipelineController の両方から呼び出される。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def resolve_source_id(
+    source_type: str,
+    rel_path: str,
+    metadata: dict[str, Any] | None,
+) -> str:
+    """source_id を決定する.
+
+    .meta に source_id があればそれを使用し、
+    なければ相対パスをフォールバックとして使用する。
+
+    Args:
+        source_type: 媒体種別
+        rel_path: source_store 内の相対パス
+        metadata: .meta から読み取ったメタデータ辞書
+
+    Returns:
+        解決された source_id
+    """
+    if metadata and "source_id" in metadata:
+        return str(metadata["source_id"])
+    return rel_path
+
+
+def resolve_title(
+    source_type: str,
+    rel_path: str,
+    metadata: dict[str, Any] | None,
+) -> str:
+    """タイトルを決定する.
+
+    .meta に title があればそれを使用し、
+    なければファイル名（拡張子除去）をフォールバックとして使用する。
+
+    Args:
+        source_type: 媒体種別
+        rel_path: source_store 内の相対パス
+        metadata: .meta から読み取ったメタデータ辞書
+
+    Returns:
+        解決されたタイトル
+    """
+    if metadata and "title" in metadata:
+        return str(metadata["title"])
+    return Path(rel_path).stem

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -22,6 +22,7 @@ from rag.store.models import (
     SourceType,
 )
 from rag.store.path_converter import url_to_path
+from rag.store.resolve import resolve_source_id, resolve_title
 
 logger = logging.getLogger(__name__)
 
@@ -382,13 +383,7 @@ class SourceStore:
         metadata: dict[str, Any] | None,
     ) -> str:
         """source_id を決定する."""
-        if metadata and "source_id" in metadata:
-            return str(metadata["source_id"])
-        # local 媒体: 相対パスが source_id
-        if source_type == "local":
-            return rel_path
-        # .meta がない場合のフォールバック: 相対パスを使用
-        return rel_path
+        return resolve_source_id(source_type, rel_path, metadata)
 
     @staticmethod
     def _resolve_title(
@@ -397,10 +392,7 @@ class SourceStore:
         metadata: dict[str, Any] | None,
     ) -> str:
         """タイトルを決定する."""
-        if metadata and "title" in metadata:
-            return str(metadata["title"])
-        # local 媒体: ファイル名（拡張子除去）
-        return Path(rel_path).stem
+        return resolve_title(source_type, rel_path, metadata)
 
     # --- コンテキストマネージャ ---
 

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -630,6 +630,19 @@ class TestEmbeddingAvailability:
         """clear は Embedding チェックを行わないこと（エラーにならない）."""
         indexer.clear()
 
+    def test_check_cached_after_first_success(
+        self, indexer: Indexer, tmp_path: Path,
+    ) -> None:
+        """疎通確認は初回成功後にキャッシュされ、2回目以降はスキップされること."""
+        assert indexer._embedding_checked is False
+        path = _write_text_file(tmp_path, "doc.txt", "Content for cache test.")
+        meta = _make_metadata(source_id="src-cache")
+
+        indexer.add("src-cache", path, meta)
+
+        # 初回 add 後にキャッシュされている
+        assert indexer._embedding_checked is True
+
 
 # --- テスト: IndexerProtocol 適合性 ---
 

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -566,6 +566,71 @@ class TestSourceIdValidation:
         indexer.add("src-ok", path, meta)
 
 
+# --- テスト: Embedding 疎通確認 ---
+
+
+class UnavailableEmbeddingProvider(EmbeddingProvider):
+    """疎通不可のモック Embedding プロバイダー."""
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.0] * 3 for _ in texts]
+
+    async def is_available(self) -> bool:
+        return False
+
+
+class TestEmbeddingAvailability:
+    """Embedding プロバイダー疎通確認のテスト."""
+
+    def test_add_raises_when_embedding_unavailable(
+        self, bm25_index: BM25Index, metadata_db: MetadataDB, tmp_path: Path,
+    ) -> None:
+        """add 時に Embedding プロバイダーが接続不可ならエラーになること."""
+        provider = UnavailableEmbeddingProvider()
+        collection_name = f"test_{uuid.uuid4().hex[:8]}"
+        vs = VectorStore.create_ephemeral(provider, collection_name)
+        idx = Indexer(
+            vector_store=vs,
+            bm25_index=bm25_index,
+            metadata_db=metadata_db,
+        )
+        path = _write_text_file(tmp_path, "doc.txt", "Some content.")
+        meta = _make_metadata(source_id="src-unavail")
+
+        with pytest.raises(ConnectionError, match="Embedding"):
+            idx.add("src-unavail", path, meta)
+
+    def test_update_raises_when_embedding_unavailable(
+        self, bm25_index: BM25Index, metadata_db: MetadataDB, tmp_path: Path,
+    ) -> None:
+        """update 時に Embedding プロバイダーが接続不可ならエラーになること."""
+        provider = UnavailableEmbeddingProvider()
+        collection_name = f"test_{uuid.uuid4().hex[:8]}"
+        vs = VectorStore.create_ephemeral(provider, collection_name)
+        idx = Indexer(
+            vector_store=vs,
+            bm25_index=bm25_index,
+            metadata_db=metadata_db,
+        )
+        path = _write_text_file(tmp_path, "doc.txt", "Some content.")
+        meta = _make_metadata(source_id="src-unavail-upd")
+
+        with pytest.raises(ConnectionError, match="Embedding"):
+            idx.update("src-unavail-upd", path, meta)
+
+    def test_delete_does_not_check_embedding(
+        self, indexer: Indexer,
+    ) -> None:
+        """delete は Embedding チェックを行わないこと（エラーにならない）."""
+        indexer.delete("nonexistent-source")
+
+    def test_clear_does_not_check_embedding(
+        self, indexer: Indexer,
+    ) -> None:
+        """clear は Embedding チェックを行わないこと（エラーにならない）."""
+        indexer.clear()
+
+
 # --- テスト: IndexerProtocol 適合性 ---
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -17,7 +17,7 @@ import pytest
 from rag.converter.converter import (
     ConversionSkippedError,
     Converter,
-    _get_converted_rel_path,
+    get_converted_rel_path,
 )
 from rag.converter.handlers import (
     convert_html,
@@ -496,28 +496,28 @@ class TestPassthrough:
 
 
 class TestGetConvertedRelPath:
-    """_get_converted_rel_path のテスト."""
+    """get_converted_rel_path のテスト."""
 
     def test_html_to_md(self) -> None:
-        assert _get_converted_rel_path("web/example/page.html") == "web/example/page.md"
+        assert get_converted_rel_path("web/example/page.html") == "web/example/page.md"
 
     def test_pdf_to_md(self) -> None:
-        assert _get_converted_rel_path("web/doc/report.pdf") == "web/doc/report.md"
+        assert get_converted_rel_path("web/doc/report.pdf") == "web/doc/report.md"
 
     def test_json_to_md(self) -> None:
-        assert _get_converted_rel_path("bluesky/did/post.json") == "bluesky/did/post.md"
+        assert get_converted_rel_path("bluesky/did/post.json") == "bluesky/did/post.md"
 
     def test_md_passthrough(self) -> None:
-        assert _get_converted_rel_path("local/notes/memo.md") == "local/notes/memo.md"
+        assert get_converted_rel_path("local/notes/memo.md") == "local/notes/memo.md"
 
     def test_txt_passthrough(self) -> None:
-        assert _get_converted_rel_path("local/note.txt") == "local/note.txt"
+        assert get_converted_rel_path("local/note.txt") == "local/note.txt"
 
     def test_adoc_passthrough(self) -> None:
-        assert _get_converted_rel_path("local/guide.adoc") == "local/guide.adoc"
+        assert get_converted_rel_path("local/guide.adoc") == "local/guide.adoc"
 
     def test_unknown_extension(self) -> None:
-        assert _get_converted_rel_path("local/file.xyz") == "local/file.xyz"
+        assert get_converted_rel_path("local/file.xyz") == "local/file.xyz"
 
 
 # ============================================================

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -547,6 +547,68 @@ class TestRunIndexOnly:
         assert indexer.cleared == [None]
         assert "local/a.txt" in indexer.added
 
+    def test_html_source_maps_to_md_converted(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """HTML ソースの run_index_only は .md に変換されたパスを探す."""
+        ctrl, _, indexer = controller
+        _place_web_file(
+            workspace["source"],
+            "web/example.com/page.html",
+            source_id="https://example.com/page",
+        )
+        ctrl.commit("initial")
+        ctrl.run_incremental()
+
+        indexer.added.clear()
+
+        # converted_store に .md ファイルを配置（実際の converter が作るパス）
+        converted_md = workspace["converted"] / "web" / "example.com" / "page.md"
+        converted_md.parent.mkdir(parents=True, exist_ok=True)
+        converted_md.write_text("converted content", encoding="utf-8")
+
+        summary = ctrl.run_index_only()
+
+        assert summary.processed == 1
+        assert "https://example.com/page" in indexer.added
+
+    def test_json_source_maps_to_md_converted(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """JSON ソースの run_index_only は .md に変換されたパスを探す."""
+        ctrl, _, indexer = controller
+        # Zenn JSON ソースを配置
+        full = workspace["source"] / "zenn" / "articles" / "article1.json"
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text('{"title": "test"}', encoding="utf-8")
+        meta = {
+            "source_id": "zenn/articles/article1",
+            "source_type": "zenn",
+            "title": "Test Article",
+            "collected_at": "2026-01-01T00:00:00+00:00",
+        }
+        meta_path = full.with_name(full.name + ".meta")
+        with open(meta_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(meta, f, allow_unicode=True)
+        ctrl.commit("initial")
+        ctrl.run_incremental()
+
+        indexer.added.clear()
+
+        # converted_store に .md ファイルを配置
+        converted_md = workspace["converted"] / "zenn" / "articles" / "article1.md"
+        converted_md.parent.mkdir(parents=True, exist_ok=True)
+        converted_md.write_text("converted content", encoding="utf-8")
+
+        summary = ctrl.run_index_only()
+
+        assert summary.processed == 1
+        assert "zenn/articles/article1" in indexer.added
+
     def test_skips_missing_converted(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -220,6 +220,106 @@ class TestAdd:
 
 
 @pytest.mark.asyncio()
+class TestAddExtension:
+    """add の拡張子付与テスト."""
+
+    async def test_extensionless_url_gets_html_extension(
+        self, source_store: SourceStore,
+    ) -> None:
+        """拡張子なし URL のファイルが .html 拡張子付きで配置されること."""
+        html_content = b"<html><head><title>Guide</title></head><body>guide</body></html>"
+        resp = _make_mock_response(content=html_content)
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=resp)
+
+        ingester = WebIngester(
+            source_store,
+            url_safety_check=False,
+            respect_robots_txt=False,
+        )
+        result = await ingester.add(
+            "https://example.com/docs/guide",
+            client=client,
+        )
+
+        assert result.placed == 1
+
+        # source_store 内に .html 拡張子付きでファイルが存在するか確認
+        files = source_store.list_files(source_type="web")
+        file_paths = [f.as_posix() for f in files]
+        assert any(p.endswith(".html") for p in file_paths), (
+            f"Expected .html file, got: {file_paths}"
+        )
+
+    async def test_url_with_html_extension_no_double(
+        self, source_store: SourceStore,
+    ) -> None:
+        """既に .html 拡張子がある URL では二重付加されないこと."""
+        html_content = b"<html><head><title>Page</title></head><body>page</body></html>"
+        resp = _make_mock_response(content=html_content)
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=resp)
+
+        ingester = WebIngester(
+            source_store,
+            url_safety_check=False,
+            respect_robots_txt=False,
+        )
+        result = await ingester.add(
+            "https://example.com/page.html",
+            client=client,
+        )
+
+        assert result.placed == 1
+
+        files = source_store.list_files(source_type="web")
+        file_paths = [f.as_posix() for f in files]
+        # .html.html にならないことを確認
+        assert not any(p.endswith(".html.html") for p in file_paths), (
+            f"Double .html detected: {file_paths}"
+        )
+
+
+@pytest.mark.asyncio()
+class TestCrawlExtension:
+    """crawl の拡張子付与テスト."""
+
+    async def test_crawl_extensionless_urls(
+        self, source_store: SourceStore,
+    ) -> None:
+        """crawl で拡張子なし URL のファイルが .html 拡張子付きで配置されること."""
+        index_html = b"""
+        <html><body>
+        <a href="https://example.com/docs/page1">Page 1</a>
+        </body></html>
+        """
+        page_html = b"<html><head><title>Page</title></head><body>content</body></html>"
+
+        index_resp = _make_mock_response(content=index_html)
+        page_resp = _make_mock_response(content=page_html)
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=[index_resp, page_resp])
+
+        ingester = WebIngester(
+            source_store,
+            url_safety_check=False,
+            respect_robots_txt=False,
+        )
+        result = await ingester.crawl(
+            "https://example.com/index",
+            client=client,
+        )
+
+        assert result.placed == 1
+
+        files = source_store.list_files(source_type="web")
+        file_paths = [f.as_posix() for f in files]
+        assert any(p.endswith(".html") for p in file_paths), (
+            f"Expected .html file, got: {file_paths}"
+        )
+
+
+@pytest.mark.asyncio()
 class TestCrawl:
     """crawl のテスト."""
 

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -25,6 +25,7 @@ from rag.pipeline.ingesters.web import (
     _check_ssrf,
     _extract_links,
     _extract_title,
+    _needs_html_extension,
     _validate_url,
 )
 from rag.store.source_store import SourceStore
@@ -168,6 +169,34 @@ def _make_mock_response(
     return resp
 
 
+class TestNeedsHtmlExtension:
+    """_needs_html_extension のテスト."""
+
+    def test_extensionless_url_needs_html(self) -> None:
+        """拡張子なし URL は .html が必要."""
+        assert _needs_html_extension("https://example.com/docs/guide") is True
+
+    def test_html_url_does_not_need_html(self) -> None:
+        """.html URL は .html 不要."""
+        assert _needs_html_extension("https://example.com/page.html") is False
+
+    def test_pdf_url_does_not_need_html(self) -> None:
+        """.pdf URL は .html 不要."""
+        assert _needs_html_extension("https://example.com/doc.pdf") is False
+
+    def test_json_url_does_not_need_html(self) -> None:
+        """.json URL は .html 不要."""
+        assert _needs_html_extension("https://example.com/data.json") is False
+
+    def test_unknown_extension_needs_html(self) -> None:
+        """未知の拡張子は .html が必要."""
+        assert _needs_html_extension("https://example.com/file.xyz") is True
+
+    def test_trailing_slash_needs_html(self) -> None:
+        """末尾スラッシュは .html が必要."""
+        assert _needs_html_extension("https://example.com/docs/") is True
+
+
 @pytest.mark.asyncio()
 class TestAdd:
     """add のテスト."""
@@ -277,6 +306,38 @@ class TestAddExtension:
         # .html.html にならないことを確認
         assert not any(p.endswith(".html.html") for p in file_paths), (
             f"Double .html detected: {file_paths}"
+        )
+
+
+    async def test_pdf_url_no_html_extension(
+        self, source_store: SourceStore,
+    ) -> None:
+        """PDF URL には .html が付かず .pdf のまま配置されること."""
+        pdf_content = b"%PDF-1.4 fake pdf"
+        resp = _make_mock_response(content=pdf_content)
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=resp)
+
+        ingester = WebIngester(
+            source_store,
+            url_safety_check=False,
+            respect_robots_txt=False,
+        )
+        result = await ingester.add(
+            "https://example.com/report.pdf",
+            client=client,
+        )
+
+        assert result.placed == 1
+
+        files = source_store.list_files(source_type="web")
+        file_paths = [f.as_posix() for f in files]
+        # .pdf.html にならないことを確認
+        assert not any(p.endswith(".pdf.html") for p in file_paths), (
+            f"Unexpected .pdf.html: {file_paths}"
+        )
+        assert any(p.endswith(".pdf") for p in file_paths), (
+            f"Expected .pdf file, got: {file_paths}"
         )
 
 


### PR DESCRIPTION
## Change type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Summary

- `run_index_only` の converted パス拡張子未変換を修正（source_store の `.html`/`.json` パスを converter の拡張子マッピングで `.md` に変換）
- WebIngester の `add`/`crawl` で拡張子なし URL に `extension=".html"` を付与（converter が未対応拡張子としてスキップする問題を修正）
- 拡張子マッピング関数 `get_converted_rel_path` を converter パッケージから公開し、`rag_knowledge.py` の重複定義を削除
- `resolve_source_id`/`resolve_title` を `rag.store.resolve` モジュールに一元化し、SourceStore と PipelineController の重複ロジックを解消
- Indexer の `add`/`update` 前に Embedding プロバイダー疎通確認（`is_available()`）を追加（仕様 indexer.md の安全制約: ハードリミット）
- テスト9件追加（全1030件通過）

## Test plan

- [x] `run_index_only`: `.html`/`.json` ソースでのインデックス再構築テスト追加
- [x] WebIngester: 拡張子なし URL テスト・二重付加防止テスト・crawl 拡張子付与テスト追加
- [x] Indexer: `is_available() = False` 時の `ConnectionError` テスト追加
- [x] 全1030テスト通過、ruff/mypy クリーン

## Related issues

Closes #286