### PR TITLE
refactor(site-ingest): _validate_url/_check_ssrf を共有ユーティリティに昇格

### DIFF
--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1736,14 +1736,14 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     import re
     import time as time_mod
 
-    from .pipeline.ingesters.web import _check_ssrf, _validate_url
     from .scrapy.bridge import import_to_source_store
     from .scrapy.runner import ScrapyRunner
+    from .utils.url import check_ssrf, validate_url
 
     # URL バリデーション
     try:
-        url = _validate_url(args.url)
-        _check_ssrf(url)
+        url = validate_url(args.url)
+        check_ssrf(url)
     except ValueError as e:
         logger.error("エラー: %s", e)
         sys.exit(1)

--- a/src/rag/pipeline/ingesters/web.py
+++ b/src/rag/pipeline/ingesters/web.py
@@ -8,10 +8,8 @@ URL 安全性チェック・robots.txt 遵守・SSRF 対策を含む。
 
 from __future__ import annotations
 
-import ipaddress
 import logging
 import re
-import socket
 import time
 from urllib.parse import urljoin, urlparse
 from urllib.robotparser import RobotFileParser
@@ -23,6 +21,7 @@ from bs4 import BeautifulSoup
 from pathlib import PurePosixPath
 
 from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.utils.url import check_ssrf, validate_url
 
 # converter が認識する拡張子（変換対象 + パススルー対象）
 # この拡張子を持つ URL は .html を付与しない
@@ -59,86 +58,6 @@ _CRAWL_ALLOWED_CONTENT_TYPES: frozenset[str] = frozenset(
 
 # Safe Browsing キャッシュ最大エントリ数
 SAFE_BROWSING_CACHE_MAX_ENTRIES = 1000
-
-# SSRF 対策: ブロック対象ホスト名
-_BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
-
-# SSRF 対策: ブロック対象ネットワーク
-_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
-    ipaddress.IPv4Network("127.0.0.0/8"),
-    ipaddress.IPv4Network("10.0.0.0/8"),
-    ipaddress.IPv4Network("172.16.0.0/12"),
-    ipaddress.IPv4Network("192.168.0.0/16"),
-    ipaddress.IPv4Network("169.254.0.0/16"),
-    ipaddress.IPv6Network("::1/128"),
-    ipaddress.IPv6Network("fc00::/7"),
-    ipaddress.IPv6Network("fe80::/10"),
-]
-
-
-def _validate_url(url: str) -> str:
-    """URL のバリデーションを行う.
-
-    Returns:
-        フラグメントを除去した URL
-
-    Raises:
-        ValueError: 不正な URL の場合
-    """
-    if not url or not url.strip():
-        raise ValueError("URL が空です")
-
-    parsed = urlparse(url)
-
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"無効な URL スキームです: {parsed.scheme}")
-
-    if not parsed.hostname:
-        raise ValueError(f"URL にホスト名がありません: {url}")
-
-    # フラグメント除去
-    if parsed.fragment:
-        url = url.split("#")[0]
-
-    return url
-
-
-def _check_ssrf(url: str) -> None:
-    """SSRF 対策: プライベート IP・ローカルホストへのリクエストを拒否する.
-
-    Raises:
-        ValueError: SSRF の疑いがある場合
-    """
-    parsed = urlparse(url)
-    hostname = parsed.hostname
-
-    if not hostname:
-        raise ValueError(f"URL にホスト名がありません: {url}")
-
-    # ホスト名文字列マッチ
-    if hostname.lower() in _BLOCKED_HOSTNAMES:
-        raise ValueError(
-            f"プライベートホストへのアクセスは拒否されています: {hostname}"
-        )
-
-    # DNS 解決 + IP 検証
-    try:
-        addrinfos = socket.getaddrinfo(hostname, None)
-    except socket.gaierror as e:
-        raise ValueError(f"DNS 解決に失敗しました: {hostname}") from e
-
-    for addrinfo in addrinfos:
-        addr = addrinfo[4][0]
-        try:
-            ip = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
-        for network in _BLOCKED_NETWORKS:
-            if ip in network:
-                raise ValueError(
-                    f"プライベート IP へのアクセスは拒否されています: "
-                    f"{hostname} ({addr})"
-                )
 
 
 def _decode_html_bytes(data: bytes) -> str:
