### PR TITLE
feat(zenn,converter): Zenn 記事の source_store 保存形式を API レスポンス全体 JSON に変更 (#295)

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -116,7 +116,7 @@ source_store のディレクトリ構成をミラーする。source_store 内の
 | `web/https/example.com/docs/guide.html` | `web/https/example.com/docs/guide.md` |
 | `web/https/example.com/docs/report.pdf` | `web/https/example.com/docs/report.md` |
 | `bluesky/did：plc：xxx/2026/03/rkey.json` | `bluesky/did：plc：xxx/2026/03/rkey.md` |
-| `zenn/alice/articles/slug.html` | `zenn/alice/articles/slug.md` |
+| `zenn/alice/articles/slug.json` | `zenn/alice/articles/slug.md` |
 | `local/my-notes/memo.md` | `local/my-notes/memo.md` |
 | `local/my-notes/note.txt` | `local/my-notes/note.txt` |
 | `local/docs/guide.adoc` | `local/docs/guide.adoc` |
@@ -256,7 +256,7 @@ PDF の特性を 3 段階で評価し、バックエンドと処理モードを�
 
 ### JSON → テキスト抽出
 
-JSON ファイルから構造化テキストを抽出する。source_store に JSON 形式で保存されるのは BlueSky 投稿と Zenn スクラップ（Zenn 記事は `.html` で保存されるため HTML → Markdown 変換パスで処理される）。
+JSON ファイルから構造化テキストを抽出する。source_store に JSON 形式で保存されるのは BlueSky 投稿、Zenn 記事、Zenn スクラップ。source_type とファイルパスに応じたハンドラを選択する。
 
 #### BlueSky 投稿（source_type: bluesky）
 
@@ -324,12 +324,21 @@ Description: 外部リンクの説明文
 - 投稿テキストを先頭に配置する（検索ヒット時に最も重要な情報が先頭に来る）
 - セクションラベルは英語表記とする（LLM による検索・解釈の精度向上のため）
 
+#### Zenn 記事（source_type: zenn、articles/ 配下の JSON）
+
+Zenn 記事の JSON（`article` オブジェクト）から `body_html` を抽出し、HTML → Markdown 変換を適用する。
+
+1. `article.body_html` フィールドを取得する
+2. `body_html` が空または存在しない場合は変換をスキップする
+3. `body_html` から `script`/`style` タグを除去し、Markdown 変換ルール（ATX 見出し、テーブル保持、リンク URL 除去等）を適用する。Zenn API の `body_html` はコンテンツ本文のみを含むため、コンテンツ領域の特定は行わない
+4. .meta からタイトルを取得し、H1 見出しとして先頭に付与する（既存の `_prepend_title_from_meta` の振る舞いを維持）
+
 #### Zenn スクラップ（source_type: zenn、scraps/ 配下の JSON）
 
 Zenn スクラップの JSON（`scrap` オブジェクト）から `comments` 配列の各コメントの `body_html` を順序保持で結合し、Markdown に変換する。
 
 1. `scrap.comments` 配列をインデックス順に走査する
-2. 各コメントの `body_html` を HTML → Markdown 変換する（HTML → Markdown 変換の共通ルールを適用）
+2. 各コメントの `body_html` から `script`/`style` タグを除去し、Markdown 変換ルール（ATX 見出し、テーブル保持、リンク URL 除去等）を適用する。Zenn API の `body_html` はコンテンツ本文のみを含むため、コンテンツ領域の特定は行わない
 3. 変換後の各コメントを `---`（水平線）で区切って結合する
 
 コメントが 0 件または全コメントの `body_html` が空の場合は、変換をスキップする。converted_store に既存ファイルがある場合は削除する。パイプライン制御にスキップ結果（変換なし）を返却し、パイプライン制御がインデクサーに当該 source_id のインデックス削除を指示する。
@@ -373,6 +382,7 @@ Zenn スクラップの JSON（`scrap` オブジェクト）から `comments` �
 | PDF のテキスト抽出結果が空 | 変換をスキップし、警告ログを出力する。converted_store にはファイルを配置しない |
 | MinerU が未インストールの環境で `rag_pdf_backend` が `auto` | auto 判定で MinerU が必要と判断された場合、pymupdf4llm にフォールバックし、警告ログを出力する |
 | MinerU が未インストールの環境で `rag_pdf_backend` が `mineru` | エラーログを出力し、当該ファイルの変換をスキップする |
+| Zenn 記事 JSON に `body_html` フィールドがない、または空 | 変換をスキップし、警告ログを出力する |
 | JSON ファイルの source_type が不明 | 変換をスキップし、警告ログを出力する。JSON の変換は source_type に依存するため、source_type 情報なしでは変換できない |
 | converted_store のディレクトリが存在しない場合 | 変換時に必要なディレクトリを自動作成する |
 | パススルー対象ファイルのコピーエラー（I/O エラー等） | エラーログを出力し、当該ファイルのコピーをスキップする |
@@ -383,3 +393,4 @@ Zenn スクラップの JSON（`scrap` オブジェクト）から `comments` �
 - [source-store.md](source-store.md) — source_store 仕様
 - [pipeline-controller.md](pipeline-controller.md) — パイプライン制御仕様
 - [ingesters/bluesky.md](ingesters/bluesky.md) — BlueSky インジェスター仕様（JSON 保存形式の定義元）
+- [ingesters/zenn.md](ingesters/zenn.md) — Zenn インジェスター仕様（JSON 保存形式の定義元）

--- a/docs/specs/ingesters/zenn.md
+++ b/docs/specs/ingesters/zenn.md
@@ -39,7 +39,7 @@ Zenn（zenn.dev）の記事およびスクラップを API 経由で取得し、
 
 - **metadata.db アクセス禁止**: metadata.db に直接アクセスしない。DB 登録はパイプライン制御が .meta を読んで実行する
 - **git 操作禁止**: git 操作はパイプライン制御のみが実行する
-- **オリジナルデータの無加工保存**: 記事は Zenn API の `body_html` をそのまま HTML ファイルとして保存する。スクラップは API レスポンスの `scrap` オブジェクト（`comments` 配列を含む）をそのまま JSON ファイルとして保存する。コメントの結合・テキスト抽出はコンバーターの範疇
+- **オリジナルデータの無加工保存**: 記事は API レスポンスの `article` オブジェクトをそのまま JSON ファイルとして保存する。スクラップは API レスポンスの `scrap` オブジェクト（`comments` 配列を含む）をそのまま JSON ファイルとして保存する。`body_html` の抽出・テキスト変換はコンバーターの範疇
 - **ファイル削除禁止**: source_store 内のファイルの物理削除は一切行わない
 
 ### 外部 HTTP リクエスト
@@ -136,22 +136,22 @@ source_store/
   zenn/
     {username}/
       articles/
-        {slug}.html
-        {slug}.html.meta
+        {slug}.json
+        {slug}.json.meta
       scraps/
         {slug}.json
         {slug}.json.meta
 ```
 
-- ファイル形式: 記事は Zenn API の `body_html` を HTML ファイルとして保存。スクラップは API レスポンスの `scrap` オブジェクトを JSON ファイルとして保存
-- ファイル名: 記事はスラッグに `.html`、スクラップはスラッグに `.json` 拡張子を付与
+- ファイル形式: 記事は API レスポンスの `article` オブジェクトを JSON ファイルとして保存。スクラップは API レスポンスの `scrap` オブジェクトを JSON ファイルとして保存
+- ファイル名: スラッグに `.json` 拡張子を付与
 - .meta: データファイルと同階層に配置
 
 ### source_id とファイルパスの対応
 
 | コンテンツ種別 | source_id | ファイルパス |
 |--------------|-----------|------------|
-| 記事 | `https://zenn.dev/{username}/articles/{slug}` | `zenn/{username}/articles/{slug}.html` |
+| 記事 | `https://zenn.dev/{username}/articles/{slug}` | `zenn/{username}/articles/{slug}.json` |
 | スクラップ | `https://zenn.dev/{username}/scraps/{slug}` | `zenn/{username}/scraps/{slug}.json` |
 
 source_id はコンテンツの公開 URL であり、安定した識別子として機能する。
@@ -270,9 +270,9 @@ flowchart TD
 ### 個別記事取得とファイル配置の処理手順
 
 1. 記事詳細 API（`/api/articles/{slug}`）にリクエストを送信する
-2. レスポンスから `body_html` を取得する
-3. `body_html` をそのまま source_store に配置する（配置先: `zenn/{username}/articles/{slug}.html`）
-4. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/articles/{slug}.html.meta`）
+2. レスポンスから `article` オブジェクトを取得する
+3. `article` オブジェクトをそのまま JSON として source_store に配置する（配置先: `zenn/{username}/articles/{slug}.json`）
+4. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/articles/{slug}.json.meta`）
 5. 重複検出: 配置先パスにファイルが既に存在する場合は上書きする
 
 ### スクラップ取得とファイル配置の処理手順
@@ -409,7 +409,7 @@ Zenn は公式の API ドキュメントを公開していない。以下は観�
 | 記事詳細取得に失敗（404 等） | 該当記事をスキップし、他の記事の処理を続行する。エラーをログ出力する |
 | 記事一覧 API のレスポンス形式変更 | JSON パースエラーまたは必須フィールド欠落として処理を中断する。エラーの詳細をログ出力する |
 | 記事詳細 API のレスポンス形式変更 | 該当記事をスキップし、他の記事の処理を続行する。エラーの詳細をログ出力する |
-| `body_html` が空 | 該当記事をスキップする。空の HTML ファイルは source_store に配置しない |
+| `article` オブジェクトが空 | 該当記事をスキップする。空の JSON ファイルは source_store に配置しない |
 | 下書き・非公開記事 | API が公開記事のみを返すため、考慮不要 |
 | 大量記事ユーザー（480 件超 = 10 ページ超） | ページネーション走査上限（10 ページ）で打ち切る。取得済み記事を処理し、上限到達の旨を警告ログに出力する |
 | 同一記事の再取り込み | source_id（記事の公開 URL）からファイルパスを導出し、既存ファイルを上書きする |

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -20,6 +20,7 @@ from typing import Literal
 from rag.converter.handlers import (
     convert_html,
     convert_json_bluesky,
+    convert_json_zenn_article,
     convert_json_zenn_scrap,
     convert_pdf,
     passthrough_copy,
@@ -370,6 +371,9 @@ class Converter:
 
         if source_type == "bluesky":
             return convert_json_bluesky(data)
+
+        if source_type == "zenn" and "/articles/" in file_path:
+            return convert_json_zenn_article(data)
 
         if source_type == "zenn" and "/scraps/" in file_path:
             return convert_json_zenn_scrap(data)

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -332,6 +332,37 @@ def convert_json_zenn_scrap(data: dict[str, Any]) -> str | None:
     return "\n\n---\n\n".join(converted_parts)
 
 
+def convert_json_zenn_article(data: dict[str, Any]) -> str | None:
+    """Zenn 記事 JSON からテキストを抽出する.
+
+    仕様: docs/specs/converter.md「Zenn 記事」
+
+    article オブジェクトの body_html を HTML → Markdown 変換する。
+
+    Args:
+        data: 記事 JSON（article オブジェクト、またはそれを含むラッパー）
+
+    Returns:
+        Markdown テキスト、または body_html が空/存在しない場合は None
+    """
+    article = data.get("article", data)
+    if not isinstance(article, dict):
+        return None
+
+    body_html = article.get("body_html", "")
+    if not isinstance(body_html, str) or not body_html.strip():
+        return None
+
+    md_converter = _create_md_converter()
+    soup = BeautifulSoup(body_html, "html.parser")
+    for tag_name in ("script", "style"):
+        for tag in soup.find_all(tag_name):
+            tag.decompose()
+
+    md_text: str = md_converter.convert_soup(soup)
+    return md_text if md_text and md_text.strip() else None
+
+
 def passthrough_copy(source_path: Path, dest_path: Path) -> None:
     """ファイルをそのままコピーする（パススルー）.
 

--- a/src/rag/pipeline/ingesters/zenn.py
+++ b/src/rag/pipeline/ingesters/zenn.py
@@ -116,15 +116,15 @@ class ZennIngester:
                 data = resp.json()
                 article = data.get("article", data)
 
-                body_html = article.get("body_html", "")
-                if not body_html:
-                    logger.info("body_html が空のためスキップ: %s", slug)
+                if not article:
+                    logger.info("article オブジェクトが空のためスキップ: %s", slug)
                     result.skipped += 1
                     continue
 
-                # ファイル配置
-                rel_path = f"zenn/{username}/articles/{slug}.html"
-                html_bytes = body_html.encode("utf-8")
+                # JSON として保存
+                rel_path = f"zenn/{username}/articles/{slug}.json"
+                json_data = json.dumps(article, ensure_ascii=False, indent=2)
+                json_bytes = json_data.encode("utf-8")
 
                 # topics の抽出
                 topics = self._extract_topics(article.get("topics", []))
@@ -149,7 +149,7 @@ class ZennIngester:
 
                 self._store.place_file(
                     source_type="zenn",
-                    data=html_bytes,
+                    data=json_bytes,
                     rel_path=rel_path,
                     metadata=metadata,
                 )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -22,6 +22,7 @@ from rag.converter.converter import (
 from rag.converter.handlers import (
     convert_html,
     convert_json_bluesky,
+    convert_json_zenn_article,
     convert_json_zenn_scrap,
     passthrough_copy,
 )
@@ -627,6 +628,87 @@ class TestConvertJsonZennScrap:
 
 
 # ============================================================
+# Zenn 記事 JSON テキスト抽出ハンドラ
+# ============================================================
+
+
+class TestConvertJsonZennArticle:
+    """convert_json_zenn_article のテスト."""
+
+    def test_basic_article(self) -> None:
+        data = {
+            "article": {
+                "body_html": "<h2>Section</h2><p>Article body text.</p>",
+            },
+        }
+        result = convert_json_zenn_article(data)
+        assert result is not None
+        assert "Section" in result
+        assert "Article body text." in result
+
+    def test_article_without_wrapper(self) -> None:
+        """article キーなしの直接オブジェクトでも動作する."""
+        data = {
+            "body_html": "<p>Direct body.</p>",
+        }
+        result = convert_json_zenn_article(data)
+        assert result is not None
+        assert "Direct body." in result
+
+    def test_empty_body_html(self) -> None:
+        data = {"article": {"body_html": ""}}
+        result = convert_json_zenn_article(data)
+        assert result is None
+
+    def test_missing_body_html(self) -> None:
+        data = {"article": {"title": "No body"}}
+        result = convert_json_zenn_article(data)
+        assert result is None
+
+    def test_whitespace_only_body_html(self) -> None:
+        data = {"article": {"body_html": "   "}}
+        result = convert_json_zenn_article(data)
+        assert result is None
+
+    def test_html_to_markdown_conversion(self) -> None:
+        data = {
+            "article": {
+                "body_html": (
+                    "<h2>Heading</h2>"
+                    "<p>Paragraph with <strong>bold</strong> text.</p>"
+                    "<ul><li>Item 1</li><li>Item 2</li></ul>"
+                ),
+            },
+        }
+        result = convert_json_zenn_article(data)
+        assert result is not None
+        assert "## Heading" in result
+        assert "bold" in result
+        assert "Item 1" in result
+
+    def test_script_style_removed(self) -> None:
+        data = {
+            "article": {
+                "body_html": (
+                    "<p>Clean text</p>"
+                    "<script>evil()</script>"
+                    "<style>.red{color:red}</style>"
+                ),
+            },
+        }
+        result = convert_json_zenn_article(data)
+        assert result is not None
+        assert "Clean text" in result
+        assert "evil" not in result
+        assert "color" not in result
+
+    def test_article_value_not_dict(self) -> None:
+        data = {"article": "not a dict"}
+        result = convert_json_zenn_article(data)
+        assert result is None
+
+
+# ============================================================
 # パススルー
 # ============================================================
 
@@ -851,6 +933,69 @@ class TestConverterConvert:
         assert "nested" in str(result)
 
 
+    def test_convert_json_zenn_article(self, tmp_path: Path) -> None:
+        article_data = json.dumps({
+            "article": {
+                "body_html": "<h2>Section</h2><p>Article content.</p>",
+            },
+        })
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "zenn/alice/articles/slug.json", article_data,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "zenn/alice/articles/slug.json", source_dir, converted_dir,
+        )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "Section" in text
+        assert "Article content." in text
+        assert result.name == "slug.md"
+
+    def test_convert_json_zenn_article_with_title(self, tmp_path: Path) -> None:
+        """Zenn 記事 JSON 変換時に .meta のタイトルが H1 として先頭付与されること."""
+        article_data = json.dumps({
+            "article": {
+                "body_html": "<h2>Section</h2><p>Article body.</p>",
+            },
+        })
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "zenn/alice/articles/slug.json", article_data,
+        )
+        # .meta ファイルを配置
+        meta_content = (
+            'source_id: "https://zenn.dev/alice/articles/slug"\n'
+            "source_type: zenn\n"
+            'title: "Sample Article Title"\n'
+            'collected_at: "2026-01-15T10:30:00+09:00"\n'
+        )
+        meta_path = source_dir / "zenn" / "alice" / "articles" / "slug.json.meta"
+        meta_path.write_text(meta_content, encoding="utf-8")
+
+        converter = Converter()
+        result = converter.convert(
+            "zenn/alice/articles/slug.json", source_dir, converted_dir,
+        )
+        text = result.read_text(encoding="utf-8")
+        assert text.startswith("# Sample Article Title")
+        assert "## Section" in text
+        assert "Article body." in text
+
+    def test_convert_json_zenn_article_empty_body(self, tmp_path: Path) -> None:
+        """Zenn 記事 JSON で body_html が空の場合は変換スキップ."""
+        article_data = json.dumps({
+            "article": {"body_html": ""},
+        })
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "zenn/alice/articles/empty.json", article_data,
+        )
+        converter = Converter()
+        with pytest.raises(ConversionSkippedError, match="Empty conversion"):
+            converter.convert(
+                "zenn/alice/articles/empty.json", source_dir, converted_dir,
+            )
+
+
 # ============================================================
 # Zenn 記事タイトル付与
 # ============================================================
@@ -858,45 +1003,6 @@ class TestConverterConvert:
 
 class TestZennArticleTitlePrepend:
     """Zenn 記事の .meta からタイトルを先頭付与するテスト."""
-
-    def test_zenn_article_with_meta(self, tmp_path: Path) -> None:
-        """Zenn 記事 HTML の変換時に .meta のタイトルが H1 として先頭付与されること."""
-        html = "<html><body><h2>Section</h2><p>Article body.</p></body></html>"
-        source_dir, converted_dir = _setup_source(
-            tmp_path, "zenn/alice/articles/sample.html", html,
-        )
-        # .meta ファイルを配置
-        meta_content = (
-            'source_id: "https://zenn.dev/alice/articles/sample"\n'
-            "source_type: zenn\n"
-            'title: "Sample Article Title"\n'
-            'collected_at: "2026-01-15T10:30:00+09:00"\n'
-        )
-        meta_path = source_dir / "zenn" / "alice" / "articles" / "sample.html.meta"
-        meta_path.write_text(meta_content, encoding="utf-8")
-
-        converter = Converter()
-        result = converter.convert(
-            "zenn/alice/articles/sample.html", source_dir, converted_dir,
-        )
-        text = result.read_text(encoding="utf-8")
-        assert text.startswith("# Sample Article Title")
-        assert "## Section" in text
-        assert "Article body." in text
-
-    def test_zenn_article_without_meta(self, tmp_path: Path) -> None:
-        """Zenn 記事で .meta が存在しない場合はタイトル付与なしで変換されること."""
-        html = "<html><body><p>Content only.</p></body></html>"
-        source_dir, converted_dir = _setup_source(
-            tmp_path, "zenn/alice/articles/no-meta.html", html,
-        )
-        converter = Converter()
-        result = converter.convert(
-            "zenn/alice/articles/no-meta.html", source_dir, converted_dir,
-        )
-        text = result.read_text(encoding="utf-8")
-        assert not text.startswith("# ")
-        assert "Content only." in text
 
     def test_non_zenn_html_no_title(self, tmp_path: Path) -> None:
         """Web HTML にはタイトルが付与されないこと."""
@@ -926,26 +1032,6 @@ class TestZennArticleTitlePrepend:
         text = result.read_text(encoding="utf-8")
         assert not text.startswith("# ")
 
-    def test_zenn_article_empty_title(self, tmp_path: Path) -> None:
-        """Zenn 記事で .meta のタイトルが空の場合はタイトル付与なしで変換されること."""
-        html = "<html><body><p>Body text.</p></body></html>"
-        source_dir, converted_dir = _setup_source(
-            tmp_path, "zenn/alice/articles/empty-title.html", html,
-        )
-        meta_content = (
-            'source_id: "https://zenn.dev/alice/articles/empty-title"\n'
-            "source_type: zenn\n"
-            'title: ""\n'
-        )
-        meta_path = source_dir / "zenn" / "alice" / "articles" / "empty-title.html.meta"
-        meta_path.write_text(meta_content, encoding="utf-8")
-
-        converter = Converter()
-        result = converter.convert(
-            "zenn/alice/articles/empty-title.html", source_dir, converted_dir,
-        )
-        text = result.read_text(encoding="utf-8")
-        assert not text.startswith("# ")
 
 
 # ============================================================

--- a/tests/test_pipeline_ingesters_zenn.py
+++ b/tests/test_pipeline_ingesters_zenn.py
@@ -8,7 +8,7 @@
 - スクラップの取得と配置
 - content_type="all" で両方取得
 - .meta サイドカーファイルの生成
-- body_html が空の記事のスキップ
+- article オブジェクトが空の記事のスキップ
 """
 
 from __future__ import annotations
@@ -241,20 +241,23 @@ class TestCrawlArticles:
         assert result.placed == 1
         assert result.errors == 0
 
-        # ファイル検証
-        html_path = (
-            source_store.root_dir / "zenn" / "testuser" / "articles" / "test-article.html"
+        # JSON ファイル検証
+        json_path = (
+            source_store.root_dir / "zenn" / "testuser" / "articles" / "test-article.json"
         )
-        assert html_path.exists()
-        assert html_path.read_text(encoding="utf-8") == "<p>Article content</p>"
+        assert json_path.exists()
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert data["slug"] == "test-article"
+        assert data["body_html"] == "<p>Article content</p>"
 
-    async def test_empty_body_html_skipped(
+    async def test_empty_article_skipped(
         self, source_store: SourceStore
     ) -> None:
-        """body_html が空の記事がスキップされること."""
+        """article オブジェクトが空の記事がスキップされること."""
+        empty_response = {"article": {}}
         client = _make_mock_client([
             _make_article_list_response(["empty-article"]),
-            _make_article_detail_response("empty-article", body_html=""),
+            empty_response,
         ])
 
         ingester = ZennIngester(source_store, max_articles=3)
@@ -290,7 +293,7 @@ class TestCrawlArticles:
             / "zenn"
             / "testuser"
             / "articles"
-            / "test-article.html.meta"
+            / "test-article.json.meta"
         )
         assert meta_path.exists()
         meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- Zenn 記事の source_store 保存形式を `body_html` のみの HTML から API レスポンスの `article` オブジェクト全体の JSON に変更
- コンバーターに Zenn 記事 JSON ハンドラ（`convert_json_zenn_article`）を追加し、`body_html` の抽出・HTML→Markdown 変換を担当
- 仕様書（zenn.md, converter.md）を更新し、保存形式変更・変換仕様を反映
- converter.md の Zenn 記事・スクラップの変換手順記述を実装に即した表現に改善（#330）
- 旧形式（`.html`）の Zenn 記事テストを削除し、新形式（`.json`）のテストに置換

## Test plan

- [x] pytest: 111 passed (converter + ingester テスト)
- [x] ruff: 違反なし
- [x] mypy: 型エラーなし
- [x] コードレビュー: Critical 0, Warning 1（対応不要判定）, Suggestion 1（対応済み）
- [x] ドキュメントレビュー: Warning 1（#330 として対応済み）

## Related issues

Closes #295
Closes #330