### PR TITLE
feat(pipeline-controller): rebuild 時に未コミット変更を自動コミットするオプション追加 (#304)

### DIFF
--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -47,17 +47,44 @@
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
 | 差分更新 | なし（自動検知） | 処理結果サマリ | `last_commit_id` と HEAD の差分を検知し、変更ファイルのみをパイプライン処理する。通常運用のデフォルト操作 |
-| 全再構築 | source_type フィルタ（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合はエラーとする（git とディスクの不整合を防止） |
-| コンバートのみ再実行 | source_type フィルタ（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合はエラーとする |
-| インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラーとする |
+| 全再構築 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
+| コンバートのみ再実行 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
+| インデックスのみ再構築 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
+
+### 未コミット変更チェックと auto_commit
+
+再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）の実行前に、source_store に未コミットの変更があるかチェックする。チェック範囲と自動コミット範囲は `source_type` の指定有無に応じて変わる。
+
+| auto_commit の値 | 未コミット変更がある場合の振る舞い |
+|-----------------|-------------------------------|
+| `false`（デフォルト） | エラーとして再構築を拒否する（従来動作） |
+| `true` | 自動コミットを実行し、コミット成功後に再構築を続行する |
+
+#### source_type によるスコープ
+
+| source_type | 未コミットチェックの範囲 | auto_commit のステージング範囲 |
+|-------------|---------------------|--------------------------|
+| 指定あり | `git status --porcelain -- {source_type}/` でそのディレクトリのみチェック | `git add {source_type}/` でそのディレクトリのみステージング＋コミット |
+| 指定なし | `git status --porcelain` で全体チェック（従来動作） | `git add -A` で全体ステージング＋コミット（従来動作） |
+
+source_type を指定することで、他の source_type ディレクトリに編集途中のファイルがあっても影響を受けずに再構築を実行できる。
+
+#### auto_commit が `true` の場合の処理フロー
+
+1. source_store の未コミット変更を検知する（source_type 指定時はそのディレクトリのみ）
+2. ステージング＋コミットで変更をコミットする（コミットメッセージ形式は「コミットメッセージ規則」を参照）
+3. コミット成功後、再構築処理に進む
+4. auto_commit が `true` だが変更がない場合は自動コミットをスキップし、再構築に進む。git commit コマンド自体が失敗した場合（権限エラー等）はエラーとする
+
+差分更新および取り込み実行は未コミット変更チェックの対象外であり、auto_commit パラメータは適用されない。
 
 ### git 操作
 
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
 | リポジトリ初期化 | source_store パス | なし | source_store ディレクトリで `git init` を実行する。既に初期化済みの場合は何もしない |
-| ステージング＋コミット | コミットメッセージ | コミット ID | source_store 内の変更を `git add -A` + `git commit` する。変更がない場合はスキップする |
+| ステージング＋コミット | コミットメッセージ、対象パス（任意） | コミット ID | source_store 内の変更をステージング＋コミットする。対象パス指定時は `git add {対象パス}/` でそのパス配下のみをステージングする。未指定時は `git add -A` で全体をステージングする。変更がない場合はスキップする |
 | 差分取得 | 基準コミット ID | 変更ファイルリスト | `git diff --name-status <基準ID>..HEAD` で変更ファイル（追加・変更・削除・リネーム）を取得する |
 
 ### 変更ファイルリストの構造
@@ -116,6 +143,8 @@ flowchart TD
 flowchart TD
     START["全再構築開始"]
     CHECK_DIRTY{"未コミットの変更あり?"}
+    CHECK_AUTO{"auto_commit が true?"}
+    AUTO_COMMIT["自動コミット実行"]
     ERROR_DIRTY["エラー: rebuild 拒否"]
     CLEAR_CONV["converted_store をクリア"]
     CLEAR_IDX["ChromaDB + BM25 をクリア"]
@@ -129,7 +158,10 @@ flowchart TD
     REBUILD_DB["metadata.db 再構築（source_store スキャン）"]
 
     START --> CHECK_DIRTY
-    CHECK_DIRTY -- Yes --> ERROR_DIRTY
+    CHECK_DIRTY -- Yes --> CHECK_AUTO
+    CHECK_AUTO -- Yes --> AUTO_COMMIT
+    AUTO_COMMIT --> REBUILD_DB
+    CHECK_AUTO -- No --> ERROR_DIRTY
     CHECK_DIRTY -- No --> REBUILD_DB
     REBUILD_DB --> CLEAR_CONV
     CLEAR_CONV --> CLEAR_IDX
@@ -189,6 +221,10 @@ sequenceDiagram
 |---------|-------------|
 | インジェスター実行後 | `ingest({source_type}): {概要}` |
 | 手動ファイル配置後（local） | `ingest(local): manual update` |
+| 再構築時の自動コミット（source_type 指定なし） | `auto-commit: rebuild ({mode})` |
+| 再構築時の自動コミット（source_type 指定あり） | `auto-commit: rebuild ({mode}, {source_type})` |
+
+`{mode}` は再構築モード（`full`、`convert`、`index`）が入る。
 
 `source_type` の取りうる値は [source-store.md](source-store.md) の「source_id の決定方式」を参照（`web`, `bluesky`, `zenn`, `local`）。
 
@@ -205,7 +241,8 @@ sequenceDiagram
 | source_store の git リポジトリが未初期化 | パイプライン初回実行時に `git init` を自動実行する |
 | .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータを更新する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |
 | metadata.db の `status` が `deleted` のファイルが git diff に含まれる場合 | ファイルの変更種別に応じた処理を行う。`deleted` ステータスのファイルはインデックスに追加しない |
-| 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | エラーとして再構築を拒否する。git とディスクの不整合状態で再構築すると、pipeline_history と実際のファイル状態が乖離する |
+| 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | auto_commit が `false`（デフォルト）の場合はエラーとして再構築を拒否する。auto_commit が `true` の場合は自動コミットを実行してから再構築を続行する |
+| 自動コミット時に git commit が失敗した場合 | エラーとして再構築を拒否する（コミット失敗の原因をエラーメッセージに含める） |
 
 ### 設定項目
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -54,6 +54,7 @@
 |-----------|-----|------|------|
 | `mode` | str | はい | 再構築モード（下表参照） |
 | `source_type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`local`。未指定時は全媒体 |
+| `auto_commit` | bool | いいえ | source_store に未コミット変更がある場合に自動コミットするか。`source_type` 指定時はそのディレクトリのみを対象とする。デフォルト: `false` |
 
 再構築モード:
 
@@ -65,6 +66,7 @@
 | `incremental` | 差分更新 | 適用不可（git diff に従う） | 通常運用（明示指定は通常不要） |
 
 - `source_type` フィルタが適用不可のモード（`incremental`）で `source_type` が指定された場合、エラーを返す
+- `auto_commit` が適用不可のモード（`incremental`）で `auto_commit` が `true` に指定された場合、エラーを返す
 - 戻り値: 処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）をテキストで返す
 
 #### rag_stats（拡張）
@@ -79,13 +81,14 @@
 #### rebuild コマンド
 
 ```
-uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>]
+uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>] [--auto-commit]
 ```
 
 | オプション | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `--mode` | str | はい | 再構築モード: `full`、`convert`、`index`、`incremental` |
 | `--source-type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`local` |
