### PR TITLE
fix(search-response): filters を key=value 形式に変更 + mypy エラー修正 (#360)

### DIFF
--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -54,7 +54,7 @@ MCP クライアントからの rag_search ツール呼び出し。
 | `query` | str | Yes | 検索キーワード |
 | `n_results` | int | No | エンジンあたりの結果件数 |
 | `source_type` | str | No | ソース種別フィルタ（`"web"`, `"zenn"`, `"bluesky"`, `"youtube"`, `"local"`, `"journal"`） |
-| `filters` | str (JSON) | No | カスタムメタデータフィルタ（JSON オブジェクト形式）。`.meta` の extra フィールドで検索結果を絞り込む。完全一致。例: `'{"repository": "rag-knowledge"}'` |
+| `filters` | str | No | カスタムメタデータフィルタ（`key=value` 形式、複数指定時はカンマ区切り）。`.meta` の extra フィールドで検索結果を絞り込む。完全一致。例: `repository=rag-knowledge` / `repository=rag-knowledge,tag=dev` |
 
 #### フィルタの動作
 
@@ -62,8 +62,10 @@ MCP クライアントからの rag_search ツール呼び出し。
 
 - `source_type` と `filters` は併用可能。両方指定時は AND 条件として結合する
 - `filters` のキーにはユーザーが `custom:` プレフィックスを付ける必要はない（内部で自動付与）
-- `filters` が無効な JSON またはオブジェクト型でない場合はエラーメッセージを返す
+- `filters` のパース形式: `key=value` をカンマ区切り。値は全て文字列として扱う
+- `filters` が不正な形式（`=` を含まないペアがある等）の場合はエラーメッセージを返す
 - `filters` 未指定時はフィルタなし（全件対象）
+- フィルタ比較: BM25 側はメタデータ値を文字列変換・大文字化して比較する（大文字小文字を区別しない。int/bool 等の非文字列カスタムフィールドにもマッチする）。ChromaDB 側は `where` 句による完全一致（型・大文字小文字を区別する）
 
 #### 振る舞い
 

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -154,7 +154,7 @@ class BM25Index:
         query: str,
         n_results: int = 10,
         source_type: str | None = None,
-        filters: dict[str, str | int | float | bool] | None = None,
+        filters: dict[str, str] | None = None,
     ) -> list[BM25Result]:
         """クエリでキーワード検索を実行する.
 
@@ -224,11 +224,18 @@ class BM25Index:
     @staticmethod
     def _matches_filters(
         metadata: dict[str, str | int | float | bool],
-        filters: dict[str, str | int | float | bool],
+        filters: dict[str, str],
     ) -> bool:
-        """メタデータがフィルタ条件に完全一致するか判定する."""
+        """メタデータがフィルタ条件に一致するか判定する.
+
+        フィルタ値（常に文字列）とメタデータ値を大文字変換して比較する。
+        これにより、メタデータの型（int/bool 等）や大文字小文字の違いを吸収する。
+        """
         for key, value in filters.items():
-            if metadata.get(key) != value:
+            meta_value = metadata.get(key)
+            if meta_value is None:
+                return False
+            if str(meta_value).upper() != value.upper():
                 return False
         return True
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urldefrag
 
+from .filter_parser import parse_filters
 from .evaluation import (
     EvaluationReport,
     FailureTag,
@@ -322,7 +323,7 @@ def main() -> None:
     search_parser.add_argument(
         "--filters",
         default=None,
-        help='メタデータフィルタ（JSON 形式、例: \'{"repository": "rag-knowledge"}\'）',
+        help="メタデータフィルタ（key=value 形式、例: 'repository=rag-knowledge'）",
     )
 
     # delete サブコマンド
@@ -1296,23 +1297,12 @@ def run_search(args: argparse.Namespace) -> None:
     source_type: str | None = args.source_type
 
     # filters パラメータのパース
-    parsed_filters: dict[str, str | int | float | bool] | None = None
+    parsed_filters: dict[str, str] | None = None
     if args.filters is not None:
         try:
-            parsed_filters = json.loads(args.filters)
-            if not isinstance(parsed_filters, dict):
-                print("エラー: --filters は JSON オブジェクト形式で指定してください")
-                return
-            allowed_types = (str, int, float, bool)
-            for key, value in parsed_filters.items():
-                if not isinstance(value, allowed_types):
-                    print(
-                        f"エラー: --filters の値は str/int/float/bool のみ使用できます"
-                        f"（キー {key!r} に不正な型 {type(value).__name__}）"
-                    )
-                    return
-        except json.JSONDecodeError:
-            print("エラー: --filters の JSON パースに失敗しました")
+            parsed_filters = parse_filters(args.filters)
+        except ValueError as e:
+            print(f"エラー: {e}")
             return
 
     raw = _asyncio.run(

--- a/src/rag/filter_parser.py
+++ b/src/rag/filter_parser.py
@@ -1,0 +1,40 @@
+"""フィルタ文字列パーサー
+
+rag_search の filters パラメータ（key=value 形式）をパースする共通モジュール。
+MCP サーバー（server.py）と CLI（cli.py）の両方から使用される。
+
+仕様: docs/specs/search-response.md
+"""
+
+from __future__ import annotations
+
+
+def parse_filters(filters_str: str) -> dict[str, str]:
+    """key=value 形式のフィルタ文字列をパースする.
+
+    Args:
+        filters_str: フィルタ文字列（例: "repository=rag-knowledge,tag=dev"）
+
+    Returns:
+        キー・値の辞書（値は常に文字列）
+
+    Raises:
+        ValueError: パースに失敗した場合
+    """
+    result: dict[str, str] = {}
+    for pair in filters_str.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise ValueError(
+                f"不正なフィルタ形式: {pair!r}（key=value 形式で指定してください。"
+                f"例: repository=rag-knowledge）"
+            )
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"フィルタのキーが空です: {pair!r}")
+        result[key] = value
+    return result

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -641,7 +641,7 @@ class RAGKnowledgeService:
         query: str,
         n_results: int = 5,
         source_type: str | None = None,
-        filters: dict[str, str | int | float | bool] | None = None,
+        filters: dict[str, str] | None = None,
     ) -> RawSearchResults:
         """ベクトル検索・BM25検索の生結果を個別に返す（準Agentic Search用）.
 
