### PR TITLE
fix(converter): .htm 拡張子をコンバーター対応に追加

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -68,6 +68,7 @@
 | 拡張子 | 入力形式 | 出力形式 | 出力拡張子 | 変換方式 |
 |--------|---------|---------|-----------|---------|
 | `.html` | HTML | Markdown | `.md` | HTML → Markdown 変換 |
+| `.htm` | HTML | Markdown | `.md` | HTML → Markdown 変換（`.html` と同一処理） |
 | `.pdf` | PDF | Markdown | `.md` | PDF テキスト抽出 |
 | `.json` | JSON | Markdown | `.md` | source_type に応じた構造化テキスト抽出 |
 | `.md` | Markdown | Markdown | `.md` | パススルー（コピー） |
@@ -94,7 +95,7 @@ flowchart TD
     OUTPUT["converted_store に配置"]
 
     INPUT --> EXT
-    EXT -->|.html| HTML
+    EXT -->|.html, .htm| HTML
     EXT -->|.pdf| PDF
     EXT -->|.json| JSON
     EXT -->|.md, .txt, .adoc| PASS

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -37,6 +37,7 @@ RegenOption = Literal["skip", "if_modified", "force"]
 # 拡張子 → 出力拡張子のマッピング（変換対象）
 _EXTENSION_OUTPUT_MAP: dict[str, str] = {
     ".html": ".md",
+    ".htm": ".md",
     ".pdf": ".md",
     ".json": ".md",
 }
@@ -322,7 +323,7 @@ class Converter:
         Returns:
             変換後テキスト、または失敗時は None
         """
-        if ext == ".html":
+        if ext in (".html", ".htm"):
             return convert_html(source_path)
 
         if ext == ".pdf":

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -837,7 +837,7 @@ class RAGKnowledgeService:
 
 # テキストファイルとして扱う拡張子
 _TEXT_EXTENSIONS: frozenset[str] = frozenset(
-    {".md", ".txt", ".adoc", ".html", ".json"}
+    {".md", ".txt", ".adoc", ".html", ".htm", ".json"}
 )
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -877,6 +877,9 @@ class TestGetConvertedRelPath:
     def test_html_to_md(self) -> None:
         assert get_converted_rel_path("web/example/page.html") == "web/example/page.md"
 
+    def test_htm_to_md(self) -> None:
+        assert get_converted_rel_path("web/example/page.htm") == "web/example/page.md"
+
     def test_pdf_to_md(self) -> None:
         assert get_converted_rel_path("web/doc/report.pdf") == "web/doc/report.md"
 
@@ -934,6 +937,23 @@ class TestConverterConvert:
         text = result.read_text(encoding="utf-8")
         assert "Title" in text
         assert "Content." in text
+        # 出力拡張子が .md
+        assert result.name == "page.md"
+
+    def test_convert_htm(self, tmp_path: Path) -> None:
+        """`.htm` 拡張子のファイルが HTML として変換されること (#346)."""
+        html = "<html><body><h1>Title</h1><p>HTM Content.</p></body></html>"
+        source_dir, converted_dir = _setup_source(
+            tmp_path, "web/example/page.htm", html,
+        )
+        converter = Converter()
+        result = converter.convert(
+            "web/example/page.htm", source_dir, converted_dir,
+        )
+        assert result.exists()
+        text = result.read_text(encoding="utf-8")
+        assert "Title" in text
+        assert "HTM Content." in text
         # 出力拡張子が .md
         assert result.name == "page.md"
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `_EXTENSION_OUTPUT_MAP` に `.htm` → `.md` マッピングを追加し、`.htm` ファイルを HTML として変換可能にした
- `_dispatch_conversion` で `.htm` を `.html` と同一の `convert_html` ハンドラに振り分け
- `_TEXT_EXTENSIONS` に `.htm` を追加し、`rag_get_document` での全文取得時にテキストファイルとして正しく認識されるようにした
- 仕様書（`converter.md`）の対応形式テーブルと mermaid フローチャートを更新
- テスト追加: `.htm` ファイルの Converter 統合テスト、パス変換ユーティリティテスト

## Test plan

- [x] `test_convert_htm`: `.htm` ファイルが HTML として変換され `.md` が出力されることを確認
- [x] `test_htm_to_md`: `get_converted_rel_path` が `.htm` → `.md` のパス変換を行うことを確認
- [x] 既存テスト 105 件全パス確認

## Related issues

Closes #346

Generated with [Claude Code](https://claude.ai/code)