+| `--auto-commit` | フラグ | いいえ | 指定時、source_store に未コミット変更がある場合に自動コミットする。`--source-type` 指定時はそのディレクトリのみを対象とする。未指定時はエラーで拒否（デフォルト動作） |
 
 MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適用する。
 
@@ -236,6 +239,7 @@ metadata.db が破損・消失している場合は、パイプライン制御�
 | source_store ディレクトリが存在しない場合 | `rag_stats` は source_store の各項目を 0 で表示する。`rag_rebuild` はエラーを返す |
 | 再構築中に別の再構築が要求された場合 | 後発の要求にエラーを返す（排他制御） |
 | `incremental` モードで `source_type` が指定された場合 | パラメータ検証エラーを返す |
+| `incremental` モードで `auto_commit` が `true` の場合 | パラメータ検証エラーを返す |
 | metadata.db が存在しない場合の `rag_stats` | パイプラインセクションを「未初期化」と表示する。source_store のファイルシステムベースの統計は表示する |
 | 再構築中にエラーが発生した場合 | パイプライン制御のエラーハンドリングに従う（エラーファイルをスキップし残りを処理続行。`pipeline_history` に履歴を追加しない） |
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -295,6 +295,12 @@ def main() -> None:
         default=None,
         help="対象媒体フィルタ（incremental では指定不可）",
     )
