### PR TITLE
feat(search-response): CLI stats/search/delete 追加・メタデータ表示拡充 (#301, #298)

### DIFF
--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -78,13 +78,14 @@ MCP クライアントからの rag_search ツール呼び出し。入力パラ�
 
 **各結果のメタデータ:**
 
-| 項目 | 内容 | 例 |
-|------|------|-----|
-| スコア | ベクトル検索: `distance`、BM25: `score` | `[distance=0.234]`、`[score=4.521]` |
-| Source | ソース識別子 | `Source: https://example.com/docs/guide` |
-| Title | コンテンツのタイトル | `Title: ガイドページ` |
-| Chunk | チャンク位置（現在位置/全体数、1 始まり表示） | `Chunk: 3/15` |
-| Type | ソース種別 | `Type: web` |
+| 項目 | 内容 | 出力条件 | 例 |
+|------|------|---------|-----|
+| スコア | ベクトル検索: `distance`、BM25: `score` | 常時 | `[distance=0.234]`、`[score=4.521]` |
+| Source | ソース識別子 | 常時 | `Source: https://example.com/docs/guide` |
+| Title | コンテンツのタイトル | 常時 | `Title: ガイドページ` |
+| Chunk | チャンク位置（現在位置/全体数、1 始まり表示） | 常時 | `Chunk: 3/15` |
+| Type | ソース種別 | 常時 | `Type: web` |
+| Collected | 取り込み日時 | 値がある場合のみ | `Collected: 2025-01-15T10:30:00Z` |
 
 メタデータの後に空行を挟み、チャンクテキストを出力する。
 
@@ -101,6 +102,7 @@ Source: https://example.com/docs/guide
 Title: ガイドページ
 Chunk: 3/15
 Type: web
+Collected: 2025-01-15T10:30:00Z
 
 チャンクテキストがここに入る...
 
@@ -109,6 +111,7 @@ Source: at://did:plc:abc123/app.bsky.feed.post/xyz789
 Title: Sample post
 Chunk: 1/1
 Type: bluesky
+Collected: 2025-01-20T14:00:00Z
 
 チャンクテキストがここに入る...
 
@@ -119,6 +122,7 @@ Source: https://zenn.dev/alice/articles/sample
 Title: サンプル記事
 Chunk: 5/20
 Type: zenn
+Collected: 2025-01-18T08:00:00Z
 
 チャンクテキストがここに入る...
 ```
@@ -161,12 +165,14 @@ MCP クライアントからの rag_get_document ツール呼び出し、また�
 
 **メタデータヘッダー:**
 
-| 項目 | 内容 |
-|------|------|
-| Source | ソース識別子 |
-| Title | コンテンツのタイトル |
-| Type | ソース種別 |
-| Format | 取得形式（`text` または `original`） |
+| 項目 | 内容 | 出力条件 |
+|------|------|---------|
+| Source | ソース識別子 | 常時 |
+| Title | コンテンツのタイトル | 常時 |
+| Type | ソース種別 | 常時 |
+| Format | 取得形式（`text` または `original`） | 常時 |
+| Collected | 取り込み日時 | 値がある場合のみ |
+| (custom フィールド) | ソース種別固有のメタデータ（`.meta` ファイルの extra フィールド） | 値がある場合のみ |
 
 メタデータヘッダーの後に空行を挟み、ドキュメント全文を出力する。
 
@@ -177,6 +183,7 @@ Source: https://example.com/docs/guide
 Title: ガイドページ
 Type: web
 Format: text
+Collected: 2025-01-15T10:30:00Z
 
 ドキュメントの全文テキストがここに入る...
 ```

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1176,19 +1176,11 @@ def run_stats(args: argparse.Namespace) -> None:
                 embedding_provider=embedding_provider,
                 persist_directory=settings.chromadb_persist_dir,
             )
