### PR TITLE
chore: uv sync で mineru を自動インストール (#371)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ asyncio_mode = "auto"
 addopts = "-n auto"
 required_plugins = ["pytest-xdist"]
 
+[tool.uv]
+# uv sync 時に mineru (CPU版) を自動インストール。
+# CUDA 版を使う場合は uv sync --extra mineru-cuda に切り替える。
+default-groups = ["dev", "with-mineru"]
+
 # PyTorch CUDA index（mineru-cuda extra 専用。CUDA 12.4 環境向け）
 [[tool.uv.index]]
 name = "pytorch-cu124"
@@ -91,3 +96,4 @@ dev = [
     "ruff>=0.14.14",
     "types-PyYAML>=6.0",
 ]
+with-mineru = ["rag-knowledge[mineru]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ required_plugins = ["pytest-xdist"]
 
 [tool.uv]
 # uv sync 時に mineru (CPU版) を自動インストール。
-# CUDA 版を使う場合は uv sync --extra mineru-cuda に切り替える。
+# CUDA 版を使う場合: uv sync --no-group with-mineru --extra mineru-cuda
 default-groups = ["dev", "with-mineru"]
 
 # PyTorch CUDA index（mineru-cuda extra 専用。CUDA 12.4 環境向け）


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装

## Summary

- `pyproject.toml` に `[tool.uv]` `default-groups` を追加し、`uv sync` 時に mineru (CPU版) が自動インストールされるようにした
- `dependency-groups` に `with-mineru` グループを追加し、プロジェクトの `mineru` extra を参照
- これにより `--extra mineru` の指定忘れによる optional 依存の消失を防止

## Test plan

- [x] `uv sync --dry-run` で mineru パッケージが含まれることを確認

## Related issues

Closes #371