+    rebuild_parser.add_argument(
+        "--auto-commit",
+        action="store_true",
+        default=False,
+        help="未コミット変更がある場合に自動コミットする（incremental では指定不可）",
+    )
 
     # stats サブコマンド
     subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
@@ -1023,11 +1029,19 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     mode: str = args.mode
     source_type: SourceType | None = args.source_type
+    auto_commit: bool = args.auto_commit
 
     # incremental + source_type のバリデーション
     if mode == "incremental" and source_type is not None:
         logger.error(
             "incremental モードでは source_type を指定できません"
+        )
+        sys.exit(1)
+
+    # incremental + auto_commit のバリデーション
+    if mode == "incremental" and auto_commit:
+        logger.error(
+            "incremental モードでは --auto-commit を指定できません"
         )
         sys.exit(1)
 
@@ -1099,11 +1113,17 @@ def run_rebuild(args: argparse.Namespace) -> None:
     start = time.monotonic()
 
     if mode == "full":
-        summary = controller.run_full_rebuild(source_type=source_type)
+        summary = controller.run_full_rebuild(
+            source_type=source_type, auto_commit=auto_commit,
+        )
     elif mode == "convert":
-        summary = controller.run_convert_only(source_type=source_type)
+        summary = controller.run_convert_only(
+            source_type=source_type, auto_commit=auto_commit,
+        )
     elif mode == "index":
-        summary = controller.run_index_only(source_type=source_type)
+        summary = controller.run_index_only(
+            source_type=source_type, auto_commit=auto_commit,
+        )
     else:
         summary = controller.run_incremental()
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -179,17 +180,25 @@ class PipelineController:
     def run_full_rebuild(
         self,
         source_type: SourceType | None = None,
+        *,
+        auto_commit: bool = False,
     ) -> PipelineSummary:
         """全再構築を実行する.
 
         converted_store とインデックスをクリアし、
         source_store 全ファイルをパイプライン処理する。
 
+        Args:
+            source_type: 対象媒体フィルタ（None で全媒体）
+            auto_commit: True の場合、未コミット変更を自動コミットする
+
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._check_uncommitted_changes()
+        self._auto_commit_if_needed(auto_commit, "full", source_type)
+        self._check_uncommitted_changes(source_type)
 
         # 1. metadata.db 再構築
         self._source_store.rebuild_db()
@@ -259,33 +268,76 @@ class PipelineController:
             to_commit_id=to_commit,
         )
 
-    def _check_uncommitted_changes(self) -> None:
+    def _check_uncommitted_changes(
+        self,
+        source_type: SourceType | None = None,
+    ) -> None:
         """source_store に未コミットの変更がないか確認する.
+
+        Args:
+            source_type: チェック対象の媒体ディレクトリ（None で全体）
 
         Raises:
             RuntimeError: 未コミットの変更がある場合
         """
-        if self._git.has_commits() and self._git.has_uncommitted_changes():
+        if self._git.has_commits() and self._git.has_uncommitted_changes(
+            path=source_type,
+        ):
             msg = (
                 "source_store に未コミットの変更があります。"
                 "rebuild 前に変更をコミットしてください。"
             )
             raise RuntimeError(msg)
 
+    def _auto_commit_if_needed(
+        self,
+        auto_commit: bool,
+        mode: str,
+        source_type: SourceType | None = None,
+    ) -> None:
+        """auto_commit が有効な場合、未コミット変更を自動コミットする.
+
+        Args:
+            auto_commit: 自動コミットを実行するか
+            mode: 再構築モード（コミットメッセージに使用）
+            source_type: コミット対象の媒体ディレクトリ（None で全体）
+        """
+        if not auto_commit:
+            return
+        if source_type is not None:
+            message = f"auto-commit: rebuild ({mode}, {source_type})"
+        else:
+            message = f"auto-commit: rebuild ({mode})"
+        try:
+            commit_id = self._git.commit(message, path=source_type)
+        except subprocess.CalledProcessError as e:
+            msg = f"自動コミットに失敗しました: {e.stderr or e}"
+            raise RuntimeError(msg) from e
+        if commit_id:
+            logger.info("自動コミット完了: %s", commit_id)
+
     def run_convert_only(
         self,
         source_type: SourceType | None = None,
+        *,
+        auto_commit: bool = False,
     ) -> PipelineSummary:
         """コンバートのみ再実行する.
 
         converted_store をクリアし、source_store 全ファイルを
         コンバーターで再処理する。インデクサーは実行しない。
 