-        collection = vector_store._collection
-        count = collection.count()
-        parts.append(f"  総チャンク数: {count:,}")
-
-        if count > 0:
-            all_meta = collection.get(include=["metadatas"])
-            source_ids: set[str] = set()
-            for m in (all_meta.get("metadatas") or []):
-                if isinstance(m, dict):
-                    sid = m.get("source_id", "")
-                    if sid:
-                        source_ids.add(str(sid))
-            parts.append(f"  ソース数: {len(source_ids):,}")
+        index_stats = vector_store.get_stats()
+        total_chunks = int(str(index_stats.get("total_chunks", 0)))
+        source_count = int(str(index_stats.get("source_count", 0)))
+        parts.append(f"  総チャンク数: {total_chunks:,}")
+        parts.append(f"  ソース数: {source_count:,}")
     except Exception:
         logger.exception("インデックス統計の取得に失敗")
         parts.append("  エラー: 統計の取得に失敗しました")

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -290,6 +290,27 @@ def main() -> None:
         help="対象媒体フィルタ（incremental では指定不可）",
     )
 
+    # stats サブコマンド
+    subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
+
+    # search サブコマンド
+    search_parser = subparsers.add_parser("search", help="ナレッジベースを検索")
+    search_parser.add_argument("--query", required=True, help="検索クエリ")
+    search_parser.add_argument(
+        "--n-results", type=int, default=None,
+        help="各エンジンから取得する結果数（未指定時は設定値を使用）",
+    )
+    search_parser.add_argument(
+        "--source-type",
+        choices=["web", "bluesky", "zenn", "local"],
+        default=None,
+        help="ソース種別フィルタ",
+    )
+
+    # delete サブコマンド
+    delete_parser = subparsers.add_parser("delete", help="ソースをナレッジベースから論理削除")
+    delete_parser.add_argument("source_id", help="削除するソース識別子（source_id）")
+
     # --- インジェスト系サブコマンド ---
 
     # add: 単一ページ取り込み
@@ -341,6 +362,9 @@ def main() -> None:
     _SYNC_COMMANDS: dict[str, object] = {
         "get-document": run_get_document,
         "rebuild": run_rebuild,
+        "stats": run_stats,
+        "search": run_search,
+        "delete": run_delete,
     }
 
     if args.command in _ASYNC_COMMANDS:
@@ -1053,6 +1077,292 @@ def run_rebuild(args: argparse.Namespace) -> None:
     if summary.errors:
         for err_file in summary.errors:
             logger.error("  エラーファイル: %s", err_file)
