### PR TITLE
feat(site-ingest): Scrapy per-request SSRF チェック Downloader Middleware

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -50,9 +50,9 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 ### Safe Browsing チェック
 
 - 数千件規模の URL に対する Google Safe Browsing API 呼び出しは非現実的なためスキップする
-- SSRF チェックは初回 URL（ユーザー入力）のみ実施する。Scrapy が後続で辿る URL（同一ドメイン内）については、per-request の IP 解決検証は行わない。DNS リバインディング等のリスクは `allowed_domains` によるドメイン制約で緩和する
-
-> **TODO:#316** per-request の SSRF チェック（Downloader Middleware）を実装し、DNS リバインディングに対応する
+- SSRF チェックは 2 層で実施する:
+  1. **初回 URL チェック**: ユーザー入力の開始 URL に対して、クロール開始前に `check_ssrf` で検証する
+  2. **per-request チェック**: Scrapy Downloader Middleware で、各リクエストの送信前に DNS 解決 → IP 検証を実行する。DNS リバインディング攻撃（初回解決時はパブリック IP、実際のリクエスト時にプライベート IP に切り替わる手法）に対応する
 
 ### robots.txt
 
@@ -101,7 +101,8 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 | 制約名 | 種別 | 値 | 解除可否 |
 |--------|------|-----|---------|
-| SSRF チェック | ハードリミット | 初回 URL に対して実施。プライベート IP・ローカルホストを拒否 | 無効化不可 |
+| SSRF チェック（初回 URL） | ハードリミット | クロール開始前に開始 URL を検証。プライベート IP・ローカルホストを拒否 | 無効化不可 |
+| SSRF チェック（per-request） | ハードリミット | Downloader Middleware で各リクエストの DNS 解決結果を検証。プライベート IP を拒否 | 無効化不可 |
 | ドメイン制約 | ハードリミット | `allowed_domains` で初回 URL と同一ドメインに制限 | 無効化不可 |
 | robots.txt 遵守 | ハードリミット | `ROBOTSTXT_OBEY = True`（固定） | 無効化不可 |
 | ページ数上限 | 設定値 | 許容範囲 1〜50,000、デフォルト 10,000 | 範囲内で変更可 |
@@ -199,6 +200,7 @@ flowchart TD
 | Spider | `src/rag/scrapy/spider.py` | 汎用 Scrapy Spider。URL・ドメイン制約・URL パターンをパラメータで受け取り、HTML ファイルを一時保存ディレクトリに保存する |
 | Runner | `src/rag/scrapy/runner.py` | subprocess ラッパー。Scrapy プロセスの起動・監視・終了判定を行う |
 | Bridge | `src/rag/scrapy/bridge.py` | JSONL + HTML を source_store に変換・配置する。.meta サイドカーファイルを生成する |
+| SSRF Middleware | `src/rag/scrapy/middleware.py` | Downloader Middleware。各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを拒否する |
 | パッケージ初期化 | `src/rag/scrapy/__init__.py` | パッケージ初期化 |
 
 ### Spider
@@ -248,7 +250,47 @@ Scrapy に渡す設定:
 | `CLOSESPIDER_ERRORCOUNT` | `site_ingest_error_count`（config.toml） |
 | `JOBDIR` | 一時保存ディレクトリ内の `jobdir/` |
 | `FEEDS` | JSONL 出力パス |
+| `DOWNLOADER_MIDDLEWARES` | SSRF Middleware を有効化（優先度 50） |
 | `LOG_LEVEL` | `INFO` |