@@ -755,7 +755,7 @@ class RAGKnowledgeService:
     @staticmethod
     def _build_where_clause(
         source_type: str | None,
-        filters: dict[str, str | int | float | bool] | None,
+        filters: dict[str, str] | None,
     ) -> dict[str, Any] | None:
         """ChromaDB の where 句を構築する.
 
@@ -782,8 +782,8 @@ class RAGKnowledgeService:
 
     @staticmethod
     def _build_bm25_filters(
-        filters: dict[str, str | int | float | bool],
-    ) -> dict[str, str | int | float | bool]:
+        filters: dict[str, str],
+    ) -> dict[str, str]:
         """BM25 用のフィルタ辞書を構築する.
 
         キーに custom: プレフィックスを付与する（ChromaDB メタデータのキーと一致させる）。

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -45,6 +45,7 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 # bm25s が "resource module not available on Windows" を stdout に print する
 # 問題への対策として、import 時に stdout を抑制する。
 from .config import ensure_utf8_streams
+from .filter_parser import parse_filters
 
 with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
@@ -323,8 +324,9 @@ async def rag_search(
         n_results: 各エンジンから取得する結果数（未指定時は設定値を使用）
         source_type: ソース種別フィルタ（"web", "zenn", "bluesky", "youtube", "local", "journal"）。
             指定時はそのソース種別のチャンクのみを検索対象とする。未指定時は全種別を検索。
-        filters: メタデータフィルタ（JSON 形式）。.meta のカスタムフィールドで検索結果を絞り込む。
-            完全一致フィルタ。例: '{"repository": "rag-knowledge"}'
+        filters: メタデータフィルタ（key=value 形式、カンマ区切りで複数指定可）。
+            .meta のカスタムフィールドで検索結果を絞り込む。完全一致。
+            例: "repository=rag-knowledge" / "repository=rag-knowledge,tag=dev"
             未指定時はフィルタなし。
 
     Returns:
@@ -338,21 +340,12 @@ async def rag_search(
         return f"無効な source_type: {source_type!r}（有効値: {valid}）"
 
     # filters パラメータのパース
-    parsed_filters: dict[str, str | int | float | bool] | None = None
+    parsed_filters: dict[str, str] | None = None
     if filters is not None:
         try:
-            parsed_filters = json.loads(filters)
-            if not isinstance(parsed_filters, dict):
-                return "エラー: filters は JSON オブジェクト形式で指定してください（例: '{\"repository\": \"rag-knowledge\"}'）"
-            allowed_types = (str, int, float, bool)
-            for key, value in parsed_filters.items():
-                if not isinstance(value, allowed_types):
-                    return (
-                        f"エラー: filters の値は str/int/float/bool のみサポートされています。"
-                        f" キー {key!r} に不正な型 {type(value).__name__} が指定されています"
-                    )
-        except json.JSONDecodeError:
-            return "エラー: filters の JSON パースに失敗しました"
+            parsed_filters = parse_filters(filters)
+        except ValueError as e:
+            return f"エラー: {e}"
 
     service = await _get_rag_service()
     if n_results is None:

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 import chromadb
 from chromadb.api.shared_system_client import SharedSystemClient
-from chromadb.api.types import Embeddings
+from chromadb.api.types import Embeddings, Metadatas
 from chromadb.config import Settings as ChromaSettings
 
 from .embedding.base import EmbeddingProvider
@@ -506,13 +506,11 @@ class VectorStore:
         if not chunk_ids:
             return
 
-        def _update_sync() -> None:
-            self._collection.update(
-                ids=chunk_ids,
-                metadatas=metadatas,  # type: ignore[arg-type]
-            )
-
-        await asyncio.to_thread(_update_sync)
+        await asyncio.to_thread(
+            self._collection.update,
+            ids=chunk_ids,
+            metadatas=cast(Metadatas, metadatas),
+        )
 
     async def clear(self) -> None:
         """コレクションを削除して再作成する（全データクリア）."""

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -506,11 +506,13 @@ class VectorStore:
         if not chunk_ids:
             return
 
-        await asyncio.to_thread(
-            self._collection.update,
-            ids=chunk_ids,
-            metadatas=metadatas,
-        )
+        def _update_sync() -> None:
+            self._collection.update(
+                ids=chunk_ids,
+                metadatas=metadatas,  # type: ignore[arg-type]
+            )
+
+        await asyncio.to_thread(_update_sync)
 
     async def clear(self) -> None:
         """コレクションを削除して再作成する（全データクリア）."""

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -14,7 +14,7 @@ from rag.filter_parser import parse_filters
 
 
 class TestParseFilters:
-    """_parse_filters のテスト."""
+    """parse_filters のテスト."""
 
     def test_single_key_value(self) -> None:
         """単一 key=value のパース."""

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -10,6 +10,56 @@ from pathlib import Path
 import pytest
 
 from rag.bm25_index import BM25Index
+from rag.filter_parser import parse_filters
+
+
+class TestParseFilters:
+    """_parse_filters のテスト."""
+
+    def test_single_key_value(self) -> None:
+        """単一 key=value のパース."""
+        result = parse_filters("repository=rag-knowledge")
+        assert result == {"repository": "rag-knowledge"}
+
+    def test_multiple_key_values(self) -> None:
+        """複数 key=value のパース."""
+        result = parse_filters("repository=rag-knowledge,tag=dev")
+        assert result == {"repository": "rag-knowledge", "tag": "dev"}
+
+    def test_whitespace_trimmed(self) -> None:
+        """前後の空白がトリムされる."""
+        result = parse_filters(" repository = rag-knowledge , tag = dev ")
+        assert result == {"repository": "rag-knowledge", "tag": "dev"}
+
+    def test_empty_string_returns_empty_dict(self) -> None:
+        """空文字列は空 dict."""
+        result = parse_filters("")
+        assert result == {}
+
+    def test_value_with_equals(self) -> None:
+        """値に = が含まれる場合（最初の = で分割）."""
+        result = parse_filters("expr=a=b")
+        assert result == {"expr": "a=b"}
+
+    def test_missing_equals_raises(self) -> None:
+        """= を含まないペアはエラー."""
+        with pytest.raises(ValueError, match="不正なフィルタ形式"):
+            parse_filters("invalid-filter")
+
+    def test_empty_key_raises(self) -> None:
+        """キーが空の場合はエラー."""
+        with pytest.raises(ValueError, match="フィルタのキーが空です"):
+            parse_filters("=value")
+
+    def test_empty_value_allowed(self) -> None:
+        """値が空は許容."""
+        result = parse_filters("key=")
+        assert result == {"key": ""}
+
+    def test_trailing_comma_ignored(self) -> None:
+        """末尾カンマは無視."""
+        result = parse_filters("repository=rag-knowledge,")
+        assert result == {"repository": "rag-knowledge"}
 
 
 class TestBM25MetadataMap:
@@ -213,6 +263,34 @@ class TestBM25MatchesFilters:
             {"custom:repository": "rag-knowledge", "custom:author": "bob"},
         ) is False
 
+    def test_case_insensitive_match(self) -> None:
+        """大文字小文字を区別しない比較."""
+        assert BM25Index._matches_filters(
+            {"custom:repository": "Rag-Knowledge"},
+            {"custom:repository": "rag-knowledge"},
+        ) is True
+
+    def test_int_metadata_matches_string_filter(self) -> None:
+        """int メタデータが文字列フィルタにマッチする."""
+        assert BM25Index._matches_filters(
+            {"custom:duration": 42},
+            {"custom:duration": "42"},
+        ) is True
+
+    def test_bool_metadata_matches_string_filter(self) -> None:
+        """bool メタデータが文字列フィルタにマッチする（大文字小文字不問）."""
+        assert BM25Index._matches_filters(
+            {"custom:closed": True},
+            {"custom:closed": "true"},
+        ) is True
+
+    def test_bool_false_matches(self) -> None:
+        """bool False が 'false' にマッチする."""
+        assert BM25Index._matches_filters(
+            {"custom:closed": False},
+            {"custom:closed": "false"},
+        ) is True
+
 
 class TestBM25MetadataPersistence:
     """BM25Index のメタデータ永続化テスト."""
@@ -263,7 +341,7 @@ class TestBuildWhereClause:
     def _build(
         self,
         source_type: str | None = None,
-        filters: dict[str, str | int | float | bool] | None = None,
+        filters: dict[str, str] | None = None,
     ) -> dict | None:
         from rag.rag_knowledge import RAGKnowledgeService
         return RAGKnowledgeService._build_where_clause(source_type, filters)
@@ -311,8 +389,8 @@ class TestBuildBM25Filters:
     """RAGKnowledgeService._build_bm25_filters のテスト."""
 
     def _build(
-        self, filters: dict[str, str | int | float | bool],
-    ) -> dict[str, str | int | float | bool]:
+        self, filters: dict[str, str],
+    ) -> dict[str, str]:
         from rag.rag_knowledge import RAGKnowledgeService
         return RAGKnowledgeService._build_bm25_filters(filters)
 
