### PR TITLE
fix(site-ingest): Bridge 配置カウント修正 + download_only 時の git コミット漏れ修正 (#333)

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -129,7 +129,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
 | `max_pages` | int | `site_ingest_max_pages` | ページ数上限。config.toml の値を上書き可能 |
 | `force` | bool | `false` | `true` の場合、ドメインディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする |
-| `download_only` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置）まで実行し、パイプライン処理（converter + indexer）をスキップする。後から `rag_rebuild` で処理可能 |
+| `download_only` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能 |
 
 ### CLI コマンド
 
@@ -145,7 +145,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `--url-pattern` | str | なし | URL フィルタパターン |
 | `--max-pages` | int | `site_ingest_max_pages` | ページ数上限 |
 | `--force` | フラグ | `false` | ドメインディレクトリ全体を削除して再クロール |
-| `--download-only` | フラグ | `false` | Scrapy クロール + Bridge まで実行し、パイプライン処理をスキップ |
+| `--download-only` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ |
 
 ### 取り込み結果の出力形式
 
@@ -361,10 +361,11 @@ sequenceDiagram
     BRIDGE->>SS: ファイル配置 + .meta 生成
     BRIDGE->>CMD: 配置結果
     alt download_only = false
-        CMD->>PC: パイプライン処理（MCP: サブプロセス経由）
+        CMD->>PC: パイプライン処理（git commit + converter + indexer、MCP: サブプロセス経由）
         PC->>CMD: パイプライン処理結果
     else download_only = true
-        Note over CMD: パイプライン処理をスキップ
+        CMD->>PC: git commit（source_store のみ）
+        Note over CMD: パイプライン処理（converter + indexer）をスキップ
     end
     CMD->>USER: 結果サマリー
 ```

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -375,7 +375,7 @@ def main() -> None:
         "--download-only",
         action="store_true",
         default=False,
-        help="Scrapy クロール + Bridge まで実行し、パイプライン処理をスキップ",
+        help="Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ",
     )
 
     args = parser.parse_args()
@@ -1785,15 +1785,19 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
 
     # パイプライン処理
     pipeline_summary = None
-    if not args.download_only and bridge_result.ingest.placed > 0:
+    has_changes = (bridge_result.ingest.placed + bridge_result.ingest.skipped) > 0
+    if has_changes and not args.download_only:
         pipeline_summary = controller.ingest_and_index(f"ingest(web): site-ingest {url}")
+    elif has_changes and args.download_only:
+        # download_only でもコミットは実行する（パイプライン処理のみスキップ）
+        controller.commit(f"ingest(web): site-ingest {url} (download_only)")
 
     # 操作全体の所要時間（クロール + Bridge + パイプライン）
     elapsed = time_mod.monotonic() - start_time
 
     # 結果表示
     print(
-        f"サイト取り込み完了: {bridge_result.ingest.placed}件配置"
+        f"サイト取り込み完了: {bridge_result.ingest.placed}件新規配置"
         f", {bridge_result.ingest.skipped}件スキップ"
         f", {bridge_result.ingest.errors}件エラー"
     )

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1785,7 +1785,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
 
     # パイプライン処理
     pipeline_summary = None
-    has_changes = (bridge_result.ingest.placed + bridge_result.ingest.skipped) > 0
+    has_changes = (bridge_result.ingest.placed + bridge_result.ingest.overwritten) > 0
     if has_changes and not args.download_only:
         pipeline_summary = controller.ingest_and_index(f"ingest(web): site-ingest {url}")
     elif has_changes and args.download_only:

--- a/src/rag/pipeline/ingesters/_common.py
+++ b/src/rag/pipeline/ingesters/_common.py
@@ -15,6 +15,7 @@ class IngestResult:
 
     placed: int = 0
     skipped: int = 0
+    overwritten: int = 0
     errors: int = 0
     error_details: list[str] = field(default_factory=list)
 

--- a/src/rag/scrapy/bridge.py
+++ b/src/rag/scrapy/bridge.py
@@ -151,9 +151,10 @@ def import_to_source_store(
             )
 
     logger.info(
-        "Bridge 完了: %d 行処理, %d 件新規配置, %d 件スキップ(既存/非200), %d 件エラー",
+        "Bridge 完了: %d 行処理, %d 件新規配置, %d 件上書き, %d 件スキップ, %d 件エラー",
         result.total_lines,
         result.ingest.placed,
+        result.ingest.overwritten,
         result.ingest.skipped,
         result.ingest.errors,
     )
@@ -228,7 +229,7 @@ def _process_record(
         if is_new:
             result.ingest.placed += 1
         else:
-            result.ingest.skipped += 1
+            result.ingest.overwritten += 1
     except Exception:
         logger.exception(
             "JSONL 行 %d: source_store 配置エラー: %s",

--- a/src/rag/scrapy/bridge.py
+++ b/src/rag/scrapy/bridge.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from rag.pipeline.ingesters._common import IngestResult
 from rag.pipeline.ingesters.web import _needs_html_extension
+from rag.store.path_converter import url_to_path
 
 if TYPE_CHECKING:
     from rag.store.source_store import SourceStore
@@ -150,7 +151,7 @@ def import_to_source_store(
             )
 
     logger.info(
-        "Bridge 完了: %d 行処理, %d 件配置, %d 件スキップ, %d 件エラー",
+        "Bridge 完了: %d 行処理, %d 件新規配置, %d 件スキップ(既存/非200), %d 件エラー",
         result.total_lines,
         result.ingest.placed,
         result.ingest.skipped,
@@ -208,16 +209,26 @@ def _process_record(
     # .meta 辞書の構築
     metadata = _build_meta(record)
 
-    # source_store に配置
+    # source_store に配置（新規 vs 上書きを区別してカウント）
     try:
         ext = ".html" if _needs_html_extension(record.url) else ""
+        # NOTE: パス構築は SourceStore.place_file_from_url と同一ロジック。
+        # place_file_from_url のパス導出が変更された場合はここも追従すること。
+        rel_path = url_to_path(record.url)
+        if ext and not rel_path.endswith(ext):
+            rel_path += ext
+        is_new = not (source_store.root_dir / rel_path).exists()
+
         source_store.place_file_from_url(
             url=record.url,
             data=data,
             metadata=metadata,
             extension=ext,
         )
-        result.ingest.placed += 1
+        if is_new:
+            result.ingest.placed += 1
+        else:
+            result.ingest.skipped += 1
     except Exception:
         logger.exception(
             "JSONL 行 %d: source_store 配置エラー: %s",

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1000,13 +1000,19 @@ async def rag_site_ingest(
 
         # パイプライン処理
         pipeline_summary: PipelineSummary | None = None
-        if not download_only and bridge_result.ingest.placed > 0:
+        has_changes = (bridge_result.ingest.placed + bridge_result.ingest.skipped) > 0
+        if has_changes and not download_only:
             pipeline_summary = await _run_ingest_and_index_subprocess(
                 f"ingest(web): site-ingest {url}",
                 ctx=ctx,
             )
             _reset_pipeline_controller()
             _reset_rag_service()
+        elif has_changes and download_only:
+            # download_only でもコミットは実行する（パイプライン処理のみスキップ）
+            await asyncio.to_thread(
+                controller.commit, f"ingest(web): site-ingest {url} (download_only)",
+            )
 
         # 操作全体の所要時間（クロール + Bridge + パイプライン）
         elapsed = time_mod.monotonic() - start_time
@@ -1014,7 +1020,7 @@ async def rag_site_ingest(
         # 結果サマリー構築
         parts: list[str] = []
         parts.append(
-            f"サイト取り込み完了: {bridge_result.ingest.placed}件配置"
+            f"サイト取り込み完了: {bridge_result.ingest.placed}件新規配置"
             f", {bridge_result.ingest.skipped}件スキップ"
             f", {bridge_result.ingest.errors}件エラー"
         )

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1000,7 +1000,7 @@ async def rag_site_ingest(
 
         # パイプライン処理
         pipeline_summary: PipelineSummary | None = None
-        has_changes = (bridge_result.ingest.placed + bridge_result.ingest.skipped) > 0
+        has_changes = (bridge_result.ingest.placed + bridge_result.ingest.overwritten) > 0
         if has_changes and not download_only:
             pipeline_summary = await _run_ingest_and_index_subprocess(
                 f"ingest(web): site-ingest {url}",

--- a/tests/test_scrapy_bridge.py
+++ b/tests/test_scrapy_bridge.py
@@ -593,9 +593,9 @@ class TestImportToSourceStore:
             source_store=source_store,
         )
 
-        # 1件目は新規配置、2件目は既存上書き（skipped）
+        # 1件目は新規配置、2件目は既存上書き（overwritten）
         assert result.ingest.placed == 1
-        assert result.ingest.skipped == 1
+        assert result.ingest.overwritten == 1
 
         # 最後の配置が有効
         record = source_store.db.get_source("https://example.com/page")

--- a/tests/test_scrapy_bridge.py
+++ b/tests/test_scrapy_bridge.py
@@ -593,7 +593,9 @@ class TestImportToSourceStore:
             source_store=source_store,
         )
 
-        assert result.ingest.placed == 2
+        # 1件目は新規配置、2件目は既存上書き（skipped）
+        assert result.ingest.placed == 1
+        assert result.ingest.skipped == 1
 
         # 最後の配置が有効
         record = source_store.db.get_source("https://example.com/page")


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- Bridge の配置カウントを「全配置数」から「新規配置数」に修正（既存ファイルへの上書きは skipped としてカウント）
- `download_only=true` 時にも source_store の git commit を実行するよう修正（パイプライン処理のみスキップ）
- CLI 側にも同一の修正を適用
- 仕様書（site-ingest.md）を更新: download_only 時の git commit 動作を明記

## Test plan

- [x] pytest 通過（test_scrapy_bridge: 30 passed、test_rag_mcp_server: 34 passed）
- [x] ruff check 通過
- [x] mypy 通過
- [x] コードレビュー実施済み
- [x] ドキュメントレビュー実施済み

## Related issues

#333（サブ Issue 残存のため Closes しない）