+
+### SSRF Middleware
+
+Scrapy Downloader Middleware として動作し、各リクエストの送信前に SSRF チェックを実行する。
+
+動作フロー:
+
+1. Scrapy がリクエストを発行する
+2. Middleware がリクエスト URL のホスト名を DNS 解決する
+3. 解決された全 IP アドレスがプライベート IP レンジに該当しないか検証する
+4. 検証に通過した場合、リクエストを次の Middleware（または Downloader）に渡す
+5. 検証に失敗した場合、リクエストを `IgnoreRequest` 例外で拒否し、警告ログを出力する
+
+拒否対象（Web インジェスターの `check_ssrf` と同一の判定基準）:
+
+| アドレス範囲 | 区分 |
+|-------------|------|
+| `127.0.0.0/8` | IPv4 ループバック |
+| `10.0.0.0/8` | RFC 1918 プライベート |
+| `172.16.0.0/12` | RFC 1918 プライベート |
+| `192.168.0.0/16` | RFC 1918 プライベート |
+| `169.254.0.0/16` | リンクローカル |
+| `::1/128` | IPv6 ループバック |
+| `fc00::/7` | IPv6 ユニークローカル |
+| `fe80::/10` | IPv6 リンクローカル |
+| `localhost` / `localhost.localdomain` | ホスト名文字列マッチ |
+
+DNS リバインディング対策:
+
+- Middleware は Scrapy の Downloader が HTTP 接続を確立する直前に DNS 解決を行い、その結果を検証する。初回 URL チェック時の DNS 結果をキャッシュして再利用するのではなく、リクエストごとに独立して DNS 解決を実行する
+- これにより、初回 DNS 解決時にパブリック IP を返し、後続の解決でプライベート IP に切り替える DNS リバインディング攻撃を検出する
+
+Middleware の優先度:
+
+- `DOWNLOADER_MIDDLEWARES` で優先度 50 に設定する。Scrapy のデフォルト Middleware（`HttpCompressionMiddleware`: 590、`RedirectMiddleware`: 600 等）より先に実行されるため、プライベート IP への接続自体を防止する
+
+判定ロジックの共有:
+
+- IP アドレスの判定ロジックは `rag.utils.url.check_ssrf` を使用する。初回 URL チェックと per-request チェックで同一の判定基準を適用する
 
 ### Bridge
 
