### PR TITLE
fix(test): TestRagCrawlPreviewTool の settings モック修正

### DIFF
--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -591,6 +591,7 @@ class TestRagCrawlPreviewTool:
         def ctx():
             with (
                 patch.object(mod, "get_settings", return_value=mock_settings),
+                patch("pathlib.Path.mkdir"),
                 patch.object(mod, "SourceStore", return_value=MagicMock()),
                 patch.object(mod, "_create_web_ingester", return_value=mock_ingester_instance),
                 patch.object(mod, "ConstrainedClient", return_value=mock_client),

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -564,11 +564,14 @@ class TestRagCrawlPreviewTool:
         preview_return: list[dict[str, str]] | None = None,
         preview_side_effect: Exception | None = None,
     ) -> contextlib.AbstractContextManager[AsyncMock]:
-        """crawl_preview の新アーキテクチャ用モックコンテキストを生成する."""
+        """crawl_preview 用モックコンテキストを生成する."""
         from contextlib import contextmanager
 
-        mock_controller = AsyncMock()
-        mock_controller.source_store = MagicMock()
+        mock_settings = MagicMock()
+        mock_settings.rag_crawl_default_depth = 1
+        mock_settings.source_store_dir = "/tmp/test_source_store"
+        mock_settings.rag_crawl_request_timeout = 10
+        mock_settings.rag_crawl_delay_sec = 0.5
 
         mock_ingester_instance = AsyncMock()
         if preview_side_effect:
@@ -587,8 +590,9 @@ class TestRagCrawlPreviewTool:
         @contextmanager
         def ctx():
             with (
-                patch.object(mod, "_get_pipeline_controller", return_value=mock_controller),
-                patch.object(mod, "PipelineWebIngester", return_value=mock_ingester_instance),
+                patch.object(mod, "get_settings", return_value=mock_settings),
+                patch.object(mod, "SourceStore", return_value=MagicMock()),
+                patch.object(mod, "_create_web_ingester", return_value=mock_ingester_instance),
                 patch.object(mod, "ConstrainedClient", return_value=mock_client),
             ):
                 yield mock_ingester_instance


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正
- [x] test: テスト追加・修正

## Summary

- `TestRagCrawlPreviewTool._mock_preview_context()` のモック対象を現行アーキテクチャに更新
- `get_settings` / `SourceStore` / `_create_web_ingester` のモックを追加
- `.env` 未配置環境でも 6 テストがパスするよう修正

## Test plan

- [x] `TestRagCrawlPreviewTool` 6/6 PASSED
- [x] `test_rag_mcp_server.py` 全体 34/34 PASSED
- [x] `uv run pytest` 全テスト 1201 PASSED
- [x] `uv run ruff check .` クリーン（既存 F401 1件のみ）
- [x] `uv run mypy src` クリーン

## Related issues

Closes #311