### PR TITLE
fix: uv sync のデフォルトを CUDA 版に変更しドキュメント整備 (#373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
-| PDF テキスト抽出 | pymupdf4llm / MinerU |
+| PDF テキスト抽出 | pymupdf4llm / MinerU（CUDA 環境、未インストール時は pymupdf4llm にフォールバック） |
 | YouTube 字幕取得 | youtube-transcript-api |
 | YouTube メタデータ・音声DL | yt-dlp |
 | 音声文字起こし | faster-whisper |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
-| PDF テキスト抽出 | pymupdf4llm / MinerU (optional, PyTorch CUDA 推奨) |
+| PDF テキスト抽出 | pymupdf4llm / MinerU |
 | YouTube 字幕取得 | youtube-transcript-api |
 | YouTube メタデータ・音声DL | yt-dlp |
 | 音声文字起こし | faster-whisper |
@@ -53,10 +53,25 @@
 
 ## セットアップ
 
+### CUDA 環境（開発用、デフォルト）
+
+NVIDIA GPU + CUDA 12.4 環境向け。MinerU + PyTorch (CUDA 12.4) を含む全依存が自動インストールされる。
+
 ```bash
 uv sync
 cp .env.example .env  # 環境依存値を編集
 ```
+
+### CPU 環境（GPU なし / AMD GPU）
+
+MinerU + PyTorch を除外してセットアップする。PDF 抽出は pymupdf4llm にフォールバックする。
+
+```bash
+uv sync --no-group with-mineru
+cp .env.example .env  # 環境依存値を編集
+```
+
+### API キー
 
 API キーは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `rag-knowledge`）。
 登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -46,7 +46,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
-| PDF テキスト抽出 | pymupdf4llm / MinerU |
+| PDF テキスト抽出 | pymupdf4llm / MinerU（CUDA 環境、未インストール時は pymupdf4llm にフォールバック） |
 | 設定管理 | pydantic-settings (.env + config.toml) |
 
 ## 4. 開発方針

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -46,7 +46,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
-| PDF テキスト抽出 | pymupdf4llm / MinerU (optional, PyTorch CUDA 推奨) |
+| PDF テキスト抽出 | pymupdf4llm / MinerU |
 | 設定管理 | pydantic-settings (.env + config.toml) |
 
 ## 4. 開発方針

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# CPU 版（PyPI デフォルト）
 mineru = ["mineru[pipeline]", "torch>=2.6", "torchvision>=0.21"]
-# CUDA 版（GPU 推論用。CUDA 12.4 環境向け）
-mineru-cuda = ["mineru[pipeline]", "torch>=2.6", "torchvision>=0.21"]
 
 [build-system]
 requires = ["hatchling"]
@@ -70,11 +67,11 @@ addopts = "-n auto"
 required_plugins = ["pytest-xdist"]
 
 [tool.uv]
-# uv sync 時に mineru (CPU版) を自動インストール。
-# CUDA 版を使う場合: uv sync --no-group with-mineru --extra mineru-cuda
+# uv sync で MinerU + PyTorch (CUDA 12.4) を自動インストール。
+# CPU 環境では uv sync --no-group with-mineru で MinerU + PyTorch を除外する。
 default-groups = ["dev", "with-mineru"]
 
-# PyTorch CUDA index（mineru-cuda extra 専用。CUDA 12.4 環境向け）
+# PyTorch CUDA 12.4 index
 [[tool.uv.index]]
 name = "pytorch-cu124"
 url = "https://download.pytorch.org/whl/cu124"
@@ -82,9 +79,8 @@ explicit = true
 
 [tool.uv.sources]
 py-common-lib = { git = "https://github.com/becky3/py-common-lib" }
-# mineru-cuda extra のみ CUDA index から取得。mineru extra は PyPI デフォルト（CPU 版）
-torch = { index = "pytorch-cu124", extra = "mineru-cuda" }
-torchvision = { index = "pytorch-cu124", extra = "mineru-cuda" }
+torch = { index = "pytorch-cu124" }
+torchvision = { index = "pytorch-cu124" }
 
 [dependency-groups]
 dev = [
@@ -96,4 +92,7 @@ dev = [
     "ruff>=0.14.14",
     "types-PyYAML>=6.0",
 ]
-with-mineru = ["rag-knowledge[mineru]"]
+# MinerU + PyTorch (CUDA) の依存を直接列挙
+# uv default-extras 未実装のため dependency-group で代替。
+# [project.optional-dependencies].mineru と同期を保つこと。
+with-mineru = ["mineru[pipeline]", "torch>=2.6", "torchvision>=0.21"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,5 @@ dev = [
     "ruff>=0.14.14",
     "types-PyYAML>=6.0",
 ]
-# MinerU + PyTorch (CUDA) の依存を直接列挙
-# uv default-extras 未実装のため dependency-group で代替。
-# [project.optional-dependencies].mineru と同期を保つこと。
-with-mineru = ["mineru[pipeline]", "torch>=2.6", "torchvision>=0.21"]
+# uv default-extras 未実装のため dependency-group で代替
+with-mineru = ["rag-knowledge[mineru]"]

--- a/uv.lock
+++ b/uv.lock
@@ -3937,9 +3937,7 @@ dev = [
     { name = "types-pyyaml" },
 ]
 with-mineru = [
-    { name = "mineru", extra = ["pipeline"] },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "rag-knowledge", extra = ["mineru"] },
 ]
 
 [package.metadata]
@@ -3980,11 +3978,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
-with-mineru = [
-    { name = "mineru", extras = ["pipeline"] },
-    { name = "torch", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu124" },
-    { name = "torchvision", specifier = ">=0.21", index = "https://download.pytorch.org/whl/cu124" },
-]
+with-mineru = [{ name = "rag-knowledge", extras = ["mineru"] }]
 
 [[package]]
 name = "referencing"

--- a/uv.lock
+++ b/uv.lock
@@ -3925,11 +3925,6 @@ mineru = [
     { name = "torch" },
     { name = "torchvision" },
 ]
-mineru-cuda = [
-    { name = "mineru", extra = ["pipeline"] },
-    { name = "torch" },
-    { name = "torchvision" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -3940,6 +3935,11 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
+]
+with-mineru = [
+    { name = "mineru", extra = ["pipeline"] },
+    { name = "torch" },
+    { name = "torchvision" },
 ]
 
 [package.metadata]
@@ -3954,7 +3954,6 @@ requires-dist = [
     { name = "markdownify", specifier = ">=0.14,<1" },
     { name = "mcp", specifier = ">=1.0,<2" },
     { name = "mineru", extras = ["pipeline"], marker = "extra == 'mineru'" },
-    { name = "mineru", extras = ["pipeline"], marker = "extra == 'mineru-cuda'" },
     { name = "openai", specifier = ">=1.12,<2" },
     { name = "py-common-lib", git = "https://github.com/becky3/py-common-lib" },
     { name = "pydantic", specifier = ">=2.6,<3" },
@@ -3962,16 +3961,14 @@ requires-dist = [
     { name = "pymupdf4llm", specifier = ">=0.0.17" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "scrapy", specifier = ">=2.11,<3" },
-    { name = "torch", marker = "extra == 'mineru'", specifier = ">=2.6" },
-    { name = "torch", marker = "extra == 'mineru-cuda'", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu124", conflict = { package = "rag-knowledge", extra = "mineru-cuda" } },
-    { name = "torchvision", marker = "extra == 'mineru'", specifier = ">=0.21" },
-    { name = "torchvision", marker = "extra == 'mineru-cuda'", specifier = ">=0.21", index = "https://download.pytorch.org/whl/cu124", conflict = { package = "rag-knowledge", extra = "mineru-cuda" } },
+    { name = "torch", marker = "extra == 'mineru'", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu124" },
+    { name = "torchvision", marker = "extra == 'mineru'", specifier = ">=0.21", index = "https://download.pytorch.org/whl/cu124" },
     { name = "tzdata", specifier = ">=2024.1" },
     { name = "unidic-lite", specifier = ">=1.0,<2" },
     { name = "youtube-transcript-api", specifier = ">=1.0,<2" },
     { name = "yt-dlp", specifier = ">=2024.0" },
 ]
-provides-extras = ["mineru", "mineru-cuda"]
+provides-extras = ["mineru"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3982,6 +3979,11 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "types-pyyaml", specifier = ">=6.0" },
+]
+with-mineru = [
+    { name = "mineru", extras = ["pipeline"] },
+    { name = "torch", specifier = ">=2.6", index = "https://download.pytorch.org/whl/cu124" },
+    { name = "torchvision", specifier = ">=0.21", index = "https://download.pytorch.org/whl/cu124" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正

## Summary

- torch source override を無条件化し、`uv sync` で CUDA 12.4 版 PyTorch がデフォルトでインストールされるように変更
- `mineru-cuda` extra を廃止し `mineru` extra に統合（開発環境は CUDA がデフォルト）
- dependency-group `with-mineru` に依存を直接列挙（uv `default-extras` 未実装のため）
- README.md にセットアップ手順を CUDA / CPU 環境別に記載
- `docs/specs/overview.md` の技術スタック記述を更新

## Test plan

- [x] `uv sync --dry-run` で CUDA 版 torch (`+cu124`) がインストールされることを確認
- [x] `uv sync --no-group with-mineru --dry-run` で MinerU + torch が除外されることを確認

## Related issues

Closes #373