### PR TITLE
perf(test): テスト実行速度の改善 — 並列化 + git subprocess 削減 (#329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ uv run python -m rag.cli evaluate \
 ## テスト
 
 ```bash
-uv run pytest
+uv run pytest          # pytest-xdist で自動並列実行（-n auto）
+uv run pytest -n0      # シングルプロセスで実行（デバッグ時）
 uv run ruff check .
 uv run mypy src
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ follow_imports = "skip"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 addopts = "-n auto"
+required_plugins = ["pytest-xdist"]
 
 # PyTorch CUDA index（mineru-cuda extra 専用。CUDA 12.4 環境向け）
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ follow_imports = "skip"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "-n auto"
 
 # PyTorch CUDA index（mineru-cuda extra 専用。CUDA 12.4 環境向け）
 [[tool.uv.index]]
@@ -77,6 +78,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=5.0",
+    "pytest-xdist>=3.5",
     "ruff>=0.14.14",
     "types-PyYAML>=6.0",
 ]

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -9,6 +9,7 @@ git 操作はパイプライン制御のみが実行する。
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from pathlib import Path
 
@@ -25,22 +26,34 @@ metadata.db-shm
 class GitOperations:
     """source_store の git リポジトリ操作."""
 
+    # パイプライン用の git user 設定（環境変数で注入）
+    _GIT_USER_ENV = {
+        "GIT_AUTHOR_NAME": "rag-pipeline",
+        "GIT_AUTHOR_EMAIL": "rag-pipeline@localhost",
+        "GIT_COMMITTER_NAME": "rag-pipeline",
+        "GIT_COMMITTER_EMAIL": "rag-pipeline@localhost",
+    }
+
     def __init__(self, repo_dir: Path) -> None:
         self._repo_dir = repo_dir
+        self._initialized = False
+        self._env = {**os.environ, **self._GIT_USER_ENV}
 
     def init_repo(self) -> None:
         """git リポジトリを初期化する.
 
-        既に初期化済みの場合も .gitignore と user 設定を補正する。
+        初回呼び出し時のみ実際の初期化処理を実行する。
+        2回目以降はスキップする（同一インスタンス内）。
         .gitignore で metadata.db を除外する。
         """
+        if self._initialized:
+            return
         git_dir = self._repo_dir / ".git"
         if not git_dir.exists():
             self._run(["git", "init"])
         # .gitignore 設定（既存リポジトリでも補正）
         self._ensure_gitignore()
-        # パイプライン用のローカル git user 設定
-        self._ensure_git_user()
+        self._initialized = True
 
     def commit(self, message: str, path: str | None = None) -> str | None:
         """ステージング + コミット.
@@ -184,25 +197,18 @@ class GitOperations:
             content += _GITIGNORE_CONTENT
             gitignore.write_text(content, encoding="utf-8")
 
-    def _ensure_git_user(self) -> None:
-        """パイプライン用のローカル git user 設定を保証する."""
-        try:
-            self._run(["git", "config", "user.name"])
-        except subprocess.CalledProcessError:
-            self._run(["git", "config", "user.name", "rag-pipeline"])
-        try:
-            self._run(["git", "config", "user.email"])
-        except subprocess.CalledProcessError:
-            self._run(["git", "config", "user.email", "rag-pipeline@localhost"])
-
     def _run(self, cmd: list[str]) -> subprocess.CompletedProcess[str]:
-        """git コマンドを実行する."""
+        """git コマンドを実行する.
+
+        GIT_AUTHOR_*/GIT_COMMITTER_* 環境変数で user 設定を注入する。
+        git config による設定が不要になり、subprocess 呼び出しを削減する。
+        """
         return subprocess.run(
             cmd,
             cwd=str(self._repo_dir),
             capture_output=True,
-            text=True,
             check=True,
             encoding="utf-8",
             stdin=subprocess.DEVNULL,
+            env=self._env,
         )

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -42,18 +42,16 @@ class GitOperations:
     def init_repo(self) -> None:
         """git リポジトリを初期化する.
 
-        初回呼び出し時のみ実際の初期化処理を実行する。
-        2回目以降はスキップする（同一インスタンス内）。
-        .gitignore で metadata.db を除外する。
+        git init は初回呼び出し時のみ実行する（同一インスタンス内）。
+        .gitignore の補正はファイルI/Oのみのため毎回実行する。
         """
-        if self._initialized:
-            return
-        git_dir = self._repo_dir / ".git"
-        if not git_dir.exists():
-            self._run(["git", "init"])
-        # .gitignore 設定（既存リポジトリでも補正）
+        if not self._initialized:
+            git_dir = self._repo_dir / ".git"
+            if not git_dir.exists():
+                self._run(["git", "init"])
+            self._initialized = True
+        # .gitignore 設定（既存リポジトリでも毎回補正）
         self._ensure_gitignore()
-        self._initialized = True
 
     def commit(self, message: str, path: str | None = None) -> str | None:
         """ステージング + コミット.

--- a/tests/test_pipeline_git_ops.py
+++ b/tests/test_pipeline_git_ops.py
@@ -68,8 +68,9 @@ class TestInitRepo:
         # .gitignore から metadata.db を除去
         gitignore = git_repo / ".gitignore"
         gitignore.write_text("*.tmp\n", encoding="utf-8")
-        # 再度 init_repo → 補正される
-        ops.init_repo()
+        # 新インスタンスで init_repo → 補正される
+        ops2 = GitOperations(git_repo)
+        ops2.init_repo()
         content = gitignore.read_text(encoding="utf-8")
         assert "*.tmp" in content
         assert "metadata.db" in content
@@ -81,8 +82,9 @@ class TestInitRepo:
         ops.init_repo()
         gitignore = git_repo / ".gitignore"
         original = gitignore.read_text(encoding="utf-8")
-        # 再度 init → 変更なし
-        ops.init_repo()
+        # 新インスタンスで init → 変更なし
+        ops2 = GitOperations(git_repo)
+        ops2.init_repo()
         assert gitignore.read_text(encoding="utf-8") == original
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -856,6 +856,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fast-langdetect"
 version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3681,6 +3690,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3859,6 +3881,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -3897,6 +3920,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]


### PR DESCRIPTION
## Change type

- [x] test: テスト追加・修正

## Summary

- pytest-xdist 導入によるテスト並列実行（`-n auto`、36コアで自動並列化）
- `git_ops.py` の `_ensure_git_user()` を廃止し、環境変数（`GIT_AUTHOR_NAME` 等）で git user 設定を注入する方式に変更。毎回の `git config` subprocess 呼び出しを削減
- `init_repo()` にキャッシュフラグ（`_initialized`）を追加。同一インスタンス内での重複初期化をスキップ
- テスト実行時間: **94.54秒 → 21.46秒（77%短縮）**

## Test plan

- [x] pytest 1250件全 pass（21.46秒）
- [x] ruff lint pass
- [x] mypy 型チェック pass
- [x] コードレビュー指摘対応済み
- [x] ドキュメントレビュー問題なし

## Related issues

Closes #329