@@ -328,9 +406,3 @@ class TestBuildBM25Filters:
             "custom:repository": "rag-knowledge",
             "custom:author": "alice",
         }
-
-    def test_preserves_value_types(self) -> None:
-        """値の型が保持される."""
-        result = self._build({"count": 42, "enabled": True})
-        assert result["custom:count"] == 42
-        assert result["custom:enabled"] is True


### PR DESCRIPTION
## Change type

- [x] fix（バグ修正）

## Summary

- `rag_search` の `filters` パラメータを JSON 形式から `key=value` 形式に変更（MCP クライアントとの型不一致を解消）
- フィルタパーサーを共通モジュール `filter_parser.py` に集約（server.py / cli.py の重複解消）
- filters パイプライン全体の型を `dict[str, str]` に統一（parse 結果が常に文字列であることを型で表現）
- BM25 `_matches_filters` に `str().upper()` 比較を導入（大文字小文字不問、int/bool メタデータにもマッチ）
- `vector_store.py` の mypy エラー修正（`update_metadata` の ChromaDB 型不一致、#357 統合）
- 仕様書更新（search-response.md: フィルタ形式・比較動作の記載）

## Test plan

- [x] pytest 1211 passed
- [x] mypy 0 errors (60 source files)
- [x] ruff all checks passed
- [x] `_parse_filters` テスト 11 件（正常系・異常系・エッジケース）
- [x] `_matches_filters` テスト追加 4 件（case-insensitive, int match, bool True/False match）

## Related issues

Closes #360
Closes #357