### PR TITLE
feat(journal): Journal インジェスター + 汎用メタデータフィルタの実装 (#46)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,7 @@
 | `ingesters/youtube.md` | `src/rag/pipeline/ingesters/youtube.py` |
 | `ingesters/zenn.md` | `src/rag/pipeline/ingesters/zenn.py` |
 | `ingesters/local.md` | `src/rag/pipeline/ingesters/local.py` |
+| `ingesters/journal.md` | `src/rag/pipeline/ingesters/journal.py` |
 
 ### Claude Code 拡張
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | **BlueSky インジェスター** | BlueSky 投稿を AT Protocol API 経由で取得・ナレッジベースに取り込み |
 | **YouTube インジェスター** | YouTube 動画の字幕・音声文字起こしを取得・ナレッジベースに取り込み |
 | **ドキュメントインジェスター** | テキストドキュメント（Markdown、テキスト、PDF、AsciiDoc）をナレッジベースに取り込み |
+| **Journal インジェスター** | 開発ジャーナル（セッション作業記録）をナレッジベースに登録・検索 |
 | **サイト一括取り込み（Scrapy）** | Scrapy subprocess による大規模サイトの一括取り込み |
 | **制約付き HTTP クライアント** | バジェット・サーキットブレーカー・レート制限を統合した安全な HTTP アクセス（py-common-lib 提供） |
 
@@ -99,6 +100,37 @@ YouTube インジェスターは非公式 API（youtube-transcript-api）を使�
 - プレイリスト一括取り込み時は `--max-videos` で段階的に取り込む（1 回あたり 10〜20 動画推奨）
 - `rag_youtube_request_interval`（デフォルト: 5.0 秒）を短くしすぎない
 - IP ブロックが発生した場合は時間を置いて再実行する
+
+## Journal CLI
+
+### 単一エントリ登録
+
+```bash
+# インライン本文
+uv run python -m rag.cli add-journal --title "セッション記録" --body "本文..." --repository rag-knowledge
+
+# ファイルから本文読み込み（長文推奨）
+uv run python -m rag.cli add-journal --title "セッション記録" --body @path/to/journal.md --repository rag-knowledge
+```
+
+| パラメータ | 短縮 | 必須 | 説明 |
+|-----------|------|------|------|
+| `--title` | `-t` | Yes | エントリタイトル |
+| `--body` | `-b` | Yes | 本文（Markdown）。`@ファイルパス` でファイルから読み込み |
+| `--repository` | `-r` | Yes | リポジトリ名 |
+| `--entry-id` | `-e` | No | エントリ識別子（省略時は自動生成） |
+
+### 既存ジャーナル一括取り込み（マイグレーション）
+
+```bash
+uv run python -m rag.cli migrate-journal --dir <path> --repository <name>
+# 事後: uv run python -m rag.cli rebuild --mode incremental
+```
+
+| パラメータ | 短縮 | 必須 | 説明 |
+|-----------|------|------|------|
+| `--dir` | `-d` | Yes | ジャーナルファイルが格納されたディレクトリパス |
+| `--repository` | `-r` | Yes | リポジトリ名（メタデータに記録） |
 
 ## RAG 評価 CLI
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -13,6 +13,7 @@
 | Zenn | [zenn.md](zenn.md) |
 | YouTube | [youtube.md](youtube.md) |
 | Local | [local.md](local.md) |
+| Journal | [journal.md](journal.md) |
 
 スコープ:
 
@@ -92,6 +93,7 @@
 | YouTube プレイリスト一括取り込み | youtube | `rag_crawl_youtube` | プレイリスト内の動画を一括取得して配置 |
 | 単一ドキュメント取り込み | local | `rag_add_document` | 指定ファイルを local/ にコピー |
 | ディレクトリ一括取り込み | local | `rag_crawl_documents` | glob パターンで検索してコピー |
+| ジャーナルエントリ登録 | journal | `rag_add_journal` | ジャーナルエントリを journal/ に配置 |
 
 各操作の入力パラメータ・振る舞い・エッジケースは媒体別仕様書を参照。
 
@@ -192,6 +194,7 @@ flowchart TB
 | zenn | Zenn URL | username + slug で一意に決定 | 上書き |
 | youtube | YouTube 動画 URL | channel_id + video_id で一意に決定 | 上書き |
 | local | 相対パス | ユーザー指定パスで一意に決定 | 上書き |
+| journal | 相対パス | リポジトリ名 + entry_id で一意に決定 | 上書き |
 
 重複検出の手順:
 

--- a/docs/specs/ingesters/journal.md
+++ b/docs/specs/ingesters/journal.md
@@ -1,0 +1,280 @@
+# Journal インジェスター
+
+## 概要
+
+Journal インジェスターは、開発ジャーナル（セッションごとの作業記録）を source_store の `journal/` ディレクトリに配置するコンポーネントである。テキスト変換・チャンキング・インデックス構築はコンバーター・インデクサーに委譲され、本インジェスターの責務は source_store へのファイル配置と .meta サイドカーファイルの生成に限定される。
+
+単一エントリの登録とディレクトリ一括取り込み（マイグレーション）の 2 つの操作を提供する。
+
+スコープ:
+
+- 単一ジャーナルエントリの source_store への配置（`rag_add_journal`）
+- 既存ジャーナルファイルの一括配置（CLI マイグレーション）
+- .meta サイドカーファイルの生成
+- エントリ ID の自動生成
+
+スコープ外:
+
+- テキスト変換（コンバーターの範疇）
+- チャンキング・インデックス構築（インデクサーの範疇）
+- ジャーナルの削除機能（ファイル削除機能の実装禁止ルールに従う）
+- /handoff スキル統合（agent-commons リポジトリ側の変更）
+- /restore スキルからの自動取り込み
+
+## 背景
+
+- ジャーナルはファイルベース（`$MEMORY_DIR/journal/*.md`）で保存されており、検索・フィルタリングができなかった
+- 3段パイプライン移行完了後の現在は、rag-knowledge の既存パイプラインを活用してジャーナルを検索可能にできる
+- ジャーナルはリポジトリ単位で記録される（プロジェクトごとに別ディレクトリ）
+
+## 制約
+
+- ローカルのメモリデータのみ対象とする（外部 HTTP リクエストは発生しない）
+- パストラバーサル対策: repository 名と entry_id に `..`, `/`, `\` を含むことを禁止する
+- **ファイル物理削除禁止**: source_store 内のファイルの物理削除は一切行わない
+- **metadata.db アクセス禁止**: metadata.db に直接アクセスしない。DB 登録はパイプライン制御が実行する
+- **git 操作禁止**: git 操作はパイプライン制御のみが実行する
+- **.meta サイドカーファイルの生成あり**: journal 媒体は .meta を持つ（local とは異なる）
+- ハードリミット（コード内定数。設定・引数・環境変数で緩和不可。厳格化は可能）:
+  - ディレクトリ一括取り込み時のファイル数上限: 500 件
+
+本コンポーネントは外部 API 通信を行わないため、想定プロファイル・ConstrainedClient 関連の安全制約セクションは省略する。
+
+## 安全制約
+
+| 制約名 | 種別 | 値 | 解除可否 |
+|--------|------|-----|---------|
+| ディレクトリ一括取り込みファイル数上限 | ハードリミット | 500 件 | 引き上げ不可（引き下げ可） |
+| パストラバーサル対策 | ハードリミット | repository / entry_id に `..`, `/`, `\` を禁止 | 無効化不可 |
+| metadata.db 直接アクセス禁止 | ハードリミット | インジェスターから metadata.db への読み書きを禁止 | 不可 |
+| git 操作禁止 | ハードリミット | インジェスターから git コマンドの直接呼び出しを禁止 | 不可 |
+| ファイル物理削除禁止 | ハードリミット | source_store 内のファイル削除を禁止 | 不可 |
+| HTTP モード無効 | ハードリミット | HTTP モードでは `rag_add_journal` ツールを無効化 | 不可 |
+
+テスト実行時の安全な値: ファイル数上限 10 件で実行する。異常値テスト（空文字列のパラメータ、パストラバーサル試行）を含めること。
+
+## インターフェース
+
+### MCP ツール
+
+| ツール | 入力 | 振る舞い |
+|--------|------|---------|
+| `rag_add_journal` | `title`, `body`, `repository`, `entry_id`（任意） | 単一ジャーナルエントリを source_store の `journal/` に配置する。同一 entry_id の再登録時は上書きする |
+
+#### rag_add_journal パラメータ
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `title` | 文字列 | はい | エントリタイトル |
+| `body` | 文字列 | はい | 本文（Markdown） |
+| `repository` | 文字列 | はい | リポジトリ名（例: `rag-knowledge`） |
+| `entry_id` | 文字列 | いいえ | エントリ識別子。未指定時は自動生成。命名規則: `YYYYMMDD-HHMMSS-{topic}` |
+
+ツール出力: 配置結果のサマリーテキスト（配置件数、パイプライン処理結果）
+
+### CLI コマンド
+
+| コマンド | 引数 | 振る舞い |
+|---------|------|---------|
+| `add-journal` | `--title`, `--body`, `--repository`, `--entry-id`（任意） | 単一ジャーナルエントリを登録する。パイプライン処理（convert → index）まで一貫して実行する |
+| `migrate-journal` | `--dir`, `--repository` | 既存ジャーナルファイルを一括で source_store に配置する。パイプライン処理は含まない（事後に `rebuild --mode incremental` を実行する） |
+
+#### add-journal パラメータ
+
+| パラメータ | 短縮 | 必須 | 説明 |
+|-----------|------|------|------|
+| `--title` | `-t` | はい | エントリタイトル |
+| `--body` | `-b` | はい | 本文（Markdown）。`@ファイルパス` でファイルから読み込み可能 |
+| `--repository` | `-r` | はい | リポジトリ名 |
+| `--entry-id` | `-e` | いいえ | エントリ識別子（省略時は自動生成） |
+
+`--body` の指定方法:
+
+- インライン: `--body "本文テキスト"` — 短い本文の直接指定
+- ファイル読み込み: `--body @path/to/file.md` — Markdown ファイルから本文を読み込む。長文ジャーナルの登録に推奨
+
+MCP ツール（`rag_add_journal`）経由では `body` パラメータに Markdown 文字列を直接渡す。文字列長の制限はない。
+
+#### migrate-journal パラメータ
+
+| パラメータ | 短縮 | 必須 | 説明 |
+|-----------|------|------|------|
+| `--dir` | `-d` | はい | ジャーナルディレクトリパス |
+| `--repository` | `-r` | はい | リポジトリ名 |
+
+### source_type
+
+`"journal"` — 新規追加する source_type。
+
+### source_id
+
+source_store 内の相対パスを source_id として使用する。
+
+- 形式: `journal/{repository}/{entry_id}.md`
+- 例: `journal/rag-knowledge/20260323-143000-session-summary.md`
+
+### entry_id 自動生成規則
+
+`entry_id` が未指定の場合、以下の規則で自動生成する:
+
+- フォーマット: `YYYYMMDD-HHMMSS-{topic}`
+- `{topic}`: title を NFKC 正規化し、英数字・ハイフン以外を除去、空白をハイフンに変換、50 文字上限
+- タイムスタンプは UTC
+- topic が空になる場合（日本語のみのタイトル等）はタイムスタンプのみ
+
+### ファイル配置規則
+
+#### 単一エントリ（`rag_add_journal`）
+
+`journal/{repository}/{entry_id}.md` に配置する。
+
+- 入力: `title="Session Summary"`, `repository="rag-knowledge"`, `entry_id=None`
+- 配置先: `source_store/journal/rag-knowledge/20260323-143000-session-summary.md`
+- source_id: `journal/rag-knowledge/20260323-143000-session-summary.md`
+
+#### ディレクトリ一括（`migrate-journal`）
+
+ファイル名をそのまま entry_id として使用する。
+
+- 入力: `dir_path=/path/to/journal/`, `repository="rag-knowledge"`
+- `20260323-143000-session-summary.md` → `source_store/journal/rag-knowledge/20260323-143000-session-summary.md`
+
+### .meta サイドカーファイル
+
+#### フィールド定義
+
+| フィールド | 型 | 内容 |
+|-----------|-----|------|
+| `source_id` | str | `journal/{repository}/{entry_id}.md` |
+| `source_type` | str | `"journal"` |
+| `title` | str | エントリタイトル |
+| `collected_at` | str | 登録日時（ISO 8601 UTC） |
+| `repository` | str | リポジトリ名 |
+
+#### 形式例
+
+```yaml
+source_id: "journal/rag-knowledge/20260323-143000-session-summary.md"
+source_type: journal
+title: "Session Summary: Pipeline Migration"
+collected_at: "2026-03-23T14:30:00+00:00"
+repository: rag-knowledge
+```
+
+### 重複検出
+
+ファイルシステムベースで行う。配置先パスにファイルが既に存在する場合は上書きする（更新動作）。
+
+### 設定項目
+
+本コンポーネント固有の設定項目はない。source_store のパスは [source-store.md](../source-store.md) の `SOURCE_STORE_DIR` を使用する。
+
+## コンポーネント構成
+
+### Journal インジェスターの位置付け
+
+```mermaid
+flowchart TB
+    CLIENT["MCP クライアント"]
+
+    subgraph MCP["MCP サーバー"]
+        TOOLS["ツール定義"]
+    end
+
+    subgraph Pipeline["パイプライン制御"]
+        PC["PipelineController"]
+    end
+
+    subgraph Ingesters["インジェスター"]
+        JING["JournalIngester"]
+    end
+
+    subgraph Storage["ストレージ"]
+        SS["source_store"]
+        JOURNAL["source_store/journal/"]
+    end
+
+    CLIENT -->|stdio| TOOLS
+    TOOLS -->|取り込み指示| JING
+    JING -->|ファイル配置 + .meta| JOURNAL
+    JING -->|取り込み完了通知| PC
+    PC -->|git add + commit + diff| SS
+```
+
+### 単一エントリ登録フロー
+
+```mermaid
+flowchart TD
+    START["rag_add_journal(title, body, repository, entry_id)"]
+    VALIDATE["パラメータバリデーション"]
+    GEN_ID{"entry_id 指定?"}
+    AUTO_ID["entry_id を自動生成"]
+    BUILD_META[".meta メタデータ構築"]
+    PLACE["source_store に配置"]
+    NOTIFY["パイプライン制御に完了通知"]
+    RESULT["結果サマリーを返却"]
+    ERROR["エラーを返却"]
+
+    START --> VALIDATE
+    VALIDATE --> GEN_ID
+    GEN_ID -->|未指定| AUTO_ID
+    GEN_ID -->|指定済み| BUILD_META
+    AUTO_ID --> BUILD_META
+    BUILD_META --> PLACE
+    PLACE --> NOTIFY
+    NOTIFY --> RESULT
+    VALIDATE -->|バリデーション失敗| ERROR
+```
+
+### 単一エントリ登録の処理手順
+
+1. パラメータバリデーション（title, body, repository の空文字チェック）
+2. repository のバリデーション（パストラバーサル防止）
+3. `entry_id` が未指定の場合、自動生成
+4. `entry_id` のバリデーション（パストラバーサル防止）
+5. `rel_path` = `journal/{repository}/{entry_id}.md` を構築
+6. .meta メタデータ辞書を構築
+7. `source_store.place_file()` でファイルと .meta を配置
+8. パイプライン制御に取り込み完了を通知
+9. 配置結果のサマリーを返す
+
+### ディレクトリ一括取り込みの処理手順
+
+1. パラメータバリデーション（dir_path, repository の空文字チェック）
+2. repository のバリデーション（パストラバーサル防止）
+3. ディレクトリの存在確認
+4. `*.md` ファイルをスキャンし、パスの辞書順でソート
+5. ファイル数がハードリミット（500 件）を超える場合、先頭 500 件にクランプし警告ログを出力
+6. 各ファイルについて:
+   a. ファイル名から entry_id を導出（拡張子を除いた部分）
+   b. ファイル名からタイトルを抽出（`YYYYMMDD-HHMMSS-` プレフィックスを除去）
+   c. ファイル内容を読み取る
+   d. .meta メタデータを構築（`collected_at` はファイルの更新日時）
+   e. `source_store.place_file()` で配置
+7. 結果サマリーを返す（配置件数、スキップ件数、エラー件数）
+
+## エッジケース
+
+| ケース | 振る舞い |
+|--------|---------|
+| title が空文字列 | バリデーションエラーとして拒否する |
+| body が空文字列 | バリデーションエラーとして拒否する |
+| repository が空文字列 | バリデーションエラーとして拒否する |
+| repository に `..` が含まれる | バリデーションエラーとして拒否する（パストラバーサル防止） |
+| repository に `/` や `\` が含まれる | バリデーションエラーとして拒否する（パストラバーサル防止） |
+| entry_id に `..` が含まれる | バリデーションエラーとして拒否する（パストラバーサル防止） |
+| entry_id に `/` や `\` が含まれる | バリデーションエラーとして拒否する（パストラバーサル防止） |
+| 同一 entry_id で再登録 | 上書き更新する |
+| entry_id 未指定 | `YYYYMMDD-HHMMSS-{topic}` 形式で自動生成する |
+| 日本語のみのタイトルで entry_id 自動生成 | topic 部分が空になり `YYYYMMDD-HHMMSS` のみとなる |
+| マイグレーション対象ディレクトリが空 | 0 件処理として正常終了する |
+| マイグレーション対象ディレクトリが存在しない | エラーを返す |
+| マイグレーション対象に 0 バイトのファイル | スキップする（スキップ数としてサマリーに計上） |
+| ファイル数がハードリミットを超過 | 先頭 500 件にクランプし警告ログを出力する |
+| HTTP モードで `rag_add_journal` 呼び出し | エラーメッセージを返す（セキュリティ上の制約） |
+
+## 関連ドキュメント
+
+- [common.md](common.md) -- インジェスター共通仕様
+- [../source-store.md](../source-store.md) -- source_store 仕様（ディレクトリ構成、.meta 形式）
+- [../pipeline-controller.md](../pipeline-controller.md) -- パイプライン制御仕様（git 操作、ステージ間連携）

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -29,6 +29,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 19 | 再構築・統計・バックアップ | パイプライン再構築の MCP/CLI 公開・統計拡張・バックアップ手順 | [rebuild-stats.md](rebuild-stats.md) |
 | 20 | サイト一括取り込み（Scrapy subprocess） | Scrapy subprocess による大規模サイトの一括取り込み | [site-ingest.md](site-ingest.md) |
 | 21 | YouTube インジェスター | YouTube 動画の字幕・音声文字起こし取得 | [ingesters/youtube.md](ingesters/youtube.md) |
+| 22 | Journal インジェスター | 開発ジャーナルの登録・検索 | [ingesters/journal.md](ingesters/journal.md) |
 
 ## 3. 技術スタック
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -5,7 +5,7 @@
 外部 Web ページから収集した知識をベクトル DB に蓄積し、
 MCP クライアントからのクエリに対して関連情報を検索・提供する
 RAG（Retrieval-Augmented Generation）基盤。
-MCP サーバーとして独立動作し、13 個のツールを提供する。
+MCP サーバーとして独立動作し、16 個のツールを提供する。
 
 スコープ:
 
@@ -118,19 +118,22 @@ MCP サーバーとして独立動作し、13 個のツールを提供する。
 
 ### MCP ツール
 
-MCP サーバーが公開する 13 個のツール。
+MCP サーバーが公開する 16 個のツール。
 
 | ツール | 入力 | 振る舞い |
 | --- | --- | --- |
-| rag_search | クエリ、件数、source_type（任意） | ベクトル検索と BM25 の生結果をチャンク単位で返す。各結果にスコア・Source・Title・Chunk位置・Typeのメタデータを含める。`source_type` 指定時はそのソース種別のチャンクのみを検索対象とする。詳細は [search-response.md](search-response.md) を参照 |
+| rag_search | クエリ、件数、source_type（任意）、filters（任意） | ベクトル検索と BM25 の生結果をチャンク単位で返す。各結果にスコア・Source・Title・Chunk位置・Typeのメタデータを含める。`source_type` 指定時はそのソース種別のチャンクのみを検索対象とする。`filters` 指定時はカスタムメタデータで絞り込む（JSON オブジェクト、完全一致）。詳細は [search-response.md](search-response.md) を参照 |
 | rag_get_document | source_id、format（任意） | ソース全文を取得する。`format=text` で変換済みテキスト（converted_store）、`format=original` でオリジナル（source_store）を返す。MCP 経由では `rag_max_response_chars` でトランケーションを行う。詳細は [search-response.md](search-response.md) を参照 |
 | rag_add | URL | 単一ページをクロールして取り込む。同一 URL の再取り込み時は既存の知識を最新に置き換える |
 | rag_crawl | URL、パターン | リンク集ページから一括クロールして取り込む。同一ドメインのみ対象 |
 | rag_crawl_preview | URL、パターン | リンク集ページからクロール対象ページのタイトルと URL の一覧を返す。取り込みは行わない |
 | rag_crawl_zenn | username、max_articles（任意） | 指定ユーザーの Zenn 記事を API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（記事の公開 URL）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、ナレッジベースに取り込む。max_posts はタイムライン全体（リポスト含む）に適用。BlueSky は投稿編集不可のため、既存 `source_id` と一致する投稿はスキップする（上書き不要） |
+| rag_add_youtube | video_url | 単一 YouTube 動画の字幕/文字起こしを取得し、ナレッジベースに取り込む。詳細は [ingesters/youtube.md](ingesters/youtube.md) を参照 |
+| rag_crawl_youtube | playlist_url、max_videos（任意） | YouTube プレイリスト内の動画を一括取り込みする。詳細は [ingesters/youtube.md](ingesters/youtube.md) を参照 |
 | rag_add_document | file_path | 単一ドキュメントファイルを読み取り、ナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
 | rag_crawl_documents | dir_path、pattern（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括でナレッジベースに取り込む。同一ファイルの再取り込み時は `source_id`（file URI）の一致で検出し、既存の知識を最新に置き換える |
+| rag_add_journal | title、body、repository、entry_id（任意） | ジャーナルエントリを source_store に配置し、パイプライン処理でインデックスに取り込む。詳細は [ingesters/journal.md](ingesters/journal.md) を参照 |
 | rag_site_ingest | url、url_pattern（任意）、max_pages（任意）、force（任意） | Scrapy subprocess で対象サイトをクロールし、source_store に配置後、パイプライン処理を実行する。大規模サイト向け（上限 50,000 ページ）。詳細は [site-ingest.md](site-ingest.md) を参照 |
 | rag_delete | URL | ソース URL 指定でナレッジを論理削除する。metadata.db のステータスを `deleted` に変更し、検索インデックスから該当チャンクを削除する。source_store 内のファイルは削除しない |
 | rag_rebuild | mode、source_type（任意） | パイプラインの再構築を実行する。mode: `full`（全再構築）、`convert`（コンバートのみ再実行）、`index`（インデックスのみ再構築）、`incremental`（差分更新）。source_type 指定時はその媒体のみ対象。詳細は [rebuild-stats.md](rebuild-stats.md) を参照 |
@@ -138,7 +141,7 @@ MCP サーバーが公開する 13 個のツール。
 
 ### 取り込みツールの出力形式
 
-取り込みツール（rag_add、rag_crawl、rag_crawl_zenn、rag_crawl_bluesky、rag_add_document、rag_crawl_documents、rag_site_ingest）は、source_store への配置結果とパイプライン処理結果を統合したサマリーを返す。配置結果には配置ファイル数・スキップ数・エラー数を含み、パイプライン処理結果にはコンバート・インデックス構築の処理件数を含む。rag_crawl_preview は source_store への配置を行わないため本出力形式の対象外。
+取り込みツール（rag_add、rag_crawl、rag_crawl_zenn、rag_crawl_bluesky、rag_add_youtube、rag_crawl_youtube、rag_add_document、rag_crawl_documents、rag_add_journal、rag_site_ingest）は、source_store への配置結果とパイプライン処理結果を統合したサマリーを返す。配置結果には配置ファイル数・スキップ数・エラー数を含み、パイプライン処理結果にはコンバート・インデックス構築の処理件数を含む。rag_crawl_preview は source_store への配置を行わないため本出力形式の対象外。
 
 ### 検索結果の設計
 
@@ -261,7 +264,7 @@ flowchart LR
 | `title` | str | コンテンツのタイトル |
 | `chunk_index` | int | チャンクの連番（0 始まり） |
 | `collected_at` | str | 取り込みタイムスタンプ（ISO 8601） |
-| `source_type` | str | データソース種別（`"web"`, `"zenn"`, `"bluesky"`, `"local"`） |
+| `source_type` | str | データソース種別（`"web"`, `"zenn"`, `"bluesky"`, `"youtube"`, `"local"`, `"journal"`） |
 
 #### カスタムフィールド
 

--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -47,13 +47,23 @@ rag_search のレスポンスをチャンク単位の返却に変更し、全文
 
 #### トリガー
 
-MCP クライアントからの rag_search ツール呼び出し。入力パラメータは既存仕様から変更なし。
+MCP クライアントからの rag_search ツール呼び出し。
 
 | パラメータ | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `query` | str | Yes | 検索キーワード |
 | `n_results` | int | No | エンジンあたりの結果件数 |
-| `source_type` | str | No | ソース種別フィルタ |
+| `source_type` | str | No | ソース種別フィルタ（`"web"`, `"zenn"`, `"bluesky"`, `"youtube"`, `"local"`, `"journal"`） |
+| `filters` | str (JSON) | No | カスタムメタデータフィルタ（JSON オブジェクト形式）。`.meta` の extra フィールドで検索結果を絞り込む。完全一致。例: `'{"repository": "rag-knowledge"}'` |
+
+#### フィルタの動作
+
+`filters` は `.meta` サイドカーのカスタムフィールドによる絞り込みを行う。内部的にはキーに `custom:` プレフィックスを付与し、ChromaDB の `where` 句と BM25 のポストフィルタに適用する。
+
+- `source_type` と `filters` は併用可能。両方指定時は AND 条件として結合する
+- `filters` のキーにはユーザーが `custom:` プレフィックスを付ける必要はない（内部で自動付与）
+- `filters` が無効な JSON またはオブジェクト型でない場合はエラーメッセージを返す
+- `filters` 未指定時はフィルタなし（全件対象）
 
 #### 振る舞い
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -50,7 +50,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 
 ### .meta サイドカーファイル
 
-- 自動取り込み媒体（web、bluesky、zenn、youtube）のファイルには `.meta` サイドカーファイルを同階層に配置する
+- 自動取り込み媒体（web、bluesky、zenn、youtube、journal）のファイルには `.meta` サイドカーファイルを同階層に配置する
 - local 媒体は `.meta` 不要。sources テーブルの各フィールドは以下から導出する:
   - `title`: ファイル名（拡張子除去）
   - `created_at`: git の初回コミット日時
@@ -116,6 +116,7 @@ flowchart TD
     SS --> BS["bluesky/"]
     SS --> ZENN["zenn/"]
     SS --> YT["youtube/"]
+    SS --> JNL["journal/"]
     SS --> DOT_GIT[".git/"]
 
     LOCAL --> L_USER["my-notes/ 等"]
@@ -134,6 +135,9 @@ flowchart TD
     Z_USER --> Z_SCR["scraps/"]
     Z_ART --> Z_SLUG["slug.html"]
     Z_ART --> Z_SLUG_META["slug.html.meta"]
+    JNL --> JNL_REPO["repository/"]
+    JNL_REPO --> JNL_ENTRY["entry_id.md"]
+    JNL_REPO --> JNL_META["entry_id.md.meta"]
 ```
 
 - **source_store/**: ルートディレクトリ。パスは `.env` の設定値で指定
@@ -144,6 +148,7 @@ flowchart TD
 - **bluesky/**: BlueSky インジェスターが DID + 年月で階層化して自動配置
 - **zenn/**: Zenn インジェスターがユーザー名 + コンテンツ種別（articles/scraps）で階層化して自動配置
 - **youtube/**: YouTube インジェスターがチャンネル ID で階層化して自動配置
+- **journal/**: Journal インジェスターがリポジトリ名で階層化して自動配置
 
 ### converted_store のディレクトリ構成
 
@@ -160,6 +165,7 @@ converted_store は source_store のディレクトリ構成をミラーする�
 | bluesky | AT URI | AT Protocol の安定識別子 | `at://did:plc:xxx/app.bsky.feed.post/rkey` |
 | zenn | Zenn 記事 URL | URL が安定識別子 | `https://zenn.dev/user/articles/slug` |
 | youtube | YouTube 動画 URL | video_id が一意識別子 | `https://www.youtube.com/watch?v=xxxxxxxxxxx` |
+| journal | source_store 内の相対パス | リポジトリ名 + entry_id で一意 | `journal/rag-knowledge/20260323-143000-session-summary.md` |
 
 ### URL パス変換規則
 
@@ -223,7 +229,7 @@ URL: `http://localhost:8080/api/docs`
 | フィールド | 型 | 内容 |
 |-----------|-----|------|
 | `source_id` | str | ソース識別子 |
-| `source_type` | str | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`）。`local` は .meta を持たないため含まない |
+| `source_type` | str | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`, `journal`）。`local` は .meta を持たないため含まない |
 | `title` | str | コンテンツのタイトル |
 | `collected_at` | str | 取り込みタイムスタンプ（ISO 8601） |
 
@@ -263,6 +269,12 @@ URL: `http://localhost:8080/api/docs`
 | `comments_count` | int | コメント数（スクラップのみ。記事では 0） |
 | `closed` | bool | クローズ状態（スクラップのみ。記事では `false`） |
 | `username` | str | 著者のユーザー名 |
+
+**journal:**
+
+| フィールド | 型 | 内容 |
+|-----------|-----|------|
+| `repository` | str | リポジトリ名 |
 
 #### .meta ファイルの形式例
 
@@ -333,6 +345,16 @@ closed: false
 username: "alice"
 ```
 
+**journal:**
+
+```yaml
+source_id: "journal/rag-knowledge/20260323-143000-session-summary.md"
+source_type: journal
+title: "Session Summary: Pipeline Migration"
+collected_at: "2026-03-23T14:30:00+00:00"
+repository: rag-knowledge
+```
+
 ### metadata.db スキーマ
 
 #### sources テーブル
@@ -342,7 +364,7 @@ source_store 内の全ファイルのメタデータ索引。
 | カラム | 型 | 制約 | 内容 |
 |--------|-----|------|------|
 | `source_id` | TEXT | PRIMARY KEY | ソース識別子 |
-| `source_type` | TEXT | NOT NULL | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`, `local`） |
+| `source_type` | TEXT | NOT NULL | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`, `local`, `journal`） |
 | `file_path` | TEXT | NOT NULL, UNIQUE | source_store 内の相対パス |
 | `title` | TEXT | NOT NULL | コンテンツのタイトル |
 | `status` | TEXT | NOT NULL, DEFAULT 'active' | `active` または `deleted` |

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -117,22 +117,26 @@ class BM25Index:
         Returns:
             追加されたドキュメント数
         """
+        if metadata_list is not None and len(metadata_list) != len(documents):
+            raise ValueError(
+                f"add_documents: length mismatch: "
+                f"documents={len(documents)}, metadata_list={len(metadata_list)}"
+            )
+
         added = 0
         updated = 0
         for i, (doc_id, text, source_url, source_type) in enumerate(documents):
             if doc_id in self._documents:
-                # 既存のドキュメントを更新
                 self._documents[doc_id] = text
                 self._doc_source_map[doc_id] = source_url
                 self._doc_source_type_map[doc_id] = source_type
                 updated += 1
             else:
-                # 新規ドキュメントを追加
                 self._documents[doc_id] = text
                 self._doc_source_map[doc_id] = source_url
                 self._doc_source_type_map[doc_id] = source_type
                 added += 1
-            if metadata_list is not None and i < len(metadata_list):
+            if metadata_list is not None:
                 self._doc_metadata_map[doc_id] = metadata_list[i]
 
         # 新規追加または更新があった場合はインデックス再構築が必要

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -90,6 +90,7 @@ class BM25Index:
         self._documents: dict[str, str] = {}  # id -> text
         self._doc_source_map: dict[str, str] = {}  # id -> source_url
         self._doc_source_type_map: dict[str, str] = {}  # id -> source_type
+        self._doc_metadata_map: dict[str, dict[str, str | int | float | bool]] = {}  # id -> chunk metadata
 
         # BM25インデックス（遅延初期化）
         self._bm25: "bm25s.BM25 | None" = None
@@ -105,18 +106,20 @@ class BM25Index:
     def add_documents(
         self,
         documents: list[tuple[str, str, str, str]],
+        metadata_list: list[dict[str, str | int | float | bool]] | None = None,
     ) -> int:
         """ドキュメントをインデックスに追加する.
 
         Args:
             documents: (id, text, source_url, source_type) のリスト
+            metadata_list: 各ドキュメントに対応するメタデータ辞書のリスト（任意）
 
         Returns:
             追加されたドキュメント数
         """
         added = 0
         updated = 0
-        for doc_id, text, source_url, source_type in documents:
+        for i, (doc_id, text, source_url, source_type) in enumerate(documents):
             if doc_id in self._documents:
                 # 既存のドキュメントを更新
                 self._documents[doc_id] = text
@@ -129,6 +132,8 @@ class BM25Index:
                 self._doc_source_map[doc_id] = source_url
                 self._doc_source_type_map[doc_id] = source_type
                 added += 1
+            if metadata_list is not None and i < len(metadata_list):
+                self._doc_metadata_map[doc_id] = metadata_list[i]
 
         # 新規追加または更新があった場合はインデックス再構築が必要
         if added > 0 or updated > 0:
@@ -145,6 +150,7 @@ class BM25Index:
         query: str,
         n_results: int = 10,
         source_type: str | None = None,
+        filters: dict[str, str | int | float | bool] | None = None,
     ) -> list[BM25Result]:
         """クエリでキーワード検索を実行する.
 
@@ -152,6 +158,7 @@ class BM25Index:
             query: 検索クエリ
             n_results: 返却する結果の最大数
             source_type: ソース種別フィルタ（指定時はそのソース種別のみ返す）
+            filters: カスタムメタデータフィルタ（完全一致。キーは custom:{key} 形式）
 
         Returns:
             BM25Resultのリスト（スコア降順）
@@ -172,9 +179,10 @@ class BM25Index:
             return []
 
         # BM25検索（k は corpus サイズ以下に制限）
-        # source_type フィルタで除外される可能性を考慮し、3倍（最低20件）を取得
+        # source_type / filters フィルタで除外される可能性を考慮し、3倍（最低20件）を取得
         fetch_count = n_results
-        if source_type is not None:
+        has_filter = source_type is not None or filters
+        if has_filter:
             fetch_count = max(n_results * 3, 20)
         k = min(fetch_count, len(self._doc_ids))
         if k == 0:
@@ -184,7 +192,7 @@ class BM25Index:
             [query_tokens], k=k, show_progress=False
         )
 
-        # スコア > 0 の結果のみ抽出（source_type フィルタ適用）
+        # スコア > 0 の結果のみ抽出（source_type + filters フィルタ適用）
         results: list[BM25Result] = []
         for idx, score in zip(doc_indices[0], scores[0]):
             if score <= 0:
@@ -192,6 +200,10 @@ class BM25Index:
             doc_id = self._doc_ids[int(idx)]
             if source_type is not None:
                 if self._doc_source_type_map.get(doc_id) != source_type:
+                    continue
+            if filters:
+                doc_meta = self._doc_metadata_map.get(doc_id, {})
+                if not self._matches_filters(doc_meta, filters):
                     continue
             results.append(
                 BM25Result(
@@ -204,6 +216,17 @@ class BM25Index:
                 break
 
         return results
+
+    @staticmethod
+    def _matches_filters(
+        metadata: dict[str, str | int | float | bool],
+        filters: dict[str, str | int | float | bool],
+    ) -> bool:
+        """メタデータがフィルタ条件に完全一致するか判定する."""
+        for key, value in filters.items():
+            if metadata.get(key) != value:
+                return False
+        return True
 
     def delete_by_source(self, source_url: str) -> int:
         """ソースURL指定でドキュメントを削除する.
@@ -224,6 +247,7 @@ class BM25Index:
             del self._documents[doc_id]
             del self._doc_source_map[doc_id]
             self._doc_source_type_map.pop(doc_id, None)  # 旧データに source_type がない場合の互換性
+            self._doc_metadata_map.pop(doc_id, None)
 
         if to_delete:
             self._needs_rebuild = True
@@ -281,6 +305,7 @@ class BM25Index:
             self._documents.pop(doc_id, None)
             self._doc_source_map.pop(doc_id, None)
             self._doc_source_type_map.pop(doc_id, None)
+            self._doc_metadata_map.pop(doc_id, None)
 
         if stale_ids:
             self._needs_rebuild = True
@@ -293,6 +318,7 @@ class BM25Index:
         self._documents.clear()
         self._doc_source_map.clear()
         self._doc_source_type_map.clear()
+        self._doc_metadata_map.clear()
         self._doc_ids.clear()
         self._bm25 = None
         self._needs_rebuild = True
@@ -364,6 +390,7 @@ class BM25Index:
                     "documents": self._documents,
                     "doc_source_map": self._doc_source_map,
                     "doc_source_type_map": self._doc_source_type_map,
+                    "doc_metadata_map": self._doc_metadata_map,
                 }
                 metadata_path = tmp_dir / METADATA_FILENAME
                 metadata_path.write_text(
@@ -454,6 +481,7 @@ class BM25Index:
             self._documents = metadata["documents"]
             self._doc_source_map = metadata["doc_source_map"]
             self._doc_source_type_map = metadata.get("doc_source_type_map", {})
+            self._doc_metadata_map = metadata["doc_metadata_map"]
 
             # bm25s モデル復元
             bm25s_dir = self._persist_dir / BM25S_SUBDIR
@@ -466,6 +494,7 @@ class BM25Index:
                 self._documents = {}
                 self._doc_source_map = {}
                 self._doc_source_type_map = {}
+                self._doc_metadata_map = {}
                 return
 
             import bm25s as bm25s_lib
@@ -487,6 +516,7 @@ class BM25Index:
             self._documents = {}
             self._doc_source_map = {}
             self._doc_source_type_map = {}
+            self._doc_metadata_map = {}
             self._doc_ids = []
             self._bm25 = None
             self._needs_rebuild = True

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1303,6 +1303,14 @@ def run_search(args: argparse.Namespace) -> None:
             if not isinstance(parsed_filters, dict):
                 print("エラー: --filters は JSON オブジェクト形式で指定してください")
                 return
+            allowed_types = (str, int, float, bool)
+            for key, value in parsed_filters.items():
+                if not isinstance(value, allowed_types):
+                    print(
+                        f"エラー: --filters の値は str/int/float/bool のみ使用できます"
+                        f"（キー {key!r} に不正な型 {type(value).__name__}）"
+                    )
+                    return
         except json.JSONDecodeError:
             print("エラー: --filters の JSON パースに失敗しました")
             return

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -291,7 +291,7 @@ def main() -> None:
     )
     rebuild_parser.add_argument(
         "--source-type",
-        choices=["web", "bluesky", "zenn", "youtube", "local"],
+        choices=["web", "bluesky", "zenn", "youtube", "local", "journal"],
         default=None,
         help="対象媒体フィルタ（incremental では指定不可）",
     )
@@ -315,9 +315,14 @@ def main() -> None:
     )
     search_parser.add_argument(
         "--source-type",
-        choices=["web", "bluesky", "zenn", "youtube", "local"],
+        choices=["web", "bluesky", "zenn", "youtube", "local", "journal"],
         default=None,
         help="ソース種別フィルタ",
+    )
+    search_parser.add_argument(
+        "--filters",
+        default=None,
+        help='メタデータフィルタ（JSON 形式、例: \'{"repository": "rag-knowledge"}\'）',
     )
 
     # delete サブコマンド
@@ -381,6 +386,18 @@ def main() -> None:
         help="Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ",
     )
 
+    # add-journal: 単一ジャーナルエントリの登録
+    aj_parser = subparsers.add_parser("add-journal", help="ジャーナルエントリをナレッジベースに登録")
+    aj_parser.add_argument("--title", "-t", required=True, help="エントリタイトル")
+    aj_parser.add_argument("--body", "-b", required=True, help="本文（Markdown）。@ファイルパス で本文をファイルから読み込み")
+    aj_parser.add_argument("--repository", "-r", required=True, help="リポジトリ名")
+    aj_parser.add_argument("--entry-id", "-e", default=None, help="エントリ識別子（省略時は自動生成）")
+
+    # migrate-journal: 既存ジャーナルファイルの一括取り込み
+    mj_parser = subparsers.add_parser("migrate-journal", help="既存ジャーナルファイルを source_store に一括配置")
+    mj_parser.add_argument("--dir", "-d", required=True, help="ジャーナルディレクトリパス")
+    mj_parser.add_argument("--repository", "-r", required=True, help="リポジトリ名")
+
     args = parser.parse_args()
 
     # コマンドディスパッチ（sync / async 統一）
@@ -397,6 +414,7 @@ def main() -> None:
         "add-document": run_add_document,
         "crawl-documents": run_crawl_documents,
         "site-ingest": run_site_ingest,
+        "add-journal": run_add_journal,
     }
     _SYNC_COMMANDS: dict[str, object] = {
         "get-document": run_get_document,
@@ -404,6 +422,7 @@ def main() -> None:
         "stats": run_stats,
         "search": run_search,
         "delete": run_delete,
+        "migrate-journal": run_migrate_journal,
     }
 
     if args.command in _ASYNC_COMMANDS:
@@ -1276,9 +1295,22 @@ def run_search(args: argparse.Namespace) -> None:
     n_results = args.n_results if args.n_results is not None else settings.rag_retrieval_count
     source_type: str | None = args.source_type
 
+    # filters パラメータのパース
+    parsed_filters: dict[str, str | int | float | bool] | None = None
+    if args.filters is not None:
+        try:
+            parsed_filters = json.loads(args.filters)
+            if not isinstance(parsed_filters, dict):
+                print("エラー: --filters は JSON オブジェクト形式で指定してください")
+                return
+        except json.JSONDecodeError:
+            print("エラー: --filters の JSON パースに失敗しました")
+            return
+
     raw = _asyncio.run(
         service.retrieve_raw_results(
             args.query, n_results=n_results, source_type=source_type,
+            filters=parsed_filters,
         )
     )
 
@@ -1354,6 +1386,83 @@ def run_delete(args: argparse.Namespace) -> None:
         for err in summary.errors:
             print(f"  - {err}", file=sys.stderr)
     print(f"削除しました: {source_id}")
+
+
+async def run_add_journal(args: argparse.Namespace) -> None:
+    """単一ジャーナルエントリを登録する.
+
+    Args:
+        args: コマンドライン引数（--title, --body, --repository, --entry-id）
+    """
+    from .pipeline.ingesters.journal import JournalIngester
+
+    controller, _settings = _build_cli_pipeline_controller()
+
+    ingester = JournalIngester(controller.source_store)
+
+    # --body が @ファイルパス の場合、ファイルから読み込む
+    body = args.body
+    if body.startswith("@"):
+        file_path = Path(body[1:])
+        if not file_path.is_file():
+            print(f"エラー: ファイルが見つかりません: {file_path}", file=sys.stderr)
+            raise SystemExit(1)
+        body = file_path.read_text(encoding="utf-8")
+
+    ingest_result = ingester.add_entry(
+        title=args.title,
+        body=body,
+        repository=args.repository,
+        entry_id=args.entry_id,
+    )
+
+    if ingest_result.errors > 0:
+        print(f"エラー: {ingest_result.error_details[0]}", file=sys.stderr)
+        raise SystemExit(1)
+
+    pipeline_summary = controller.ingest_and_index(
+        f"ingest(journal): add {args.title}"
+    )
+    _print_ingest_result(
+        ingest_result, pipeline_summary, context=f"journal/{args.repository}"
+    )
+
+
+def run_migrate_journal(args: argparse.Namespace) -> None:
+    """既存ジャーナルファイルを source_store に一括配置する.
+
+    Args:
+        args: コマンドライン引数（--dir, --repository）
+    """
+    from .pipeline.ingesters.journal import JournalIngester
+    from .store.source_store import SourceStore
+
+    from .config import get_settings
+    settings = get_settings()
+
+    if not settings.source_store_dir:
+        print("エラー: source_store_dir が設定されていません", file=sys.stderr)
+        raise SystemExit(1)
+
+    store = SourceStore(Path(settings.source_store_dir))
+    store.initialize()
+
+    try:
+        ingester = JournalIngester(store)
+        result = ingester.import_directory(
+            dir_path=args.dir,
+            repository=args.repository,
+        )
+
+        print(result.summary(context=f"repository={args.repository}"))
+
+        if result.placed > 0:
+            print(
+                "\n事後処理: 以下のコマンドでインデックスを構築してください:\n"
+                "  uv run python -m rag.cli rebuild --mode incremental"
+            )
+    finally:
+        store.close()
 
 
 def _format_cli_size(size_bytes: int) -> str:

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -253,6 +253,7 @@ class Indexer:
 
         doc_chunks: list[DocumentChunk] = []
         bm25_docs: list[tuple[str, str, str, str]] = []
+        bm25_metadata_list: list[dict[str, str | int | float | bool]] = []
 
         for i, text in enumerate(chunk_texts):
             chunk_id = generate_chunk_id(source_id, i)
@@ -266,12 +267,13 @@ class Indexer:
             bm25_docs.append((
                 chunk_id, text, source_id, metadata.source_type,
             ))
+            bm25_metadata_list.append(meta)
 
         # ChromaDB に upsert（async → sync ブリッジ）
         _run_async(self._vector_store.add_documents(doc_chunks))
 
         # BM25 に追加
-        self._bm25.add_documents(bm25_docs)
+        self._bm25.add_documents(bm25_docs, metadata_list=bm25_metadata_list)
 
     def _clear_all(self) -> None:
         """全インデックスをクリアする."""

--- a/src/rag/pipeline/ingesters/journal.py
+++ b/src/rag/pipeline/ingesters/journal.py
@@ -32,6 +32,7 @@ class JournalIngester:
 
     def __init__(self, source_store: SourceStore) -> None:
         self._store = source_store
+        self.last_entry_id: str | None = None
 
     def add_entry(
         self,
@@ -78,6 +79,7 @@ class JournalIngester:
                 metadata=metadata,
             )
             result.placed = 1
+            self.last_entry_id = entry_id
         except ValueError as e:
             result.errors = 1
             result.error_details.append(str(e))

--- a/src/rag/pipeline/ingesters/journal.py
+++ b/src/rag/pipeline/ingesters/journal.py
@@ -1,0 +1,230 @@
+"""Journal インジェスター — ジャーナルエントリを source_store に配置.
+
+仕様: docs/specs/ingesters/journal.md
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rag.pipeline.ingesters._common import IngestResult
+
+if TYPE_CHECKING:
+    from rag.store.source_store import SourceStore
+
+logger = logging.getLogger(__name__)
+
+MAX_FILES_HARD_LIMIT = 500
+_ENTRY_ID_PATTERN = re.compile(r"^\d{8}-\d{6}-")
+_TOPIC_MAX_LENGTH = 50
+
+
+class JournalIngester:
+    """ジャーナルエントリ取り込み用インジェスター.
+
+    仕様: docs/specs/ingesters/journal.md
+    """
+
+    def __init__(self, source_store: SourceStore) -> None:
+        self._store = source_store
+
+    def add_entry(
+        self,
+        title: str,
+        body: str,
+        repository: str,
+        entry_id: str | None = None,
+    ) -> IngestResult:
+        """単一ジャーナルエントリを source_store に配置する.
+
+        Args:
+            title: エントリタイトル
+            body: 本文（Markdown）
+            repository: リポジトリ名
+            entry_id: エントリ識別子（未指定時は自動生成）
+        """
+        result = IngestResult()
+        try:
+            self._validate_text(title, "title")
+            self._validate_text(body, "body")
+            self._validate_repository(repository)
+
+            if entry_id is None:
+                entry_id = self._generate_entry_id(title)
+            else:
+                self._validate_entry_id(entry_id)
+
+            rel_path = f"journal/{repository}/{entry_id}.md"
+            now_iso = datetime.now(timezone.utc).isoformat()
+
+            metadata = {
+                "source_id": rel_path,
+                "source_type": "journal",
+                "title": title,
+                "collected_at": now_iso,
+                "repository": repository,
+            }
+
+            data = body.encode("utf-8")
+            self._store.place_file(
+                source_type="journal",
+                data=data,
+                rel_path=rel_path,
+                metadata=metadata,
+            )
+            result.placed = 1
+        except ValueError as e:
+            result.errors = 1
+            result.error_details.append(str(e))
+        except OSError as e:
+            logger.exception("Failed to place journal entry")
+            result.errors = 1
+            result.error_details.append(str(e))
+        return result
+
+    def import_directory(
+        self,
+        dir_path: str,
+        repository: str,
+    ) -> IngestResult:
+        """既存ジャーナルファイルを一括で source_store に配置する.
+
+        Args:
+            dir_path: ジャーナルディレクトリパス
+            repository: リポジトリ名
+        """
+        result = IngestResult()
+        try:
+            self._validate_text(dir_path, "dir_path")
+            self._validate_repository(repository)
+        except ValueError as e:
+            result.errors = 1
+            result.error_details.append(str(e))
+            return result
+
+        resolved_dir = Path(dir_path.strip()).resolve()
+        if not resolved_dir.exists():
+            result.errors = 1
+            result.error_details.append(f"Directory not found: {resolved_dir}")
+            return result
+        if not resolved_dir.is_dir():
+            result.errors = 1
+            result.error_details.append(f"Path is not a directory: {resolved_dir}")
+            return result
+
+        files = sorted(resolved_dir.glob("*.md"), key=lambda p: str(p))
+        if len(files) > MAX_FILES_HARD_LIMIT:
+            logger.warning(
+                "File count %d exceeds limit %d, clamping to %d",
+                len(files), MAX_FILES_HARD_LIMIT, MAX_FILES_HARD_LIMIT,
+            )
+            files = files[:MAX_FILES_HARD_LIMIT]
+
+        for fp in files:
+            try:
+                if fp.stat().st_size == 0:
+                    logger.warning("Skipping empty file (0 bytes): %s", fp)
+                    result.skipped += 1
+                    continue
+
+                entry_id = fp.stem
+                title = self._parse_title_from_filename(entry_id)
+                data = fp.read_bytes()
+
+                # collected_at はファイルの更新日時を使用
+                mtime = fp.stat().st_mtime
+                collected_at = datetime.fromtimestamp(
+                    mtime, tz=timezone.utc,
+                ).isoformat()
+
+                rel_path = f"journal/{repository}/{entry_id}.md"
+                metadata = {
+                    "source_id": rel_path,
+                    "source_type": "journal",
+                    "title": title,
+                    "collected_at": collected_at,
+                    "repository": repository,
+                }
+
+                self._store.place_file(
+                    source_type="journal",
+                    data=data,
+                    rel_path=rel_path,
+                    metadata=metadata,
+                )
+                result.placed += 1
+            except OSError:
+                logger.exception("Failed to import journal file: %s", fp)
+                result.errors += 1
+                result.error_details.append(str(fp))
+
+        return result
+
+    @staticmethod
+    def _validate_text(value: str, name: str) -> None:
+        """文字列パラメータのバリデーション."""
+        if not value or not value.strip():
+            raise ValueError(f"{name} must not be empty")
+
+    @staticmethod
+    def _validate_repository(repository: str) -> None:
+        """リポジトリ名のバリデーション."""
+        if not repository or not repository.strip():
+            raise ValueError("repository must not be empty")
+        repo = repository.strip()
+        if ".." in repo or "/" in repo or "\\" in repo:
+            raise ValueError(
+                f"repository に不正な文字が含まれています: {repo!r}"
+            )
+
+    @staticmethod
+    def _validate_entry_id(entry_id: str) -> None:
+        """entry_id のバリデーション."""
+        if not entry_id or not entry_id.strip():
+            raise ValueError("entry_id must not be empty")
+        eid = entry_id.strip()
+        if ".." in eid or "/" in eid or "\\" in eid:
+            raise ValueError(
+                f"entry_id に不正な文字が含まれています: {eid!r}"
+            )
+
+    @staticmethod
+    def _generate_entry_id(title: str) -> str:
+        """title からエントリ ID を自動生成する."""
+        now = datetime.now(timezone.utc)
+        timestamp = now.strftime("%Y%m%d-%H%M%S")
+        topic = _sanitize_topic(title)
+        if topic:
+            return f"{timestamp}-{topic}"
+        return timestamp
+
+    @staticmethod
+    def _parse_title_from_filename(entry_id: str) -> str:
+        """ファイル名（拡張子除去済み）からタイトルを抽出する."""
+        if _ENTRY_ID_PATTERN.match(entry_id):
+            # YYYYMMDD-HHMMSS- プレフィックスを除去
+            return entry_id[16:]
+        return entry_id
+
+
+def _sanitize_topic(title: str) -> str:
+    """タイトルをサニタイズしてトピック文字列を生成する."""
+    # NFKC 正規化
+    normalized = unicodedata.normalize("NFKC", title.strip().lower())
+    # 英数字・ハイフン以外を空白に変換
+    cleaned = re.sub(r"[^a-z0-9\-\s]", " ", normalized)
+    # 連続空白をハイフンに
+    topic = re.sub(r"\s+", "-", cleaned.strip())
+    # 連続ハイフンを1つに
+    topic = re.sub(r"-+", "-", topic)
+    # 先頭・末尾のハイフン除去
+    topic = topic.strip("-")
+    # 長さ制限
+    if len(topic) > _TOPIC_MAX_LENGTH:
+        topic = topic[:_TOPIC_MAX_LENGTH].rstrip("-")
+    return topic

--- a/src/rag/pipeline/models.py
+++ b/src/rag/pipeline/models.py
@@ -62,4 +62,6 @@ def detect_source_type(rel_path: str) -> SourceType:
         return "zenn"
     if rel_path.startswith("youtube/"):
         return "youtube"
+    if rel_path.startswith("journal/"):
+        return "journal"
     return "local"

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -641,6 +641,7 @@ class RAGKnowledgeService:
         query: str,
         n_results: int = 5,
         source_type: str | None = None,
+        filters: dict[str, str | int | float | bool] | None = None,
     ) -> RawSearchResults:
         """ベクトル検索・BM25検索の生結果を個別に返す（準Agentic Search用）.
 
@@ -652,14 +653,13 @@ class RAGKnowledgeService:
             query: 検索クエリ
             n_results: 各エンジンから返却する結果の最大数
             source_type: ソース種別フィルタ（指定時はそのソース種別のみ検索対象）
+            filters: カスタムメタデータフィルタ（完全一致。キーは .meta の extra フィールドに対応）
 
         Returns:
             RawSearchResults: ベクトル検索とBM25検索の生結果
         """
         # ベクトル検索（閾値フィルタなし: LLMが判断する）
-        where: dict[str, str | int | float | bool] | None = (
-            {"source_type": source_type} if source_type is not None else None
-        )
+        where = self._build_where_clause(source_type, filters)
         vector_results_raw = await self._vector_store.search(
             query,
             n_results=n_results,
@@ -693,9 +693,11 @@ class RAGKnowledgeService:
 
         # BM25検索
         bm25_items: list[BM25SearchItem] = []
+        bm25_filters = self._build_bm25_filters(filters) if filters else None
         if self._bm25_index is not None:
             bm25_results_raw = self._bm25_index.search(
                 query, n_results=n_results, source_type=source_type,
+                filters=bm25_filters,
             )
 
             # BM25結果のメタデータをChromaDBから一括取得
@@ -749,6 +751,45 @@ class RAGKnowledgeService:
             vector_results=vector_items,
             bm25_results=bm25_items,
         )
+
+    @staticmethod
+    def _build_where_clause(
+        source_type: str | None,
+        filters: dict[str, str | int | float | bool] | None,
+    ) -> dict[str, str | int | float | bool] | None:
+        """ChromaDB の where 句を構築する.
+
+        source_type と filters（custom: プレフィックス付き）を統合する。
+        複数条件の場合は $and で結合する。
+        """
+        conditions: dict[str, str | int | float | bool] = {}
+        if source_type is not None:
+            conditions["source_type"] = source_type
+        if filters:
+            for key, value in filters.items():
+                conditions[f"custom:{key}"] = value
+
+        if not conditions:
+            return None
+        if len(conditions) == 1:
+            return conditions
+        # ChromaDB $and: 型としては dict[str, Any] だが VectorStore.search の
+        # where パラメータは query_kwargs 経由で渡されるため cast で通す
+        from typing import cast
+        return cast(
+            dict[str, str | int | float | bool],
+            {"$and": [{k: v} for k, v in conditions.items()]},
+        )
+
+    @staticmethod
+    def _build_bm25_filters(
+        filters: dict[str, str | int | float | bool],
+    ) -> dict[str, str | int | float | bool]:
+        """BM25 用のフィルタ辞書を構築する.
+
+        キーに custom: プレフィックスを付与する（ChromaDB メタデータのキーと一致させる）。
+        """
+        return {f"custom:{key}": value for key, value in filters.items()}
 
     async def source_exists(self, source_url: str) -> bool:
         """ソースURLに対応するチャンクが存在するか確認する（軽量版）.

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -12,7 +12,7 @@ import mimetypes
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urldefrag
 
 from .chunker import chunk_text
@@ -756,11 +756,16 @@ class RAGKnowledgeService:
     def _build_where_clause(
         source_type: str | None,
         filters: dict[str, str | int | float | bool] | None,
-    ) -> dict[str, str | int | float | bool] | None:
+    ) -> dict[str, Any] | None:
         """ChromaDB の where 句を構築する.
 
-        source_type と filters（custom: プレフィックス付き）を統合する。
-        複数条件の場合は $and で結合する。
+        source_type と filters を統合する。filters のキーには custom: プレフィックスを
+        自動付与する。複数条件の場合は ChromaDB の $and 演算子で結合する。
+
+        Returns:
+            単一条件: {"key": value}
+            複数条件: {"$and": [{"key1": value1}, {"key2": value2}]}
+            条件なし: None
         """
         conditions: dict[str, str | int | float | bool] = {}
         if source_type is not None:
@@ -773,13 +778,7 @@ class RAGKnowledgeService:
             return None
         if len(conditions) == 1:
             return conditions
-        # ChromaDB $and: 型としては dict[str, Any] だが VectorStore.search の
-        # where パラメータは query_kwargs 経由で渡されるため cast で通す
-        from typing import cast
-        return cast(
-            dict[str, str | int | float | bool],
-            {"$and": [{k: v} for k, v in conditions.items()]},
-        )
+        return {"$and": [{k: v} for k, v in conditions.items()]}
 
     @staticmethod
     def _build_bm25_filters(

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -344,6 +344,13 @@ async def rag_search(
             parsed_filters = json.loads(filters)
             if not isinstance(parsed_filters, dict):
                 return "エラー: filters は JSON オブジェクト形式で指定してください（例: '{\"repository\": \"rag-knowledge\"}'）"
+            allowed_types = (str, int, float, bool)
+            for key, value in parsed_filters.items():
+                if not isinstance(value, allowed_types):
+                    return (
+                        f"エラー: filters の値は str/int/float/bool のみサポートされています。"
+                        f" キー {key!r} に不正な型 {type(value).__name__} が指定されています"
+                    )
         except json.JSONDecodeError:
             return "エラー: filters の JSON パースに失敗しました"
 
@@ -1052,9 +1059,10 @@ async def rag_add_journal(
         _reset_pipeline_controller()
         _reset_rag_service()
 
+        resolved_entry_id = journal_ingester.last_entry_id or entry_id or title
         return _format_ingest_response(
             ingest_result, pipeline_summary,
-            context=f"journal: {repository}/{title}",
+            context=f"journal: {repository}/{resolved_entry_id}",
         )
     except ValueError as e:
         return f"エラー: {e}"

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,7 +3,7 @@
 仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 13 個の RAG ツールを公開する:
+FastMCP を使用して 16 個の RAG ツールを公開する:
 - rag_search: ナレッジベース検索（チャンク単位返却）
 - rag_get_document: ソース全文取得
 - rag_add: 単一ページをナレッジベースに取り込み
@@ -11,7 +11,10 @@ FastMCP を使用して 13 個の RAG ツールを公開する:
 - rag_crawl_preview: クロール対象ページのプレビュー（タイトル・URL一覧）
 - rag_crawl_zenn: Zenn 記事の一括取り込み
 - rag_crawl_bluesky: BlueSky 投稿の一括取り込み
+- rag_add_youtube: YouTube 動画の字幕・文字起こしをナレッジベースに取り込み
+- rag_crawl_youtube: YouTube プレイリスト・チャンネルの一括取り込み
 - rag_add_document: ドキュメントファイルをナレッジベースに取り込み
+- rag_add_journal: ジャーナルエントリをナレッジベースに登録
 - rag_crawl_documents: ディレクトリ内ドキュメントを一括取り込み
 - rag_site_ingest: Scrapy によるサイト一括取り込み（大規模サイト向け）
 - rag_delete: ソースURL指定でナレッジから論理削除
@@ -59,6 +62,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .pipeline.controller import PipelineController
     from .pipeline.ingesters._common import IngestResult
     from .pipeline.ingesters.bluesky import BlueskyIngester as PipelineBlueskyIngester
+    from .pipeline.ingesters.journal import JournalIngester as PipelineJournalIngester
     from .pipeline.ingesters.local import LocalIngester as PipelineLocalIngester
     from .pipeline.ingesters.web import WebIngester as PipelineWebIngester
     from .pipeline.ingesters.youtube import YoutubeIngester as PipelineYoutubeIngester
@@ -281,7 +285,7 @@ def _get_supported_extensions() -> list[str]:
 
 # --- MCP ツール定義 ---
 
-_VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "youtube", "local"})
+_VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "youtube", "local", "journal"})
 
 
 def _format_chunk_position(chunk_index: int, total_chunks: int) -> str:
@@ -305,6 +309,7 @@ async def rag_search(
     query: str,
     n_results: int | None = None,
     source_type: str | None = None,
+    filters: str | None = None,
 ) -> str:
     """[rag-knowledge] RAG search - ナレッジベース検索。挨拶・雑談以外の質問では必ずこのツールを最初に呼び出すこと。
 
@@ -316,8 +321,11 @@ async def rag_search(
     Args:
         query: 検索クエリ（ユーザーの質問からキーワードを抽出して構成する）
         n_results: 各エンジンから取得する結果数（未指定時は設定値を使用）
-        source_type: ソース種別フィルタ（"web", "zenn", "bluesky", "youtube", "local"）。
+        source_type: ソース種別フィルタ（"web", "zenn", "bluesky", "youtube", "local", "journal"）。
             指定時はそのソース種別のチャンクのみを検索対象とする。未指定時は全種別を検索。
+        filters: メタデータフィルタ（JSON 形式）。.meta のカスタムフィールドで検索結果を絞り込む。
+            完全一致フィルタ。例: '{"repository": "rag-knowledge"}'
+            未指定時はフィルタなし。
 
     Returns:
         検索結果テキスト。ベクトル検索結果とBM25検索結果をセクション分けして返す。
@@ -329,12 +337,23 @@ async def rag_search(
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
         return f"無効な source_type: {source_type!r}（有効値: {valid}）"
 
+    # filters パラメータのパース
+    parsed_filters: dict[str, str | int | float | bool] | None = None
+    if filters is not None:
+        try:
+            parsed_filters = json.loads(filters)
+            if not isinstance(parsed_filters, dict):
+                return "エラー: filters は JSON オブジェクト形式で指定してください（例: '{\"repository\": \"rag-knowledge\"}'）"
+        except json.JSONDecodeError:
+            return "エラー: filters の JSON パースに失敗しました"
+
     service = await _get_rag_service()
     if n_results is None:
         n_results = get_settings().rag_retrieval_count
 
     raw = await service.retrieve_raw_results(
         query, n_results=n_results, source_type=source_type,
+        filters=parsed_filters,
     )
 
     if not raw.vector_results and not raw.bm25_results:
@@ -980,6 +999,68 @@ async def rag_add_document(
     except Exception:
         logger.exception("Failed to add document file: %s", file_path)
         return f"エラー: ファイルの取り込みに失敗しました。パス: {file_path}"
+
+
+@mcp.tool()
+async def rag_add_journal(
+    title: str,
+    body: str,
+    repository: str,
+    entry_id: str | None = None,
+    ctx: MCPContext | None = None,
+) -> str:
+    """[rag-knowledge] RAG add journal - ジャーナルエントリをナレッジベースに登録する.
+
+    journal, session log, work record, development diary.
+    セッションごとの作業記録（ジャーナル）をナレッジベースに追加する。
+    stdio モード専用。HTTP モードでは無効。
+
+    Args:
+        title: エントリタイトル
+        body: 本文（Markdown）
+        repository: リポジトリ名（例: rag-knowledge）
+        entry_id: エントリ識別子（更新時に使用。未指定時は自動生成。命名規則: YYYYMMDD-HHMMSS-topic）
+
+    Returns:
+        取り込み結果のメッセージ
+    """
+    if get_settings().rag_transport == "http":
+        return "エラー: rag_add_journal は HTTP モードでは無効です（セキュリティ上の制約）"
+
+    controller = await _get_pipeline_controller()
+    journal_ingester = PipelineJournalIngester(controller.source_store)
+
+    try:
+        ingest_result = await asyncio.to_thread(
+            journal_ingester.add_entry,
+            title,
+            body,
+            repository,
+            entry_id=entry_id,
+        )
+
+        if ingest_result.placed == 0 and ingest_result.errors == 0:
+            return "エラー: ジャーナルエントリの登録に失敗しました"
+
+        if ingest_result.errors > 0:
+            return f"エラー: {ingest_result.error_details[0]}"
+
+        pipeline_summary = await _run_ingest_and_index_subprocess(
+            f"ingest(journal): {repository}/{entry_id or title}",
+            ctx=ctx,
+        )
+        _reset_pipeline_controller()
+        _reset_rag_service()
+
+        return _format_ingest_response(
+            ingest_result, pipeline_summary,
+            context=f"journal: {repository}/{title}",
+        )
+    except ValueError as e:
+        return f"エラー: {e}"
+    except Exception:
+        logger.exception("Failed to add journal entry: %s/%s", repository, title)
+        return f"エラー: ジャーナルエントリの登録に失敗しました: {title}"
 
 
 @mcp.tool()

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-SourceType = Literal["web", "bluesky", "zenn", "youtube", "local"]
+SourceType = Literal["web", "bluesky", "zenn", "youtube", "local", "journal"]
 SourceStatus = Literal["active", "deleted"]
 
 # git null commit hash（初回パイプライン実行時の from_commit_id）

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -440,6 +440,8 @@ class SourceStore:
             return "bluesky"
         if rel_path.startswith("zenn/"):
             return "zenn"
+        if rel_path.startswith("journal/"):
+            return "journal"
         return "local"
 
     @staticmethod

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -54,6 +54,16 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_bluesky_request_timeout": 30,
     "rag_bluesky_request_interval": 1.0,
     "rag_bluesky_include_reposts": True,
+    # YouTube インジェスター
+    "rag_youtube_whisper_model": "base",
+    "rag_youtube_whisper_device": "cpu",
+    "rag_youtube_max_videos": 100,
+    "rag_youtube_request_interval": 5.0,
+    "rag_youtube_request_timeout": 30,
+    "rag_youtube_transcript_languages": ["ja", "en"],
+    "rag_youtube_merge_gap_sec": 2.0,
+    "rag_youtube_merge_max_chars": 300,
+    "rag_youtube_max_duration": 14400,
     # PDF バックエンド
     "rag_pdf_backend": "auto",
     "rag_pdf_mineru_mfd_conf_thres": 0.6,

--- a/tests/test_cli_migrate_journal.py
+++ b/tests/test_cli_migrate_journal.py
@@ -1,0 +1,200 @@
+"""migrate-journal CLI サブコマンドのテスト
+
+FR-2: 初回マイグレーション CLI
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rag.cli import run_migrate_journal
+from rag.pipeline.ingesters._common import IngestResult
+
+_PATCH_GET_SETTINGS = "rag.config.get_settings"
+_PATCH_SOURCE_STORE = "rag.store.source_store.SourceStore"
+_PATCH_JOURNAL_INGESTER = "rag.pipeline.ingesters.journal.JournalIngester"
+
+
+class TestRunMigrateJournal:
+    """run_migrate_journal CLI 関数のテスト."""
+
+    @pytest.fixture()
+    def journal_dir(self, tmp_path: Path) -> Path:
+        """テスト用ジャーナルディレクトリを作成する."""
+        d = tmp_path / "journals"
+        d.mkdir()
+        (d / "20260323-143000-test-entry.md").write_text(
+            "# Test Entry\n\nBody text.", encoding="utf-8",
+        )
+        (d / "20260323-150000-another-entry.md").write_text(
+            "# Another Entry\n\nMore content.", encoding="utf-8",
+        )
+        return d
+
+    def _make_args(self, dir_path: str, repository: str) -> argparse.Namespace:
+        return argparse.Namespace(dir=dir_path, repository=repository)
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_successful_migration(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """正常なマイグレーション実行."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+
+        result = IngestResult()
+        result.placed = 2
+        mock_ingester_cls.return_value.import_directory.return_value = result
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        run_migrate_journal(args)
+
+        mock_ingester_cls.return_value.import_directory.assert_called_once_with(
+            dir_path=str(journal_dir),
+            repository="test-repo",
+        )
+        captured = capsys.readouterr()
+        assert "2件配置" in captured.out
+        assert "rebuild --mode incremental" in captured.out
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_no_files_placed_skips_postprocess_message(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """配置0件の場合はインデックス構築メッセージが出ない."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+
+        result = IngestResult()
+        result.placed = 0
+        mock_ingester_cls.return_value.import_directory.return_value = result
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        run_migrate_journal(args)
+
+        captured = capsys.readouterr()
+        assert "0件配置" in captured.out
+        assert "rebuild" not in captured.out
+
+    @patch(_PATCH_GET_SETTINGS)
+    def test_missing_source_store_dir_exits(
+        self,
+        mock_get_settings: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """source_store_dir 未設定時は sys.exit(1)."""
+        mock_get_settings.return_value.source_store_dir = ""
+
+        args = self._make_args("/any/dir", "test-repo")
+        with pytest.raises(SystemExit) as exc_info:
+            run_migrate_journal(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "source_store_dir" in captured.err
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_store_close_called_on_success(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+    ) -> None:
+        """正常終了時に store.close() が呼ばれる."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+
+        result = IngestResult()
+        result.placed = 1
+        mock_ingester_cls.return_value.import_directory.return_value = result
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        run_migrate_journal(args)
+
+        mock_store_cls.return_value.close.assert_called_once()
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_store_close_called_on_error(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+    ) -> None:
+        """例外発生時でも store.close() が呼ばれる."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+        mock_ingester_cls.return_value.import_directory.side_effect = RuntimeError("fail")
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        with pytest.raises(RuntimeError, match="fail"):
+            run_migrate_journal(args)
+
+        mock_store_cls.return_value.close.assert_called_once()
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_store_initialize_called(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+    ) -> None:
+        """store.initialize() が呼ばれる."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+
+        result = IngestResult()
+        mock_ingester_cls.return_value.import_directory.return_value = result
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        run_migrate_journal(args)
+
+        mock_store_cls.return_value.initialize.assert_called_once()
+
+    @patch(_PATCH_GET_SETTINGS)
+    @patch(_PATCH_SOURCE_STORE)
+    @patch(_PATCH_JOURNAL_INGESTER)
+    def test_result_with_errors_shows_details(
+        self,
+        mock_ingester_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_get_settings: MagicMock,
+        journal_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """エラー件数を含む結果が表示される."""
+        mock_get_settings.return_value.source_store_dir = "/tmp/source_store"
+
+        result = IngestResult()
+        result.placed = 1
+        result.errors = 1
+        result.error_details = ["/path/to/failed.md"]
+        mock_ingester_cls.return_value.import_directory.return_value = result
+
+        args = self._make_args(str(journal_dir), "test-repo")
+        run_migrate_journal(args)
+
+        captured = capsys.readouterr()
+        assert "1件配置" in captured.out
+        assert "エラー: 1件" in captured.out

--- a/tests/test_pipeline_ingesters_journal.py
+++ b/tests/test_pipeline_ingesters_journal.py
@@ -1,0 +1,405 @@
+"""Journal インジェスターのテスト.
+
+仕様: docs/specs/ingesters/journal.md
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from rag.pipeline.ingesters.journal import (
+    MAX_FILES_HARD_LIMIT,
+    JournalIngester,
+    _sanitize_topic,
+)
+from rag.store.meta import read_meta
+from rag.store.source_store import SourceStore
+
+
+_FIXED_NOW = datetime(2026, 3, 23, 14, 30, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_datetime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """datetime.now() を固定してテストの安定性を確保する."""
+    original_datetime = datetime
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def now(cls, tz: timezone | None = None) -> datetime:  # type: ignore[override]
+            if tz is not None:
+                return _FIXED_NOW.astimezone(tz)
+            return _FIXED_NOW
+
+        @classmethod
+        def fromtimestamp(cls, t: float, tz: timezone | None = None) -> datetime:
+            return original_datetime.fromtimestamp(t, tz=tz)
+
+    monkeypatch.setattr(
+        "rag.pipeline.ingesters.journal.datetime", FakeDatetime,
+    )
+
+
+@pytest.fixture()
+def source_store(tmp_path: Path) -> SourceStore:
+    store = SourceStore(tmp_path / "source_store")
+    store.initialize()
+    return store
+
+
+@pytest.fixture()
+def ingester(source_store: SourceStore) -> JournalIngester:
+    return JournalIngester(source_store)
+
+
+class TestAddEntry:
+    """add_entry() の正常系・異常系テスト."""
+
+    def test_add_entry_with_auto_id(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        result = ingester.add_entry(
+            title="Session Summary",
+            body="# Summary\nToday's work",
+            repository="rag-knowledge",
+        )
+        assert result.placed == 1
+        assert result.errors == 0
+
+        # ファイルが配置されていること
+        journal_dir = source_store.root_dir / "journal" / "rag-knowledge"
+        assert journal_dir.exists()
+        md_files = list(journal_dir.glob("*.md"))
+        assert len(md_files) == 1
+        assert md_files[0].read_text(encoding="utf-8") == "# Summary\nToday's work"
+
+        # entry_id が自動生成されていること（YYYYMMDD-HHMMSS-topic 形式）
+        assert md_files[0].stem.startswith("20260323-143000-")
+
+    def test_add_entry_with_explicit_id(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        result = ingester.add_entry(
+            title="Test Entry",
+            body="Content here",
+            repository="my-repo",
+            entry_id="20260323-120000-test-entry",
+        )
+        assert result.placed == 1
+        placed = source_store.root_dir / "journal" / "my-repo" / "20260323-120000-test-entry.md"
+        assert placed.exists()
+        assert placed.read_text(encoding="utf-8") == "Content here"
+
+    def test_meta_file_generated(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        ingester.add_entry(
+            title="Meta Test",
+            body="Body text",
+            repository="test-repo",
+            entry_id="20260323-143000-meta-test",
+        )
+        data_file = (
+            source_store.root_dir / "journal" / "test-repo"
+            / "20260323-143000-meta-test.md"
+        )
+        meta = read_meta(data_file)
+        assert meta["source_id"] == "journal/test-repo/20260323-143000-meta-test.md"
+        assert meta["source_type"] == "journal"
+        assert meta["title"] == "Meta Test"
+        assert meta["repository"] == "test-repo"
+        assert "collected_at" in meta
+
+    def test_overwrite_existing_entry(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        """同一 entry_id で再登録すると上書きされること."""
+        ingester.add_entry(
+            title="V1", body="Version 1", repository="repo",
+            entry_id="entry-001",
+        )
+        result = ingester.add_entry(
+            title="V2", body="Version 2", repository="repo",
+            entry_id="entry-001",
+        )
+        assert result.placed == 1
+        placed = source_store.root_dir / "journal" / "repo" / "entry-001.md"
+        assert placed.read_text(encoding="utf-8") == "Version 2"
+
+    def test_metadata_db_registered(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        ingester.add_entry(
+            title="DB Test", body="Content", repository="repo",
+            entry_id="db-test-001",
+        )
+        record = source_store.db.get_source("journal/repo/db-test-001.md")
+        assert record is not None
+        assert record.source_type == "journal"
+        assert record.title == "DB Test"
+
+    def test_empty_title_rejected(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(title="", body="content", repository="repo")
+        assert result.errors == 1
+        assert result.placed == 0
+
+    def test_empty_body_rejected(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(title="Title", body="", repository="repo")
+        assert result.errors == 1
+
+    def test_empty_repository_rejected(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(title="Title", body="Body", repository="")
+        assert result.errors == 1
+
+    def test_whitespace_only_title_rejected(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(title="   ", body="Body", repository="repo")
+        assert result.errors == 1
+
+    def test_repository_path_traversal_dotdot(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(
+            title="T", body="B", repository="../evil",
+        )
+        assert result.errors == 1
+        assert ".." in result.error_details[0] or "不正" in result.error_details[0]
+
+    def test_repository_path_traversal_slash(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(
+            title="T", body="B", repository="evil/path",
+        )
+        assert result.errors == 1
+
+    def test_repository_path_traversal_backslash(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(
+            title="T", body="B", repository="evil\\path",
+        )
+        assert result.errors == 1
+
+    def test_entry_id_path_traversal(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(
+            title="T", body="B", repository="repo",
+            entry_id="../../../etc/passwd",
+        )
+        assert result.errors == 1
+
+    def test_entry_id_empty_string_rejected(self, ingester: JournalIngester) -> None:
+        result = ingester.add_entry(
+            title="T", body="B", repository="repo", entry_id="",
+        )
+        assert result.errors == 1
+
+
+class TestEntryIdGeneration:
+    """entry_id 自動生成のテスト."""
+
+    def test_english_title(self, ingester: JournalIngester, source_store: SourceStore) -> None:
+        ingester.add_entry(
+            title="Pipeline Migration Review",
+            body="Content", repository="repo",
+        )
+        journal_dir = source_store.root_dir / "journal" / "repo"
+        md_files = list(journal_dir.glob("*.md"))
+        assert len(md_files) == 1
+        assert md_files[0].stem == "20260323-143000-pipeline-migration-review"
+
+    def test_japanese_title_becomes_timestamp_only(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        """日本語のみのタイトルでは topic が空になり、タイムスタンプのみになる."""
+        ingester.add_entry(
+            title="セッション記録", body="Content", repository="repo",
+        )
+        journal_dir = source_store.root_dir / "journal" / "repo"
+        md_files = list(journal_dir.glob("*.md"))
+        assert len(md_files) == 1
+        assert md_files[0].stem == "20260323-143000"
+
+    def test_mixed_title(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        ingester.add_entry(
+            title="PR #123 対応", body="Content", repository="repo",
+        )
+        journal_dir = source_store.root_dir / "journal" / "repo"
+        md_files = list(journal_dir.glob("*.md"))
+        assert len(md_files) == 1
+        # 英数字部分のみが残る
+        stem = md_files[0].stem
+        assert stem.startswith("20260323-143000-")
+        assert "123" in stem
+
+
+class TestSanitizeTopic:
+    """_sanitize_topic() の単体テスト."""
+
+    def test_simple_english(self) -> None:
+        assert _sanitize_topic("Hello World") == "hello-world"
+
+    def test_special_characters(self) -> None:
+        assert _sanitize_topic("Fix: Bug #42!") == "fix-bug-42"
+
+    def test_japanese_only(self) -> None:
+        assert _sanitize_topic("日本語テスト") == ""
+
+    def test_mixed(self) -> None:
+        result = _sanitize_topic("PR 123 の対応")
+        assert "pr" in result
+        assert "123" in result
+
+    def test_truncation(self) -> None:
+        long_title = "a" * 100
+        result = _sanitize_topic(long_title)
+        assert len(result) <= 50
+
+    def test_empty_string(self) -> None:
+        assert _sanitize_topic("") == ""
+
+    def test_hyphens_normalized(self) -> None:
+        assert _sanitize_topic("a---b") == "a-b"
+
+
+class TestImportDirectory:
+    """import_directory() のテスト."""
+
+    @pytest.fixture()
+    def journal_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "journal"
+        d.mkdir()
+        (d / "20260320-100000-first-session.md").write_text(
+            "# First Session\nContent", encoding="utf-8",
+        )
+        (d / "20260321-140000-second-session.md").write_text(
+            "# Second Session\nMore content", encoding="utf-8",
+        )
+        (d / "custom-name.md").write_text(
+            "# Custom\nCustom content", encoding="utf-8",
+        )
+        return d
+
+    def test_import_all_files(
+        self, ingester: JournalIngester, journal_dir: Path, source_store: SourceStore,
+    ) -> None:
+        result = ingester.import_directory(str(journal_dir), "rag-knowledge")
+        assert result.placed == 3
+        assert result.errors == 0
+
+        repo_dir = source_store.root_dir / "journal" / "rag-knowledge"
+        assert (repo_dir / "20260320-100000-first-session.md").exists()
+        assert (repo_dir / "20260321-140000-second-session.md").exists()
+        assert (repo_dir / "custom-name.md").exists()
+
+    def test_import_generates_meta(
+        self, ingester: JournalIngester, journal_dir: Path, source_store: SourceStore,
+    ) -> None:
+        ingester.import_directory(str(journal_dir), "repo")
+        data_file = (
+            source_store.root_dir / "journal" / "repo"
+            / "20260320-100000-first-session.md"
+        )
+        meta = read_meta(data_file)
+        assert meta["source_type"] == "journal"
+        assert meta["title"] == "first-session"
+        assert meta["repository"] == "repo"
+
+    def test_import_custom_name_title(
+        self, ingester: JournalIngester, journal_dir: Path, source_store: SourceStore,
+    ) -> None:
+        """YYYYMMDD-HHMMSS- パターンに一致しないファイルはファイル名全体がタイトル."""
+        ingester.import_directory(str(journal_dir), "repo")
+        data_file = source_store.root_dir / "journal" / "repo" / "custom-name.md"
+        meta = read_meta(data_file)
+        assert meta["title"] == "custom-name"
+
+    def test_import_empty_directory(
+        self, ingester: JournalIngester, tmp_path: Path,
+    ) -> None:
+        d = tmp_path / "empty"
+        d.mkdir()
+        result = ingester.import_directory(str(d), "repo")
+        assert result.placed == 0
+        assert result.errors == 0
+
+    def test_import_nonexistent_directory(self, ingester: JournalIngester) -> None:
+        result = ingester.import_directory("/nonexistent/path", "repo")
+        assert result.errors == 1
+
+    def test_import_file_as_directory(
+        self, ingester: JournalIngester, tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "not_a_dir.md"
+        f.write_text("content")
+        result = ingester.import_directory(str(f), "repo")
+        assert result.errors == 1
+
+    def test_import_empty_dir_path(self, ingester: JournalIngester) -> None:
+        result = ingester.import_directory("", "repo")
+        assert result.errors == 1
+
+    def test_import_empty_repository(
+        self, ingester: JournalIngester, tmp_path: Path,
+    ) -> None:
+        d = tmp_path / "dir"
+        d.mkdir()
+        result = ingester.import_directory(str(d), "")
+        assert result.errors == 1
+
+    def test_import_skips_empty_files(
+        self, ingester: JournalIngester, tmp_path: Path,
+    ) -> None:
+        d = tmp_path / "with_empty"
+        d.mkdir()
+        (d / "empty.md").write_text("")
+        (d / "content.md").write_text("has content")
+        result = ingester.import_directory(str(d), "repo")
+        assert result.placed == 1
+        assert result.skipped == 1
+
+    def test_import_hard_limit(
+        self, ingester: JournalIngester, tmp_path: Path,
+    ) -> None:
+        d = tmp_path / "many"
+        d.mkdir()
+        count = MAX_FILES_HARD_LIMIT + 10
+        for i in range(count):
+            (d / f"entry_{i:04d}.md").write_text(f"Content {i}")
+        result = ingester.import_directory(str(d), "repo")
+        assert result.placed == MAX_FILES_HARD_LIMIT
+
+    def test_import_repository_traversal(self, ingester: JournalIngester, tmp_path: Path) -> None:
+        d = tmp_path / "dir"
+        d.mkdir()
+        (d / "test.md").write_text("content")
+        result = ingester.import_directory(str(d), "../evil")
+        assert result.errors == 1
+        assert result.placed == 0
+
+
+class TestSourceTypeIntegration:
+    """source_type "journal" の統合テスト."""
+
+    def test_detect_source_type_from_path(self, source_store: SourceStore) -> None:
+        """source_store が journal/ プレフィックスを正しく判定すること."""
+        assert source_store._detect_source_type("journal/repo/entry.md") == "journal"
+
+    def test_detect_source_type_pipeline_models(self) -> None:
+        """pipeline/models.py の detect_source_type も journal を判定すること."""
+        from rag.pipeline.models import detect_source_type
+        assert detect_source_type("journal/repo/entry.md") == "journal"
+
+    def test_journal_not_in_no_meta_types(self) -> None:
+        """journal は _NO_META_TYPES に含まれないこと（.meta を持つ）."""
+        from rag.store.source_store import _NO_META_TYPES
+        assert "journal" not in _NO_META_TYPES
+
+    def test_list_files_by_source_type(
+        self, ingester: JournalIngester, source_store: SourceStore,
+    ) -> None:
+        ingester.add_entry(
+            title="List Test", body="Body", repository="repo",
+            entry_id="list-test-001",
+        )
+        files = source_store.list_files(source_type="journal")
+        assert len(files) == 1
+        assert files[0].as_posix().startswith("journal/")

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -205,6 +205,13 @@ rag_pdf_quality_greek_threshold = 0.15
 rag_pdf_quality_cjk_min_threshold = 0.05
 rag_pdf_quality_min_chars_per_page = 10
 rag_pdf_quality_sample_pages = 10
+rag_youtube_max_videos = 100
+rag_youtube_request_interval = 5.0
+rag_youtube_request_timeout = 30
+rag_youtube_transcript_languages = ["ja", "en"]
+rag_youtube_merge_gap_sec = 2.0
+rag_youtube_merge_max_chars = 300
+rag_youtube_max_duration = 14400
 site_ingest_delay_sec = 0.1
 site_ingest_max_pages = 10000
 site_ingest_download_timeout = 30
@@ -226,6 +233,8 @@ site_ingest_error_count = 10
             "RAG_HTTP_PORT": "8081",
             "RAG_DNS_REBINDING_PROTECTION": "true",
             "RAG_DEBUG_LOG_ENABLED": "false",
+            "RAG_YOUTUBE_WHISPER_MODEL": "base",
+            "RAG_YOUTUBE_WHISPER_DEVICE": "cpu",
             "SITE_INGEST_TEMP_DIR": ".tmp/site_ingest",
         }
         defaults.update(overrides)

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -1295,5 +1295,5 @@ class TestRetrieveRawResults:
             where={"source_type": "bluesky"},
         )
         mock_bm25.search.assert_called_once_with(
-            "test", n_results=3, source_type="bluesky",
+            "test", n_results=3, source_type="bluesky", filters=None,
         )

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -2,8 +2,9 @@
 
 仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md, docs/specs/rebuild-stats.md,
       docs/specs/site-ingest.md
-13個のRAGツール（rag_search, rag_get_document, rag_add, rag_crawl, rag_crawl_preview,
-rag_crawl_zenn, rag_crawl_bluesky, rag_add_document, rag_crawl_documents,
+16個のRAGツール（rag_search, rag_get_document, rag_add, rag_crawl, rag_crawl_preview,
+rag_crawl_zenn, rag_crawl_bluesky, rag_add_youtube, rag_crawl_youtube,
+rag_add_document, rag_crawl_documents, rag_add_journal,
 rag_site_ingest, rag_delete, rag_rebuild, rag_stats）が
 MCPサーバーとして公開されていることを検証する。
 """
@@ -32,8 +33,8 @@ def _reset_rag_global_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_thirteen_tools() -> None:
-    """RAG MCPサーバーが13個のツールを公開すること."""
+async def test_rag_server_exposes_sixteen_tools() -> None:
+    """RAG MCPサーバーが16個のツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -43,20 +44,21 @@ async def test_rag_server_exposes_thirteen_tools() -> None:
     expected = {
         "rag_search", "rag_get_document", "rag_add", "rag_crawl",
         "rag_crawl_preview", "rag_crawl_zenn", "rag_crawl_bluesky",
-        "rag_add_document", "rag_crawl_documents", "rag_site_ingest",
-        "rag_delete", "rag_rebuild", "rag_stats",
+        "rag_add_youtube", "rag_crawl_youtube",
+        "rag_add_document", "rag_add_journal", "rag_crawl_documents",
+        "rag_site_ingest", "rag_delete", "rag_rebuild", "rag_stats",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が正確に13であること."""
+    """RAG MCPサーバーのツール数が正確に16であること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    assert len(tools) == 13
+    assert len(tools) == 16
 
 
 class TestRagSearchOutput:

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -1046,8 +1046,8 @@ class TestRagStats:
 
 
 @pytest.mark.asyncio
-async def test_rag_server_exposes_thirteen_tools() -> None:
-    """RAG MCPサーバーが13個のツールを公開すること."""
+async def test_rag_server_exposes_sixteen_tools() -> None:
+    """RAG MCPサーバーが16個のツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
@@ -1057,7 +1057,8 @@ async def test_rag_server_exposes_thirteen_tools() -> None:
     expected = {
         "rag_search", "rag_get_document", "rag_add", "rag_crawl",
         "rag_crawl_preview", "rag_crawl_zenn", "rag_crawl_bluesky",
-        "rag_add_document", "rag_crawl_documents", "rag_site_ingest",
-        "rag_delete", "rag_rebuild", "rag_stats",
+        "rag_add_youtube", "rag_crawl_youtube",
+        "rag_add_document", "rag_add_journal", "rag_crawl_documents",
+        "rag_site_ingest", "rag_delete", "rag_rebuild", "rag_stats",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -1,0 +1,336 @@
+"""検索フィルタ機能のテスト
+
+FR-4: 汎用カスタムメタデータフィルタ（rag_search 拡張）
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.bm25_index import BM25Index
+
+
+class TestBM25MetadataMap:
+    """BM25Index の _doc_metadata_map 関連テスト."""
+
+    def test_add_documents_with_metadata(self) -> None:
+        """add_documents に metadata_list を渡すとメタデータが保持される."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "テスト文書1", "source1", "journal"),
+            ("doc2", "テスト文書2", "source2", "journal"),
+        ]
+        metadata_list = [
+            {"source_type": "journal", "custom:repository": "repo-a"},
+            {"source_type": "journal", "custom:repository": "repo-b"},
+        ]
+        added = index.add_documents(docs, metadata_list=metadata_list)
+        assert added == 2
+        assert index._doc_metadata_map["doc1"]["custom:repository"] == "repo-a"
+        assert index._doc_metadata_map["doc2"]["custom:repository"] == "repo-b"
+
+    def test_add_documents_without_metadata(self) -> None:
+        """metadata_list なしでも従来通り動作する."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "テスト文書1", "source1", "web"),
+        ]
+        added = index.add_documents(docs)
+        assert added == 1
+        assert "doc1" not in index._doc_metadata_map
+
+    def test_update_document_metadata(self) -> None:
+        """既存ドキュメントを更新するとメタデータも更新される."""
+        index = BM25Index()
+        docs = [("doc1", "テスト文書1", "source1", "journal")]
+        meta = [{"custom:repository": "repo-a"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        # 更新
+        docs2 = [("doc1", "テスト文書1更新版", "source1", "journal")]
+        meta2 = [{"custom:repository": "repo-b"}]
+        index.add_documents(docs2, metadata_list=meta2)
+
+        assert index._doc_metadata_map["doc1"]["custom:repository"] == "repo-b"
+
+    def test_delete_by_source_cleans_metadata(self) -> None:
+        """delete_by_source でメタデータも削除される."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "文書1", "source1", "journal"),
+            ("doc2", "文書2", "source2", "journal"),
+        ]
+        meta = [
+            {"custom:repository": "repo-a"},
+            {"custom:repository": "repo-b"},
+        ]
+        index.add_documents(docs, metadata_list=meta)
+
+        index.delete_by_source("source1")
+        assert "doc1" not in index._doc_metadata_map
+        assert "doc2" in index._doc_metadata_map
+
+    def test_delete_stale_docs_cleans_metadata(self) -> None:
+        """delete_stale_docs でメタデータも削除される."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "文書1", "source1", "journal"),
+            ("doc2", "文書2", "source1", "journal"),
+        ]
+        meta = [
+            {"custom:repository": "repo-a"},
+            {"custom:repository": "repo-a"},
+        ]
+        index.add_documents(docs, metadata_list=meta)
+
+        deleted = index.delete_stale_docs("source1", valid_ids={"doc1"})
+        assert deleted == 1
+        assert "doc1" in index._doc_metadata_map
+        assert "doc2" not in index._doc_metadata_map
+
+    def test_clear_cleans_metadata(self) -> None:
+        """clear でメタデータも全削除される."""
+        index = BM25Index()
+        docs = [("doc1", "文書1", "source1", "journal")]
+        meta = [{"custom:repository": "repo-a"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        index.clear()
+        assert len(index._doc_metadata_map) == 0
+
+
+class TestBM25SearchWithFilters:
+    """BM25 search の filters パラメータテスト."""
+
+    @pytest.fixture()
+    def index_with_metadata(self) -> BM25Index:
+        """メタデータ付きドキュメントを持つ BM25Index."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "パイプライン移行の作業記録", "source1", "journal"),
+            ("doc2", "検索精度の改善に関するメモ", "source2", "journal"),
+            ("doc3", "パイプライン設計の技術文書", "source3", "web"),
+        ]
+        metadata_list = [
+            {"source_type": "journal", "custom:repository": "rag-knowledge"},
+            {"source_type": "journal", "custom:repository": "ai-assistant"},
+            {"source_type": "web"},
+        ]
+        index.add_documents(docs, metadata_list=metadata_list)
+        return index
+
+    def test_filter_by_custom_field(self, index_with_metadata: BM25Index) -> None:
+        """custom: フィールドでフィルタできる."""
+        results = index_with_metadata.search(
+            "パイプライン", n_results=10,
+            filters={"custom:repository": "rag-knowledge"},
+        )
+        assert len(results) > 0
+        assert all(r.doc_id == "doc1" for r in results)
+
+    def test_filter_excludes_non_matching(self, index_with_metadata: BM25Index) -> None:
+        """フィルタ条件に合わないドキュメントは除外される."""
+        results = index_with_metadata.search(
+            "パイプライン", n_results=10,
+            filters={"custom:repository": "nonexistent"},
+        )
+        assert results == []
+
+    def test_filter_none_returns_all(self, index_with_metadata: BM25Index) -> None:
+        """filters=None は全件対象."""
+        results = index_with_metadata.search(
+            "パイプライン", n_results=10, filters=None,
+        )
+        assert len(results) > 0
+
+    def test_filter_with_source_type(self, index_with_metadata: BM25Index) -> None:
+        """source_type と filters の併用."""
+        results = index_with_metadata.search(
+            "パイプライン", n_results=10,
+            source_type="journal",
+            filters={"custom:repository": "rag-knowledge"},
+        )
+        assert len(results) > 0
+        assert all(r.doc_id == "doc1" for r in results)
+
+    def test_no_metadata_doc_excluded_by_filter(self) -> None:
+        """メタデータを持たないドキュメントはフィルタで除外される."""
+        index = BM25Index()
+        docs = [
+            ("doc1", "テスト文書", "source1", "web"),
+        ]
+        # metadata_list なしで追加
+        index.add_documents(docs)
+
+        results = index.search(
+            "テスト", n_results=10,
+            filters={"custom:repository": "any"},
+        )
+        assert results == []
+
+
+class TestBM25MatchesFilters:
+    """BM25Index._matches_filters の単体テスト."""
+
+    def test_empty_filters_matches_all(self) -> None:
+        """空の filters は常に True."""
+        assert BM25Index._matches_filters({"key": "val"}, {}) is True
+
+    def test_single_key_match(self) -> None:
+        """単一キー一致."""
+        assert BM25Index._matches_filters(
+            {"custom:repository": "rag-knowledge"},
+            {"custom:repository": "rag-knowledge"},
+        ) is True
+
+    def test_single_key_mismatch(self) -> None:
+        """単一キー不一致."""
+        assert BM25Index._matches_filters(
+            {"custom:repository": "rag-knowledge"},
+            {"custom:repository": "other"},
+        ) is False
+
+    def test_missing_key_mismatch(self) -> None:
+        """メタデータにキーがない場合は不一致."""
+        assert BM25Index._matches_filters(
+            {},
+            {"custom:repository": "rag-knowledge"},
+        ) is False
+
+    def test_multiple_keys_all_match(self) -> None:
+        """複数キーが全て一致."""
+        assert BM25Index._matches_filters(
+            {"custom:repository": "rag-knowledge", "custom:author": "alice"},
+            {"custom:repository": "rag-knowledge", "custom:author": "alice"},
+        ) is True
+
+    def test_multiple_keys_partial_mismatch(self) -> None:
+        """複数キーのうち1つが不一致."""
+        assert BM25Index._matches_filters(
+            {"custom:repository": "rag-knowledge", "custom:author": "alice"},
+            {"custom:repository": "rag-knowledge", "custom:author": "bob"},
+        ) is False
+
+
+class TestBM25MetadataPersistence:
+    """BM25Index のメタデータ永続化テスト."""
+
+    @pytest.fixture()
+    def persist_dir(self, tmp_path: Path) -> str:
+        return str(tmp_path / "bm25_filter_test")
+
+    def test_metadata_map_persisted_and_restored(self, persist_dir: str) -> None:
+        """_doc_metadata_map が永続化・復元される."""
+        index = BM25Index(persist_dir=persist_dir)
+        docs = [
+            ("doc1", "テスト文書", "source1", "journal"),
+        ]
+        meta = [{"source_type": "journal", "custom:repository": "rag-knowledge"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        # 新インスタンスで復元
+        index2 = BM25Index(persist_dir=persist_dir)
+        assert index2._doc_metadata_map["doc1"]["custom:repository"] == "rag-knowledge"
+
+    def test_filter_works_after_persistence(self, persist_dir: str) -> None:
+        """永続化→復元後もフィルタ検索が動作する."""
+        index = BM25Index(persist_dir=persist_dir)
+        docs = [
+            ("doc1", "パイプライン移行の作業記録", "source1", "journal"),
+            ("doc2", "検索精度の改善メモ", "source2", "journal"),
+        ]
+        meta = [
+            {"source_type": "journal", "custom:repository": "rag-knowledge"},
+            {"source_type": "journal", "custom:repository": "ai-assistant"},
+        ]
+        index.add_documents(docs, metadata_list=meta)
+
+        # 永続化→復元
+        index2 = BM25Index(persist_dir=persist_dir)
+        results = index2.search(
+            "パイプライン", n_results=10,
+            filters={"custom:repository": "rag-knowledge"},
+        )
+        assert len(results) > 0
+        assert all(r.doc_id == "doc1" for r in results)
+
+
+class TestBuildWhereClause:
+    """RAGKnowledgeService._build_where_clause のテスト."""
+
+    def _build(
+        self,
+        source_type: str | None = None,
+        filters: dict[str, str | int | float | bool] | None = None,
+    ) -> dict | None:
+        from rag.rag_knowledge import RAGKnowledgeService
+        return RAGKnowledgeService._build_where_clause(source_type, filters)
+
+    def test_both_none_returns_none(self) -> None:
+        """source_type=None, filters=None → None."""
+        assert self._build() is None
+
+    def test_source_type_only(self) -> None:
+        """source_type のみ → 単純な dict."""
+        result = self._build(source_type="journal")
+        assert result == {"source_type": "journal"}
+
+    def test_filters_only(self) -> None:
+        """filters のみ → custom: プレフィックス付き."""
+        result = self._build(filters={"repository": "rag-knowledge"})
+        assert result == {"custom:repository": "rag-knowledge"}
+
+    def test_source_type_and_filters_combined(self) -> None:
+        """source_type + filters → $and 結合."""
+        result = self._build(
+            source_type="journal",
+            filters={"repository": "rag-knowledge"},
+        )
+        assert "$and" in result
+        and_conditions = result["$and"]
+        assert {"source_type": "journal"} in and_conditions
+        assert {"custom:repository": "rag-knowledge"} in and_conditions
+
+    def test_multiple_filters(self) -> None:
+        """複数 filters → $and 結合."""
+        result = self._build(
+            filters={"repository": "rag-knowledge", "author": "alice"},
+        )
+        assert "$and" in result
+        and_conditions = result["$and"]
+        assert len(and_conditions) == 2
+
+    def test_empty_filters_treated_as_none(self) -> None:
+        """空 dict の filters → None."""
+        assert self._build(filters={}) is None
+
+
+class TestBuildBM25Filters:
+    """RAGKnowledgeService._build_bm25_filters のテスト."""
+
+    def _build(
+        self, filters: dict[str, str | int | float | bool],
+    ) -> dict[str, str | int | float | bool]:
+        from rag.rag_knowledge import RAGKnowledgeService
+        return RAGKnowledgeService._build_bm25_filters(filters)
+
+    def test_adds_custom_prefix(self) -> None:
+        """キーに custom: プレフィックスが付く."""
+        result = self._build({"repository": "rag-knowledge"})
+        assert result == {"custom:repository": "rag-knowledge"}
+
+    def test_multiple_keys(self) -> None:
+        """複数キーに custom: プレフィックスが付く."""
+        result = self._build({"repository": "rag-knowledge", "author": "alice"})
+        assert result == {
+            "custom:repository": "rag-knowledge",
+            "custom:author": "alice",
+        }
+
+    def test_preserves_value_types(self) -> None:
+        """値の型が保持される."""
+        result = self._build({"count": 42, "enabled": True})
+        assert result["custom:count"] == 42
+        assert result["custom:enabled"] is True


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `rag_add_journal` MCP ツール + `add-journal` CLI で単一ジャーナルエントリを登録（パイプライン処理込み）
- `migrate-journal` CLI で既存ジャーナルファイルの一括取り込み（source_store 配置のみ）
- 新規 `source_type: "journal"` 追加（`source_store/journal/{repository}/{entry_id}.md` 構造）
- `rag_search` に汎用 `filters` パラメータ追加（JSON 形式のカスタムメタデータフィルタ、ChromaDB + BM25 対応）
- BM25Index にカスタムメタデータ保持・フィルタ機能追加
- Journal インジェスター仕様書（`docs/specs/ingesters/journal.md`）新規作成
- 既存仕様書 6 件（source-store, rag-knowledge, search-response, overview, common, ARCHITECTURE）+ README 更新
- ユニットテスト 75 件追加（JournalIngester 39件 + 検索フィルタ 28件 + CLI 7件 + 既存テスト修正）

## Test plan

- [x] pytest 1199 passed
- [x] ruff: All checks passed
- [x] mypy: 0 new errors（既存 1 件は Issue #357 で対応）
- [x] CLI 動作確認: add-journal（インライン/ファイル読み込み）、migrate-journal、rebuild、search（source_type + filters）、stats、get-document
- [x] 複数リポジトリ（rag-knowledge / ai-assistant）のジャーナルを取り込み、リポジトリ別フィルタ検索で正しく分離されることを確認

## Related issues

Closes #46