@@ -313,8 +232,8 @@ class WebIngester:
         """
         result = IngestResult()
 
-        url = _validate_url(url)
-        _check_ssrf(url)
+        url = validate_url(url)
+        check_ssrf(url)
 
         if client is None:
             raise ValueError("client (ConstrainedClient) が必要です")
@@ -405,8 +324,8 @@ class WebIngester:
         """
         result = IngestResult()
 
-        url = _validate_url(url)
-        _check_ssrf(url)
+        url = validate_url(url)
+        check_ssrf(url)
 
         if client is None:
             raise ValueError("client (ConstrainedClient) が必要です")
@@ -538,7 +457,7 @@ class WebIngester:
                     break
 
                 try:
-                    _check_ssrf(link)
+                    check_ssrf(link)
 
                     page_resp = await client.get(link, follow_redirects=False)
                     if 300 <= page_resp.status_code < 400:
@@ -636,11 +555,11 @@ class WebIngester:
             タイトルと URL の辞書リスト
         """
         try:
-            url = _validate_url(url)
+            url = validate_url(url)
         except ValueError:
             return []
 
-        _check_ssrf(url)
+        check_ssrf(url)
 
         if client is None:
             raise ValueError("client (ConstrainedClient) が必要です")
@@ -731,7 +650,7 @@ class WebIngester:
 
                 title = ""
                 try:
-                    _check_ssrf(link)
+                    check_ssrf(link)
 
                     page_resp = await client.get(
                         link, follow_redirects=False

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -943,16 +943,16 @@ async def rag_site_ingest(
     import re
     import time as time_mod
 
-    from .pipeline.ingesters.web import _check_ssrf, _validate_url
     from .scrapy.bridge import import_to_source_store
     from .scrapy.runner import ScrapyRunner
+    from .utils.url import check_ssrf, validate_url
 
     settings = get_settings()
 
     # URL バリデーション
     try:
-        url = _validate_url(url)
-        _check_ssrf(url)
+        url = validate_url(url)
+        check_ssrf(url)
     except ValueError as e:
         return f"エラー: {e}"
 

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -14,7 +14,9 @@ from urllib.parse import urlparse
 _BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
 
 # SSRF 対策: ブロック対象ネットワーク
-_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+_BLOCKED_NETWORKS: tuple[
+    ipaddress.IPv4Network | ipaddress.IPv6Network, ...
+] = (
     ipaddress.IPv4Network("127.0.0.0/8"),
     ipaddress.IPv4Network("10.0.0.0/8"),
     ipaddress.IPv4Network("172.16.0.0/12"),
@@ -23,7 +25,7 @@ _BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ipaddress.IPv6Network("::1/128"),
     ipaddress.IPv6Network("fc00::/7"),
     ipaddress.IPv6Network("fe80::/10"),
-]
+)
 
 
 def validate_url(url: str) -> str:
@@ -79,10 +81,16 @@ def check_ssrf(url: str) -> None:
 
     for addrinfo in addrinfos:
         addr = addrinfo[4][0]
+        # IPv6 の zone index（例: "fe80::1%lo0" の "%lo0"）を除去
+        if isinstance(addr, str) and "%" in addr:
+            addr = addr.split("%", 1)[0]
         try:
             ip = ipaddress.ip_address(addr)
         except ValueError:
             continue
+        # IPv4-mapped IPv6（例: "::ffff:127.0.0.1"）は IPv4 として判定
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 raise ValueError(

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -1,0 +1,91 @@
+"""URL バリデーション・SSRF 対策ユーティリティ.
+
+Web インジェスター・Scrapy サイト取り込み等で共通利用する
+URL 検証・SSRF チェック関数を提供する。
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# SSRF 対策: ブロック対象ホスト名
+_BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
+
+# SSRF 対策: ブロック対象ネットワーク
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.IPv4Network("127.0.0.0/8"),
+    ipaddress.IPv4Network("10.0.0.0/8"),
+    ipaddress.IPv4Network("172.16.0.0/12"),
+    ipaddress.IPv4Network("192.168.0.0/16"),
+    ipaddress.IPv4Network("169.254.0.0/16"),
+    ipaddress.IPv6Network("::1/128"),
+    ipaddress.IPv6Network("fc00::/7"),
+    ipaddress.IPv6Network("fe80::/10"),
+]
+
+
+def validate_url(url: str) -> str:
+    """URL のバリデーションを行う.
+
+    Returns:
+        フラグメントを除去した URL
+
+    Raises:
+        ValueError: 不正な URL の場合
+    """
+    if not url or not url.strip():
+        raise ValueError("URL が空です")
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"無効な URL スキームです: {parsed.scheme}")
+
+    if not parsed.hostname:
+        raise ValueError(f"URL にホスト名がありません: {url}")
+
+    # フラグメント除去
+    if parsed.fragment:
+        url = url.split("#")[0]
+
+    return url
+
+
+def check_ssrf(url: str) -> None:
+    """SSRF 対策: プライベート IP・ローカルホストへのリクエストを拒否する.
+
+    Raises:
+        ValueError: SSRF の疑いがある場合
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+
+    if not hostname:
+        raise ValueError(f"URL にホスト名がありません: {url}")
+
+    # ホスト名文字列マッチ
+    if hostname.lower() in _BLOCKED_HOSTNAMES:
+        raise ValueError(
+            f"プライベートホストへのアクセスは拒否されています: {hostname}"
+        )
+
+    # DNS 解決 + IP 検証
+    try:
+        addrinfos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise ValueError(f"DNS 解決に失敗しました: {hostname}") from e
+
+    for addrinfo in addrinfos:
+        addr = addrinfo[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        for network in _BLOCKED_NETWORKS:
+            if ip in network:
+                raise ValueError(
+                    f"プライベート IP へのアクセスは拒否されています: "
+                    f"{hostname} ({addr})"
+                )

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -86,8 +86,12 @@ def check_ssrf(url: str) -> None:
             addr = addr.split("%", 1)[0]
         try:
             ip = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
+        except ValueError as e:
+            # パース不能なアドレスは fail-closed として拒否する
+            raise ValueError(
+                f"DNS 解決結果に無効な IP アドレスが含まれています: "
+                f"{hostname} ({addr})"
+            ) from e
         # IPv4-mapped IPv6（例: "::ffff:127.0.0.1"）は IPv4 として判定
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
             ip = ip.ipv4_mapped

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -22,17 +22,15 @@ import pytest
 from rag.pipeline.ingesters.web import (
     MAX_CRAWL_DEPTH_HARD_LIMIT,
     WebIngester,
-    _check_ssrf,
     _decode_html_bytes,
     _extract_links,
     _extract_title,
     _is_allowed_content_type,
     _is_crawlable_url,
-    _looks_like_msys_path,
     _needs_html_extension,
-    _validate_url,
 )
 from rag.store.source_store import SourceStore
+from rag.utils.url import check_ssrf, validate_url
 
 
 @pytest.fixture()
@@ -44,62 +42,62 @@ def source_store(tmp_path: Path) -> SourceStore:
 
 
 class TestValidateUrl:
-    """_validate_url のテスト."""
+    """validate_url() のテスト."""
 
     def test_valid_http(self) -> None:
         """http スキームが通ること."""
-        assert _validate_url("http://example.com/page") == "http://example.com/page"
+        assert validate_url("http://example.com/page") == "http://example.com/page"
 
     def test_valid_https(self) -> None:
         """https スキームが通ること."""
-        assert _validate_url("https://example.com/page") == "https://example.com/page"
+        assert validate_url("https://example.com/page") == "https://example.com/page"
 
     def test_empty_raises(self) -> None:
         """空の URL でエラーになること."""
         with pytest.raises(ValueError, match="空"):
-            _validate_url("")
+            validate_url("")
 
     def test_invalid_scheme_raises(self) -> None:
         """無効なスキームでエラーになること."""
         with pytest.raises(ValueError, match="スキーム"):
-            _validate_url("ftp://example.com/file")
+            validate_url("ftp://example.com/file")
 
     def test_no_hostname_raises(self) -> None:
         """ホスト名なしでエラーになること."""
         with pytest.raises(ValueError, match="ホスト名"):
-            _validate_url("https:///path")
+            validate_url("https:///path")
 
     def test_fragment_removed(self) -> None:
         """フラグメントが除去されること."""
-        result = _validate_url("https://example.com/page#section")
+        result = validate_url("https://example.com/page#section")
         assert "#" not in result
         assert result == "https://example.com/page"
 
 
 class TestCheckSsrf:
-    """_check_ssrf のテスト."""
+    """check_ssrf() のテスト."""
 
     def test_localhost_blocked(self) -> None:
         """localhost がブロックされること."""
         with pytest.raises(ValueError, match="プライベートホスト"):
-            _check_ssrf("http://localhost/api")
+            check_ssrf("http://localhost/api")
 
     def test_localhost_localdomain_blocked(self) -> None:
         """localhost.localdomain がブロックされること."""
         with pytest.raises(ValueError, match="プライベートホスト"):
-            _check_ssrf("http://localhost.localdomain/api")
+            check_ssrf("http://localhost.localdomain/api")
 
     def test_private_ip_blocked(self) -> None:
         """プライベート IP がブロックされること."""
         with pytest.raises(ValueError, match="プライベート"):
-            _check_ssrf("http://127.0.0.1/api")
+            check_ssrf("http://127.0.0.1/api")
 
     @patch("socket.getaddrinfo")
     def test_public_ip_allowed(self, mock_getaddr: MagicMock) -> None:
         """パブリック IP が許可されること."""
         mock_getaddr.return_value = [(2, 1, 6, "", ("93.184.216.34", 80))]
         # パブリック IP は SSRF ブロックされない（例外が発生しないことを確認）
-        _check_ssrf("http://example.com/")
+        check_ssrf("http://example.com/")
 
 
 class TestExtractTitle:

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -99,6 +99,24 @@ class TestCheckSsrf:
         # パブリック IP は SSRF ブロックされない（例外が発生しないことを確認）
         check_ssrf("http://example.com/")
 
+    @patch("socket.getaddrinfo")
+    def test_ipv4_mapped_ipv6_blocked(self, mock_getaddr: MagicMock) -> None:
+        """IPv4-mapped IPv6 アドレスがブロックされること."""
+        mock_getaddr.return_value = [
+            (10, 1, 6, "", ("::ffff:127.0.0.1", 80, 0, 0))
+        ]
+        with pytest.raises(ValueError, match="プライベート"):
+            check_ssrf("http://mapped-v6.example.com/")
+
+    @patch("socket.getaddrinfo")
+    def test_ipv6_zone_index_blocked(self, mock_getaddr: MagicMock) -> None:
+        """zone index 付き IPv6 リンクローカルアドレスがブロックされること."""
+        mock_getaddr.return_value = [
+            (10, 1, 6, "", ("fe80::1%lo0", 80, 0, 0))
+        ]
+        with pytest.raises(ValueError, match="プライベート"):
+            check_ssrf("http://link-local.example.com/")
+
 
 class TestExtractTitle:
     """_extract_title のテスト."""

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -117,6 +117,15 @@ class TestCheckSsrf:
         with pytest.raises(ValueError, match="プライベート"):
             check_ssrf("http://link-local.example.com/")
 
+    @patch("socket.getaddrinfo")
+    def test_unparseable_ip_rejected(self, mock_getaddr: MagicMock) -> None:
+        """パース不能な IP アドレスは fail-closed で拒否されること."""
+        mock_getaddr.return_value = [
+            (2, 1, 6, "", ("not-an-ip", 80))
+        ]
+        with pytest.raises(ValueError, match="無効な IP アドレス"):
+            check_ssrf("http://bad-dns.example.com/")
+
 
 class TestExtractTitle:
     """_extract_title のテスト."""


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `src/rag/utils/url.py` を新規作成し、`validate_url` / `check_ssrf` を公開関数として提供
- `web.py` / `cli.py` / `server.py` / テストの import を更新
- 未使用 import (`_looks_like_msys_path`) を除去
- 後方互換エイリアスは設置しない（呼び出し元を直接変更）

## Test plan

- [x] `test_pipeline_ingesters_web.py` 65 PASSED
- [x] `uv run pytest` 全テスト 1195 passed, 6 failed（TestRagCrawlPreviewTool — #311 で修正対象）
- [x] `uv run ruff check .` クリーン
- [x] `uv run mypy src` クリーン（59 source files）

## Related issues

Closes #315