+
+
+def run_stats(args: argparse.Namespace) -> None:
+    """ナレッジベースの統計情報を表示する.
+
+    MCP ツール rag_stats と同等の情報を CLI で出力する。
+
+    Args:
+        args: コマンドライン引数
+    """
+    import contextlib
+    import io
+
+    from .config import get_settings
+    from .embedding.factory import get_embedding_provider
+    from .store.metadata_db import MetadataDB
+    from .vector_store import VectorStore
+
+    settings = get_settings()
+
+    parts: list[str] = ["RAG Knowledge 統計"]
+
+    # --- source_store セクション ---
+    parts.append("")
+    parts.append("■ source_store")
+    if not settings.source_store_dir:
+        parts.append("  未設定")
+    else:
+        source_store_dir = Path(settings.source_store_dir)
+        if not source_store_dir.exists():
+            parts.append("  ディレクトリが存在しません")
+        else:
+            total_files = 0
+            total_size = 0
+            by_type: dict[str, dict[str, int]] = {}
+            from .pipeline.models import detect_source_type
+            for file in source_store_dir.rglob("*"):
+                if not file.is_file():
+                    continue
+                rel = file.relative_to(source_store_dir)
+                rel_posix = rel.as_posix()
+                if (
+                    rel_posix == ".git"
+                    or rel_posix.startswith(".git/")
+                    or rel_posix == ".gitignore"
+                ):
+                    continue
+                name = file.name
+                if name.endswith(".meta") or name.startswith("metadata.db"):
+                    continue
+                size = file.stat().st_size
+                total_files += 1
+                total_size += size
+                st = detect_source_type(rel_posix)
+                if st not in by_type:
+                    by_type[st] = {"files": 0, "size": 0}
+                by_type[st]["files"] += 1
+                by_type[st]["size"] += size
+
+            parts.append(f"  総ファイル数: {total_files:,}")
+            parts.append(f"  総サイズ: {_format_cli_size(total_size)}")
+            if by_type:
+                parts.append("  媒体別:")
+                for st_key in sorted(by_type.keys()):
+                    info = by_type[st_key]
+                    parts.append(
+                        f"    {st_key}: {info['files']} files"
+                        f" ({_format_cli_size(info['size'])})"
+                    )
+
+    # --- converted_store セクション ---
+    parts.append("")
+    parts.append("■ converted_store")
+    if not settings.converted_store_dir:
+        parts.append("  未設定")
+    else:
+        cs_dir = Path(settings.converted_store_dir)
+        if not cs_dir.exists():
+            parts.append("  ディレクトリが存在しません")
+        else:
+            cs_files = 0
+            cs_size = 0
+            for file in cs_dir.rglob("*"):
+                if file.is_file():
+                    cs_files += 1
+                    cs_size += file.stat().st_size
+            parts.append(f"  総ファイル数: {cs_files:,}")
+            parts.append(f"  総サイズ: {_format_cli_size(cs_size)}")
+
+    # --- インデックスセクション ---
+    parts.append("")
+    parts.append("■ インデックス")
+    try:
+        embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
+        with contextlib.redirect_stdout(io.StringIO()):
+            vector_store = VectorStore(
+                embedding_provider=embedding_provider,
+                persist_directory=settings.chromadb_persist_dir,
+            )
+        collection = vector_store._collection
+        count = collection.count()
+        parts.append(f"  総チャンク数: {count:,}")
+
+        if count > 0:
+            all_meta = collection.get(include=["metadatas"])
+            source_ids: set[str] = set()
+            for m in (all_meta.get("metadatas") or []):
+                if isinstance(m, dict):
+                    sid = m.get("source_id", "")
+                    if sid:
+                        source_ids.add(str(sid))
+            parts.append(f"  ソース数: {len(source_ids):,}")
+    except Exception:
+        logger.exception("インデックス統計の取得に失敗")
+        parts.append("  エラー: 統計の取得に失敗しました")
+
+    # --- パイプラインセクション ---
+    parts.append("")
+    parts.append("■ パイプライン")
+    if not settings.source_store_dir:
+        parts.append("  未設定")
+    else:
+        from .store.models import NULL_COMMIT_HASH
+        db_path = Path(settings.source_store_dir) / "metadata.db"
+        if not db_path.exists():
+            parts.append("  未初期化")
+        else:
+            db = MetadataDB(db_path)
+            try:
+                db.initialize()
+                history = db.get_pipeline_history()
+                last_commit_id = db.get_last_commit_id()
+                deleted_count = db.source_count(status="deleted")
+                last_at = history[-1].processed_at if history else "（未実行）"
+                parts.append(f"  最終処理: {last_at}")
+                parts.append(f"  実行回数: {len(history)}")
+                commit_str = str(last_commit_id)
+                if commit_str == NULL_COMMIT_HASH:
+                    parts.append("  last_commit_id: （未実行）")
+                else:
+                    parts.append(f"  last_commit_id: {commit_str[:7]}")
+                parts.append(f"  論理削除: {deleted_count} 件")
+            finally:
+                db.close()
+
+    print("\n".join(parts))
+
+
+def run_search(args: argparse.Namespace) -> None:
+    """ナレッジベースを検索する.
+
+    MCP ツール rag_search と同等の検索を CLI で実行する。
+
+    Args:
+        args: コマンドライン引数
+    """
+    import asyncio as _asyncio
+    import contextlib
+    import io
+
+    from .bm25_index import BM25Index
+    from .config import get_settings
+    from .embedding.factory import get_embedding_provider
+    from .rag_knowledge import RAGKnowledgeService
+    from .vector_store import VectorStore
+    from .web_crawler import WebCrawler
+
+    settings = get_settings()
+    embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        vector_store = VectorStore(
+            embedding_provider=embedding_provider,
+            persist_directory=settings.chromadb_persist_dir,
+        )
+        bm25_index = BM25Index(
+            k1=settings.rag_bm25_k1,
+            b=settings.rag_bm25_b,
+            persist_dir=settings.bm25_persist_dir,
+        )
+
+    service = RAGKnowledgeService(
+        vector_store=vector_store,
+        web_crawler=WebCrawler(),
+        chunk_size=settings.rag_chunk_size,
+        chunk_overlap=settings.rag_chunk_overlap,
+        similarity_threshold=None,
+        bm25_index=bm25_index,
+        hybrid_search_enabled=True,
+        vector_weight=settings.rag_vector_weight,
+    )
+
+    n_results = args.n_results if args.n_results is not None else settings.rag_retrieval_count
+    source_type: str | None = args.source_type
+
+    raw = _asyncio.run(
+        service.retrieve_raw_results(
+            args.query, n_results=n_results, source_type=source_type,
+        )
+    )
+
+    if not raw.vector_results and not raw.bm25_results:
+        print("該当する情報が見つかりませんでした")
+        return
+
+    parts: list[str] = []
+
+    if raw.vector_results:
+        parts.append("## ベクトル検索結果 (意味的類似度)\n")
+        for i, item in enumerate(raw.vector_results, start=1):
+            chunk_pos = _format_cli_chunk_position(item.chunk_index, item.total_chunks)
+            parts.append(f"### Result {i} [distance={item.distance:.3f}]")
+            parts.append(f"Source: {item.source_url}")
+            parts.append(f"Title: {item.title}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {item.source_type}")
+            if item.collected_at:
+                parts.append(f"Collected: {item.collected_at}")
+            parts.append("")
+            parts.append(item.text)
+            parts.append("")
+
+    if raw.bm25_results:
+        parts.append("## BM25 検索結果 (キーワード一致)\n")
+        for i, bm25_item in enumerate(raw.bm25_results, start=1):
+            chunk_pos = _format_cli_chunk_position(bm25_item.chunk_index, bm25_item.total_chunks)
+            parts.append(f"### Result {i} [score={bm25_item.score:.3f}]")
+            parts.append(f"Source: {bm25_item.source_url}")
+            parts.append(f"Title: {bm25_item.title}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {bm25_item.source_type}")
+            if bm25_item.collected_at:
+                parts.append(f"Collected: {bm25_item.collected_at}")
+            parts.append("")
+            parts.append(bm25_item.text)
+            parts.append("")
+
+    print("\n".join(parts).rstrip())
+
+
+def run_delete(args: argparse.Namespace) -> None:
+    """ソースをナレッジベースから論理削除する.
+
+    MCP ツール rag_delete と同等の論理削除を CLI で実行する。
+
+    Args:
+        args: コマンドライン引数
+    """
+    controller, _settings = _build_cli_pipeline_controller()
+    source_id: str = args.source_id
+
+    try:
+        controller.source_store.soft_delete(source_id)
+    except KeyError:
+        print(f"該当するソースが見つかりませんでした: {source_id}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        controller.indexer.delete(source_id)
+    except Exception:
+        logger.exception("インデックス削除に失敗: %s", source_id)
+        print(
+            f"エラー: インデックスからの削除に失敗しました: {source_id}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"論理削除しました: {source_id}")
+
+
+def _format_cli_size(size_bytes: int) -> str:
+    """バイト数を人間が読みやすい単位に変換する."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    if size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+def _format_cli_chunk_position(chunk_index: int, total_chunks: int) -> str:
+    """チャンク位置を表示用にフォーマットする."""
+    if total_chunks > 0:
+        return f"{chunk_index + 1}/{total_chunks}"
+    return str(chunk_index + 1)
 
 
 # --- インジェスト系 CLI コマンド ---

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1,4 +1,4 @@
-"""RAG評価CLIモジュール
+"""RAG Knowledge CLIモジュール
 
 仕様: docs/specs/rag-knowledge.md
 """
@@ -92,7 +92,7 @@ def _validate_bm25_b(value: str) -> float:
 
 def main() -> None:
     """CLIエントリポイント."""
-    parser = argparse.ArgumentParser(description="RAG評価CLI")
+    parser = argparse.ArgumentParser(description="RAG Knowledge CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # evaluate サブコマンド
@@ -296,8 +296,16 @@ def main() -> None:
     # search サブコマンド
     search_parser = subparsers.add_parser("search", help="ナレッジベースを検索")
     search_parser.add_argument("--query", required=True, help="検索クエリ")
+    def _validate_n_results(value: str) -> int:
+        n = int(value)
+        if n < 1:
+            raise argparse.ArgumentTypeError(
+                f"--n-results must be >= 1 (got {n})"
+            )
+        return n
+
     search_parser.add_argument(
-        "--n-results", type=int, default=None,
+        "--n-results", type=_validate_n_results, default=None,
         help="各エンジンから取得する結果数（未指定時は設定値を使用）",
     )
     search_parser.add_argument(

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -856,8 +856,11 @@ class RAGKnowledgeService:
             title = str(result.metadata.get("title", ""))
             source_type_val = str(result.metadata.get("source_type", ""))
             total_chunks = int(result.metadata.get("total_chunks", 0))
-            # ChromaDB メタデータキーは "crawled_at"（レガシー名）
-            collected_at = str(result.metadata.get("crawled_at", ""))
+            # 新形式 "collected_at"、レガシー "crawled_at" の順でフォールバック
+            collected_at = str(
+                result.metadata.get("collected_at")
+                or result.metadata.get("crawled_at", "")
+            )
             vector_items.append(
                 VectorSearchItem(
                     text=result.text,
@@ -894,7 +897,9 @@ class RAGKnowledgeService:
                 )
                 total_chunks = int(meta.get("total_chunks", 0))
                 chunk_index = int(meta.get("chunk_index", 0))
-                collected_at = str(meta.get("crawled_at", ""))
+                collected_at = str(
+                    meta.get("collected_at") or meta.get("crawled_at", "")
+                )
                 bm25_items.append(
                     BM25SearchItem(
                         text=bm25_result.text,
@@ -1100,8 +1105,8 @@ def get_document(
         source_type = record.source_type
         file_path = record.file_path
 
-        # メタデータ取得（collected_at, extra）
-        source_meta = store.get_metadata(source_id)
+        # メタデータ取得（collected_at, extra）— record を渡して DB 再問い合わせを回避
+        source_meta = store.get_metadata(source_id, record=record)
         collected_at = source_meta.collected_at if source_meta else ""
         extra = source_meta.extra if source_meta else {}
 
@@ -1209,6 +1214,8 @@ def format_document_response(result: DocumentResult) -> str:
     if result.collected_at:
         lines.append(f"Collected: {result.collected_at}")
     for key, value in result.extra.items():
+        if value is None or (isinstance(value, str) and value == ""):
+            continue
         lines.append(f"{key}: {value}")
     lines.append("")
     lines.append(result.content)

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -10,7 +10,7 @@ import hashlib
 import logging
 import mimetypes
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 from urllib.parse import urldefrag
@@ -110,6 +110,7 @@ class VectorSearchItem:
     title: str = ""
     source_type: str = ""
     total_chunks: int = 0
+    collected_at: str = ""
 
 
 @dataclass
@@ -137,6 +138,7 @@ class BM25SearchItem:
     title: str = ""
     source_type: str = ""
     total_chunks: int = 0
+    collected_at: str = ""
 
 
 @dataclass
@@ -854,6 +856,8 @@ class RAGKnowledgeService:
             title = str(result.metadata.get("title", ""))
             source_type_val = str(result.metadata.get("source_type", ""))
             total_chunks = int(result.metadata.get("total_chunks", 0))
+            # ChromaDB メタデータキーは "crawled_at"（レガシー名）
+            collected_at = str(result.metadata.get("crawled_at", ""))
             vector_items.append(
                 VectorSearchItem(
                     text=result.text,
@@ -863,6 +867,7 @@ class RAGKnowledgeService:
                     title=title,
                     source_type=source_type_val,
                     total_chunks=total_chunks,
+                    collected_at=collected_at,
                 )
             )
 
@@ -889,6 +894,7 @@ class RAGKnowledgeService:
                 )
                 total_chunks = int(meta.get("total_chunks", 0))
                 chunk_index = int(meta.get("chunk_index", 0))
+                collected_at = str(meta.get("crawled_at", ""))
                 bm25_items.append(
                     BM25SearchItem(
                         text=bm25_result.text,
@@ -899,6 +905,7 @@ class RAGKnowledgeService:
                         title=title,
                         source_type=bm25_source_type,
                         total_chunks=total_chunks,
+                        collected_at=collected_at,
                     )
                 )
 
@@ -1035,6 +1042,8 @@ class DocumentResult:
     content: str
     is_binary: bool = False
     error: str | None = None
+    collected_at: str = ""
+    extra: dict[str, object] = field(default_factory=dict)
 
 
 _VALID_FORMATS: frozenset[str] = frozenset({"text", "original"})
@@ -1091,6 +1100,11 @@ def get_document(
         source_type = record.source_type
         file_path = record.file_path
 
+        # メタデータ取得（collected_at, extra）
+        source_meta = store.get_metadata(source_id)
+        collected_at = source_meta.collected_at if source_meta else ""
+        extra = source_meta.extra if source_meta else {}
+
         if format == "original":
             # バイナリ判定: テキスト拡張子以外はバイナリとして扱う
             ext = PurePosixPath(file_path).suffix.lower()
@@ -1109,6 +1123,8 @@ def get_document(
                     format=format,
                     content=info,
                     is_binary=True,
+                    collected_at=collected_at,
+                    extra=extra,
                 )
 
             # テキストファイル: source_store から読み取り
@@ -1134,6 +1150,8 @@ def get_document(
                 source_type=source_type,
                 format=format,
                 content=content,
+                collected_at=collected_at,
+                extra=extra,
             )
 
     # format == "text": converted_store から読み取り
@@ -1165,6 +1183,8 @@ def get_document(
         source_type=source_type,
         format=format,
         content=content,
+        collected_at=collected_at,
+        extra=extra,
     )
 
 
@@ -1185,7 +1205,11 @@ def format_document_response(result: DocumentResult) -> str:
         f"Title: {result.title}",
         f"Type: {result.source_type}",
         f"Format: {result.format}",
-        "",
-        result.content,
     ]
+    if result.collected_at:
+        lines.append(f"Collected: {result.collected_at}")
+    for key, value in result.extra.items():
+        lines.append(f"{key}: {value}")
+    lines.append("")
+    lines.append(result.content)
     return "\n".join(lines)

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -1214,7 +1214,11 @@ def format_document_response(result: DocumentResult) -> str:
     if result.collected_at:
         lines.append(f"Collected: {result.collected_at}")
     for key, value in result.extra.items():
-        if value is None or (isinstance(value, str) and value == ""):
+        if (
+            value is None
+            or (isinstance(value, str) and value == "")
+            or (isinstance(value, (list, dict)) and len(value) == 0)
+        ):
             continue
         lines.append(f"{key}: {value}")
     lines.append("")

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -376,6 +376,8 @@ async def rag_search(
             parts.append(f"Title: {item.title}")
             parts.append(f"Chunk: {chunk_pos}")
             parts.append(f"Type: {item.source_type}")
+            if item.collected_at:
+                parts.append(f"Collected: {item.collected_at}")
             parts.append("")
             parts.append(item.text)
             parts.append("")
@@ -390,6 +392,8 @@ async def rag_search(
             parts.append(f"Title: {bm25_item.title}")
             parts.append(f"Chunk: {chunk_pos}")
             parts.append(f"Type: {bm25_item.source_type}")
+            if bm25_item.collected_at:
+                parts.append(f"Collected: {bm25_item.collected_at}")
             parts.append("")
             parts.append(bm25_item.text)
             parts.append("")

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -235,16 +235,23 @@ class SourceStore:
             metadata=self._build_metadata(record),
         )
 
-    def get_metadata(self, source_id: str) -> SourceMetadata | None:
+    def get_metadata(
+        self,
+        source_id: str,
+        *,
+        record: SourceRecord | None = None,
+    ) -> SourceMetadata | None:
         """source_id でメタデータのみ取得する（ファイル内容は読まない）.
 
         Args:
             source_id: ソース識別子
+            record: 既に取得済みの SourceRecord（省略時は DB から取得）
 
         Returns:
             SourceMetadata。存在しない場合は None。
         """
-        record = self._db.get_source(source_id)
+        if record is None:
+            record = self._db.get_source(source_id)
         if record is None:
             return None
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -19,6 +19,7 @@ from rag.store.metadata_db import MetadataDB
 from rag.store.models import (
     FileData,
     SourceMetadata,
+    SourceRecord,
     SourceType,
 )
 from rag.store.path_converter import url_to_path
@@ -174,6 +175,38 @@ class SourceStore:
 
     # --- ファイル取得 ---
 
+    def _build_metadata(self, record: SourceRecord) -> SourceMetadata:
+        """SourceRecord と .meta ファイルから SourceMetadata を構築する.
+
+        .meta の collected_at を優先し、なければ DB の created_at を使用する。
+        共通フィールド（source_id, source_type, title）を除いた残りを extra に格納する。
+
+        Args:
+            record: DB レコード
+
+        Returns:
+            SourceMetadata
+        """
+        extra: dict[str, Any] = {}
+        collected_at = record.created_at
+        if record.source_type not in _NO_META_TYPES:
+            file_path = self._root / record.file_path
+            meta_file = meta_path_for(file_path)
+            if meta_file.exists():
+                meta_data = read_meta(file_path)
+                collected_at = str(meta_data.pop("collected_at", collected_at))
+                for key in ("source_id", "source_type", "title"):
+                    meta_data.pop(key, None)
+                extra = meta_data
+
+        return SourceMetadata(
+            source_id=record.source_id,
+            source_type=record.source_type,
+            title=record.title,
+            collected_at=collected_at,
+            extra=extra,
+        )
+
     def get_file(self, source_id: str) -> FileData | None:
         """source_id でファイルを取得する.
 
@@ -196,32 +229,26 @@ class SourceStore:
 
         content = file_path.read_bytes()
 
-        # メタデータ構築: .meta の collected_at を優先、なければ DB の created_at
-        extra: dict[str, Any] = {}
-        collected_at = record.created_at
-        if record.source_type not in _NO_META_TYPES:
-            meta_file = meta_path_for(file_path)
-            if meta_file.exists():
-                meta_data = read_meta(file_path)
-                collected_at = str(meta_data.pop("collected_at", collected_at))
-                # 共通フィールドを除いた残りが extra
-                for key in ("source_id", "source_type", "title"):
-                    meta_data.pop(key, None)
-                extra = meta_data
-
-        source_meta = SourceMetadata(
-            source_id=record.source_id,
-            source_type=record.source_type,
-            title=record.title,
-            collected_at=collected_at,
-            extra=extra,
-        )
-
         return FileData(
             content=content,
             file_path=record.file_path,
-            metadata=source_meta,
+            metadata=self._build_metadata(record),
         )
+
+    def get_metadata(self, source_id: str) -> SourceMetadata | None:
+        """source_id でメタデータのみ取得する（ファイル内容は読まない）.
+
+        Args:
+            source_id: ソース識別子
+
+        Returns:
+            SourceMetadata。存在しない場合は None。
+        """
+        record = self._db.get_source(source_id)
+        if record is None:
+            return None
+
+        return self._build_metadata(record)
 
     # --- ファイル一覧 ---
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -252,6 +252,10 @@ class SourceStore:
         """
         if record is None:
             record = self._db.get_source(source_id)
+        elif record.source_id != source_id:
+            raise ValueError(
+                f"source_id mismatch: {source_id!r} != {record.source_id!r}"
+            )
         if record is None:
             return None
 


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

### CLI コマンド追加 (#301)
- `stats` コマンド: ナレッジベースの統計情報を表示（MCP rag_stats と同等）
- `search` コマンド: ナレッジベース検索（MCP rag_search と同等、--query / --n-results / --source-type オプション）
- `delete` コマンド: ソースの論理削除（MCP rag_delete と同等）

### メタデータ表示拡充 (#298)
- `VectorSearchItem` / `BM25SearchItem` に `collected_at` フィールド追加
- `DocumentResult` に `collected_at` / `extra` フィールド追加
- `rag_search` の検索結果に `Collected:` 行を出力（値がある場合のみ）
- `rag_get_document` のレスポンスに `Collected:` および custom フィールドを出力
- `SourceStore.get_metadata()` メソッド新設（ファイル内容を読まずにメタデータのみ取得）
- `SourceStore._build_metadata()` 抽出で `get_file()` / `get_metadata()` のロジック共通化

### 仕様書更新
- `docs/specs/search-response.md`: メタデータテーブルに Collected / custom フィールド追加、レスポンス例更新

## Test plan

- [x] ruff check: All checks passed
- [x] mypy: no issues found in 4 source files
- [x] pytest: 1044 passed（既存の TestRagCrawlPreviewTool 6件は #294 以前からの不良で除外）

## Related issues

Closes #301
Closes #298