@@ -359,6 +401,8 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | 同一 URL が既に source_store に存在する場合 | `SourceStore.place_file_from_url` が既存ファイルを上書きする（通常の重複検出動作） |
 | `url_pattern` が無効な正規表現の場合 | バリデーションエラーとして拒否する |
 | Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--force` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
+| DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
+| SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
 
 ## 関連ドキュメント
 

--- a/src/rag/scrapy/middleware.py
+++ b/src/rag/scrapy/middleware.py
@@ -1,0 +1,55 @@
+"""Scrapy Downloader Middleware for SSRF protection.
+
+仕様: docs/specs/site-ingest.md
+
+各リクエストの送信前に DNS 解決 → IP 検証を実行し、
+プライベート IP へのアクセスを拒否する。
+DNS リバインディング攻撃に対応する。
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from scrapy.exceptions import IgnoreRequest
+from scrapy.http import Request, Response
+
+from rag.utils.url import check_ssrf
+
+logger = logging.getLogger(__name__)
+
+
+class SsrfMiddleware:
+    """per-request SSRF チェック Downloader Middleware.
+
+    各リクエストの送信前にホスト名を DNS 解決し、
+    解決結果がプライベート IP に該当する場合は IgnoreRequest で拒否する。
+    """
+
+    def process_request(
+        self, request: Request, spider: object
+    ) -> Response | None:
+        """リクエスト送信前に SSRF チェックを実行する.
+
+        Returns:
+            None: 検証通過。次の Middleware / Downloader に処理を渡す。
+
+        Raises:
+            IgnoreRequest: プライベート IP / ローカルホスト / DNS 解決失敗の場合
+        """
+        url = request.url
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+
+        if not hostname:
+            logger.warning("SSRF Middleware: ホスト名なし、リクエストを拒否: %s", url)
+            raise IgnoreRequest(f"SSRF check: no hostname in {url}")
+
+        try:
+            check_ssrf(url)
+        except ValueError as e:
+            logger.warning("SSRF Middleware: リクエストを拒否: %s (%s)", url, e)
+            raise IgnoreRequest(f"SSRF check failed: {e}") from e
+
+        return None

--- a/src/rag/scrapy/middleware.py
+++ b/src/rag/scrapy/middleware.py
@@ -14,6 +14,8 @@ from urllib.parse import urlparse
 
 from scrapy.exceptions import IgnoreRequest
 from scrapy.http import Request, Response
+from twisted.internet import defer, threads
+from twisted.python.failure import Failure
 
 from rag.utils.url import check_ssrf
 
@@ -25,15 +27,21 @@ class SsrfMiddleware:
 
     各リクエストの送信前にホスト名を DNS 解決し、
     解決結果がプライベート IP に該当する場合は IgnoreRequest で拒否する。
+
+    DNS 解決は同期 I/O のため、deferToThread でスレッドプールに
+    オフロードして Twisted reactor のブロッキングを回避する。
     """
 
     def process_request(
         self, request: Request, spider: object
-    ) -> Response | None:
+    ) -> defer.Deferred[Response | None]:
         """リクエスト送信前に SSRF チェックを実行する.
 
+        DNS 解決を含む check_ssrf をスレッドプールで実行し、
+        Deferred を返すことで reactor をブロックしない。
+
         Returns:
-            None: 検証通過。次の Middleware / Downloader に処理を渡す。
+            Deferred[None]: 検証通過。次の Middleware / Downloader に処理を渡す。
 
         Raises:
             IgnoreRequest: プライベート IP / ローカルホスト / DNS 解決失敗の場合
@@ -44,12 +52,18 @@ class SsrfMiddleware:
 
         if not hostname:
             logger.warning("SSRF Middleware: ホスト名なし、リクエストを拒否: %s", url)
-            raise IgnoreRequest(f"SSRF check: no hostname in {url}")
+            raise IgnoreRequest(f"SSRF check failed: no hostname in {url}")
 
-        try:
-            check_ssrf(url)
-        except ValueError as e:
-            logger.warning("SSRF Middleware: リクエストを拒否: %s (%s)", url, e)
-            raise IgnoreRequest(f"SSRF check failed: {e}") from e
+        d: defer.Deferred[None] = threads.deferToThread(check_ssrf, url)  # type: ignore[no-untyped-call]
+        d.addErrback(self._on_ssrf_error, url)
+        return d
 
-        return None
+    @staticmethod
+    def _on_ssrf_error(
+        failure: Failure,
+        url: str,
+    ) -> None:
+        """check_ssrf が ValueError を送出した場合に IgnoreRequest に変換する."""
+        failure.trap(ValueError)  # type: ignore[no-untyped-call]
+        logger.warning("SSRF Middleware: リクエストを拒否: %s (%s)", url, failure.value)
+        raise IgnoreRequest(f"SSRF check failed: {failure.value}")

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -221,14 +221,12 @@ with open({json.dumps(safe_params_path)}, encoding='utf-8') as f:
 
 from scrapy.crawler import CrawlerProcess
 from rag.scrapy.spider import SiteSpider
-from rag.scrapy.middleware import SsrfMiddleware
-
 settings = {{
     # ハード制約（Spider 実装変更で無効化されないよう Runner 側で明示）
     'ROBOTSTXT_OBEY': True,
     'TELNETCONSOLE_ENABLED': False,
     'DOWNLOADER_MIDDLEWARES': {{
-        SsrfMiddleware: 50,
+        'rag.scrapy.middleware.SsrfMiddleware': 50,
     }},
     # クロール設定
     'JOBDIR': params['jobdir'],

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -221,11 +221,15 @@ with open({json.dumps(safe_params_path)}, encoding='utf-8') as f:
 
 from scrapy.crawler import CrawlerProcess
 from rag.scrapy.spider import SiteSpider
+from rag.scrapy.middleware import SsrfMiddleware
 
 settings = {{
     # ハード制約（Spider 実装変更で無効化されないよう Runner 側で明示）
     'ROBOTSTXT_OBEY': True,
     'TELNETCONSOLE_ENABLED': False,
+    'DOWNLOADER_MIDDLEWARES': {{
+        SsrfMiddleware: 50,
+    }},
     # クロール設定
     'JOBDIR': params['jobdir'],
     'FEEDS': {{

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -14,7 +14,9 @@ from urllib.parse import urlparse
 _BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
 
 # SSRF 対策: ブロック対象ネットワーク
-_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+_BLOCKED_NETWORKS: tuple[
+    ipaddress.IPv4Network | ipaddress.IPv6Network, ...
+] = (
     ipaddress.IPv4Network("127.0.0.0/8"),
     ipaddress.IPv4Network("10.0.0.0/8"),
     ipaddress.IPv4Network("172.16.0.0/12"),
@@ -23,7 +25,7 @@ _BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
     ipaddress.IPv6Network("::1/128"),
     ipaddress.IPv6Network("fc00::/7"),
     ipaddress.IPv6Network("fe80::/10"),
-]
+)
 
 
 def validate_url(url: str) -> str:
@@ -79,18 +81,20 @@ def check_ssrf(url: str) -> None:
 
     for addrinfo in addrinfos:
         addr = addrinfo[4][0]
+        # IPv6 の zone index（例: "fe80::1%lo0" の "%lo0"）を除去
+        if isinstance(addr, str) and "%" in addr:
+            addr = addr.split("%", 1)[0]
         try:
             ip = ipaddress.ip_address(addr)
         except ValueError as e:
-            # パース不能なアドレス表現は fail-closed として拒否する
+            # パース不能なアドレスは fail-closed として拒否する
             raise ValueError(
-                f"DNS 解決結果に無効な IP アドレスが含まれています: {hostname} ({addr})"
+                f"DNS 解決結果に無効な IP アドレスが含まれています: "
+                f"{hostname} ({addr})"
             ) from e
-
-        # IPv4-mapped IPv6 (::ffff:127.0.0.1 など) は対応する IPv4 として評価する
+        # IPv4-mapped IPv6（例: "::ffff:127.0.0.1"）は IPv4 として判定
         if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
             ip = ip.ipv4_mapped
-
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 raise ValueError(

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -81,8 +81,16 @@ def check_ssrf(url: str) -> None:
         addr = addrinfo[4][0]
         try:
             ip = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
+        except ValueError as e:
+            # パース不能なアドレス表現は fail-closed として拒否する
+            raise ValueError(
+                f"DNS 解決結果に無効な IP アドレスが含まれています: {hostname} ({addr})"
+            ) from e
+
+        # IPv4-mapped IPv6 (::ffff:127.0.0.1 など) は対応する IPv4 として評価する
+        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+
         for network in _BLOCKED_NETWORKS:
             if ip in network:
                 raise ValueError(

--- a/src/rag/utils/url.py
+++ b/src/rag/utils/url.py
@@ -1,0 +1,91 @@
+"""URL バリデーション・SSRF 対策ユーティリティ.
+
+Web インジェスター・Scrapy サイト取り込み等で共通利用する
+URL 検証・SSRF チェック関数を提供する。
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# SSRF 対策: ブロック対象ホスト名
+_BLOCKED_HOSTNAMES = frozenset({"localhost", "localhost.localdomain"})
+
+# SSRF 対策: ブロック対象ネットワーク
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.IPv4Network("127.0.0.0/8"),
+    ipaddress.IPv4Network("10.0.0.0/8"),
+    ipaddress.IPv4Network("172.16.0.0/12"),
+    ipaddress.IPv4Network("192.168.0.0/16"),
+    ipaddress.IPv4Network("169.254.0.0/16"),
+    ipaddress.IPv6Network("::1/128"),
+    ipaddress.IPv6Network("fc00::/7"),
+    ipaddress.IPv6Network("fe80::/10"),
+]
+
+
+def validate_url(url: str) -> str:
+    """URL のバリデーションを行う.
+
+    Returns:
+        フラグメントを除去した URL
+
+    Raises:
+        ValueError: 不正な URL の場合
+    """
+    if not url or not url.strip():
+        raise ValueError("URL が空です")
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"無効な URL スキームです: {parsed.scheme}")
+
+    if not parsed.hostname:
+        raise ValueError(f"URL にホスト名がありません: {url}")
+
+    # フラグメント除去
+    if parsed.fragment:
+        url = url.split("#")[0]
+
+    return url
+
+
+def check_ssrf(url: str) -> None:
+    """SSRF 対策: プライベート IP・ローカルホストへのリクエストを拒否する.
+
+    Raises:
+        ValueError: SSRF の疑いがある場合
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+
+    if not hostname:
+        raise ValueError(f"URL にホスト名がありません: {url}")
+
+    # ホスト名文字列マッチ
+    if hostname.lower() in _BLOCKED_HOSTNAMES:
+        raise ValueError(
+            f"プライベートホストへのアクセスは拒否されています: {hostname}"
+        )
+
+    # DNS 解決 + IP 検証
+    try:
+        addrinfos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        raise ValueError(f"DNS 解決に失敗しました: {hostname}") from e
+
+    for addrinfo in addrinfos:
+        addr = addrinfo[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        for network in _BLOCKED_NETWORKS:
+            if ip in network:
+                raise ValueError(
+                    f"プライベート IP へのアクセスは拒否されています: "
+                    f"{hostname} ({addr})"
+                )

--- a/tests/test_scrapy_middleware.py
+++ b/tests/test_scrapy_middleware.py
@@ -181,6 +181,17 @@ class TestCheckSsrf:
         with pytest.raises(ValueError, match="ホスト名がありません"):
             check_ssrf("https:///path/only")
 
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_ipv6_zone_index_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """zone index 付き IPv6 リンクローカルアドレスが拒否されること."""
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("fe80::1%lo0", 80, 0, 0)),
+        ]
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://link-local-zone.example.com/page")
+
 
 class TestSsrfMiddleware:
     """SsrfMiddleware のテスト.

--- a/tests/test_scrapy_middleware.py
+++ b/tests/test_scrapy_middleware.py
@@ -8,6 +8,8 @@
 - localhost は IgnoreRequest で拒否すること
 - DNS 解決に失敗した場合は IgnoreRequest で拒否すること
 - ホスト名なしの URL は IgnoreRequest で拒否すること
+- IPv4-mapped IPv6 アドレスは対応する IPv4 として評価すること
+- パース不能な IP アドレスは fail-closed で拒否すること
 """
 
 from __future__ import annotations
@@ -20,15 +22,11 @@ from scrapy.exceptions import IgnoreRequest
 from scrapy.http import Request
 
 from rag.scrapy.middleware import SsrfMiddleware
+from rag.utils.url import check_ssrf
 
 
-class TestSsrfMiddleware:
-    """SsrfMiddleware のテスト."""
-
-    def setup_method(self) -> None:
-        """各テスト前に Middleware インスタンスを生成する."""
-        self.middleware = SsrfMiddleware()
-        self.spider = MagicMock()
+class TestCheckSsrf:
+    """check_ssrf ユーティリティのテスト."""
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_public_ip_passes(self, mock_getaddrinfo: MagicMock) -> None:
@@ -36,9 +34,7 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("93.184.216.34", 0)),
         ]
-        request = Request(url="https://example.com/page")
-        result = self.middleware.process_request(request, self.spider)
-        assert result is None
+        check_ssrf("https://example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_private_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -46,9 +42,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("10.0.0.1", 0)),
         ]
-        request = Request(url="https://evil.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://evil.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_loopback_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -56,9 +51,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("127.0.0.1", 0)),
         ]
-        request = Request(url="https://rebind.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://rebind.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_link_local_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -66,9 +60,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("169.254.1.1", 0)),
         ]
-        request = Request(url="https://link-local.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://link-local.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_rfc1918_172_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -76,9 +69,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("172.16.0.1", 0)),
         ]
-        request = Request(url="https://internal.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://internal.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_rfc1918_192_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -86,21 +78,18 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (2, 1, 6, "", ("192.168.1.1", 0)),
         ]
-        request = Request(url="https://home.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://home.example.com/page")
 
     def test_localhost_hostname_rejected(self) -> None:
         """localhost ホスト名は DNS 解決前にホスト名マッチで拒否する."""
-        request = Request(url="https://localhost/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベートホスト"):
+            check_ssrf("https://localhost/page")
 
     def test_localhost_localdomain_rejected(self) -> None:
         """localhost.localdomain ホスト名は拒否する."""
-        request = Request(url="https://localhost.localdomain/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベートホスト"):
+            check_ssrf("https://localhost.localdomain/page")
 
     @patch(
         "rag.utils.url.socket.getaddrinfo",
@@ -108,9 +97,8 @@ class TestSsrfMiddleware:
     )
     def test_dns_failure_rejected(self, mock_getaddrinfo: MagicMock) -> None:
         """DNS 解決に失敗した場合は拒否する."""
-        request = Request(url="https://nonexistent.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="DNS 解決に失敗"):
+            check_ssrf("https://nonexistent.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_ipv6_loopback_rejected(self, mock_getaddrinfo: MagicMock) -> None:
@@ -118,9 +106,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (10, 1, 6, "", ("::1", 0, 0, 0)),
         ]
-        request = Request(url="https://ipv6-loopback.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://ipv6-loopback.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_ipv6_unique_local_rejected(
@@ -130,9 +117,8 @@ class TestSsrfMiddleware:
         mock_getaddrinfo.return_value = [
             (10, 1, 6, "", ("fd00::1", 0, 0, 0)),
         ]
-        request = Request(url="https://ipv6-ula.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://ipv6-ula.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_mixed_ips_with_private_rejected(
@@ -143,9 +129,8 @@ class TestSsrfMiddleware:
             (2, 1, 6, "", ("93.184.216.34", 0)),
             (2, 1, 6, "", ("10.0.0.1", 0)),
         ]
-        request = Request(url="https://dual.example.com/page")
-        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
-            self.middleware.process_request(request, self.spider)
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://dual.example.com/page")
 
     @patch("rag.utils.url.socket.getaddrinfo")
     def test_multiple_public_ips_pass(
@@ -156,6 +141,57 @@ class TestSsrfMiddleware:
             (2, 1, 6, "", ("93.184.216.34", 0)),
             (2, 1, 6, "", ("93.184.216.35", 0)),
         ]
-        request = Request(url="https://cdn.example.com/page")
-        result = self.middleware.process_request(request, self.spider)
-        assert result is None
+        check_ssrf("https://cdn.example.com/page")
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_ipv4_mapped_ipv6_loopback_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """IPv4-mapped IPv6（::ffff:127.0.0.1）はループバックとして拒否する."""
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("::ffff:127.0.0.1", 0, 0, 0)),
+        ]
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://mapped-loopback.example.com/page")
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_ipv4_mapped_ipv6_private_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """IPv4-mapped IPv6（::ffff:10.0.0.1）はプライベート IP として拒否する."""
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("::ffff:10.0.0.1", 0, 0, 0)),
+        ]
+        with pytest.raises(ValueError, match="プライベート IP"):
+            check_ssrf("https://mapped-private.example.com/page")
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_unparseable_ip_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """パース不能な IP アドレスは fail-closed で拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("not-an-ip", 0)),
+        ]
+        with pytest.raises(ValueError, match="無効な IP アドレス"):
+            check_ssrf("https://bad-dns.example.com/page")
+
+    def test_no_hostname_rejected(self) -> None:
+        """ホスト名なしの URL は拒否する."""
+        with pytest.raises(ValueError, match="ホスト名がありません"):
+            check_ssrf("https:///path/only")
+
+
+class TestSsrfMiddleware:
+    """SsrfMiddleware のテスト（同期パス）."""
+
+    def setup_method(self) -> None:
+        """各テスト前に Middleware インスタンスを生成する."""
+        self.middleware = SsrfMiddleware()
+        self.spider = MagicMock()
+
+    def test_no_hostname_rejected(self) -> None:
+        """ホスト名なしの URL は同期パスで即座に拒否する."""
+        request = Request(url="https:///path/only")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)

--- a/tests/test_scrapy_middleware.py
+++ b/tests/test_scrapy_middleware.py
@@ -183,7 +183,12 @@ class TestCheckSsrf:
 
 
 class TestSsrfMiddleware:
-    """SsrfMiddleware のテスト（同期パス）."""
+    """SsrfMiddleware のテスト.
+
+    process_request は Deferred を返す（deferToThread 経由）。
+    テストでは deferToThread をモックして同期的に実行し、
+    Middleware のフロー（pass / IgnoreRequest 変換）を検証する。
+    """
 
     def setup_method(self) -> None:
         """各テスト前に Middleware インスタンスを生成する."""
@@ -195,3 +200,55 @@ class TestSsrfMiddleware:
         request = Request(url="https:///path/only")
         with pytest.raises(IgnoreRequest, match="SSRF check failed"):
             self.middleware.process_request(request, self.spider)
+
+    @patch("rag.scrapy.middleware.threads.deferToThread")
+    def test_public_ip_returns_deferred(
+        self, mock_defer: MagicMock
+    ) -> None:
+        """パブリック IP の場合、Deferred を返すこと."""
+        from twisted.internet import defer as twisted_defer
+
+        # check_ssrf が成功（何も返さない）をシミュレート
+        mock_defer.return_value = twisted_defer.succeed(None)
+        request = Request(url="https://example.com/page")
+        result = self.middleware.process_request(request, self.spider)
+        assert isinstance(result, twisted_defer.Deferred)
+        mock_defer.assert_called_once_with(check_ssrf, "https://example.com/page")
+
+    @patch("rag.scrapy.middleware.threads.deferToThread")
+    def test_private_ip_raises_ignore_request(
+        self, mock_defer: MagicMock
+    ) -> None:
+        """プライベート IP の場合、errback で IgnoreRequest に変換すること."""
+        from twisted.internet import defer as twisted_defer
+        from twisted.python.failure import Failure
+
+        # check_ssrf が ValueError を送出するシミュレート
+        err = ValueError("プライベート IP へのアクセスは拒否されています: evil.com (10.0.0.1)")
+        mock_defer.return_value = twisted_defer.fail(Failure(err))
+        request = Request(url="https://evil.com/page")
+        d = self.middleware.process_request(request, self.spider)
+
+        # errback が IgnoreRequest を送出するか検証
+        errors: list[Failure] = []
+        d.addErrback(lambda f: errors.append(f))
+        assert len(errors) == 1
+        assert errors[0].check(IgnoreRequest)
+
+    @patch("rag.scrapy.middleware.threads.deferToThread")
+    def test_dns_failure_raises_ignore_request(
+        self, mock_defer: MagicMock
+    ) -> None:
+        """DNS 解決失敗の場合、errback で IgnoreRequest に変換すること."""
+        from twisted.internet import defer as twisted_defer
+        from twisted.python.failure import Failure
+
+        err = ValueError("DNS 解決に失敗しました: nonexistent.com")
+        mock_defer.return_value = twisted_defer.fail(Failure(err))
+        request = Request(url="https://nonexistent.com/page")
+        d = self.middleware.process_request(request, self.spider)
+
+        errors: list[Failure] = []
+        d.addErrback(lambda f: errors.append(f))
+        assert len(errors) == 1
+        assert errors[0].check(IgnoreRequest)

--- a/tests/test_scrapy_middleware.py
+++ b/tests/test_scrapy_middleware.py
@@ -1,0 +1,161 @@
+"""Scrapy SSRF Middleware のユニットテスト.
+
+仕様: docs/specs/site-ingest.md
+
+テスト方針:
+- パブリック IP に解決される URL は通過すること
+- プライベート IP に解決される URL は IgnoreRequest で拒否すること
+- localhost は IgnoreRequest で拒否すること
+- DNS 解決に失敗した場合は IgnoreRequest で拒否すること
+- ホスト名なしの URL は IgnoreRequest で拒否すること
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+from scrapy.exceptions import IgnoreRequest
+from scrapy.http import Request
+
+from rag.scrapy.middleware import SsrfMiddleware
+
+
+class TestSsrfMiddleware:
+    """SsrfMiddleware のテスト."""
+
+    def setup_method(self) -> None:
+        """各テスト前に Middleware インスタンスを生成する."""
+        self.middleware = SsrfMiddleware()
+        self.spider = MagicMock()
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_public_ip_passes(self, mock_getaddrinfo: MagicMock) -> None:
+        """パブリック IP に解決される URL は通過する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+        ]
+        request = Request(url="https://example.com/page")
+        result = self.middleware.process_request(request, self.spider)
+        assert result is None
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_private_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """プライベート IP（10.0.0.0/8）に解決される URL は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]
+        request = Request(url="https://evil.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_loopback_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """ループバック IP（127.0.0.0/8）に解決される URL は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        request = Request(url="https://rebind.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_link_local_ip_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """リンクローカル IP（169.254.0.0/16）に解決される URL は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.1.1", 0)),
+        ]
+        request = Request(url="https://link-local.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_rfc1918_172_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """RFC 1918 プライベート IP（172.16.0.0/12）は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("172.16.0.1", 0)),
+        ]
+        request = Request(url="https://internal.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_rfc1918_192_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """RFC 1918 プライベート IP（192.168.0.0/16）は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("192.168.1.1", 0)),
+        ]
+        request = Request(url="https://home.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    def test_localhost_hostname_rejected(self) -> None:
+        """localhost ホスト名は DNS 解決前にホスト名マッチで拒否する."""
+        request = Request(url="https://localhost/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    def test_localhost_localdomain_rejected(self) -> None:
+        """localhost.localdomain ホスト名は拒否する."""
+        request = Request(url="https://localhost.localdomain/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch(
+        "rag.utils.url.socket.getaddrinfo",
+        side_effect=socket.gaierror("DNS resolution failed"),
+    )
+    def test_dns_failure_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """DNS 解決に失敗した場合は拒否する."""
+        request = Request(url="https://nonexistent.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_ipv6_loopback_rejected(self, mock_getaddrinfo: MagicMock) -> None:
+        """IPv6 ループバック（::1）に解決される URL は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("::1", 0, 0, 0)),
+        ]
+        request = Request(url="https://ipv6-loopback.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_ipv6_unique_local_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """IPv6 ユニークローカル（fc00::/7）に解決される URL は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("fd00::1", 0, 0, 0)),
+        ]
+        request = Request(url="https://ipv6-ula.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_mixed_ips_with_private_rejected(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """パブリック IP とプライベート IP が混在する場合は拒否する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]
+        request = Request(url="https://dual.example.com/page")
+        with pytest.raises(IgnoreRequest, match="SSRF check failed"):
+            self.middleware.process_request(request, self.spider)
+
+    @patch("rag.utils.url.socket.getaddrinfo")
+    def test_multiple_public_ips_pass(
+        self, mock_getaddrinfo: MagicMock
+    ) -> None:
+        """複数のパブリック IP は全て通過する."""
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("93.184.216.35", 0)),
+        ]
+        request = Request(url="https://cdn.example.com/page")
+        result = self.middleware.process_request(request, self.spider)
+        assert result is None


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- `SsrfMiddleware` (Downloader Middleware) を新規作成し、各リクエストの DNS 解決結果を検証
- プライベート IP（127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 等）へのアクセスを拒否
- DNS リバインディング攻撃に対応（リクエストごとに独立して DNS 解決を実行）
- `runner.py` の `DOWNLOADER_MIDDLEWARES` に優先度 50 で登録
- `docs/specs/site-ingest.md` の安全制約を 2 層構成（初回 URL + per-request）に更新
- `rag.utils.url.check_ssrf` を共有ユーティリティとして使用（#315 のコピーを含む）

**依存**: #315 を先にマージすること（`src/rag/utils/url.py` の共有ユーティリティ）

## Test plan

- [x] `test_scrapy_middleware.py` 13 PASSED
- [x] `uv run pytest` 全テスト 1208 passed, 6 failed（TestRagCrawlPreviewTool — #311 で修正対象）
- [x] `uv run ruff check .` クリーン（既存 F401 1件のみ — #315 で修正済み）
- [x] `uv run mypy src` クリーン（60 source files）

## Related issues

Closes #316