### PR TITLE
fix(rebuild-stats,site-ingest): テストの auto_commit 引数残存・文言不一致を修正 (#337)

### DIFF
--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -418,7 +418,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="convert", source_type="web")
 
         assert "再構築完了" in result
-        mock_subprocess.assert_called_once_with("convert", "web", False, ctx=None)
+        mock_subprocess.assert_called_once_with("convert", "web", ctx=None)
 
     @pytest.mark.asyncio
     async def test_incremental_mode(
@@ -449,7 +449,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="incremental")
 
         assert "差分更新" in result
-        mock_subprocess.assert_called_once_with("incremental", None, False, ctx=None)
+        mock_subprocess.assert_called_once_with("incremental", None, ctx=None)
 
     @pytest.mark.asyncio
     async def test_index_only_mode(
@@ -480,7 +480,7 @@ class TestRagRebuild:
             result = await rag_rebuild(mode="index", source_type="local")
 
         assert "インデックスのみ再構築" in result
-        mock_subprocess.assert_called_once_with("index", "local", False, ctx=None)
+        mock_subprocess.assert_called_once_with("index", "local", ctx=None)
 
     @pytest.mark.asyncio
     async def test_exception_releases_lock(
@@ -556,7 +556,7 @@ class TestRunRebuildSubprocess:
         )
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            result = await _run_rebuild_subprocess("full", None, False)
+            result = await _run_rebuild_subprocess("full", None)
 
         assert "再構築完了" in result
         assert "全再構築" in result
@@ -571,7 +571,7 @@ class TestRunRebuildSubprocess:
         mock_process = _make_mock_process(b"not json", b"", 0)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            result = await _run_rebuild_subprocess("full", None, False)
+            result = await _run_rebuild_subprocess("full", None)
 
         assert "結果なし" in result
 
@@ -583,7 +583,7 @@ class TestRunRebuildSubprocess:
         mock_process = _make_mock_process(b"", b"RuntimeError: DB locked\n", 1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            result = await _run_rebuild_subprocess("full", None, False)
+            result = await _run_rebuild_subprocess("full", None)
 
         assert "異常終了" in result
         assert "DB locked" in result
@@ -596,7 +596,7 @@ class TestRunRebuildSubprocess:
         mock_process = _make_mock_process(b"", b"", -11)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            result = await _run_rebuild_subprocess("full", None, False)
+            result = await _run_rebuild_subprocess("full", None)
 
         assert "クラッシュ" in result
         assert "SEGFAULT" in result
@@ -612,7 +612,7 @@ class TestRunRebuildSubprocess:
         )
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            result = await _run_rebuild_subprocess("full", None, False)
+            result = await _run_rebuild_subprocess("full", None)
 
         assert "source_store not found" in result
 

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -256,7 +256,7 @@ class TestMcpSiteIngestFlow:
                 max_pages=10,
                 force=False,
             )
-            assert "3件配置" in result
+            assert "3件新規配置" in result
             assert "1件スキップ" in result
             assert "パイプライン: 3件処理" in result
             mock_bridge.assert_called_once()
@@ -306,7 +306,7 @@ class TestMcpSiteIngestFlow:
                 max_pages=10,
                 force=False,
             )
-            assert "0件配置" in result
+            assert "0件新規配置" in result
             assert "5件スキップ" in result
             mock_subprocess.assert_not_called()
 
@@ -366,7 +366,7 @@ class TestMcpSiteIngestFlow:
                 max_pages=10,
                 force=False,
             )
-            assert "2件配置" in result
+            assert "2件新規配置" in result
             assert "exit_code=1" in result
             assert "部分的な結果" in result
 
@@ -583,7 +583,7 @@ class TestCliSiteIngestFlow:
 
             await run_site_ingest(args)
             captured = capsys.readouterr()
-            assert "5件配置" in captured.out
+            assert "5件新規配置" in captured.out
             assert "2件スキップ" in captured.out
             assert "1件エラー" in captured.out
             assert "パイプライン: 5件処理" in captured.out
@@ -630,7 +630,7 @@ class TestCliSiteIngestFlow:
 
             await run_site_ingest(args)
             captured = capsys.readouterr()
-            assert "0件配置" in captured.out
+            assert "0件新規配置" in captured.out
             mock_controller.ingest_and_index.assert_not_called()
 
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正
- [x] test: テスト追加・修正

## Summary

- `test_rebuild_stats.py`: `_run_rebuild_subprocess` のアサーション・直接呼び出しに残存していた `auto_commit` 引数（`False`）を削除（8箇所）
- `test_scrapy_site_ingest.py`: サイト取り込み結果の文言が `"件配置"` → `"件新規配置"` に変更されたのにテストが追従していなかった問題を修正（5箇所）

## Test plan

- [x] `uv run pytest` 全1273件パス（8件の失敗が解消）
- [x] `uv run ruff check` パス
- [x] `uv run mypy src/rag/server.py` パス

## Related issues

Closes #337