### PR TITLE
docs(rag-knowledge): fix markdownlint violations (#365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,14 @@ uv run python -m rag.cli --help
 YouTube インジェスターは非公式 API（youtube-transcript-api）を使用して字幕を取得する。短時間に多数のリクエストを送ると YouTube に IP をブロックされる場合がある。
 
 **実測データ（ローカル PC 環境）:**
+
 - 約 20 動画を 30 分間で取り込んだ時点で字幕取得 API（youtube-transcript-api）の IP ブロックが発生
 - ブロックは字幕取得 API（youtube-transcript-api）のみに影響し、メタデータ取得・音声ダウンロード（yt-dlp）は継続動作
 - IP ブロック時は Whisper フォールバックせずエラーとしてスキップされる（品質低下防止のため）
 - ブロックは一時的（通常は数十分〜数時間で解除）
 
 **推奨運用:**
+
 - プレイリスト一括取り込み時は `--max-videos` で段階的に取り込む（1 回あたり 10〜20 動画推奨）
 - `rag_youtube_request_interval`（デフォルト: 5.0 秒）を短くしすぎない
 - IP ブロックが発生した場合は時間を置いて再実行する

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -141,7 +141,12 @@ MCP サーバーが公開する 16 個のツール。
 
 ### 取り込みツールの出力形式
 
-取り込みツール（rag_add、rag_crawl、rag_crawl_zenn、rag_crawl_bluesky、rag_add_youtube、rag_crawl_youtube、rag_add_document、rag_crawl_documents、rag_add_journal、rag_site_ingest）は、source_store への配置結果とパイプライン処理結果を統合したサマリーを返す。配置結果には配置ファイル数・スキップ数・エラー数を含み、パイプライン処理結果にはコンバート・インデックス構築の処理件数を含む。rag_crawl_preview は source_store への配置を行わないため本出力形式の対象外。
+取り込みツール（rag_add、rag_crawl、rag_crawl_zenn、rag_crawl_bluesky、rag_add_youtube、rag_crawl_youtube、
+rag_add_document、rag_crawl_documents、rag_add_journal、rag_site_ingest）は、
+source_store への配置結果とパイプライン処理結果を統合したサマリーを返す。
+配置結果には配置ファイル数・スキップ数・エラー数を含み、
+パイプライン処理結果にはコンバート・インデックス構築の処理件数を含む。
+rag_crawl_preview は source_store への配置を行わないため本出力形式の対象外。
 
 ### 検索結果の設計
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新 ★

## Summary

- `docs/specs/rag-knowledge.md` L145: MD013 (line-length) 324文字の長行を複数行に分割
- `README.md` L95, L101: MD032 (blanks-around-lists) リスト前の空行を追加

## Test plan

- [x] markdownlint-cli2 で対象2ファイルの違反が 0 件であることを確認済み

## Related issues

Closes #365

Generated with [Claude Code](https://claude.ai/code)