### PR TITLE
feat(rebuild-stats,site-ingest): MCP 進捗通知 + download_only モード (#326, #322)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,3 @@ reports/
 .claude/settings.local.json
 .claude/*.lock
 scheduled_tasks.lock
-.claude/scheduled_tasks.lock

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -52,6 +52,8 @@
 | インデックスのみ再構築 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
 
+全操作は `progress_callback`（任意）を受け取り、ファイル処理完了ごとにコールバックを呼び出す。callback シグネチャ: `(processed: int, total: int, current: str) -> None`。未指定時は進捗通知なし。詳細は [rebuild-stats.md](rebuild-stats.md) のサブプロセス進捗通知セクションを参照。
+
 ### 未コミット変更チェックと auto_commit
 
 再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）の実行前に、source_store に未コミットの変更があるかチェックする。チェック範囲と自動コミット範囲は `source_type` の指定有無に応じて変わる。

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -125,10 +125,66 @@ flowchart TD
 
 MCP 経由の場合、パイプライン処理（再構築・取り込み後のインデックス構築・削除）は `pipeline/worker.py` をサブプロセスとして実行する。C 拡張の SEGFAULT が発生してもサーバープロセスは生存し、exit code からエラーメッセージを返却する。CLI は独立プロセスのためサブプロセス化は不要。
 
+### サブプロセス進捗通知
+
+MCP ツール経由のパイプライン処理中、サブプロセスの進捗をリアルタイムで MCP クライアントに通知する。
+
+#### 通知方式
+
+2 系統の通知を並行して送信する:
+
+| 方式 | MCP メッセージ | 用途 | クライアント要件 |
+|------|--------------|------|----------------|
+| Logging notification | `notifications/message` | テキストベースの進捗メッセージ | なし（標準 MCP） |
+| Progress notification | `notifications/progress` | 数値進捗（processed / total） | `progressToken` の送信が必要。未送信時は no-op |
+
+FastMCP の `Context` オブジェクト経由で送信する。ツール関数に `ctx: Context` パラメータを追加する。
+
+#### Worker stdout プロトコル
+
+worker.py は処理中に JSON Lines 形式で stdout に出力する。各行は `type` フィールドで識別する。
+
+| `type` 値 | 出力タイミング | フィールド |
+|-----------|-------------|-----------|
+| `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
+| `result` | 処理完了時（最終行） | 既存の結果 JSON と同一（`mode`, `total_files`, `processed`, `skipped`, `errors`, `elapsed`） |
+| `error` | エラー時（最終行） | `message`（str） |
+
+親プロセス（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
+
+#### サーバー側の処理
+
+`_run_worker_subprocess` を行単位ストリーミングに変更する:
+
+1. `asyncio.create_subprocess_exec` で subprocess を起動（従来通り）
+2. stdout を行単位で非同期に読み取る（`communicate()` → `readline()` ループ）
+3. 各行を JSON パースし:
+   - `type: "progress"` → `ctx.info()` でログ通知 + `ctx.report_progress()` で数値通知
+   - `type: "result"` → 結果として返却
+   - `type: "error"` → エラーとして処理
+4. stderr は従来通りプロセス終了後に読み取る
+
+#### PipelineController の変更
+
+処理ループを持つメソッドに `progress_callback` パラメータを追加する:
+
+| メソッド | 対象ループ |
+|---------|-----------|
+| `run_full_rebuild` | 全レコードのコンバート + インデックス |
+| `run_convert_only` | 全レコードのコンバート |
+| `run_index_only` | 全レコードのインデックス |
+| `_process_changes` | 差分変更エントリの処理 |
+
+callback シグネチャ: `(processed: int, total: int, current: str) -> None`
+
+`ingest_and_index` および `run_incremental` も `progress_callback` パラメータを受け取り、内部的に `_process_changes` に中継する。
+
+worker.py はこの callback 内で進捗 JSON を stdout に出力する。CLI は現時点では callback を使用しない（将来対応予定）。callback 未指定時は従来通り無出力。
+
 | ファイル | 役割 |
 |-------------|------|
-| `src/rag/pipeline/worker.py` | MCP 用サブプロセスエントリポイント。`rebuild` / `ingest-and-index` / `delete` のサブコマンドを受け取りパイプライン処理を実行、結果 JSON を stdout に出力 |
-| `src/rag/server.py` | MCP ツール。パラメータ検証・排他制御を行い worker をサブプロセスで起動 |
+| `src/rag/pipeline/worker.py` | MCP 用サブプロセスエントリポイント。`rebuild` / `ingest-and-index` / `delete` のサブコマンドを受け取りパイプライン処理を実行。処理中は進捗 JSON（type: progress）、完了時は結果 JSON（type: result）を stdout に JSON Lines 形式で出力 |
+| `src/rag/server.py` | MCP ツール。パラメータ検証・排他制御を行い worker をサブプロセスで起動。stdout を行単位でストリーミングし、進捗を MCP 通知として転送 |
 | `src/rag/cli.py` | CLI コマンド。パイプライン制御を直接呼び出す（サブプロセス化なし） |
 
 ### rag_stats 出力項目

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -119,7 +119,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| `rag_site_ingest` | `url`（必須）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意） | Scrapy subprocess で対象サイトをクロールし、取得した HTML を source_store に配置後、パイプライン処理を実行する。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
+| `rag_site_ingest` | `url`（必須）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`download_only`（任意） | Scrapy subprocess で対象サイトをクロールし、取得した HTML を source_store に配置後、パイプライン処理を実行する（`download_only` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
 
 #### `rag_site_ingest` パラメータ
 
@@ -129,6 +129,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
 | `max_pages` | int | `site_ingest_max_pages` | ページ数上限。config.toml の値を上書き可能 |
 | `force` | bool | `false` | `true` の場合、ドメインディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする |
+| `download_only` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置）まで実行し、パイプライン処理（converter + indexer）をスキップする。後から `rag_rebuild` で処理可能 |
 
 ### CLI コマンド
 
@@ -144,6 +145,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `--url-pattern` | str | なし | URL フィルタパターン |
 | `--max-pages` | int | `site_ingest_max_pages` | ページ数上限 |
 | `--force` | フラグ | `false` | ドメインディレクトリ全体を削除して再クロール |
+| `--download-only` | フラグ | `false` | Scrapy クロール + Bridge まで実行し、パイプライン処理をスキップ |
 
 ### 取り込み結果の出力形式
 
@@ -358,8 +360,12 @@ sequenceDiagram
     CMD->>BRIDGE: JSONL + HTML → source_store 変換
     BRIDGE->>SS: ファイル配置 + .meta 生成
     BRIDGE->>CMD: 配置結果
-    CMD->>PC: パイプライン処理（MCP: サブプロセス経由）
-    PC->>CMD: パイプライン処理結果
+    alt download_only = false
+        CMD->>PC: パイプライン処理（MCP: サブプロセス経由）
+        PC->>CMD: パイプライン処理結果
+    else download_only = true
+        Note over CMD: パイプライン処理をスキップ
+    end
     CMD->>USER: 結果サマリー
 ```
 
@@ -404,6 +410,7 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--force` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
 | DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
+| `download_only` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
 
 ## 関連ドキュメント
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -371,6 +371,12 @@ def main() -> None:
     siteingest_parser.add_argument("--url-pattern", default="", help="URL フィルタパターン（正規表現）")
     siteingest_parser.add_argument("--max-pages", type=int, default=None, help="ページ数上限")
     siteingest_parser.add_argument("--force", action="store_true", help="JOBDIR を削除して再クロール")
+    siteingest_parser.add_argument(
+        "--download-only",
+        action="store_true",
+        default=False,
+        help="Scrapy クロール + Bridge まで実行し、パイプライン処理をスキップ",
+    )
 
     args = parser.parse_args()
 
@@ -1779,7 +1785,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
 
     # パイプライン処理
     pipeline_summary = None
-    if bridge_result.ingest.placed > 0:
+    if not args.download_only and bridge_result.ingest.placed > 0:
         pipeline_summary = controller.ingest_and_index(f"ingest(web): site-ingest {url}")
 
     # 操作全体の所要時間（クロール + Bridge + パイプライン）
@@ -1792,7 +1798,9 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
         f", {bridge_result.ingest.errors}件エラー"
     )
     print(f"所要時間: {elapsed:.1f}秒")
-    if pipeline_summary is not None:
+    if args.download_only:
+        print("パイプライン処理: スキップ（download_only）")
+    elif pipeline_summary is not None:
         print(f"パイプライン: {pipeline_summary.processed}件処理")
         if pipeline_summary.errors:
             print(f"パイプラインエラー: {len(pipeline_summary.errors)}件")

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import subprocess
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -36,6 +37,9 @@ from rag.store.resolve import resolve_source_id, resolve_title
 from rag.store.source_store import SourceStore
 
 logger = logging.getLogger(__name__)
+
+# 進捗コールバック型: (processed, total, current_file) -> None
+ProgressCallback = Callable[[int, int, str], None]
 
 # .meta を持たない媒体
 _NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})
@@ -93,23 +97,28 @@ class PipelineController:
         self._git.init_repo()
         return self._git.commit(message)
 
-    def ingest_and_index(self, message: str) -> PipelineSummary:
+    def ingest_and_index(
+        self,
+        message: str,
+        progress_callback: ProgressCallback | None = None,
+    ) -> PipelineSummary:
         """インジェスター実行後の後処理を一括実行する.
 
         source_store の変更を git commit し、差分更新を実行する。
 
         Args:
             message: コミットメッセージ
+            progress_callback: 進捗コールバック
 
         Returns:
             パイプライン処理結果サマリ
         """
         self.commit(message)
-        return self.run_incremental()
+        return self.run_incremental(progress_callback=progress_callback)
 
     # --- パイプライン実行 ---
 
-    def run_incremental(self) -> PipelineSummary:
+    def run_incremental(self, progress_callback: ProgressCallback | None = None) -> PipelineSummary:
         """差分更新を実行する.
 
         last_commit_id と HEAD の差分を検知し、
@@ -165,6 +174,7 @@ class PipelineController:
 
         summary = self._process_changes(
             changes, PipelineMode.INCREMENTAL, last_commit_id, head_commit,
+            progress_callback=progress_callback,
         )
 
         # 正常完了時のみ pipeline_history に記録
@@ -182,6 +192,7 @@ class PipelineController:
         source_type: SourceType | None = None,
         *,
         auto_commit: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """全再構築を実行する.
 
@@ -245,6 +256,8 @@ class PipelineController:
                 logger.exception("全再構築中にエラー: %s", record.file_path)
                 errors.append(record.file_path)
                 skipped += 1
+            if progress_callback is not None:
+                progress_callback(processed + skipped, len(records), record.file_path)
 
         # pipeline_history に記録（正常完了時のみ）
         to_commit = ""
@@ -321,6 +334,7 @@ class PipelineController:
         source_type: SourceType | None = None,
         *,
         auto_commit: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """コンバートのみ再実行する.
 
@@ -378,6 +392,8 @@ class PipelineController:
                 )
                 errors.append(record.file_path)
                 skipped += 1
+            if progress_callback is not None:
+                progress_callback(processed + skipped, len(records), record.file_path)
 
         return PipelineSummary(
             mode=PipelineMode.CONVERT_ONLY,
@@ -392,6 +408,7 @@ class PipelineController:
         source_type: SourceType | None = None,
         *,
         auto_commit: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """インデックスのみ再構築する.
 
@@ -456,6 +473,8 @@ class PipelineController:
                 )
                 errors.append(record.file_path)
                 skipped += 1
+            if progress_callback is not None:
+                progress_callback(processed + skipped, len(records), record.file_path)
 
         return PipelineSummary(
             mode=PipelineMode.INDEX_ONLY,
@@ -537,6 +556,7 @@ class PipelineController:
         mode: PipelineMode,
         from_commit_id: str,
         to_commit_id: str,
+        progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """変更エントリを処理する."""
         processed = 0
@@ -553,6 +573,8 @@ class PipelineController:
                 )
                 errors.append(entry.file_path)
                 skipped += 1
+            if progress_callback is not None:
+                progress_callback(processed + skipped, len(changes), entry.file_path)
 
         return PipelineSummary(
             mode=mode,

--- a/src/rag/pipeline/worker.py
+++ b/src/rag/pipeline/worker.py
@@ -34,6 +34,7 @@ from rag.store.models import SourceType
 def _summary_to_dict(summary: PipelineSummary, elapsed: float) -> dict[str, object]:
     """PipelineSummary を JSON 出力用 dict に変換する."""
     return {
+        "type": "result",
         "mode": summary.mode.value,
         "total_files": summary.total_files,
         "processed": summary.processed,
@@ -45,8 +46,19 @@ def _summary_to_dict(summary: PipelineSummary, elapsed: float) -> dict[str, obje
 
 def _emit_error(exc: Exception) -> NoReturn:
     """エラー JSON を stdout に出力し、exit code 1 で終了する."""
-    print(json.dumps({"error": True, "message": str(exc)}, ensure_ascii=False))
+    print(json.dumps({"type": "error", "error": True, "message": str(exc)}, ensure_ascii=False))
     sys.exit(1)
+
+
+def _emit_progress(processed: int, total: int, current: str) -> None:
+    """進捗 JSON を stdout に出力する."""
+    print(
+        json.dumps(
+            {"type": "progress", "processed": processed, "total": total, "current": current},
+            ensure_ascii=False,
+        ),
+        flush=True,
+    )
 
 
 def run_rebuild(args: argparse.Namespace) -> None:
@@ -59,10 +71,10 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     # incremental モードのバリデーション（CLI と同等）
     if mode == "incremental" and source_type is not None:
-        print(json.dumps({"error": True, "message": "incremental モードでは source_type を指定できません"}))
+        print(json.dumps({"type": "error", "error": True, "message": "incremental モードでは source_type を指定できません"}))
         sys.exit(1)
     if mode == "incremental" and auto_commit:
-        print(json.dumps({"error": True, "message": "incremental モードでは auto_commit を指定できません"}))
+        print(json.dumps({"type": "error", "error": True, "message": "incremental モードでは auto_commit を指定できません"}))
         sys.exit(1)
 
     try:
@@ -73,17 +85,22 @@ def run_rebuild(args: argparse.Namespace) -> None:
         if mode == "full":
             summary = controller.run_full_rebuild(
                 source_type=source_type, auto_commit=auto_commit,
+                progress_callback=_emit_progress,
             )
         elif mode == "convert":
             summary = controller.run_convert_only(
                 source_type=source_type, auto_commit=auto_commit,
+                progress_callback=_emit_progress,
             )
         elif mode == "index":
             summary = controller.run_index_only(
                 source_type=source_type, auto_commit=auto_commit,
+                progress_callback=_emit_progress,
             )
         else:
-            summary = controller.run_incremental()
+            summary = controller.run_incremental(
+                progress_callback=_emit_progress,
+            )
 
         elapsed = time.monotonic() - start
 
@@ -100,7 +117,7 @@ def run_ingest_and_index(args: argparse.Namespace) -> None:
         controller = build_pipeline_controller()
 
         start = time.monotonic()
-        summary = controller.ingest_and_index(args.commit_message)
+        summary = controller.ingest_and_index(args.commit_message, progress_callback=_emit_progress)
         elapsed = time.monotonic() - start
 
         print(json.dumps(_summary_to_dict(summary, elapsed), ensure_ascii=False))
@@ -119,14 +136,15 @@ def run_delete(args: argparse.Namespace) -> None:
         try:
             controller.source_store.remove_file(source_id)
         except KeyError:
-            print(json.dumps({"not_found": True}))
+            print(json.dumps({"type": "result", "not_found": True}))
             return  # exit code 0（not_found は正常系）
 
         start = time.monotonic()
-        summary = controller.ingest_and_index(f"delete: {source_id}")
+        summary = controller.ingest_and_index(f"delete: {source_id}", progress_callback=_emit_progress)
         elapsed = time.monotonic() - start
 
         result = {
+            "type": "result",
             "deleted": True,
             "pipeline": _summary_to_dict(summary, elapsed),
         }

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -70,7 +70,10 @@ with contextlib.redirect_stdout(io.StringIO()):
 from py_common_lib.httpx import ConstrainedClient  # safety:allowed
 from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+
+# MCP Context の具象型パラメータ（ツール関数では型パラメータ不要のため Any で統一）
+MCPContext = Context[Any, Any, Any]
 
 # Windows 環境で stderr が cp932 等の場合に UTF-8 へ再構成する
 # stdout は MCP stdio プロトコルが使うため変更しない
@@ -416,7 +419,7 @@ async def rag_get_document(
 
 
 @mcp.tool()
-async def rag_add(url: str) -> str:
+async def rag_add(url: str, ctx: MCPContext | None = None) -> str:
     """[rag-knowledge] RAG add - 単一ページをナレッジベースに取り込む（非推奨: rag_site_ingest を推奨）.
 
     knowledge base, ingest, web page, crawl single URL.
@@ -447,6 +450,7 @@ async def rag_add(url: str) -> str:
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(web): add {url}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -461,7 +465,8 @@ async def rag_add(url: str) -> str:
 
 @mcp.tool()
 async def rag_crawl(
-    url: str, pattern: str = "", depth: int | None = None
+    url: str, pattern: str = "", depth: int | None = None,
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl - リンク集ページからクロール＆一括取り込み（非推奨: rag_site_ingest を推奨）.
 
@@ -517,6 +522,7 @@ async def rag_crawl(
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(web): crawl {url}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -609,6 +615,7 @@ async def rag_crawl_zenn(
     username: str,
     max_articles: int | None = None,
     content_type: str = "all",
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Zenn - Zenn コンテンツを API 経由で取得し一括取り込み.
 
@@ -664,6 +671,7 @@ async def rag_crawl_zenn(
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(zenn): {username.strip()}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -683,6 +691,7 @@ async def rag_crawl_bluesky(
     handle: str,
     max_posts: int | None = None,
     include_reposts: bool | None = None,
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl BlueSky - BlueSky 投稿を AT Protocol API 経由で取得し一括取り込み.
 
@@ -745,6 +754,7 @@ async def rag_crawl_bluesky(
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(bluesky): {handle}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -768,6 +778,7 @@ _VALID_UPLOAD_MODES: frozenset[str] = frozenset({"fail", "replace"})
 async def rag_add_document(
     file_path: str,
     upload_mode: str = "fail",
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add document - ドキュメントファイルをナレッジベースに取り込む.
 
@@ -810,6 +821,7 @@ async def rag_add_document(
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(local): add {file_path}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -829,6 +841,7 @@ async def rag_crawl_documents(
     dir_path: str,
     pattern: str = "**/*",
     upload_mode: str = "fail",
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl documents - ディレクトリ内のドキュメントを一括取り込み.
 
@@ -869,6 +882,7 @@ async def rag_crawl_documents(
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
             f"ingest(local): crawl {dir_path}",
+            ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
@@ -889,6 +903,8 @@ async def rag_site_ingest(
     url_pattern: str = "",
     max_pages: int | None = None,
     force: bool = False,
+    download_only: bool = False,
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG site ingest - Scrapy でサイトを一括取り込み.
 
@@ -901,6 +917,8 @@ async def rag_site_ingest(
         url_pattern: URL フィルタパターン（正規表現、任意）
         max_pages: ページ数上限（未指定時は設定値を使用）
         force: True の場合、JOBDIR を削除して最初からクロール
+        download_only: True の場合、Scrapy クロール + Bridge まで実行し、
+            パイプライン処理（コンバート・インデックス構築）をスキップする
 
     Returns:
         取り込み結果のサマリー
@@ -982,9 +1000,10 @@ async def rag_site_ingest(
 
         # パイプライン処理
         pipeline_summary: PipelineSummary | None = None
-        if bridge_result.ingest.placed > 0:
+        if not download_only and bridge_result.ingest.placed > 0:
             pipeline_summary = await _run_ingest_and_index_subprocess(
                 f"ingest(web): site-ingest {url}",
+                ctx=ctx,
             )
             _reset_pipeline_controller()
             _reset_rag_service()
@@ -1000,7 +1019,9 @@ async def rag_site_ingest(
             f", {bridge_result.ingest.errors}件エラー"
         )
         parts.append(f"所要時間: {elapsed:.1f}秒")
-        if pipeline_summary is not None:
+        if download_only:
+            parts.append("パイプライン処理: スキップ（download_only）")
+        elif pipeline_summary is not None:
             parts.append(f"パイプライン: {pipeline_summary.processed}件処理")
             if pipeline_summary.errors:
                 parts.append(f"パイプラインエラー: {len(pipeline_summary.errors)}件")
@@ -1014,7 +1035,7 @@ async def rag_site_ingest(
 
 
 @mcp.tool()
-async def rag_delete(url: str) -> str:
+async def rag_delete(url: str, ctx: MCPContext | None = None) -> str:
     """[rag-knowledge] RAG delete - ソースURL指定でナレッジから削除.
 
     knowledge base, remove source, delete document.
@@ -1034,7 +1055,7 @@ async def rag_delete(url: str) -> str:
     _reset_pipeline_controller()
 
     try:
-        result = await _run_delete_subprocess(url)
+        result = await _run_delete_subprocess(url, ctx=ctx)
         if result.get("not_found"):
             return f"該当するソースが見つかりませんでした: {url}"
 
@@ -1198,6 +1219,7 @@ async def rag_rebuild(
     mode: str,
     source_type: str | None = None,
     auto_commit: bool = False,
+    ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG rebuild - ナレッジベースの再構築を実行する.
 
@@ -1254,7 +1276,7 @@ async def rag_rebuild(
         return "エラー: 別の再構築が実行中です"
 
     try:
-        result = await _run_rebuild_subprocess(mode, source_type, auto_commit)
+        result = await _run_rebuild_subprocess(mode, source_type, auto_commit, ctx=ctx)
 
         # rebuild はインデックスを全操作するため、両方リセット
         _reset_pipeline_controller()
@@ -1271,14 +1293,21 @@ async def rag_rebuild(
 async def _run_worker_subprocess(
     subcommand: str,
     args: list[str],
+    ctx: MCPContext | None = None,
 ) -> tuple[int, str, str]:
     """worker.py サブコマンドをサブプロセスで実行する.
 
     C 拡張（BM25s 等）の SEGFAULT がサーバープロセスを巻き込まないよう、
     別プロセスで実行してエラーを安全にハンドリングする。
 
+    Args:
+        subcommand: worker サブコマンド名
+        args: サブコマンド引数
+        ctx: MCP Context（進捗通知用、任意）
+
     Returns:
         (exit_code, stdout_text, stderr_tail) のタプル
+        stdout_text には progress 行を除いた最終結果行のみが含まれる
     """
     cmd = [
         sys.executable, "-m", "rag.pipeline.worker",
@@ -1295,25 +1324,60 @@ async def _run_worker_subprocess(
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
+
+    result_line = ""
     try:
-        stdout_bytes, stderr_bytes = await process.communicate()
+        assert process.stdout is not None  # noqa: S101
+        while True:
+            raw = await process.stdout.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+
+            # JSON パースを試みて progress 行をフィルタ
+            try:
+                data = json.loads(line)
+                if isinstance(data, dict) and data.get("type") == "progress":
+                    if ctx is not None:
+                        processed = data.get("processed", 0)
+                        total = data.get("total", 0)
+                        current = data.get("current", "")
+                        await ctx.info(f"処理中: {processed}/{total} - {current}")
+                        await ctx.report_progress(float(processed), float(total))
+                    continue
+            except json.JSONDecodeError:
+                pass
+
+            # progress 以外の行は result_line として保持
+            # （worker は result/error を最終行に1行のみ出力する前提）
+            result_line = line
     except asyncio.CancelledError:
-        # タスクキャンセル時に子プロセスを確実に終了させる
         if process.returncode is None:
             with contextlib.suppress(ProcessLookupError):
                 process.kill()
             with contextlib.suppress(asyncio.CancelledError):
                 await process.wait()
         raise
+
+    # stderr 読み取り + wait
+    # NOTE: stderr はプロセス終了後に読み取る。worker が stderr に大量出力
+    # （64KB超）した場合、stdout readline 中にパイプバッファが満杯になり
+    # デッドロックするリスクがある。現時点では worker の stderr 出力量は
+    # 少量のため問題ないが、大規模処理で顕在化する場合は stderr の
+    # 並行読み取りへの変更を検討する。
+    stderr_bytes = await process.stderr.read() if process.stderr else b""
+    await process.wait()
+
     assert process.returncode is not None  # noqa: S101
     exit_code = process.returncode
 
-    stdout_text = stdout_bytes.decode("utf-8", errors="replace").strip() if stdout_bytes else ""
     stderr_text = stderr_bytes.decode("utf-8", errors="replace") if stderr_bytes else ""
     stderr_lines = stderr_text.rstrip().splitlines()
     stderr_tail = "\n".join(stderr_lines[-10:])
 
-    return exit_code, stdout_text, stderr_tail
+    return exit_code, result_line, stderr_tail
 
 
 def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
@@ -1333,7 +1397,10 @@ def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
         return None
 
 
-async def _run_ingest_and_index_subprocess(commit_message: str) -> PipelineSummary:
+async def _run_ingest_and_index_subprocess(
+    commit_message: str,
+    ctx: MCPContext | None = None,
+) -> PipelineSummary:
     """ingest_and_index をサブプロセスで実行し PipelineSummary を返す.
 
     Raises:
@@ -1341,6 +1408,7 @@ async def _run_ingest_and_index_subprocess(commit_message: str) -> PipelineSumma
     """
     exit_code, stdout_text, stderr_tail = await _run_worker_subprocess(
         "ingest-and-index", ["--commit-message", commit_message],
+        ctx=ctx,
     )
 
     if exit_code != 0:
@@ -1377,7 +1445,10 @@ async def _run_ingest_and_index_subprocess(commit_message: str) -> PipelineSumma
     return summary
 
 
-async def _run_delete_subprocess(source_id: str) -> dict[str, Any]:
+async def _run_delete_subprocess(
+    source_id: str,
+    ctx: MCPContext | None = None,
+) -> dict[str, Any]:
     """delete をサブプロセスで実行する.
 
     Returns:
@@ -1385,6 +1456,7 @@ async def _run_delete_subprocess(source_id: str) -> dict[str, Any]:
     """
     exit_code, stdout_text, stderr_tail = await _run_worker_subprocess(
         "delete", ["--source-id", source_id],
+        ctx=ctx,
     )
 
     if exit_code != 0:
@@ -1422,6 +1494,7 @@ async def _run_rebuild_subprocess(
     mode: str,
     source_type: str | None,
     auto_commit: bool,
+    ctx: MCPContext | None = None,
 ) -> str:
     """rebuild を CLI サブプロセスで実行する."""
     args = ["--mode", mode]
@@ -1430,7 +1503,9 @@ async def _run_rebuild_subprocess(
     if auto_commit:
         args.append("--auto-commit")
 
-    exit_code, stdout_text, stderr_tail = await _run_worker_subprocess("rebuild", args)
+    exit_code, stdout_text, stderr_tail = await _run_worker_subprocess(
+        "rebuild", args, ctx=ctx,
+    )
 
     # クラッシュ検出
     if exit_code != 0:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1336,23 +1336,25 @@ async def _run_worker_subprocess(
             if not line:
                 continue
 
-            # JSON パースを試みて progress 行をフィルタ
+            # JSON パースを試みて type フィールドで分岐
             try:
                 data = json.loads(line)
-                if isinstance(data, dict) and data.get("type") == "progress":
-                    if ctx is not None:
-                        processed = data.get("processed", 0)
-                        total = data.get("total", 0)
-                        current = data.get("current", "")
-                        await ctx.info(f"処理中: {processed}/{total} - {current}")
-                        await ctx.report_progress(float(processed), float(total))
-                    continue
+                if isinstance(data, dict):
+                    msg_type = data.get("type")
+                    if msg_type == "progress":
+                        if ctx is not None:
+                            processed = data.get("processed", 0)
+                            total = data.get("total", 0)
+                            current = data.get("current", "")
+                            await ctx.info(f"処理中: {processed}/{total} - {current}")
+                            await ctx.report_progress(float(processed), float(total))
+                        continue
+                    # result/error のみ最終結果として保持（ログ等の非JSON行で上書きしない）
+                    if msg_type in {"result", "error"}:
+                        result_line = line
             except json.JSONDecodeError:
+                # 非 JSON 行（ログ等）は result_line を上書きしない
                 pass
-
-            # progress 以外の行は result_line として保持
-            # （worker は result/error を最終行に1行のみ出力する前提）
-            result_line = line
     except asyncio.CancelledError:
         if process.returncode is None:
             with contextlib.suppress(ProcessLookupError):

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -550,7 +550,7 @@ class TestRunRebuildSubprocess:
         from rag.server import _run_rebuild_subprocess
 
         mock_process = _make_mock_process(
-            b'{"mode":"full_rebuild","total_files":5,"processed":5,'
+            b'{"type":"result","mode":"full_rebuild","total_files":5,"processed":5,'
             b'"skipped":0,"errors":[],"elapsed":1.2}',
             b"", 0,
         )
@@ -563,8 +563,9 @@ class TestRunRebuildSubprocess:
         assert "処理件数: 5" in result
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_invalid_json_result(self) -> None:
-        """JSON パース失敗時にフォールバックすること."""
+        """非 JSON 行のみの場合、結果なしとして処理されること."""
         from rag.server import _run_rebuild_subprocess
 
         mock_process = _make_mock_process(b"not json", b"", 0)
@@ -572,7 +573,7 @@ class TestRunRebuildSubprocess:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
 
-        assert "結果の解析に失敗" in result
+        assert "結果なし" in result
 
     @pytest.mark.asyncio
     async def test_nonzero_exit_with_stderr(self) -> None:
@@ -606,7 +607,7 @@ class TestRunRebuildSubprocess:
         from rag.server import _run_rebuild_subprocess
 
         mock_process = _make_mock_process(
-            b'{"error":true,"message":"source_store not found"}',
+            b'{"type":"error","error":true,"message":"source_store not found"}',
             b"Traceback ...\n", 1,
         )
 
@@ -628,7 +629,7 @@ class TestRunIngestAndIndexSubprocess:
         from rag.server import _run_ingest_and_index_subprocess
 
         mock_process = _make_mock_process(
-            b'{"mode":"incremental","total_files":3,"processed":3,'
+            b'{"type":"result","mode":"incremental","total_files":3,"processed":3,'
             b'"skipped":0,"errors":[],"elapsed":0.5}',
             b"", 0,
         )
@@ -667,7 +668,7 @@ class TestRunIngestAndIndexSubprocess:
         from rag.server import _run_ingest_and_index_subprocess
 
         mock_process = _make_mock_process(
-            b'{"error":true,"message":"DB connection failed"}',
+            b'{"type":"error","error":true,"message":"DB connection failed"}',
             b"", 1,
         )
 
@@ -699,7 +700,7 @@ class TestRunDeleteSubprocess:
         from rag.server import _run_delete_subprocess
 
         mock_process = _make_mock_process(
-            b'{"deleted":true,"pipeline":{"mode":"incremental",'
+            b'{"type":"result","deleted":true,"pipeline":{"type":"result","mode":"incremental",'
             b'"total_files":1,"processed":1,"skipped":0,"errors":[],"elapsed":0.3}}',
             b"", 0,
         )
@@ -715,7 +716,7 @@ class TestRunDeleteSubprocess:
         """該当なし時に not_found=True が返されること."""
         from rag.server import _run_delete_subprocess
 
-        mock_process = _make_mock_process(b'{"not_found":true}', b"", 0)
+        mock_process = _make_mock_process(b'{"type":"result","not_found":true}', b"", 0)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_delete_subprocess("https://example.com/missing")

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -26,6 +26,33 @@ from rag.server import (
 from rag.store.metadata_db import MetadataDB
 
 
+def _make_mock_process(
+    stdout_data: bytes, stderr_data: bytes, returncode: int,
+) -> AsyncMock:
+    """readline ベースの _run_worker_subprocess 用モックプロセスを生成する."""
+    mock_process = AsyncMock()
+
+    # stdout: readline で行単位返却 → b"" で EOF
+    lines: list[bytes] = []
+    if stdout_data:
+        lines = [line + b"\n" for line in stdout_data.split(b"\n") if line]
+    lines.append(b"")  # EOF
+
+    mock_stdout = AsyncMock()
+    mock_stdout.readline = AsyncMock(side_effect=lines)
+    mock_process.stdout = mock_stdout
+
+    # stderr: read で一括返却
+    mock_stderr = AsyncMock()
+    mock_stderr.read = AsyncMock(return_value=stderr_data)
+    mock_process.stderr = mock_stderr
+
+    mock_process.returncode = returncode
+    mock_process.wait = AsyncMock()
+
+    return mock_process
+
+
 @pytest.fixture(autouse=True)
 def _reset_rag_global_state() -> None:
     """各テスト前にRAGサービスのグローバル状態をリセットする."""
@@ -391,7 +418,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="convert", source_type="web")
 
         assert "再構築完了" in result
-        mock_subprocess.assert_called_once_with("convert", "web", False)
+        mock_subprocess.assert_called_once_with("convert", "web", False, ctx=None)
 
     @pytest.mark.asyncio
     async def test_incremental_mode(
@@ -422,7 +449,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="incremental")
 
         assert "差分更新" in result
-        mock_subprocess.assert_called_once_with("incremental", None, False)
+        mock_subprocess.assert_called_once_with("incremental", None, False, ctx=None)
 
     @pytest.mark.asyncio
     async def test_index_only_mode(
@@ -453,7 +480,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="index", source_type="local")
 
         assert "インデックスのみ再構築" in result
-        mock_subprocess.assert_called_once_with("index", "local", False)
+        mock_subprocess.assert_called_once_with("index", "local", False, ctx=None)
 
     @pytest.mark.asyncio
     async def test_exception_releases_lock(
@@ -522,13 +549,11 @@ class TestRunRebuildSubprocess:
         """正常な JSON 結果がフォーマットされること."""
         from rag.server import _run_rebuild_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (
+        mock_process = _make_mock_process(
             b'{"mode":"full_rebuild","total_files":5,"processed":5,'
             b'"skipped":0,"errors":[],"elapsed":1.2}',
-            b"",
+            b"", 0,
         )
-        mock_process.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
@@ -542,9 +567,7 @@ class TestRunRebuildSubprocess:
         """JSON パース失敗時にフォールバックすること."""
         from rag.server import _run_rebuild_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"not json", b"")
-        mock_process.returncode = 0
+        mock_process = _make_mock_process(b"not json", b"", 0)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
@@ -556,9 +579,7 @@ class TestRunRebuildSubprocess:
         """異常終了時に stderr が返されること."""
         from rag.server import _run_rebuild_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"RuntimeError: DB locked\n")
-        mock_process.returncode = 1
+        mock_process = _make_mock_process(b"", b"RuntimeError: DB locked\n", 1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
@@ -571,9 +592,7 @@ class TestRunRebuildSubprocess:
         """SEGFAULT exit code でクラッシュメッセージが返されること."""
         from rag.server import _run_rebuild_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"")
-        mock_process.returncode = -11
+        mock_process = _make_mock_process(b"", b"", -11)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
@@ -586,12 +605,10 @@ class TestRunRebuildSubprocess:
         """worker のエラー JSON が異常終了時に活用されること."""
         from rag.server import _run_rebuild_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (
+        mock_process = _make_mock_process(
             b'{"error":true,"message":"source_store not found"}',
-            b"Traceback ...\n",
+            b"Traceback ...\n", 1,
         )
-        mock_process.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_rebuild_subprocess("full", None, False)
@@ -610,13 +627,11 @@ class TestRunIngestAndIndexSubprocess:
         """正常な JSON 結果が PipelineSummary として返されること."""
         from rag.server import _run_ingest_and_index_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (
+        mock_process = _make_mock_process(
             b'{"mode":"incremental","total_files":3,"processed":3,'
             b'"skipped":0,"errors":[],"elapsed":0.5}',
-            b"",
+            b"", 0,
         )
-        mock_process.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_ingest_and_index_subprocess("test commit")
@@ -629,9 +644,7 @@ class TestRunIngestAndIndexSubprocess:
         """SEGFAULT exit code で RuntimeError が送出されること."""
         from rag.server import _run_ingest_and_index_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"")
-        mock_process.returncode = -11
+        mock_process = _make_mock_process(b"", b"", -11)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="SEGFAULT"):
@@ -642,9 +655,7 @@ class TestRunIngestAndIndexSubprocess:
         """異常終了時に RuntimeError が送出されること."""
         from rag.server import _run_ingest_and_index_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"some error\n")
-        mock_process.returncode = 1
+        mock_process = _make_mock_process(b"", b"some error\n", 1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="異常終了"):
@@ -655,12 +666,10 @@ class TestRunIngestAndIndexSubprocess:
         """worker のエラー JSON メッセージが RuntimeError に含まれること."""
         from rag.server import _run_ingest_and_index_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (
+        mock_process = _make_mock_process(
             b'{"error":true,"message":"DB connection failed"}',
-            b"",
+            b"", 1,
         )
-        mock_process.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="DB connection failed"):
@@ -671,9 +680,7 @@ class TestRunIngestAndIndexSubprocess:
         """stdout が空の場合に RuntimeError が送出されること."""
         from rag.server import _run_ingest_and_index_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"")
-        mock_process.returncode = 0
+        mock_process = _make_mock_process(b"", b"", 0)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="出力が空"):
@@ -691,13 +698,11 @@ class TestRunDeleteSubprocess:
         """削除成功時に deleted=True と PipelineSummary が返されること."""
         from rag.server import _run_delete_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (
+        mock_process = _make_mock_process(
             b'{"deleted":true,"pipeline":{"mode":"incremental",'
             b'"total_files":1,"processed":1,"skipped":0,"errors":[],"elapsed":0.3}}',
-            b"",
+            b"", 0,
         )
-        mock_process.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_delete_subprocess("https://example.com/page")
@@ -710,9 +715,7 @@ class TestRunDeleteSubprocess:
         """該当なし時に not_found=True が返されること."""
         from rag.server import _run_delete_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b'{"not_found":true}', b"")
-        mock_process.returncode = 0
+        mock_process = _make_mock_process(b'{"not_found":true}', b"", 0)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await _run_delete_subprocess("https://example.com/missing")
@@ -724,9 +727,7 @@ class TestRunDeleteSubprocess:
         """SEGFAULT exit code で RuntimeError が送出されること."""
         from rag.server import _run_delete_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"")
-        mock_process.returncode = -11
+        mock_process = _make_mock_process(b"", b"", -11)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="SEGFAULT"):
@@ -737,9 +738,7 @@ class TestRunDeleteSubprocess:
         """異常終了時に RuntimeError が送出されること."""
         from rag.server import _run_delete_subprocess
 
-        mock_process = AsyncMock()
-        mock_process.communicate.return_value = (b"", b"error trace\n")
-        mock_process.returncode = 1
+        mock_process = _make_mock_process(b"", b"error trace\n", 1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(RuntimeError, match="異常終了"):

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -382,7 +382,7 @@ class TestCliSiteIngestValidation:
         """空 URL で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url="", url_pattern="", max_pages=None, force=False)
+        args = argparse.Namespace(url="", url_pattern="", max_pages=None, force=False, download_only=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -392,7 +392,7 @@ class TestCliSiteIngestValidation:
         """不正スキームで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url="ftp://example.com", url_pattern="", max_pages=None, force=False)
+        args = argparse.Namespace(url="ftp://example.com", url_pattern="", max_pages=None, force=False, download_only=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -402,7 +402,7 @@ class TestCliSiteIngestValidation:
         """プライベート IP で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url="http://10.0.0.1/page", url_pattern="", max_pages=None, force=False)
+        args = argparse.Namespace(url="http://10.0.0.1/page", url_pattern="", max_pages=None, force=False, download_only=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -412,7 +412,7 @@ class TestCliSiteIngestValidation:
         """不正な正規表現パターンで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="[bad(", max_pages=None, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="[bad(", max_pages=None, force=False, download_only=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -445,7 +445,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=-1, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=-1, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -469,7 +469,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=999999, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=999999, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -496,7 +496,7 @@ class TestCliSiteIngestMaxPagesClamp:
         mock_settings = _make_cli_mock_settings()
         mock_settings.site_ingest_max_pages = 2000
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=None, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=None, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -524,7 +524,7 @@ class TestCliSiteIngestFlow:
             success=True,
         )
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -572,7 +572,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index.return_value = mock_pipeline_summary
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -619,7 +619,7 @@ class TestCliSiteIngestFlow:
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
 
-        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False)
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=False)
 
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- サブプロセスの進捗をリアルタイムで MCP クライアントに通知する仕組みを実装（#326）
  - PipelineController に `progress_callback` パラメータを追加（`run_full_rebuild`, `run_convert_only`, `run_index_only`, `_process_changes`, `run_incremental`, `ingest_and_index`）
  - worker.py で JSON Lines 形式の進捗出力（`type: "progress"` / `type: "result"` / `type: "error"`）
  - server.py の `_run_worker_subprocess` を `communicate()` から `readline()` ストリーミングに変更
  - FastMCP Context 経由で `ctx.info()` + `ctx.report_progress()` を MCP 通知として送信
  - 全サブプロセス系 MCP ツール（10ツール）に `ctx: MCPContext` パラメータを追加
- `rag_site_ingest` に `download_only` モードを追加（#322）
  - MCP: `download_only: bool = False` パラメータ追加
  - CLI: `--download-only` フラグ追加
  - `True` 時は Scrapy クロール + Bridge まで実行し、パイプライン処理をスキップ

## Test plan

- [x] pytest 1250 passed（全テスト通過）
- [x] ruff check — lint 違反なし
- [x] mypy — 型エラーなし
- [x] code-reviewer — 指摘対応済み
- [x] doc-reviewer — 指摘対応済み

## Related issues

Closes #326
Closes #322