### PR TITLE
fix(site-ingest): JOBDIR 状態リークを修正 — クロールキーによるディレクトリ分離 (#334)

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -329,7 +329,7 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 
 ### JOBDIR の分離
 
-一時保存ディレクトリは `{domain}/{crawl_key}/` の 2 階層で管理する。`crawl_key` は `start_url` と effective `url_pattern`（自動生成後の値）の SHA-256 先頭 8 文字。
+一時保存ディレクトリは `{domain}/{crawl_key}/` の 2 階層で管理する。`crawl_key` は `start_url` と effective `url_pattern`（自動生成後の値）の SHA-256 先頭 16 文字。
 
 - 同じ `start_url` + `url_pattern` の組み合わせ → 同じクロールディレクトリ → レジューム可能
 - 異なる `start_url` または `url_pattern` → 異なるクロールディレクトリ → JOBDIR のスケジューラキューが分離され、状態リークを防止

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -128,7 +128,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url` | str | — | クロール開始 URL（必須） |
 | `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
 | `max_pages` | int | `site_ingest_max_pages` | ページ数上限。config.toml の値を上書き可能 |
-| `force` | bool | `false` | `true` の場合、ドメインディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする |
+| `force` | bool | `false` | `true` の場合、クロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする |
 | `download_only` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能 |
 
 ### CLI コマンド
@@ -144,7 +144,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url`（位置引数） | str | — | クロール開始 URL |
 | `--url-pattern` | str | なし | URL フィルタパターン |
 | `--max-pages` | int | `site_ingest_max_pages` | ページ数上限 |
-| `--force` | フラグ | `false` | ドメインディレクトリ全体を削除して再クロール |
+| `--force` | フラグ | `false` | クロールディレクトリ全体を削除して再クロール |
 | `--download-only` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ |
 
 ### 取り込み結果の出力形式
@@ -342,7 +342,7 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 | JSONL メタデータ | `{SITE_INGEST_TEMP_DIR}/{domain}/{crawl_key}/metadata.jsonl` |
 | JOBDIR | `{SITE_INGEST_TEMP_DIR}/{domain}/{crawl_key}/jobdir/` |
 
-`SITE_INGEST_TEMP_DIR` のデフォルト値は `.tmp/site_ingest`。`crawl_key` は `start_url` + effective `url_pattern` から生成される 8 文字のハッシュ。
+`SITE_INGEST_TEMP_DIR` のデフォルト値は `.tmp/site_ingest`。`crawl_key` の詳細は「JOBDIR の分離」セクションを参照。
 
 ### 処理フロー
 

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -251,7 +251,7 @@ Scrapy に渡す設定:
 | `CLOSESPIDER_PAGECOUNT` | `max_pages` パラメータまたは `site_ingest_max_pages`（config.toml） |
 | `CLOSESPIDER_TIMEOUT` | `site_ingest_timeout_sec`（config.toml） |
 | `CLOSESPIDER_ERRORCOUNT` | `site_ingest_error_count`（config.toml） |
-| `JOBDIR` | 一時保存ディレクトリ内の `jobdir/` |
+| `JOBDIR` | クロールディレクトリ内の `jobdir/`（`{domain}/{crawl_key}/jobdir/`） |
 | `FEEDS` | JSONL 出力パス |
 | `DOWNLOADER_MIDDLEWARES` | SSRF Middleware を有効化（優先度 50） |
 | `LOG_LEVEL` | `INFO` |
@@ -325,17 +325,24 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 - JOBDIR にスケジューラキューと重複フィルタが永続化される
 - 同じ JOBDIR で再実行すると、処理済み URL をスキップして続きから取得
 - JOBDIR のレジュームは「重複スキップ付き再クロール」として動作する（Scrapy Issue #4106）。プロセス強制終了時にキューが失われる場合がある
-- `--force` オプション指定時はドメインディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする
+- `--force` オプション指定時はクロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする
+
+### JOBDIR の分離
+
+一時保存ディレクトリは `{domain}/{crawl_key}/` の 2 階層で管理する。`crawl_key` は `start_url` と effective `url_pattern`（自動生成後の値）の SHA-256 先頭 8 文字。
+
+- 同じ `start_url` + `url_pattern` の組み合わせ → 同じクロールディレクトリ → レジューム可能
+- 異なる `start_url` または `url_pattern` → 異なるクロールディレクトリ → JOBDIR のスケジューラキューが分離され、状態リークを防止
 
 ### 一時保存ディレクトリ
 
 | 内容 | パス |
 |------|------|
-| HTML ファイル | `{SITE_INGEST_TEMP_DIR}/{domain}/html/` |
-| JSONL メタデータ | `{SITE_INGEST_TEMP_DIR}/{domain}/metadata.jsonl` |
-| JOBDIR | `{SITE_INGEST_TEMP_DIR}/{domain}/jobdir/` |
+| HTML ファイル | `{SITE_INGEST_TEMP_DIR}/{domain}/{crawl_key}/html/` |
+| JSONL メタデータ | `{SITE_INGEST_TEMP_DIR}/{domain}/{crawl_key}/metadata.jsonl` |
+| JOBDIR | `{SITE_INGEST_TEMP_DIR}/{domain}/{crawl_key}/jobdir/` |
 
-`SITE_INGEST_TEMP_DIR` のデフォルト値は `.tmp/site_ingest`。
+`SITE_INGEST_TEMP_DIR` のデフォルト値は `.tmp/site_ingest`。`crawl_key` は `start_url` + effective `url_pattern` から生成される 8 文字のハッシュ。
 
 ### 処理フロー
 
@@ -412,6 +419,7 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
 | `download_only` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
+| 同一ドメインへの異なるパラメータでの複数回クロール | クロールキー（`start_url` + effective `url_pattern` のハッシュ）により JOBDIR が分離されるため、前回クロールの URL キューが残留しない |
 
 ## 関連ドキュメント
 

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -31,7 +31,7 @@ def _crawl_key(start_url: str, url_pattern: str) -> str:
     異なる組み合わせは異なるキーを返し、JOBDIR の分離を保証する。
     """
     raw = f"{start_url}\n{url_pattern}"
-    return hashlib.sha256(raw.encode()).hexdigest()[:8]
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 @dataclass
@@ -85,7 +85,7 @@ class ScrapyRunner:
             allowed_domains: ドメイン制約（カンマ区切り）
             url_pattern: URL フィルタ正規表現
             max_pages: ページ数上限（None の場合はインスタンス設定値を使用）
-            force: True の場合、JOBDIR を削除して最初からクロール
+            force: True の場合、クロールディレクトリ全体を削除して最初からクロール
 
         Returns:
             クロール実行結果

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -10,6 +10,7 @@ JOBDIR 指定で中断再開に対応する。
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -21,6 +22,16 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+
+def _crawl_key(start_url: str, url_pattern: str) -> str:
+    """クロールパラメータから一意のキーを生成する.
+
+    同じ start_url + url_pattern の組み合わせは同じキーを返す。
+    異なる組み合わせは異なるキーを返し、JOBDIR の分離を保証する。
+    """
+    raw = f"{start_url}\n{url_pattern}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:8]
 
 
 @dataclass
@@ -92,30 +103,34 @@ class ScrapyRunner:
                 url_pattern = f"^{re.escape(base_prefix)}(?:/|$)"
                 logger.info("url_pattern を自動生成: %s", url_pattern)
 
-        # ドメインから一時保存ディレクトリを決定
+        # ドメイン + クロールキーから一時保存ディレクトリを決定
+        # クロールキー: start_url + effective url_pattern のハッシュ
+        # 同じパラメータなら同じディレクトリ（レジューム可能）、
+        # 異なるパラメータなら別ディレクトリ（JOBDIR 状態リーク防止）
         domain = parsed.hostname or "unknown"
-        domain_dir = self._temp_dir / domain
+        key = _crawl_key(start_url, url_pattern)
+        crawl_dir = self._temp_dir / domain / key
 
-        html_dir = domain_dir / "html"
-        jsonl_path = domain_dir / "metadata.jsonl"
-        jobdir = domain_dir / "jobdir"
+        html_dir = crawl_dir / "html"
+        jsonl_path = crawl_dir / "metadata.jsonl"
+        jobdir = crawl_dir / "jobdir"
 
-        # --force: ドメインディレクトリ全体をクリア（html/, metadata.jsonl, jobdir/）
-        if force and domain_dir.exists():
-            logger.info("--force: ドメインディレクトリを削除します: %s", domain_dir)
+        # --force: クロールディレクトリ全体をクリア（html/, metadata.jsonl, jobdir/）
+        if force and crawl_dir.exists():
+            logger.info("--force: クロールディレクトリを削除します: %s", crawl_dir)
             try:
-                shutil.rmtree(domain_dir)
+                shutil.rmtree(crawl_dir)
             except OSError as exc:
-                msg = f"--force 指定時にドメインディレクトリの削除に失敗しました: {domain_dir}"
+                msg = f"--force 指定時にクロールディレクトリの削除に失敗しました: {crawl_dir}"
                 logger.error(msg, exc_info=True)
                 raise RuntimeError(msg) from exc
 
         # ディレクトリ準備
         html_dir.mkdir(parents=True, exist_ok=True)
-        domain_dir.mkdir(parents=True, exist_ok=True)
+        crawl_dir.mkdir(parents=True, exist_ok=True)
 
         # パラメータを JSON ファイルに書き出し（コードインジェクション防止）
-        params_path = domain_dir / "spider_params.json"
+        params_path = crawl_dir / "spider_params.json"
         params = {
             "start_url": start_url,
             "allowed_domains": allowed_domains,
@@ -147,7 +162,7 @@ class ScrapyRunner:
 
         # stderr をファイルにリダイレクト（Windows で Twisted の子プロセス/スレッドが
         # stderr パイプを継承し、メインプロセス終了後もパイプが閉じない問題を回避）
-        stderr_path = domain_dir / "stderr.log"
+        stderr_path = crawl_dir / "stderr.log"
         stderr_file = open(stderr_path, "w", encoding="utf-8")  # noqa: SIM115
         try:
             process = await asyncio.create_subprocess_exec(

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -5,25 +5,79 @@
 テスト方針:
 - subprocess ラッパーのモックテスト（Scrapy プロセスの起動・終了・エラーハンドリング）
 - _build_spider_script の設定値埋め込み（JSON ファイル経由）
-- ディレクトリ構造の準備（domain_dir, html_dir, jobdir）
-- --force オプションによる JOBDIR 削除
+- ディレクトリ構造の準備（crawl_dir, html_dir, jobdir）
+- --force オプションによるクロールディレクトリ削除
+- クロールキーによる JOBDIR 分離
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
-from rag.scrapy.runner import CrawlResult, ScrapyRunner
+from rag.scrapy.runner import CrawlResult, ScrapyRunner, _crawl_key
 
 
 async def _async_lines_iter(lines: list[bytes]):
     """AsyncMock の stderr 用の非同期イテレータ."""
     for line in lines:
         yield line
+
+
+def _expected_crawl_dir(
+    tmp_path: Path, start_url: str, url_pattern: str = "",
+) -> Path:
+    """テスト用: runner.run() と同じロジックでクロールディレクトリを計算する."""
+    parsed = urlparse(start_url)
+    effective_pattern = url_pattern
+    if not effective_pattern:
+        path = parsed.path.rstrip("/")
+        if path and path != "/":
+            base_prefix = f"{parsed.scheme}://{parsed.hostname}{path}"
+            effective_pattern = f"^{re.escape(base_prefix)}(?:/|$)"
+    domain = parsed.hostname or "unknown"
+    key = _crawl_key(start_url, effective_pattern)
+    return tmp_path / domain / key
+
+
+# --- _crawl_key テスト ---
+
+
+class TestCrawlKey:
+    """クロールキー生成のテスト."""
+
+    def test_same_params_same_key(self) -> None:
+        """同じパラメータは同じキーを返す."""
+        key1 = _crawl_key("https://example.com/a", "/a/.*")
+        key2 = _crawl_key("https://example.com/a", "/a/.*")
+        assert key1 == key2
+
+    def test_different_start_url_different_key(self) -> None:
+        """異なる start_url は異なるキーを返す."""
+        key1 = _crawl_key("https://example.com/a", "")
+        key2 = _crawl_key("https://example.com/b", "")
+        assert key1 != key2
+
+    def test_different_url_pattern_different_key(self) -> None:
+        """異なる url_pattern は異なるキーを返す."""
+        key1 = _crawl_key("https://example.com", "/a/.*")
+        key2 = _crawl_key("https://example.com", "/b/.*")
+        assert key1 != key2
+
+    def test_key_length(self) -> None:
+        """キーは8文字."""
+        key = _crawl_key("https://example.com", "")
+        assert len(key) == 8
+
+    def test_key_is_hex(self) -> None:
+        """キーは16進文字列."""
+        key = _crawl_key("https://example.com", "")
+        int(key, 16)  # hex でなければ ValueError
 
 
 # --- CrawlResult テスト ---
@@ -182,10 +236,11 @@ class TestScrapyRunnerRun:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await runner.run(start_url="https://example.com")
 
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
         assert result.success is True
         assert result.exit_code == 0
-        assert result.output_dir == tmp_path / "example.com" / "html"
-        assert result.jsonl_path == tmp_path / "example.com" / "metadata.jsonl"
+        assert result.output_dir == crawl_dir / "html"
+        assert result.jsonl_path == crawl_dir / "metadata.jsonl"
 
     @pytest.mark.asyncio()
     async def test_failed_crawl(self, tmp_path: Path) -> None:
@@ -195,12 +250,7 @@ class TestScrapyRunnerRun:
         mock_process = AsyncMock()
         mock_process.wait.return_value = 1
 
-        # stderr はファイルリダイレクト方式のため、
-        # subprocess 起動時に stderr.log にエラーを書き込む
-        domain_dir = tmp_path / "example.com"
-
         async def fake_exec(*args, **kwargs):
-            domain_dir.mkdir(parents=True, exist_ok=True)
             stderr_file = kwargs.get("stderr")
             if stderr_file and hasattr(stderr_file, "write"):
                 stderr_file.write("ERROR: Something failed\n")
@@ -222,28 +272,31 @@ class TestScrapyRunnerRun:
         mock_process.wait.return_value = 0
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://docs.example.com/guide")
+            result = await runner.run(start_url="https://docs.example.com/guide")
 
-        # ドメインベースのディレクトリが作成される
-        assert (tmp_path / "docs.example.com" / "html").exists()
+        # クロールキーベースのディレクトリが作成される
+        assert result.output_dir.exists()
+        assert result.output_dir.name == "html"
+        # ドメインディレクトリの下にクロールキーディレクトリがある
+        assert result.output_dir.parent.parent.name == "docs.example.com"
 
     @pytest.mark.asyncio()
-    async def test_force_deletes_domain_dir(self, tmp_path: Path) -> None:
-        """--force でドメインディレクトリ全体が削除されること."""
+    async def test_force_deletes_crawl_dir(self, tmp_path: Path) -> None:
+        """--force でクロールディレクトリが削除されること."""
         runner = ScrapyRunner(temp_dir=tmp_path)
 
-        domain_dir = tmp_path / "example.com"
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
 
         # 事前に JOBDIR, html/, metadata.jsonl を作成
-        jobdir = domain_dir / "jobdir"
+        jobdir = crawl_dir / "jobdir"
         jobdir.mkdir(parents=True)
         (jobdir / "requests.seen").write_text("data", encoding="utf-8")
 
-        html_dir = domain_dir / "html"
+        html_dir = crawl_dir / "html"
         html_dir.mkdir(parents=True)
         (html_dir / "page.html").write_text("<html>old</html>", encoding="utf-8")
 
-        jsonl_path = domain_dir / "metadata.jsonl"
+        jsonl_path = crawl_dir / "metadata.jsonl"
         jsonl_path.write_text('{"url":"old"}\n', encoding="utf-8")
 
         mock_process = AsyncMock()
@@ -273,7 +326,8 @@ class TestScrapyRunnerRun:
             await runner.run(start_url="https://example.com", max_pages=50)
 
         # パラメータ JSON ファイルに max_pages=50 が書き込まれていること
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
+        params_path = crawl_dir / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["max_pages"] == 50
 
@@ -313,7 +367,10 @@ class TestScrapyRunnerRun:
                 url_pattern=r"/docs/.*",
             )
 
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(
+            tmp_path, "https://example.com/docs", r"/docs/.*",
+        )
+        params_path = crawl_dir / "spider_params.json"
         assert params_path.exists()
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["start_url"] == "https://example.com/docs"
@@ -339,7 +396,8 @@ class TestScrapyRunnerRun:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             await runner.run(start_url="https://example.com")
 
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
+        params_path = crawl_dir / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["timeout_sec"] == 600
         assert params["error_count"] == 50
@@ -356,7 +414,8 @@ class TestScrapyRunnerRun:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             await runner.run(start_url="https://example.com/docs/guide/")
 
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com/docs/guide/")
+        params_path = crawl_dir / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         # re.escape でドメインのドットがエスケープされたパターン
         assert params["url_pattern"] == r"^https://example\.com/docs/guide(?:/|$)"
@@ -373,7 +432,8 @@ class TestScrapyRunnerRun:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             await runner.run(start_url="https://example.com/")
 
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com/")
+        params_path = crawl_dir / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["url_pattern"] == ""
 
@@ -392,6 +452,111 @@ class TestScrapyRunnerRun:
                 url_pattern=r"/custom/.*",
             )
 
-        params_path = tmp_path / "example.com" / "spider_params.json"
+        crawl_dir = _expected_crawl_dir(
+            tmp_path, "https://example.com/docs/guide", r"/custom/.*",
+        )
+        params_path = crawl_dir / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["url_pattern"] == r"/custom/.*"
+
+
+# --- JOBDIR 分離テスト ---
+
+
+class TestJobdirIsolation:
+    """異なるクロール設定間の JOBDIR 分離テスト."""
+
+    @pytest.mark.asyncio()
+    async def test_different_start_url_different_jobdir(self, tmp_path: Path) -> None:
+        """同一ドメインでも異なる start_url は異なる JOBDIR を使用する."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result_a = await runner.run(
+                start_url="https://example.com/a.html",
+                url_pattern="a",
+            )
+            result_b = await runner.run(
+                start_url="https://example.com/b.html",
+                url_pattern="b",
+            )
+
+        # 出力ディレクトリが異なること
+        assert result_a.output_dir != result_b.output_dir
+        # どちらも同一ドメインの下にあること
+        assert result_a.output_dir.parent.parent.name == "example.com"
+        assert result_b.output_dir.parent.parent.name == "example.com"
+
+    @pytest.mark.asyncio()
+    async def test_different_url_pattern_different_jobdir(self, tmp_path: Path) -> None:
+        """同じ start_url でも異なる url_pattern は異なる JOBDIR を使用する."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result_a = await runner.run(
+                start_url="https://example.com",
+                url_pattern="/docs/.*",
+            )
+            result_b = await runner.run(
+                start_url="https://example.com",
+                url_pattern="/api/.*",
+            )
+
+        assert result_a.output_dir != result_b.output_dir
+
+    @pytest.mark.asyncio()
+    async def test_same_params_same_directory(self, tmp_path: Path) -> None:
+        """同じパラメータは同じディレクトリを使用する（レジューム可能）."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result_1 = await runner.run(
+                start_url="https://example.com/docs",
+                url_pattern="/docs/.*",
+            )
+            result_2 = await runner.run(
+                start_url="https://example.com/docs",
+                url_pattern="/docs/.*",
+            )
+
+        assert result_1.output_dir == result_2.output_dir
+        assert result_1.jsonl_path == result_2.jsonl_path
+
+    @pytest.mark.asyncio()
+    async def test_force_does_not_affect_other_crawl(self, tmp_path: Path) -> None:
+        """--force は対象クロールのディレクトリのみ削除し、他のクロールに影響しない."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+
+        # 1回目のクロール（a.html）を実行してファイルを作成
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result_a = await runner.run(
+                start_url="https://example.com/a.html",
+                url_pattern="a",
+            )
+
+        # a のクロールディレクトリにダミーファイルを作成
+        marker_file = result_a.output_dir / "marker.html"
+        marker_file.write_text("data", encoding="utf-8")
+
+        # 2回目のクロール（b.html）を --force で実行
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            await runner.run(
+                start_url="https://example.com/b.html",
+                url_pattern="b",
+                force=True,
+            )
+
+        # a のマーカーファイルは影響を受けていない
+        assert marker_file.exists()

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -70,9 +70,9 @@ class TestCrawlKey:
         assert key1 != key2
 
     def test_key_length(self) -> None:
-        """キーは8文字."""
+        """キーは16文字."""
         key = _crawl_key("https://example.com", "")
-        assert len(key) == 8
+        assert len(key) == 16
 
     def test_key_is_hex(self) -> None:
         """キーは16進文字列."""
@@ -236,11 +236,12 @@ class TestScrapyRunnerRun:
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             result = await runner.run(start_url="https://example.com")
 
-        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
         assert result.success is True
         assert result.exit_code == 0
-        assert result.output_dir == crawl_dir / "html"
-        assert result.jsonl_path == crawl_dir / "metadata.jsonl"
+        assert result.output_dir.name == "html"
+        assert result.jsonl_path.name == "metadata.jsonl"
+        # output_dir と jsonl_path は同じクロールディレクトリ配下
+        assert result.output_dir.parent == result.jsonl_path.parent
 
     @pytest.mark.asyncio()
     async def test_failed_crawl(self, tmp_path: Path) -> None:
@@ -323,11 +324,10 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://example.com", max_pages=50)
+            result = await runner.run(start_url="https://example.com", max_pages=50)
 
         # パラメータ JSON ファイルに max_pages=50 が書き込まれていること
-        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["max_pages"] == 50
 
@@ -361,16 +361,13 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(
+            result = await runner.run(
                 start_url="https://example.com/docs",
                 allowed_domains="example.com",
                 url_pattern=r"/docs/.*",
             )
 
-        crawl_dir = _expected_crawl_dir(
-            tmp_path, "https://example.com/docs", r"/docs/.*",
-        )
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         assert params_path.exists()
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["start_url"] == "https://example.com/docs"
@@ -394,10 +391,9 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://example.com")
+            result = await runner.run(start_url="https://example.com")
 
-        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["timeout_sec"] == 600
         assert params["error_count"] == 50
@@ -412,10 +408,9 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://example.com/docs/guide/")
+            result = await runner.run(start_url="https://example.com/docs/guide/")
 
-        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com/docs/guide/")
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         # re.escape でドメインのドットがエスケープされたパターン
         assert params["url_pattern"] == r"^https://example\.com/docs/guide(?:/|$)"
@@ -430,10 +425,9 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://example.com/")
+            result = await runner.run(start_url="https://example.com/")
 
-        crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com/")
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["url_pattern"] == ""
 
@@ -447,15 +441,12 @@ class TestScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(
+            result = await runner.run(
                 start_url="https://example.com/docs/guide",
                 url_pattern=r"/custom/.*",
             )
 
-        crawl_dir = _expected_crawl_dir(
-            tmp_path, "https://example.com/docs/guide", r"/custom/.*",
-        )
-        params_path = crawl_dir / "spider_params.json"
+        params_path = result.output_dir.parent / "spider_params.json"
         params = json.loads(params_path.read_text(encoding="utf-8"))
         assert params["url_pattern"] == r"/custom/.*"
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- 同一ドメインへの複数回 `rag_site_ingest` 呼び出しで JOBDIR が共有され、前回クロールの URL キューが残留する問題を修正
- `start_url` + effective `url_pattern` の SHA-256 先頭 8 文字をクロールキーとして、ドメインの下にクロール固有サブディレクトリを作成
- 同じパラメータなら同じディレクトリ（レジューム可能）、異なるパラメータなら別ディレクトリ（状態リーク防止）
- `--force` はクロールディレクトリのみ削除（他クロールに影響しない）
- 仕様書の一時保存ディレクトリ構造・中断再開セクション・エッジケースを更新

## Test plan

- [x] `TestCrawlKey` — クロールキー生成ロジック（同一/異なるパラメータ、長さ、hex 形式）
- [x] `TestJobdirIsolation` — 異なる start_url/url_pattern での JOBDIR 分離、同一パラメータでのレジューム、--force の影響範囲
- [x] 既存テスト 29 件全て通過
- [x] ruff / mypy チェック通過

## Related issues

Closes #334