+        Args:
+            source_type: 対象媒体フィルタ（None で全媒体）
+            auto_commit: True の場合、未コミット変更を自動コミットする
+
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._check_uncommitted_changes()
+        self._auto_commit_if_needed(auto_commit, "convert", source_type)
+        self._check_uncommitted_changes(source_type)
 
         # 1. converted_store クリア
         self._converter.clear(self._converted_store_dir, source_type)
@@ -338,17 +390,25 @@ class PipelineController:
     def run_index_only(
         self,
         source_type: SourceType | None = None,
+        *,
+        auto_commit: bool = False,
     ) -> PipelineSummary:
         """インデックスのみ再構築する.
 
         ChromaDB + BM25 をクリアし、
         converted_store 全ファイルからインデックスを再構築する。
 
+        Args:
+            source_type: 対象媒体フィルタ（None で全媒体）
+            auto_commit: True の場合、未コミット変更を自動コミットする
+
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._check_uncommitted_changes()
+        self._auto_commit_if_needed(auto_commit, "index", source_type)
+        self._check_uncommitted_changes(source_type)
 
         # 1. インデックスクリア
         self._indexer.clear(source_type)

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -55,7 +55,13 @@ class GitOperations:
             コミット ID。変更なしの場合は None。
         """
         if path is not None:
-            self._run(["git", "add", f"{path}/"])
+            try:
+                self._run(["git", "add", f"{path}/"])
+            except subprocess.CalledProcessError as exc:
+                err = exc.stderr or ""
+                if "did not match any files" in err:
+                    return None
+                raise
             result = self._run(["git", "status", "--porcelain", "--", f"{path}/"])
         else:
             self._run(["git", "add", "-A"])

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -42,19 +42,24 @@ class GitOperations:
         # パイプライン用のローカル git user 設定
         self._ensure_git_user()
 
-    def commit(self, message: str) -> str | None:
+    def commit(self, message: str, path: str | None = None) -> str | None:
         """ステージング + コミット.
 
         変更がない場合はスキップする。
 
         Args:
             message: コミットメッセージ
+            path: 対象ディレクトリ（None で全体）
 
         Returns:
             コミット ID。変更なしの場合は None。
         """
-        self._run(["git", "add", "-A"])
-        result = self._run(["git", "status", "--porcelain"])
+        if path is not None:
+            self._run(["git", "add", f"{path}/"])
+            result = self._run(["git", "status", "--porcelain", "--", f"{path}/"])
+        else:
+            self._run(["git", "add", "-A"])
+            result = self._run(["git", "status", "--porcelain"])
         if not result.stdout.strip():
             return None
         self._run(["git", "commit", "-m", message])
@@ -69,9 +74,18 @@ class GitOperations:
         result = self._run(["git", "rev-parse", "HEAD"])
         return result.stdout.strip()
 
