### PR TITLE
fix(pipeline-controller): delete時に物理削除+git経由でパイプライン処理し、re-addでインデックス復帰 (#299)

### DIFF
--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -47,9 +47,9 @@
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
 | 差分更新 | なし（自動検知） | 処理結果サマリ | `last_commit_id` と HEAD の差分を検知し、変更ファイルのみをパイプライン処理する。通常運用のデフォルト操作 |
-| 全再構築 | source_type フィルタ（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用 |
-| コンバートのみ再実行 | source_type フィルタ（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する |
-| インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用 |
+| 全再構築 | source_type フィルタ（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合はエラーとする（git とディスクの不整合を防止） |
+| コンバートのみ再実行 | source_type フィルタ（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合はエラーとする |
+| インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラーとする |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
 
 ### git 操作
@@ -115,6 +115,8 @@ flowchart TD
 ```mermaid
 flowchart TD
     START["全再構築開始"]
+    CHECK_DIRTY{"未コミットの変更あり?"}
+    ERROR_DIRTY["エラー: rebuild 拒否"]
     CLEAR_CONV["converted_store をクリア"]
     CLEAR_IDX["ChromaDB + BM25 をクリア"]
     SCAN["source_store 全ファイルをスキャン"]
@@ -126,7 +128,9 @@ flowchart TD
 
     REBUILD_DB["metadata.db 再構築（source_store スキャン）"]
 
-    START --> REBUILD_DB
+    START --> CHECK_DIRTY
+    CHECK_DIRTY -- Yes --> ERROR_DIRTY
+    CHECK_DIRTY -- No --> REBUILD_DB
     REBUILD_DB --> CLEAR_CONV
     CLEAR_CONV --> CLEAR_IDX
     CLEAR_IDX --> SCAN
@@ -201,6 +205,7 @@ sequenceDiagram
 | source_store の git リポジトリが未初期化 | パイプライン初回実行時に `git init` を自動実行する |
 | .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータを更新する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |
 | metadata.db の `status` が `deleted` のファイルが git diff に含まれる場合 | ファイルの変更種別に応じた処理を行う。`deleted` ステータスのファイルはインデックスに追加しない |
+| 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | エラーとして再構築を拒否する。git とディスクの不整合状態で再構築すると、pipeline_history と実際のファイル状態が乖離する |
 
 ### 設定項目
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -81,7 +81,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
 | 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。パイプライン制御の内部処理で使用 |
 | 論理削除解除 | source_id | なし | metadata.db のステータスを `active` に戻す |
-| ファイル取得 | source_id | ファイルデータ + メタデータ | source_id に対応するファイルと .meta を返す。物理削除済みの場合はエラーを返す（復元が必要な場合は source_store の git リポジトリから `git checkout` で復元する） |
+| ファイル取得 | source_id | ファイルデータ + メタデータ / `None` | source_id に対応するファイルと .meta を返す。物理削除済み（ファイル欠落）の場合は警告ログを出力して `None` を返す（復元が必要な場合は source_store の git リポジトリから `git checkout` で復元する） |
 
 ### metadata.db 操作
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -13,7 +13,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 - metadata.db によるメタデータの索引
 - source_id の決定規則
 - URL とファイルパスの双方向変換
-- 論理削除
+- 削除（物理削除 + 論理削除）
 
 スコープ外:
 
@@ -31,9 +31,9 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 
 ### データ保全
 
-- **オリジナルデータの物理削除機能は一切実装しない**。設定パス誤りによるシステムファイル削除リスクを排除する
 - オリジナルデータは無加工で保存する。メタデータの埋め込み等の加工を行わない
-- 参照させたくないデータは論理削除（metadata.db のステータス変更）で対応する
+- source_store は git 管理下にあるため、物理削除されたファイルも `git checkout` で復旧可能。この復旧可能性を前提に、物理削除を許容する
+- 物理削除は source_store の git リポジトリ内でのみ行う。`remove_file` は metadata.db から取得した `file_path` を使い、source_store ルートからの相対パスで操作する
 
 ### git 管理
 
@@ -78,9 +78,10 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | .meta 読み取り | ファイルパス | メタデータ辞書 | 指定ファイルの .meta サイドカーを YAML として読み取る |
 | .meta 書き込み | ファイルパス、メタデータ辞書 | なし | 指定ファイルの .meta サイドカーを YAML として書き込む |
 | ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを列挙する。source_type 指定時はそのディレクトリのみ。`.meta`、`metadata.db`、`.git/`、`.gitignore` は除外する |
-| 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。ファイル自体は削除しない |
+| ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
+| 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。パイプライン制御の内部処理で使用 |
 | 論理削除解除 | source_id | なし | metadata.db のステータスを `active` に戻す |
-| ファイル取得 | source_id | ファイルデータ + メタデータ | source_id に対応するファイルと .meta を返す。論理削除済みのファイルも取得可能（全文取得ツール等で使用） |
+| ファイル取得 | source_id | ファイルデータ + メタデータ | source_id に対応するファイルと .meta を返す。物理削除済みの場合はエラーを返す（復元が必要な場合は source_store の git リポジトリから `git checkout` で復元する） |
 
 ### metadata.db 操作
 
@@ -377,7 +378,8 @@ source_store 内の全ファイルのメタデータ索引。
 | URL にクエリパラメータが含まれる場合 | クエリパラメータも含めてパスに変換する（`?` → `？` の全角変換）。同一パスで異なるクエリの URL は異なるファイルとして扱う |
 | source_store の git リポジトリが未初期化の場合 | パイプライン制御が初回実行時に `git init` を行う |
 | 同一 source_id のファイルが既に存在する場合 | 上書きする（再取り込み時の更新動作） |
-| metadata.db の `status` が `deleted` のファイルへの再取り込み | ステータスを `active` に戻し、ファイルを上書きする |
+| 物理削除済みファイルの再取り込み | `place_file` でファイルを配置し、`ingest_and_index` を実行する。git diff が `A`（追加）として検知し、パイプラインが変換・インデックス追加・metadata.db 登録を行う |
+| metadata.db の `status` が `deleted` のファイルへの再取り込み | `place_file` が `register_source` でステータスを `active` に戻し、ファイルを上書きする |
 | URL にフラグメント（`#section`）が含まれる場合 | パス変換前にフラグメント部分を除去する。フラグメント違いの URL は同一ファイルとして扱う |
 | `LongPathsEnabled` が無効で長いパスの操作に失敗した場合 | OS エラーをそのまま伝播し、エラーログに `LongPathsEnabled` の有効化を促すメッセージを出力する |
 | パス内の全角代替文字がユーザーの手動配置で使用された場合（local 媒体） | local 媒体は URL 逆変換を行わないため影響なし。web 媒体のパス配下にユーザーが手動でファイルを配置することは想定しない |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1318,9 +1318,10 @@ def run_search(args: argparse.Namespace) -> None:
 
 
 def run_delete(args: argparse.Namespace) -> None:
-    """ソースをナレッジベースから論理削除する.
+    """ソースをナレッジベースから削除する.
 
-    MCP ツール rag_delete と同等の論理削除を CLI で実行する。
+    MCP ツール rag_delete と同等の削除を CLI で実行する。
+    ファイルを物理削除し、パイプライン経由でインデックス・metadata.db を更新する。
 
     Args:
         args: コマンドライン引数
@@ -1329,22 +1330,26 @@ def run_delete(args: argparse.Namespace) -> None:
     source_id: str = args.source_id
 
     try:
-        controller.source_store.soft_delete(source_id)
+        controller.source_store.remove_file(source_id)
     except KeyError:
         print(f"該当するソースが見つかりませんでした: {source_id}", file=sys.stderr)
         sys.exit(1)
 
     try:
-        controller.indexer.delete(source_id)
+        summary = controller.ingest_and_index(f"delete: {source_id}")
     except Exception:
-        logger.exception("インデックス削除に失敗: %s", source_id)
+        logger.exception("削除パイプライン実行に失敗: %s", source_id)
         print(
-            f"エラー: インデックスからの削除に失敗しました: {source_id}",
+            f"エラー: 削除に失敗しました: {source_id}",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print(f"論理削除しました: {source_id}")
+    if summary.errors:
+        print(f"警告: パイプラインでエラーが発生しました: {source_id}", file=sys.stderr)
+        for err in summary.errors:
+            print(f"  - {err}", file=sys.stderr)
+    print(f"削除しました: {source_id}")
 
 
 def _format_cli_size(size_bytes: int) -> str:

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -184,8 +184,12 @@ class PipelineController:
 
         converted_store とインデックスをクリアし、
         source_store 全ファイルをパイプライン処理する。
+
+        Raises:
+            RuntimeError: source_store に未コミットの変更がある場合
         """
         self._git.init_repo()
+        self._check_uncommitted_changes()
 
         # 1. metadata.db 再構築
         self._source_store.rebuild_db()
@@ -255,6 +259,19 @@ class PipelineController:
             to_commit_id=to_commit,
         )
 
+    def _check_uncommitted_changes(self) -> None:
+        """source_store に未コミットの変更がないか確認する.
+
+        Raises:
+            RuntimeError: 未コミットの変更がある場合
+        """
+        if self._git.has_commits() and self._git.has_uncommitted_changes():
+            msg = (
+                "source_store に未コミットの変更があります。"
+                "rebuild 前に変更をコミットしてください。"
+            )
+            raise RuntimeError(msg)
+
     def run_convert_only(
         self,
         source_type: SourceType | None = None,
@@ -263,7 +280,13 @@ class PipelineController:
 
         converted_store をクリアし、source_store 全ファイルを
         コンバーターで再処理する。インデクサーは実行しない。
+
+        Raises:
+            RuntimeError: source_store に未コミットの変更がある場合
         """
+        self._git.init_repo()
+        self._check_uncommitted_changes()
+
         # 1. converted_store クリア
         self._converter.clear(self._converted_store_dir, source_type)
 
@@ -320,7 +343,13 @@ class PipelineController:
 
         ChromaDB + BM25 をクリアし、
         converted_store 全ファイルからインデックスを再構築する。
+
+        Raises:
+            RuntimeError: source_store に未コミットの変更がある場合
         """
+        self._git.init_repo()
+        self._check_uncommitted_changes()
+
         # 1. インデックスクリア
         self._indexer.clear(source_type)
 

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -70,8 +70,7 @@ class GitOperations:
         return result.stdout.strip()
 
     def has_uncommitted_changes(self) -> bool:
-        """未コミットの変更があるか確認する."""
-        self._run(["git", "add", "-A"])
+        """未コミットの変更があるか確認する（副作用なし）."""
         result = self._run(["git", "status", "--porcelain"])
         return bool(result.stdout.strip())
 

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -69,6 +69,12 @@ class GitOperations:
         result = self._run(["git", "rev-parse", "HEAD"])
         return result.stdout.strip()
 
+    def has_uncommitted_changes(self) -> bool:
+        """未コミットの変更があるか確認する."""
+        self._run(["git", "add", "-A"])
+        result = self._run(["git", "status", "--porcelain"])
+        return bool(result.stdout.strip())
+
     def has_commits(self) -> bool:
         """リポジトリにコミットが存在するか確認する."""
         try:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -868,12 +868,12 @@ async def rag_crawl_documents(
 
 @mcp.tool()
 async def rag_delete(url: str) -> str:
-    """[rag-knowledge] RAG delete - ソースURL指定でナレッジから論理削除.
+    """[rag-knowledge] RAG delete - ソースURL指定でナレッジから削除.
 
-    knowledge base, remove source, delete document, soft delete.
-    source_store 内のファイルは削除せず、metadata.db で論理削除する。
-    検索インデックスからは即座に除去される。
-    復旧は rag_rebuild で全再構築を行えば可能。
+    knowledge base, remove source, delete document.
+    source_store からファイルを物理削除し、パイプライン経由で
+    インデックス・metadata.db を更新する。
+    git 管理下のため、削除後も git checkout で復旧可能。
 
     Args:
         url: 削除するソースURL（source_id）
@@ -888,23 +888,24 @@ async def rag_delete(url: str) -> str:
     controller = await _get_pipeline_controller()
 
     try:
-        # source_id として url をそのまま使用
         source_id = url
 
-        def _do_delete() -> bool:
+        def _do_delete() -> PipelineSummary | None:
             try:
-                controller.source_store.soft_delete(source_id)
+                controller.source_store.remove_file(source_id)
             except KeyError:
-                return False
-            controller.indexer.delete(source_id)
-            return True
+                return None
+            return controller.ingest_and_index(f"delete: {source_id}")
 
-        deleted = await asyncio.to_thread(_do_delete)
-        if not deleted:
+        result = await asyncio.to_thread(_do_delete)
+        if result is None:
             return f"該当するソースが見つかりませんでした: {url}"
 
         _reset_rag_service()
-        return f"論理削除しました: {url}"
+        if result.errors:
+            errors_text = "; ".join(result.errors)
+            return f"削除しましたが、パイプラインでエラーが発生しました: {url} ({errors_text})"
+        return f"削除しました: {url}"
     except Exception:
         logger.exception("Failed to delete: %s", url)
         return f"エラー: 削除に失敗しました。URL: {url}"

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -307,7 +307,32 @@ class SourceStore:
 
         return sorted(result)
 
-    # --- 論理削除 ---
+    # --- 削除 ---
+
+    def remove_file(self, source_id: str) -> None:
+        """ソースファイルと .meta サイドカーをディスクから削除する.
+
+        metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。
+        呼び出し後に controller.ingest_and_index() を実行すること。
+
+        Args:
+            source_id: 削除対象のソース識別子
+
+        Raises:
+            KeyError: source_id が metadata.db に存在しない場合
+        """
+        record = self._db.get_source(source_id)
+        if record is None:
+            msg = f"source_id が存在しません: {source_id}"
+            raise KeyError(msg)
+
+        file_path = self._root / record.file_path
+        if file_path.exists():
+            file_path.unlink()
+
+        meta_file = meta_path_for(file_path)
+        if meta_file.exists():
+            meta_file.unlink()
 
     def soft_delete(self, source_id: str) -> None:
         """ソースを論理削除する.

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -326,6 +326,7 @@ class SourceStore:
             msg = f"source_id が存在しません: {source_id}"
             raise KeyError(msg)
 
+        self._validate_rel_path(record.file_path)
         file_path = self._root / record.file_path
         if file_path.exists():
             file_path.unlink()

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -438,8 +438,200 @@ class TestRunIncremental:
         assert "local/b.txt" in converter.converted
 
 
+class TestDeleteAndReAdd:
+    """物理削除 → 再追加フローのテスト."""
+
+    def test_delete_and_readd_same_content(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """同一内容ファイルの削除→再追加でインデックスに復帰する."""
+        ctrl, converter, indexer = controller
+        content = "test content for readd"
+
+        # 1. 初回追加
+        _place_local_file(workspace["source"], "local/a.txt", content)
+        ctrl.commit("add a")
+        ctrl.run_incremental()
+        assert "local/a.txt" in indexer.added
+
+        # 2. 物理削除（remove_file 相当: ファイル削除 + commit + pipeline）
+        (workspace["source"] / "local" / "a.txt").unlink()
+        ctrl.commit("delete a")
+        ctrl.run_incremental()
+        assert "local/a.txt" in indexer.deleted_ids
+        record = ctrl.db.get_source("local/a.txt")
+        assert record is not None
+        assert record.status == "deleted"
+
+        # スタブをリセット
+        indexer.added.clear()
+        indexer.deleted_ids.clear()
+        converter.converted.clear()
+
+        # 3. 同一内容で再追加
+        _place_local_file(workspace["source"], "local/a.txt", content)
+        # place_file 相当: metadata.db を active に戻す
+        ctrl.source_store._db.register_source(
+            source_id="local/a.txt",
+            source_type="local",
+            file_path="local/a.txt",
+            title="a",
+            content_hash="dummy",
+            file_size=len(content),
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        ctrl.commit("readd a")
+        summary = ctrl.run_incremental()
+
+        # git diff は A（追加）として検知し、パイプラインが処理する
+        assert summary.processed == 1
+        assert "local/a.txt" in indexer.added
+        record = ctrl.db.get_source("local/a.txt")
+        assert record is not None
+        assert record.status == "active"
+
+    def test_delete_and_readd_different_content(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """異なる内容でのファイル削除→再追加でインデックスに復帰する."""
+        ctrl, converter, indexer = controller
+
+        # 1. 初回追加
+        _place_local_file(workspace["source"], "local/b.txt", "original")
+        ctrl.commit("add b")
+        ctrl.run_incremental()
+
+        # 2. 物理削除
+        (workspace["source"] / "local" / "b.txt").unlink()
+        ctrl.commit("delete b")
+        ctrl.run_incremental()
+
+        indexer.added.clear()
+        indexer.deleted_ids.clear()
+        converter.converted.clear()
+
+        # 3. 異なる内容で再追加
+        _place_local_file(workspace["source"], "local/b.txt", "new content")
+        ctrl.source_store._db.register_source(
+            source_id="local/b.txt",
+            source_type="local",
+            file_path="local/b.txt",
+            title="b",
+            content_hash="dummy2",
+            file_size=11,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        ctrl.commit("readd b with new content")
+        summary = ctrl.run_incremental()
+
+        assert summary.processed == 1
+        assert "local/b.txt" in indexer.added
+
+
+class TestRemoveFile:
+    """source_store.remove_file のテスト."""
+
+    def test_remove_file_deletes_file_and_meta(
+        self,
+        workspace: dict[str, Path],
+    ) -> None:
+        """ファイルと .meta を削除する."""
+        source_dir = workspace["source"]
+        source_store = SourceStore(source_dir)
+        source_store.initialize()
+
+        # web ファイル + .meta を配置
+        _place_web_file(
+            source_dir,
+            "web/https/example.com/page.html",
+            "<html>test</html>",
+            title="Test",
+            source_id="https://example.com/page",
+        )
+        # metadata.db に登録
+        source_store._db.register_source(
+            source_id="https://example.com/page",
+            source_type="web",
+            file_path="web/https/example.com/page.html",
+            title="Test",
+            content_hash="dummy",
+            file_size=17,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        file_path = source_dir / "web/https/example.com/page.html"
+        meta_path = source_dir / "web/https/example.com/page.html.meta"
+        assert file_path.exists()
+        assert meta_path.exists()
+
+        source_store.remove_file("https://example.com/page")
+
+        assert not file_path.exists()
+        assert not meta_path.exists()
+
+    def test_remove_file_raises_for_unknown_source(
+        self,
+        workspace: dict[str, Path],
+    ) -> None:
+        """存在しない source_id で KeyError."""
+        source_dir = workspace["source"]
+        source_store = SourceStore(source_dir)
+        source_store.initialize()
+
+        with pytest.raises(KeyError):
+            source_store.remove_file("nonexistent")
+
+    def test_remove_file_tolerates_missing_file(
+        self,
+        workspace: dict[str, Path],
+    ) -> None:
+        """ファイルが既にディスク上にない場合もエラーにならない."""
+        source_dir = workspace["source"]
+        source_store = SourceStore(source_dir)
+        source_store.initialize()
+
+        # DB にだけ登録（ファイルは作らない）
+        source_store._db.register_source(
+            source_id="local/ghost.txt",
+            source_type="local",
+            file_path="local/ghost.txt",
+            title="ghost",
+            content_hash="dummy",
+            file_size=0,
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        # エラーにならない
+        source_store.remove_file("local/ghost.txt")
+
+
 class TestRunFullRebuild:
     """全再構築のテスト."""
+
+    def test_rebuild_rejects_uncommitted_changes(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """未コミットの変更がある場合、rebuild はエラーになる."""
+        ctrl, _, _ = controller
+        # 最初のコミットを作る（has_commits が True になるように）
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+
+        # 未コミットのファイルを追加
+        _place_local_file(workspace["source"], "local/uncommitted.txt")
+
+        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
+            ctrl.run_full_rebuild()
 
     def test_rebuilds_all(
         self,


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- delete 操作を物理削除 + git commit + パイプライン経由に変更し、re-add 時に git diff が `A`（追加）として検知されインデックスに正常復帰するよう修正
- source-store 仕様の「物理削除禁止」ルールを撤廃（git 管理下での復旧可能性を根拠）
- `source_store.remove_file()` メソッド追加（ファイル + .meta をディスクから削除）
- `rag_delete`（MCP / CLI）を `remove_file` + `ingest_and_index` 経由に変更
- 再構築操作（full / convert / index）に未コミット変更チェックガードを追加
- `rag_delete` MCP ツールに `summary.errors` チェックを追加（CLI と一貫性）

## Test plan

- [x] pytest 104 passed（パイプラインコントローラ + CLI + source_store）
- [x] ruff / mypy 違反なし
- [x] markdownlint 違反なし
- [x] CLI 動作確認: 全4インジェスター（local / BlueSky / Zenn / Web）で add → delete → re-add → search 確認
- [x] MCP 動作確認: local add → delete → re-add → search 確認
- [x] git restore + rebuild による全データ復旧確認
- [x] rebuild ガード動作確認（未コミットファイルでエラー → クリーン状態で成功）

## Related issues

Closes #299