### PR TITLE
feat(rebuild-stats): auto_commit パラメータ廃止、incremental 自動コミット化 (#337)

### DIFF
--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -46,40 +46,42 @@
 
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
-| 差分更新 | なし（自動検知） | 処理結果サマリ | `last_commit_id` と HEAD の差分を検知し、変更ファイルのみをパイプライン処理する。通常運用のデフォルト操作 |
-| 全再構築 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
-| コンバートのみ再実行 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
-| インデックスのみ再構築 | source_type フィルタ（任意）、auto_commit（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合の振る舞いは auto_commit の設定に従う |
+| 差分更新 | なし（自動検知） | 処理結果サマリ | source_store に未コミットの変更がある場合は自動コミットし、`last_commit_id` と HEAD の差分を検知して変更ファイルのみをパイプライン処理する。通常運用のデフォルト操作 |
+| 全再構築 | source_type フィルタ（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合はエラー |
+| コンバートのみ再実行 | source_type フィルタ（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合はエラー |
+| インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラー |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
 
 全操作は `progress_callback`（任意）を受け取り、ファイル処理完了ごとにコールバックを呼び出す。callback シグネチャ: `(processed: int, total: int, current: str) -> None`。未指定時は進捗通知なし。詳細は [rebuild-stats.md](rebuild-stats.md) のサブプロセス進捗通知セクションを参照。
 
-### 未コミット変更チェックと auto_commit
+### 未コミット変更の扱い
 
-再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）の実行前に、source_store に未コミットの変更があるかチェックする。チェック範囲と自動コミット範囲は `source_type` の指定有無に応じて変わる。
+モードによって未コミット変更の扱いが異なる。
 
-| auto_commit の値 | 未コミット変更がある場合の振る舞い |
-|-----------------|-------------------------------|
-| `false`（デフォルト） | エラーとして再構築を拒否する（従来動作） |
-| `true` | 自動コミットを実行し、コミット成功後に再構築を続行する |
+| モード | 未コミット変更がある場合の振る舞い |
+|--------|-------------------------------|
+| 差分更新（incremental） | 自動コミットしてから差分更新を実行する |
+| 全再構築 / コンバートのみ / インデックスのみ | エラーとして再構築を拒否する |
+| 取り込み実行 | 取り込み時のコミットに含まれる（従来動作） |
 
-#### source_type によるスコープ
+#### 差分更新の自動コミット
 
-| source_type | 未コミットチェックの範囲 | auto_commit のステージング範囲 |
-|-------------|---------------------|--------------------------|
-| 指定あり | `git status --porcelain -- {source_type}/` でそのディレクトリのみチェック | `git add {source_type}/` でそのディレクトリのみステージング＋コミット |
-| 指定なし | `git status --porcelain` で全体チェック（従来動作） | `git add -A` で全体ステージング＋コミット（従来動作） |
+差分更新（incremental）は、未コミットの変更がある場合に自動コミットを実行してから差分を処理する。
 
-source_type を指定することで、他の source_type ディレクトリに編集途中のファイルがあっても影響を受けずに再構築を実行できる。
+1. source_store の未コミット変更を検知する
+2. 変更がある場合、ステージング＋コミットで変更をコミットする（コミットメッセージ形式は「コミットメッセージ規則」を参照）
+3. コミット成功後、差分更新処理に進む
+4. 変更がない場合は自動コミットをスキップし、差分更新に進む
+5. git commit コマンド自体が失敗した場合（権限エラー等）はエラーとする
 
-#### auto_commit が `true` の場合の処理フロー
+#### 再構築操作の未コミットチェック
 
-1. source_store の未コミット変更を検知する（source_type 指定時はそのディレクトリのみ）
-2. ステージング＋コミットで変更をコミットする（コミットメッセージ形式は「コミットメッセージ規則」を参照）
-3. コミット成功後、再構築処理に進む
-4. auto_commit が `true` だが変更がない場合は自動コミットをスキップし、再構築に進む。git commit コマンド自体が失敗した場合（権限エラー等）はエラーとする
+再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）は、未コミットの変更がある場合エラーとする。`source_type` 指定時はそのディレクトリのみをチェックする。
 
-差分更新および取り込み実行は未コミット変更チェックの対象外であり、auto_commit パラメータは適用されない。
+| source_type | 未コミットチェックの範囲 |
+|-------------|---------------------|
+| 指定あり | `git status --porcelain -- {source_type}/` でそのディレクトリのみチェック |
+| 指定なし | `git status --porcelain` で全体チェック |
 
 ### git 操作
 
@@ -106,6 +108,8 @@ git diff から取得する変更ファイルリストの各エントリが持�
 ```mermaid
 flowchart TD
     START["パイプライン開始"]
+    CHECK_DIRTY{"未コミットの変更あり?"}
+    AUTO_COMMIT["自動コミット実行"]
     GET_STATE["pipeline_history から last_commit_id 取得"]
     CHECK["last_commit_id が null commit hash か"]
     DIFF["git diff last_commit_id..HEAD"]
@@ -126,7 +130,10 @@ flowchart TD
     UPDATE_STATE["pipeline_history に実行履歴を追加"]
     END_NODE["パイプライン完了"]
 
-    START --> GET_STATE
+    START --> CHECK_DIRTY
+    CHECK_DIRTY -- Yes --> AUTO_COMMIT
+    AUTO_COMMIT --> GET_STATE
+    CHECK_DIRTY -- No --> GET_STATE
     GET_STATE --> CHECK
     CHECK -->|通常のコミット ID| DIFF
     CHECK -->|null commit hash（初回）| FULL
@@ -145,8 +152,6 @@ flowchart TD
 flowchart TD
     START["全再構築開始"]
     CHECK_DIRTY{"未コミットの変更あり?"}
-    CHECK_AUTO{"auto_commit が true?"}
-    AUTO_COMMIT["自動コミット実行"]
     ERROR_DIRTY["エラー: rebuild 拒否"]
     CLEAR_CONV["converted_store をクリア"]
     CLEAR_IDX["ChromaDB + BM25 をクリア"]
@@ -160,10 +165,7 @@ flowchart TD
     REBUILD_DB["metadata.db 再構築（source_store スキャン）"]
 
     START --> CHECK_DIRTY
-    CHECK_DIRTY -- Yes --> CHECK_AUTO
-    CHECK_AUTO -- Yes --> AUTO_COMMIT
-    AUTO_COMMIT --> REBUILD_DB
-    CHECK_AUTO -- No --> ERROR_DIRTY
+    CHECK_DIRTY -- Yes --> ERROR_DIRTY
     CHECK_DIRTY -- No --> REBUILD_DB
     REBUILD_DB --> CLEAR_CONV
     CLEAR_CONV --> CLEAR_IDX
@@ -223,10 +225,7 @@ sequenceDiagram
 |---------|-------------|
 | インジェスター実行後 | `ingest({source_type}): {概要}` |
 | 手動ファイル配置後（local） | `ingest(local): manual update` |
-| 再構築時の自動コミット（source_type 指定なし） | `auto-commit: rebuild ({mode})` |
-| 再構築時の自動コミット（source_type 指定あり） | `auto-commit: rebuild ({mode}, {source_type})` |
-
-`{mode}` は再構築モード（`full`、`convert`、`index`）が入る。
+| 差分更新時の自動コミット | `auto-commit: incremental` |
 
 `source_type` の取りうる値は [source-store.md](source-store.md) の「source_id の決定方式」を参照（`web`, `bluesky`, `zenn`, `local`）。
 
@@ -243,8 +242,9 @@ sequenceDiagram
 | source_store の git リポジトリが未初期化 | パイプライン初回実行時に `git init` を自動実行する |
 | .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータを更新する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |
 | metadata.db の `status` が `deleted` のファイルが git diff に含まれる場合 | ファイルの変更種別に応じた処理を行う。`deleted` ステータスのファイルはインデックスに追加しない |
-| 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | auto_commit が `false`（デフォルト）の場合はエラーとして再構築を拒否する。auto_commit が `true` の場合は自動コミットを実行してから再構築を続行する |
-| 自動コミット時に git commit が失敗した場合 | エラーとして再構築を拒否する（コミット失敗の原因をエラーメッセージに含める） |
+| 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | エラーとして再構築を拒否する |
+| 差分更新時に source_store に未コミットの変更がある場合 | 自動コミットを実行してから差分更新を続行する |
+| 差分更新の自動コミット時に git commit が失敗した場合 | エラーとして差分更新を拒否する（コミット失敗の原因をエラーメッセージに含める） |
 
 ### 設定項目
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -55,19 +55,17 @@
 |-----------|-----|------|------|
 | `mode` | str | はい | 再構築モード（下表参照） |
 | `source_type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`local`。未指定時は全媒体 |
-| `auto_commit` | bool | いいえ | source_store に未コミット変更がある場合に自動コミットするか。`source_type` 指定時はそのディレクトリのみを対象とする。デフォルト: `false` |
 
 再構築モード:
 
 | モード値 | 対応するパイプライン操作 | `source_type` フィルタ | 用途 |
 |---------|----------------------|----------------------|------|
-| `full` | 全再構築 | 適用可 | データ破損時や大規模な設計変更時 |
-| `convert` | コンバートのみ再実行 | 適用可 | コンバーターの変換ロジック改修時 |
-| `index` | インデックスのみ再構築 | 適用可 | Embedding モデル変更時やチャンクパラメータ変更時 |
-| `incremental` | 差分更新 | 適用不可（git diff に従う） | 通常運用（明示指定は通常不要） |
+| `full` | 全再構築 | 適用可 | データ破損時や大規模な設計変更時。未コミット変更があればエラー |
+| `convert` | コンバートのみ再実行 | 適用可 | コンバーターの変換ロジック改修時。未コミット変更があればエラー |
+| `index` | インデックスのみ再構築 | 適用可 | Embedding モデル変更時やチャンクパラメータ変更時。未コミット変更があればエラー |
+| `incremental` | 差分更新 | 適用不可（git diff に従う） | 通常運用。未コミット変更は自動コミットされる |
 
 - `source_type` フィルタが適用不可のモード（`incremental`）で `source_type` が指定された場合、エラーを返す
-- `auto_commit` が適用不可のモード（`incremental`）で `auto_commit` が `true` に指定された場合、エラーを返す
 - 戻り値: 処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）をテキストで返す
 
 #### rag_stats（拡張）
@@ -82,14 +80,13 @@
 #### rebuild コマンド
 
 ```
-uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>] [--auto-commit]
+uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>]
 ```
 
 | オプション | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `--mode` | str | はい | 再構築モード: `full`、`convert`、`index`、`incremental` |
 | `--source-type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`local` |
-| `--auto-commit` | フラグ | いいえ | 指定時、source_store に未コミット変更がある場合に自動コミットする。`--source-type` 指定時はそのディレクトリのみを対象とする。未指定時はエラーで拒否（デフォルト動作） |
 
 MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適用する。
 
@@ -313,7 +310,6 @@ metadata.db が破損・消失している場合は、パイプライン制御�
 | source_store ディレクトリが存在しない場合 | `rag_stats` は source_store の各項目を 0 で表示する。`rag_rebuild` はエラーを返す |
 | 再構築中に別の再構築が要求された場合 | 後発の要求にエラーを返す（排他制御） |
 | `incremental` モードで `source_type` が指定された場合 | パラメータ検証エラーを返す |
-| `incremental` モードで `auto_commit` が `true` の場合 | パラメータ検証エラーを返す |
 | metadata.db が存在しない場合の `rag_stats` | パイプラインセクションを「未初期化」と表示する。source_store のファイルシステムベースの統計は表示する |
 | 再構築中にエラーが発生した場合 | パイプライン制御のエラーハンドリングに従う（エラーファイルをスキップし残りを処理続行。`pipeline_history` に履歴を追加しない） |
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -295,12 +295,6 @@ def main() -> None:
         default=None,
         help="対象媒体フィルタ（incremental では指定不可）",
     )
-    rebuild_parser.add_argument(
-        "--auto-commit",
-        action="store_true",
-        default=False,
-        help="未コミット変更がある場合に自動コミットする（incremental では指定不可）",
-    )
     # stats サブコマンド
     subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
 
@@ -1025,19 +1019,11 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     mode: str = args.mode
     source_type: SourceType | None = args.source_type
-    auto_commit: bool = args.auto_commit
 
     # incremental + source_type のバリデーション
     if mode == "incremental" and source_type is not None:
         logger.error(
             "incremental モードでは source_type を指定できません"
-        )
-        sys.exit(1)
-
-    # incremental + auto_commit のバリデーション
-    if mode == "incremental" and auto_commit:
-        logger.error(
-            "incremental モードでは --auto-commit を指定できません"
         )
         sys.exit(1)
 
@@ -1067,15 +1053,15 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     if mode == "full":
         summary = controller.run_full_rebuild(
-            source_type=source_type, auto_commit=auto_commit,
+            source_type=source_type,
         )
     elif mode == "convert":
         summary = controller.run_convert_only(
-            source_type=source_type, auto_commit=auto_commit,
+            source_type=source_type,
         )
     elif mode == "index":
         summary = controller.run_index_only(
-            source_type=source_type, auto_commit=auto_commit,
+            source_type=source_type,
         )
     else:
         summary = controller.run_incremental()

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -127,7 +127,8 @@ class PipelineController:
         self._git.init_repo()
 
         # 未コミット変更の自動コミット
-        self._auto_commit_for_incremental()
+        if self._git.has_uncommitted_changes():
+            self._auto_commit_for_incremental()
 
         if not self._git.has_commits():
             return PipelineSummary(
@@ -292,7 +293,7 @@ class PipelineController:
         Raises:
             RuntimeError: 未コミットの変更がある場合
         """
-        if self._git.has_commits() and self._git.has_uncommitted_changes(
+        if self._git.has_uncommitted_changes(
             path=source_type,
         ):
             msg = (

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -121,10 +121,13 @@ class PipelineController:
     def run_incremental(self, progress_callback: ProgressCallback | None = None) -> PipelineSummary:
         """差分更新を実行する.
 
-        last_commit_id と HEAD の差分を検知し、
-        変更ファイルのみをパイプライン処理する。
+        source_store に未コミットの変更がある場合は自動コミットし、
+        last_commit_id と HEAD の差分を検知して変更ファイルのみをパイプライン処理する。
         """
         self._git.init_repo()
+
+        # 未コミット変更の自動コミット
+        self._auto_commit_for_incremental()
 
         if not self._git.has_commits():
             return PipelineSummary(
@@ -191,7 +194,6 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
-        auto_commit: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """全再構築を実行する.
@@ -201,14 +203,11 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
-            auto_commit: True の場合、未コミット変更を自動コミットする
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
-                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._auto_commit_if_needed(auto_commit, "full", source_type)
         self._check_uncommitted_changes(source_type)
 
         # 1. metadata.db 再構築
@@ -302,27 +301,10 @@ class PipelineController:
             )
             raise RuntimeError(msg)
 
-    def _auto_commit_if_needed(
-        self,
-        auto_commit: bool,
-        mode: str,
-        source_type: SourceType | None = None,
-    ) -> None:
-        """auto_commit が有効な場合、未コミット変更を自動コミットする.
-
-        Args:
-            auto_commit: 自動コミットを実行するか
-            mode: 再構築モード（コミットメッセージに使用）
-            source_type: コミット対象の媒体ディレクトリ（None で全体）
-        """
-        if not auto_commit:
-            return
-        if source_type is not None:
-            message = f"auto-commit: rebuild ({mode}, {source_type})"
-        else:
-            message = f"auto-commit: rebuild ({mode})"
+    def _auto_commit_for_incremental(self) -> None:
+        """差分更新時に未コミット変更を自動コミットする."""
         try:
-            commit_id = self._git.commit(message, path=source_type)
+            commit_id = self._git.commit("auto-commit: incremental")
         except subprocess.CalledProcessError as e:
             msg = f"自動コミットに失敗しました: {e.stderr or e}"
             raise RuntimeError(msg) from e
@@ -333,7 +315,6 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
-        auto_commit: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """コンバートのみ再実行する.
@@ -343,14 +324,11 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
-            auto_commit: True の場合、未コミット変更を自動コミットする
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
-                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._auto_commit_if_needed(auto_commit, "convert", source_type)
         self._check_uncommitted_changes(source_type)
 
         # 1. converted_store クリア
@@ -407,7 +385,6 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
-        auto_commit: bool = False,
         progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """インデックスのみ再構築する.
@@ -417,14 +394,11 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
-            auto_commit: True の場合、未コミット変更を自動コミットする
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
-                (auto_commit=False 時)
         """
         self._git.init_repo()
-        self._auto_commit_if_needed(auto_commit, "index", source_type)
         self._check_uncommitted_changes(source_type)
 
         # 1. インデックスクリア

--- a/src/rag/pipeline/worker.py
+++ b/src/rag/pipeline/worker.py
@@ -9,7 +9,7 @@ C 拡張（BM25s 等）の SEGFAULT がサーバープロセスを巻き込ま�
 
 Usage:
     python -m rag.pipeline.worker rebuild \\
-        --mode full --source-type web --auto-commit
+        --mode full --source-type web
     python -m rag.pipeline.worker ingest-and-index \\
         --commit-message "add: new document"
     python -m rag.pipeline.worker delete \\
@@ -67,14 +67,10 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     mode: str = args.mode
     source_type: SourceType | None = args.source_type
-    auto_commit: bool = args.auto_commit
 
     # incremental モードのバリデーション（CLI と同等）
     if mode == "incremental" and source_type is not None:
         print(json.dumps({"type": "error", "error": True, "message": "incremental モードでは source_type を指定できません"}))
-        sys.exit(1)
-    if mode == "incremental" and auto_commit:
-        print(json.dumps({"type": "error", "error": True, "message": "incremental モードでは auto_commit を指定できません"}))
         sys.exit(1)
 
     try:
@@ -84,17 +80,17 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
         if mode == "full":
             summary = controller.run_full_rebuild(
-                source_type=source_type, auto_commit=auto_commit,
+                source_type=source_type,
                 progress_callback=_emit_progress,
             )
         elif mode == "convert":
             summary = controller.run_convert_only(
-                source_type=source_type, auto_commit=auto_commit,
+                source_type=source_type,
                 progress_callback=_emit_progress,
             )
         elif mode == "index":
             summary = controller.run_index_only(
-                source_type=source_type, auto_commit=auto_commit,
+                source_type=source_type,
                 progress_callback=_emit_progress,
             )
         else:
@@ -167,9 +163,6 @@ def main() -> None:
         "--source-type",
         choices=["web", "bluesky", "zenn", "local"],
         default=None,
-    )
-    rebuild_parser.add_argument(
-        "--auto-commit", action="store_true", default=False,
     )
 
     ingest_parser = subparsers.add_parser("ingest-and-index")

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1234,7 +1234,6 @@ def _collect_pipeline_stats(
 async def rag_rebuild(
     mode: str,
     source_type: str | None = None,
-    auto_commit: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG rebuild - ナレッジベースの再構築を実行する.
@@ -1249,11 +1248,9 @@ async def rag_rebuild(
             "full" — 全再構築（データ破損時・大規模設計変更時）
             "convert" — コンバートのみ再実行（変換ロジック改修時）
             "index" — インデックスのみ再構築（Embedding モデル変更時）
-            "incremental" — 差分更新（通常運用）
+            "incremental" — 差分更新（通常運用。未コミット変更は自動コミット）
         source_type: 対象媒体フィルタ: "web", "bluesky", "zenn", "local"。
             未指定時は全媒体。incremental モードでは指定不可。
-        auto_commit: source_store に未コミット変更がある場合に自動コミットするか。
-            デフォルト: false。incremental モードでは指定不可。
 
     Returns:
         処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）
@@ -1273,9 +1270,6 @@ async def rag_rebuild(
             "（git diff に従います）"
         )
 
-    if mode == "incremental" and auto_commit:
-        return "エラー: incremental モードでは auto_commit を指定できません"
-
     # 設定の検証
     settings = get_settings()
     if not settings.source_store_dir:
@@ -1292,7 +1286,7 @@ async def rag_rebuild(
         return "エラー: 別の再構築が実行中です"
 
     try:
-        result = await _run_rebuild_subprocess(mode, source_type, auto_commit, ctx=ctx)
+        result = await _run_rebuild_subprocess(mode, source_type, ctx=ctx)
 
         # rebuild はインデックスを全操作するため、両方リセット
         _reset_pipeline_controller()
@@ -1511,15 +1505,12 @@ async def _run_delete_subprocess(
 async def _run_rebuild_subprocess(
     mode: str,
     source_type: str | None,
-    auto_commit: bool,
     ctx: MCPContext | None = None,
 ) -> str:
     """rebuild を CLI サブプロセスで実行する."""
     args = ["--mode", mode]
     if source_type is not None:
         args.extend(["--source-type", source_type])
-    if auto_commit:
-        args.append("--auto-commit")
 
     exit_code, stdout_text, stderr_tail = await _run_worker_subprocess(
         "rebuild", args, ctx=ctx,

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -684,6 +684,7 @@ class TestRunFullRebuild:
     ) -> None:
         ctrl, _, _ = controller
         ctrl.init_repo()
+        ctrl.commit("initial")
         summary = ctrl.run_full_rebuild()
         assert summary.total_files == 0
         assert summary.processed == 0

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -957,15 +957,15 @@ class TestRenamedLocalSourceId:
         assert "local/new.txt" in indexer.added
 
 
-class TestAutoCommit:
-    """auto_commit オプションのテスト."""
+class TestUncommittedChanges:
+    """未コミット変更の扱いのテスト."""
 
-    def test_auto_commit_full_rebuild_with_uncommitted(
+    def test_incremental_auto_commits_uncommitted_changes(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
     ) -> None:
-        """auto_commit=True + 未コミット変更あり → 自動コミットされて rebuild 成功."""
+        """incremental は未コミット変更を自動コミットして処理する."""
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
@@ -977,100 +977,26 @@ class TestAutoCommit:
         converter.converted.clear()
         indexer.added.clear()
 
-        # auto_commit=True なので成功する
-        summary = ctrl.run_full_rebuild(auto_commit=True)
-        assert summary.mode == PipelineMode.FULL_REBUILD
-        assert summary.processed == 2  # a.txt + new.txt
+        # incremental は自動コミットして差分処理する
+        summary = ctrl.run_incremental()
+        assert summary.mode == PipelineMode.INCREMENTAL
+        assert summary.processed == 1  # new.txt のみ（差分）
 
-    def test_auto_commit_false_with_uncommitted_raises(
+    def test_incremental_auto_commit_message_format(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
     ) -> None:
-        """auto_commit=False（デフォルト） + 未コミット変更あり → RuntimeError."""
+        """incremental の自動コミットメッセージが仕様通りの形式になる."""
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-
-        _place_local_file(workspace["source"], "local/uncommitted.txt")
-
-        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
-            ctrl.run_full_rebuild()
-
-    def test_auto_commit_no_changes(
-        self,
-        controller: tuple[PipelineController, StubConverter, StubIndexer],
-        workspace: dict[str, Path],
-    ) -> None:
-        """auto_commit=True + 変更なし → 正常に rebuild 実行."""
-        ctrl, converter, indexer = controller
-        _place_local_file(workspace["source"], "local/a.txt")
-        ctrl.commit("first")
         ctrl.run_incremental()
-
-        converter.converted.clear()
-        indexer.added.clear()
-
-        summary = ctrl.run_full_rebuild(auto_commit=True)
-        assert summary.mode == PipelineMode.FULL_REBUILD
-        assert summary.processed == 1  # a.txt
-
-    def test_auto_commit_convert_only(
-        self,
-        controller: tuple[PipelineController, StubConverter, StubIndexer],
-        workspace: dict[str, Path],
-    ) -> None:
-        """run_convert_only で auto_commit が機能する."""
-        ctrl, converter, _ = controller
-        _place_local_file(workspace["source"], "local/a.txt")
-        ctrl.commit("first")
-        ctrl.run_incremental()
-
-        # 既存ファイルを変更（未コミット状態にする）
-        _place_local_file(workspace["source"], "local/a.txt", "updated")
-
-        converter.converted.clear()
-
-        # auto_commit=False ならエラーになるが、True なので成功する
-        summary = ctrl.run_convert_only(auto_commit=True)
-        assert summary.mode == PipelineMode.CONVERT_ONLY
-        assert summary.processed == 1  # a.txt（metadata.db に登録済み）
-
-    def test_auto_commit_index_only(
-        self,
-        controller: tuple[PipelineController, StubConverter, StubIndexer],
-        workspace: dict[str, Path],
-    ) -> None:
-        """run_index_only で auto_commit が機能する."""
-        ctrl, _, indexer = controller
-        _place_local_file(workspace["source"], "local/a.txt")
-        ctrl.commit("first")
-        ctrl.run_incremental()
-
-        # 既存ファイルを変更（未コミット状態にする）
-        _place_local_file(workspace["source"], "local/a.txt", "updated")
-
-        indexer.added.clear()
-
-        # auto_commit=False ならエラーになるが、True なので成功する
-        summary = ctrl.run_index_only(auto_commit=True)
-        assert summary.mode == PipelineMode.INDEX_ONLY
-        assert summary.processed == 1  # a.txt（converted_store にある）
-
-    def test_auto_commit_message_format(
-        self,
-        controller: tuple[PipelineController, StubConverter, StubIndexer],
-        workspace: dict[str, Path],
-    ) -> None:
-        """自動コミットのメッセージが仕様通りの形式になる."""
-        ctrl, _, _ = controller
-        _place_local_file(workspace["source"], "local/a.txt")
-        ctrl.commit("first")
 
         # 未コミットのファイルを追加
         _place_local_file(workspace["source"], "local/new.txt")
 
-        ctrl.run_full_rebuild(auto_commit=True)
+        ctrl.run_incremental()
 
         # git log で最新コミットメッセージを確認
         result = subprocess.run(
@@ -1081,66 +1007,70 @@ class TestAutoCommit:
             check=True,
             encoding="utf-8",
         )
-        assert result.stdout.strip() == "auto-commit: rebuild (full)"
+        assert result.stdout.strip() == "auto-commit: incremental"
 
-    def test_auto_commit_scoped_by_source_type(
+    def test_incremental_no_uncommitted_changes(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
     ) -> None:
-        """source_type 指定時、他の source_type の変更はコミットされない."""
+        """incremental で未コミット変更がない場合は正常に動作する."""
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
-        _place_web_file(workspace["source"], "web/example.com/page.html")
         ctrl.commit("first")
         ctrl.run_incremental()
 
-        # 両方に未コミット変更を追加
-        _place_local_file(workspace["source"], "local/b.txt", "new local")
-        _place_web_file(
-            workspace["source"],
-            "web/example.com/page2.html",
-            title="Page 2",
-            source_id="web/example.com/page2.html",
-        )
+        # 変更なしで再実行 → 差分なしで正常終了
+        summary = ctrl.run_incremental()
+        assert summary.mode == PipelineMode.INCREMENTAL
+        assert summary.processed == 0
 
-        # source_type="local" で auto_commit → local だけコミットされる
-        ctrl.run_full_rebuild(source_type="local", auto_commit=True)
-
-        # web の変更はまだ未コミットのはず
-        result = subprocess.run(
-            ["git", "status", "--porcelain", "--", "web/"],
-            cwd=str(workspace["source"]),
-            capture_output=True,
-            text=True,
-            check=True,
-            encoding="utf-8",
-        )
-        assert result.stdout.strip() != ""  # web にはまだ変更がある
-
-    def test_auto_commit_source_type_message_format(
+    def test_full_rebuild_with_uncommitted_raises(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
     ) -> None:
-        """source_type 指定時のコミットメッセージ形式を確認."""
+        """full rebuild は未コミット変更があると RuntimeError."""
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
 
-        _place_local_file(workspace["source"], "local/new.txt")
+        _place_local_file(workspace["source"], "local/uncommitted.txt")
 
-        ctrl.run_full_rebuild(source_type="local", auto_commit=True)
+        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
+            ctrl.run_full_rebuild()
 
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%s"],
-            cwd=str(workspace["source"]),
-            capture_output=True,
-            text=True,
-            check=True,
-            encoding="utf-8",
-        )
-        assert result.stdout.strip() == "auto-commit: rebuild (full, local)"
+    def test_convert_only_with_uncommitted_raises(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """convert_only は未コミット変更があると RuntimeError."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        _place_local_file(workspace["source"], "local/a.txt", "updated")
+
+        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
+            ctrl.run_convert_only()
+
+    def test_index_only_with_uncommitted_raises(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """index_only は未コミット変更があると RuntimeError."""
+        ctrl, _, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        ctrl.commit("first")
+        ctrl.run_incremental()
+
+        _place_local_file(workspace["source"], "local/a.txt", "updated")
+
+        with pytest.raises(RuntimeError, match="未コミットの変更があります"):
+            ctrl.run_index_only()
 
     def test_uncommitted_check_scoped_by_source_type(
         self,


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `auto_commit` パラメータを MCP ツール・CLI・worker から廃止
- `incremental` モードは未コミット変更を常に自動コミットしてから差分処理する
- `full` / `convert` / `index` モードは未コミット変更がある場合エラーで拒否する
- 仕様書（pipeline-controller.md, rebuild-stats.md）を設計変更に合わせて更新
- mermaid フロー図に差分更新の自動コミットステップを追加
- テストクラス `TestAutoCommit` → `TestUncommittedChanges` に改名・テスト内容を書き換え

## Test plan

- [x] pytest: 62 passed（test_pipeline_controller.py, test_rag_cli.py）
- [x] ruff: 違反なし
- [x] mypy: エラーなし
- [x] コードレビュー: 問題なし
- [x] ドキュメントレビュー: Warning 1件（mermaid 図の不整合 → 修正済み）

## Related issues

Closes #337