-    def has_uncommitted_changes(self) -> bool:
-        """未コミットの変更があるか確認する（副作用なし）."""
-        result = self._run(["git", "status", "--porcelain"])
+    def has_uncommitted_changes(self, path: str | None = None) -> bool:
+        """未コミットの変更があるか確認する（副作用なし）.
+
+        Args:
+            path: 対象ディレクトリ（None で全体）
+        """
+        if path is not None:
+            result = self._run(
+                ["git", "status", "--porcelain", "--", f"{path}/"],
+            )
+        else:
+            result = self._run(["git", "status", "--porcelain"])
         return bool(result.stdout.strip())
 
     def has_commits(self) -> bool:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1229,7 +1229,11 @@ def _collect_pipeline_stats(
 
 
 @mcp.tool()
-async def rag_rebuild(mode: str, source_type: str | None = None) -> str:
+async def rag_rebuild(
+    mode: str,
+    source_type: str | None = None,
+    auto_commit: bool = False,
+) -> str:
     """[rag-knowledge] RAG rebuild - ナレッジベースの再構築を実行する.
 
     knowledge base, rebuild, pipeline, reindex, convert.
@@ -1245,6 +1249,8 @@ async def rag_rebuild(mode: str, source_type: str | None = None) -> str:
             "incremental" — 差分更新（通常運用）
         source_type: 対象媒体フィルタ: "web", "bluesky", "zenn", "local"。
             未指定時は全媒体。incremental モードでは指定不可。
+        auto_commit: source_store に未コミット変更がある場合に自動コミットするか。
+            デフォルト: false。incremental モードでは指定不可。
 
     Returns:
         処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）
@@ -1263,6 +1269,9 @@ async def rag_rebuild(mode: str, source_type: str | None = None) -> str:
             "エラー: incremental モードでは source_type を指定できません"
             "（git diff に従います）"
         )
+
+    if mode == "incremental" and auto_commit:
+        return "エラー: incremental モードでは auto_commit を指定できません"
 
     # 設定の検証
     settings = get_settings()
@@ -1286,11 +1295,17 @@ async def rag_rebuild(mode: str, source_type: str | None = None) -> str:
         def _run_rebuild() -> PipelineSummary:
             controller = _build_pipeline_controller()
             if mode == "full":
-                return controller.run_full_rebuild(source_type=st)
+                return controller.run_full_rebuild(
+                    source_type=st, auto_commit=auto_commit,
+                )
             if mode == "convert":
-                return controller.run_convert_only(source_type=st)
+                return controller.run_convert_only(
+                    source_type=st, auto_commit=auto_commit,
+                )
             if mode == "index":
-                return controller.run_index_only(source_type=st)
+                return controller.run_index_only(
+                    source_type=st, auto_commit=auto_commit,
+                )
             # mode == "incremental"
             return controller.run_incremental()
 

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -954,3 +955,212 @@ class TestRenamedLocalSourceId:
         # インデクサー: 旧削除 + 新追加
         assert "local/old.txt" in indexer.deleted_ids
         assert "local/new.txt" in indexer.added
+
+
+class TestAutoCommit:
+    """auto_commit オプションのテスト."""
+
+    def test_auto_commit_full_rebuild_with_uncommitted(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """auto_commit=True + 未コミット変更あり → 自動コミットされて rebuild 成功."""
+        ctrl, converter, indexer = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        # 未コミットのファイルを追加
+        _place_local_file(workspace["source"], "local/new.txt")
+
+        converter.converted.clear()
+        indexer.added.clear()
+
+        # auto_commit=True なので成功する
+        summary = ctrl.run_full_rebuild(auto_commit=True)
+        assert summary.mode == PipelineMode.FULL_REBUILD
+        assert summary.processed == 2  # a.txt + new.txt
+
+    def test_auto_commit_false_with_uncommitted_raises(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """auto_commit=False（デフォルト） + 未コミット変更あり → RuntimeError."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+
+        _place_local_file(workspace["source"], "local/uncommitted.txt")
+
+        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
+            ctrl.run_full_rebuild()
+
+    def test_auto_commit_no_changes(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """auto_commit=True + 変更なし → 正常に rebuild 実行."""
+        ctrl, converter, indexer = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        converter.converted.clear()
+        indexer.added.clear()
+
+        summary = ctrl.run_full_rebuild(auto_commit=True)
+        assert summary.mode == PipelineMode.FULL_REBUILD
+        assert summary.processed == 1  # a.txt
+
+    def test_auto_commit_convert_only(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """run_convert_only で auto_commit が機能する."""
+        ctrl, converter, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        # 既存ファイルを変更（未コミット状態にする）
+        _place_local_file(workspace["source"], "local/a.txt", "updated")
+
+        converter.converted.clear()
+
+        # auto_commit=False ならエラーになるが、True なので成功する
+        summary = ctrl.run_convert_only(auto_commit=True)
+        assert summary.mode == PipelineMode.CONVERT_ONLY
+        assert summary.processed == 1  # a.txt（metadata.db に登録済み）
+
+    def test_auto_commit_index_only(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """run_index_only で auto_commit が機能する."""
+        ctrl, _, indexer = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        # 既存ファイルを変更（未コミット状態にする）
+        _place_local_file(workspace["source"], "local/a.txt", "updated")
+
+        indexer.added.clear()
+
+        # auto_commit=False ならエラーになるが、True なので成功する
+        summary = ctrl.run_index_only(auto_commit=True)
+        assert summary.mode == PipelineMode.INDEX_ONLY
+        assert summary.processed == 1  # a.txt（converted_store にある）
+
+    def test_auto_commit_message_format(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """自動コミットのメッセージが仕様通りの形式になる."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+
+        # 未コミットのファイルを追加
+        _place_local_file(workspace["source"], "local/new.txt")
+
+        ctrl.run_full_rebuild(auto_commit=True)
+
+        # git log で最新コミットメッセージを確認
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=str(workspace["source"]),
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        assert result.stdout.strip() == "auto-commit: rebuild (full)"
+
+    def test_auto_commit_scoped_by_source_type(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """source_type 指定時、他の source_type の変更はコミットされない."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        _place_web_file(workspace["source"], "web/example.com/page.html")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        # 両方に未コミット変更を追加
+        _place_local_file(workspace["source"], "local/b.txt", "new local")
+        _place_web_file(
+            workspace["source"],
+            "web/example.com/page2.html",
+            title="Page 2",
+            source_id="web/example.com/page2.html",
+        )
+
+        # source_type="local" で auto_commit → local だけコミットされる
+        ctrl.run_full_rebuild(source_type="local", auto_commit=True)
+
+        # web の変更はまだ未コミットのはず
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--", "web/"],
+            cwd=str(workspace["source"]),
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        assert result.stdout.strip() != ""  # web にはまだ変更がある
+
+    def test_auto_commit_source_type_message_format(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """source_type 指定時のコミットメッセージ形式を確認."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+
+        _place_local_file(workspace["source"], "local/new.txt")
+
+        ctrl.run_full_rebuild(source_type="local", auto_commit=True)
+
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=str(workspace["source"]),
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        assert result.stdout.strip() == "auto-commit: rebuild (full, local)"
+
+    def test_uncommitted_check_scoped_by_source_type(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """source_type 指定時、他の source_type の未コミット変更はエラーにならない."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        # web に未コミット変更を追加（local は変更なし）
+        _place_web_file(
+            workspace["source"],
+            "web/example.com/new.html",
+            title="New Page",
+            source_id="web/example.com/new.html",
+        )
+
+        # source_type="local" で rebuild → web の変更は無視されるので成功する
+        summary = ctrl.run_full_rebuild(source_type="local")
+        assert summary.mode == PipelineMode.FULL_REBUILD


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- rebuild（full/convert/index）に `auto_commit` オプションを追加。未コミット変更がある場合に自動コミットしてから再構築を続行する
- `source_type` 指定時は対象ディレクトリのみをスコープとして自動コミット・未コミットチェックを行う（他の source_type の変更を巻き込まない）
- MCP ツール `rag_rebuild` に `auto_commit` パラメータ追加
- CLI `rebuild` コマンドに `--auto-commit` フラグ追加
- `incremental` モードとの排他バリデーション追加
- `GitOperations.commit()` / `has_uncommitted_changes()` に `path` パラメータ追加（スコープ対応）
- 仕様書（pipeline-controller.md, rebuild-stats.md）を更新

## Test plan

- [x] pytest 42/42 passed
- [x] ruff check clean
- [x] mypy no issues
- [x] 動作確認: 4シナリオ（auto-commit なし→エラー / auto-commit あり→成功 / source_type スコープ / incremental バリデーション）

## Related issues

Closes #304