### PR TITLE
refactor(heading-chunker,indexer): チャンク見出しフォーマットの改善実装 (#376)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,59 @@ MCP サーバー enabled 中は、**同じ DB に対する CLI 操作・テス�
 
 MCP を disable → CLI `rebuild --mode full` で復旧する。
 
+### worktree 環境セットアップ
+
+worktree で CLI 操作・動作確認を行う場合、以下のセットアップを実施すること。
+
+1. メインリポジトリから `.env` をコピーする:
+
+   ```bash
+   cp .env <worktree-path>/.env
+   ```
+
+2. worktree の `.env` でストレージパスを worktree 内の絶対パスに変更する（相対パスだとメインリポジトリのストレージを参照してしまう）:
+
+   ```
+   CHROMADB_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_chroma_db
+   BM25_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_bm25_index
+   SOURCE_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_source_store
+   CONVERTED_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_converted_store
+   ```
+
+3. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する:
+
+   ```
+   LMSTUDIO_BASE_URL=http://localhost:1234/v1
+   ```
+
+4. `.tmp` ディレクトリを作成する:
+
+   ```bash
+   mkdir -p <worktree-path>/.tmp
+   ```
+
+### CLI 動作確認の確認観点
+
+データ取り込み後、以下の確認を行うこと。
+
+#### 登録データの直接確認
+
+ChromaDB に格納されたデータを直接確認する。
+
+- チャンク数が妥当か
+- メタデータ（`section_path`, `source_type`, `title` 等）が正しく設定されているか
+- ドキュメント（Embedding 入力）の内容が期待通りか
+
+#### 検索結果の確認
+
+```bash
+uv run python -m rag.cli search --query "<クエリ>"
+```
+
+- ベクトル検索・BM25 の両方で結果が返ること
+- メタデータ行（Source, Title, Chunk, Type, Section, Collected）が正しく表示されること
+- 検索結果の内容がクエリに関連していること
+
 ### worktree コードでの MCP 動作確認
 
 worktree で開発中のコードを MCP サーバーとして動作確認する手順:

--- a/config.toml
+++ b/config.toml
@@ -13,8 +13,6 @@ rag_chunk_overlap = 30
 rag_embedding_context_length = 512
 # 最悪ケーストークン/文字比率。導出手順: docs/specs/indexer.md「トークン/文字比率の導出手順」
 rag_worst_token_char_ratio = 0.7
-# 見出しチャンカーの breadcrumb + heading オーバーヘッド目安（文字数）
-rag_heading_overhead = 100
 
 # 検索
 rag_retrieval_count = 3

--- a/docs/specs/indexer.md
+++ b/docs/specs/indexer.md
@@ -216,7 +216,7 @@ flowchart TD
     DETECT -->|見出し付き/混在| HEADING
     DETECT -->|散文| PROSE
 
-    TABLE --> METADATA["チャンクメタデータ付与<br>(section_path 生成)"]
+    TABLE --> METADATA["チャンクメタデータ付与<br>(section_path 付与)"]
     HEADING --> METADATA
     PROSE --> METADATA
 
@@ -260,7 +260,7 @@ flowchart LR
 | `chunk_index` | int | チャンクの連番（0 始まり） |
 | `total_chunks` | int | 当該ソースのチャンク総数（新規フィールド。既存の rag-knowledge.md には未定義） |
 | `collected_at` | str | 取り込みタイムスタンプ（ISO 8601）。metadata.db の `created_at` から取得（.meta の `collected_at` 由来） |
-| `section_path` | str | 見出し階層（`>` 区切り、現セクションを含む）。見出しチャンカー・テーブルチャンカーが生成する。テキストチャンカーでは空文字列。例: `第1章 データ処理 > 1.1 前処理 > 1.1.1 正規化` |
+| `section_path` | str | 見出し階層（`>` 区切り、現セクションを含む）。見出しチャンカーが生成する。テーブルチャンカー・テキストチャンカーでは空文字列。例: `第1章 データ処理 > 1.1 前処理 > 1.1.1 正規化` |
 
 #### カスタムフィールド
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -271,7 +271,7 @@ flowchart LR
 | `chunk_index` | int | チャンクの連番（0 始まり） |
 | `collected_at` | str | 取り込みタイムスタンプ（ISO 8601） |
 | `source_type` | str | データソース種別（`"web"`, `"zenn"`, `"bluesky"`, `"youtube"`, `"local"`, `"journal"`, `"aozora"`） |
-| `section_path` | str | 見出し階層（`>` 区切り、現セクションを含む）。見出しチャンカー・テーブルチャンカーが生成する。テキストチャンカーでは空文字列 |
+| `section_path` | str | 見出し階層（`>` 区切り、現セクションを含む）。見出しチャンカーが生成する。テーブルチャンカー・テキストチャンカーでは空文字列 |
 
 #### カスタムフィールド
 

--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -97,6 +97,7 @@ MCP クライアントからの rag_search ツール呼び出し。
 | Title | コンテンツのタイトル | 常時 | `Title: ガイドページ` |
 | Chunk | チャンク位置（現在位置/全体数、1 始まり表示） | 常時 | `Chunk: 3/15` |
 | Type | ソース種別 | 常時 | `Type: web` |
+| Section | 見出し階層（`section_path`） | 値がある場合のみ | `Section: 第1章 > 1.1 前処理` |
 | Collected | 取り込み日時 | 値がある場合のみ | `Collected: 2025-01-15T10:30:00Z` |
 
 メタデータの後に空行を挟み、チャンクテキストを出力する。
@@ -114,6 +115,7 @@ Source: https://example.com/docs/guide
 Title: ガイドページ
 Chunk: 3/15
 Type: web
+Section: 第1章 導入 > 1.1 セットアップ
 Collected: 2025-01-15T10:30:00Z
 
 チャンクテキストがここに入る...

--- a/scripts/collect_evaluation_data.py
+++ b/scripts/collect_evaluation_data.py
@@ -136,7 +136,10 @@ async def collect_documents(
 
     documents: list[dict[str, str]] = []
 
-    async with httpx.AsyncClient() as client:
+    headers = {
+        "User-Agent": "Mozilla/5.0 (compatible; EvalDataCollector/1.0)",
+    }
+    async with httpx.AsyncClient(headers=headers) as client:
         for i, (cluster, title, lang) in enumerate(requests, 1):
             logger.info("[%d/%d] Fetching: %s (%s) [%s]", i, total, title, lang, cluster)
 

--- a/scripts/reproduce_token_overflow.py
+++ b/scripts/reproduce_token_overflow.py
@@ -51,12 +51,12 @@ def count_tokens(tok: Tokenizer, text: str) -> int:
 
 
 def chunk_like_indexer(text: str) -> tuple[str, list[str]]:
-    """indexer._chunk_text と同等のロジック. (content_type_name, chunks) を返す."""
+    """indexer._chunk_text の content 部分のみを取得する. (content_type_name, chunks) を返す."""
     content_type = detect_content_type(text)
 
     if content_type == ContentType.TABLE:
         table_chunks = chunk_table_data(text)
-        chunks = [c.formatted_text for c in table_chunks] if table_chunks else []
+        chunks = [c.content for c in table_chunks] if table_chunks else []
         return content_type.name, chunks
 
     if content_type in (ContentType.HEADING, ContentType.MIXED):
@@ -65,7 +65,7 @@ def chunk_like_indexer(text: str) -> tuple[str, list[str]]:
             max_chunk_size=CHUNK_SIZE,
             min_chunk_size=max(1, CHUNK_SIZE // 4),
         )
-        chunks = [c.formatted_text for c in heading_chunks] if heading_chunks else []
+        chunks = [c.content for c in heading_chunks] if heading_chunks else []
         return content_type.name, chunks
 
     chunks = chunk_text(text, chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP)

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1341,43 +1341,9 @@ def run_search(args: argparse.Namespace) -> None:
         )
     )
 
-    if not raw.vector_results and not raw.bm25_results:
-        print("該当する情報が見つかりませんでした")
-        return
+    from .rag_knowledge import format_raw_search_results
 
-    parts: list[str] = []
-
-    if raw.vector_results:
-        parts.append("## ベクトル検索結果 (意味的類似度)\n")
-        for i, item in enumerate(raw.vector_results, start=1):
-            chunk_pos = _format_cli_chunk_position(item.chunk_index, item.total_chunks)
-            parts.append(f"### Result {i} [distance={item.distance:.3f}]")
-            parts.append(f"Source: {item.source_url}")
-            parts.append(f"Title: {item.title}")
-            parts.append(f"Chunk: {chunk_pos}")
-            parts.append(f"Type: {item.source_type}")
-            if item.collected_at:
-                parts.append(f"Collected: {item.collected_at}")
-            parts.append("")
-            parts.append(item.text)
-            parts.append("")
-
-    if raw.bm25_results:
-        parts.append("## BM25 検索結果 (キーワード一致)\n")
-        for i, bm25_item in enumerate(raw.bm25_results, start=1):
-            chunk_pos = _format_cli_chunk_position(bm25_item.chunk_index, bm25_item.total_chunks)
-            parts.append(f"### Result {i} [score={bm25_item.score:.3f}]")
-            parts.append(f"Source: {bm25_item.source_url}")
-            parts.append(f"Title: {bm25_item.title}")
-            parts.append(f"Chunk: {chunk_pos}")
-            parts.append(f"Type: {bm25_item.source_type}")
-            if bm25_item.collected_at:
-                parts.append(f"Collected: {bm25_item.collected_at}")
-            parts.append("")
-            parts.append(bm25_item.text)
-            parts.append("")
-
-    print("\n".join(parts).rstrip())
+    print(format_raw_search_results(raw))
 
 
 def run_delete(args: argparse.Namespace) -> None:
@@ -1501,13 +1467,6 @@ def _format_cli_size(size_bytes: int) -> str:
     if size_bytes < 1024 * 1024 * 1024:
         return f"{size_bytes / (1024 * 1024):.1f} MB"
     return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
-
-
-def _format_cli_chunk_position(chunk_index: int, total_chunks: int) -> str:
-    """チャンク位置を表示用にフォーマットする."""
-    if total_chunks > 0:
-        return f"{chunk_index + 1}/{total_chunks}"
-    return str(chunk_index + 1)
 
 
 # --- インジェスト系 CLI コマンド ---

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -553,8 +553,12 @@ def _build_bm25_index_from_fixture(
         chunks = smart_chunk(content, chunk_size, chunk_overlap)
         normalized_url, _ = urldefrag(source_url)
         url_hash = hashlib.sha256(normalized_url.encode()).hexdigest()[:16]
-        for i, chunk in enumerate(chunks):
-            documents.append((f"{url_hash}_{i}", chunk, normalized_url, "web"))
+        for i, (chunk_text, section_path) in enumerate(chunks):
+            # BM25 には section_path + 本文を結合したテキストを登録
+            bm25_text = (
+                f"{section_path}\n{chunk_text}" if section_path else chunk_text
+            )
+            documents.append((f"{url_hash}_{i}", bm25_text, normalized_url, "web"))
 
     added = bm25_index.add_documents(documents)
     logger.info("BM25 index built with %d chunks from fixture", added)
@@ -1577,7 +1581,6 @@ def _build_cli_pipeline_controller() -> tuple[
         embedding_prefix_enabled=settings.embedding_prefix_enabled,
         embedding_context_length=settings.rag_embedding_context_length,
         worst_token_char_ratio=settings.rag_worst_token_char_ratio,
-        heading_overhead=settings.rag_heading_overhead,
     )
 
     controller = PipelineController(

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -125,8 +125,6 @@ class RAGSettings(BaseModel):
     rag_chunk_overlap: int = Field(ge=0)
     rag_embedding_context_length: int = Field(default=512, ge=1)
     rag_worst_token_char_ratio: float = Field(default=0.7, gt=0.0, le=1.0)
-    rag_heading_overhead: int = Field(default=100, ge=0)
-
     # 検索
     rag_retrieval_count: int = Field(ge=1)
     rag_similarity_threshold: float | None = Field(

--- a/src/rag/heading_chunker.py
+++ b/src/rag/heading_chunker.py
@@ -15,37 +15,21 @@ class HeadingChunk:
 
     見出しとその配下のテキストをセットでチャンク化。
     親見出しの階層情報も保持する。
+    見出し階層は section_path プロパティで取得する。
     """
 
     heading: str  # 見出しテキスト
     content: str  # 本文
     heading_level: int  # 見出しレベル（1〜6）
     parent_headings: list[str] = field(default_factory=list)  # 親見出しの階層
-    formatted_text: str = ""  # 検索用にフォーマットされたテキスト
 
-    def __post_init__(self) -> None:
-        """フォーマット済みテキストを生成する."""
-        if not self.formatted_text:
-            self.formatted_text = self._format()
-
-    def _format(self) -> str:
-        """検索用のフォーマット済みテキストを生成する."""
-        parts: list[str] = []
-
-        # 親見出しをパンくずリスト形式で追加
-        if self.parent_headings:
-            breadcrumb = " > ".join(self.parent_headings)
-            parts.append(f"[{breadcrumb}]")
-
-        # 現在の見出し
+    @property
+    def section_path(self) -> str:
+        """見出し階層を > 区切りで返す."""
+        parts = list(self.parent_headings)
         if self.heading:
-            parts.append(f"# {self.heading}")
-
-        # 本文
-        if self.content:
-            parts.append(self.content)
-
-        return "\n".join(parts)
+            parts.append(self.heading)
+        return " > ".join(parts)
 
 
 def chunk_by_headings(
@@ -90,7 +74,6 @@ def chunk_by_headings(
                     content=text,
                     heading_level=0,
                     parent_headings=[],
-                    formatted_text=text,
                 )
             ]
         # 大きすぎる場合は段落で分割
@@ -153,51 +136,7 @@ def chunk_by_headings(
                     )
                 )
 
-    return _enforce_formatted_text_limit(chunks, max_chunk_size)
-
-
-def _enforce_formatted_text_limit(
-    chunks: list[HeadingChunk],
-    max_chunk_size: int,
-) -> list[HeadingChunk]:
-    """formatted_text が max_chunk_size を超えるチャンクの content を縮小する.
-
-    breadcrumb + heading のオーバーヘッドにより formatted_text が
-    max_chunk_size を超える場合、content を切り詰めて制限内に収める。
-    """
-    result: list[HeadingChunk] = []
-    for chunk in chunks:
-        if len(chunk.formatted_text) <= max_chunk_size:
-            result.append(chunk)
-            continue
-
-        # formatted_text のオーバーヘッド（breadcrumb + heading + 改行）を算出
-        overhead = len(chunk.formatted_text) - len(chunk.content)
-        available = max_chunk_size - overhead
-        if available <= 0:
-            # オーバーヘッドだけで超過する場合は heading/breadcrumb を省略
-            result.append(
-                HeadingChunk(
-                    heading="",
-                    content=chunk.content[:max_chunk_size],
-                    heading_level=chunk.heading_level,
-                    parent_headings=[],
-                    formatted_text=chunk.content[:max_chunk_size],
-                )
-            )
-            continue
-
-        # content を縮小して再生成
-        trimmed_content = chunk.content[:available]
-        result.append(
-            HeadingChunk(
-                heading=chunk.heading,
-                content=trimmed_content,
-                heading_level=chunk.heading_level,
-                parent_headings=chunk.parent_headings.copy(),
-            )
-        )
-    return result
+    return chunks
 
 
 def _convert_html_headings_to_markdown(text: str) -> str:
@@ -261,6 +200,24 @@ def _split_content_preserving_heading(
     """見出し情報を保持しながらコンテンツを分割する."""
     chunks: list[HeadingChunk] = []
 
+    # 2つ目以降のチャンク用: heading を parent_headings に含めて section_path を維持
+    parents_with_heading = (
+        parent_headings + [heading] if heading else parent_headings
+    )
+
+    def _append(text: str) -> None:
+        """チャンクを追加する。最初のチャンクには heading を設定する."""
+        if not chunks:
+            chunks.append(HeadingChunk(
+                heading=heading, content=text,
+                heading_level=level, parent_headings=parent_headings.copy(),
+            ))
+        else:
+            chunks.append(HeadingChunk(
+                heading="", content=text,
+                heading_level=level, parent_headings=parents_with_heading.copy(),
+            ))
+
     # 段落で分割
     paragraphs = re.split(r"\n\s*\n", content)
     current_content_parts: list[str] = []
@@ -275,60 +232,25 @@ def _split_content_preserving_heading(
 
         # 単一段落が max_chunk_size を超える場合はフォールバック分割
         if para_size > max_chunk_size:
-            # 現在の蓄積分を確定
             if current_content_parts:
-                chunk_content = "\n\n".join(current_content_parts)
-                chunks.append(
-                    HeadingChunk(
-                        heading=heading if not chunks else f"{heading} (続き)",
-                        content=chunk_content,
-                        heading_level=level,
-                        parent_headings=parent_headings.copy(),
-                    )
-                )
+                _append("\n\n".join(current_content_parts))
                 current_content_parts = []
                 current_size = 0
 
-            # 行ベース → 文字ベースのフォールバックで分割
             for sub in _split_large_block(para, max_chunk_size):
-                chunks.append(
-                    HeadingChunk(
-                        heading=heading if not chunks else f"{heading} (続き)",
-                        content=sub,
-                        heading_level=level,
-                        parent_headings=parent_headings.copy(),
-                    )
-                )
+                _append(sub)
             continue
 
         if current_size + para_size + 2 > max_chunk_size and current_content_parts:
-            # 現在のチャンクを確定
-            chunk_content = "\n\n".join(current_content_parts)
-            chunks.append(
-                HeadingChunk(
-                    heading=heading if not chunks else f"{heading} (続き)",
-                    content=chunk_content,
-                    heading_level=level,
-                    parent_headings=parent_headings.copy(),
-                )
-            )
+            _append("\n\n".join(current_content_parts))
             current_content_parts = [para]
             current_size = para_size
         else:
             current_content_parts.append(para)
             current_size += para_size + 2
 
-    # 残りのチャンク
     if current_content_parts:
-        chunk_content = "\n\n".join(current_content_parts)
-        chunks.append(
-            HeadingChunk(
-                heading=heading if not chunks else f"{heading} (続き)",
-                content=chunk_content,
-                heading_level=level,
-                parent_headings=parent_headings.copy(),
-            )
-        )
+        _append("\n\n".join(current_content_parts))
 
     return chunks
 
@@ -361,7 +283,6 @@ def _split_prose_into_chunks(
                         content=chunk_content,
                         heading_level=0,
                         parent_headings=[],
-                        formatted_text=chunk_content,
                     )
                 )
                 current_parts = []
@@ -374,7 +295,6 @@ def _split_prose_into_chunks(
                         content=sub,
                         heading_level=0,
                         parent_headings=[],
-                        formatted_text=sub,
                     )
                 )
             continue
@@ -387,7 +307,6 @@ def _split_prose_into_chunks(
                     content=chunk_content,
                     heading_level=0,
                     parent_headings=[],
-                    formatted_text=chunk_content,
                 )
             )
             current_parts = [para]
@@ -404,7 +323,6 @@ def _split_prose_into_chunks(
                 content=chunk_content,
                 heading_level=0,
                 parent_headings=[],
-                formatted_text=chunk_content,
             )
         )
 

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -193,10 +193,21 @@ class Indexer:
             return
 
         total_chunks = len(chunk_ids)
+
+        # 既存チャンクの section_path を保持する（メタデータのみ更新時に消さない）
+        existing_meta_map = _run_async(
+            self._vector_store.get_metadata_by_ids(chunk_ids),
+        )
+
         metadatas = []
         for chunk_id in chunk_ids:
             chunk_index = parse_chunk_index(chunk_id)
-            meta = build_chunk_metadata(metadata, chunk_index, total_chunks)
+            existing_sp = str(
+                existing_meta_map.get(chunk_id, {}).get("section_path", ""),
+            )
+            meta = build_chunk_metadata(
+                metadata, chunk_index, total_chunks, section_path=existing_sp,
+            )
             metadatas.append(meta)
 
         _run_async(self._vector_store.update_metadata(chunk_ids, metadatas))

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -47,7 +47,6 @@ class Indexer:
         embedding_prefix_enabled: bool = True,
         embedding_context_length: int = 512,
         worst_token_char_ratio: float = 0.7,
-        heading_overhead: int = 100,
     ) -> None:
         """Indexer を初期化する.
 
@@ -60,7 +59,6 @@ class Indexer:
             embedding_prefix_enabled: Embedding プレフィックスの付与有無
             embedding_context_length: Embedding モデルのコンテキスト長（トークン数）
             worst_token_char_ratio: 最悪ケーストークン/文字比率
-            heading_overhead: 見出しチャンカーの breadcrumb + heading オーバーヘッド目安
         """
         self._vector_store = vector_store
         self._bm25 = bm25_index
@@ -70,12 +68,11 @@ class Indexer:
         self._embedding_checked = False
 
         # 実効サイズの算出: min(chunk_size, 安全上限 - overhead)
-        # 仕様: docs/specs/indexer.md「チャンカー別オーバーヘッドと実効サイズ」
+        # 仕様: docs/specs/indexer.md「オーバーヘッドと実効サイズ」
         token_safe_limit = int(embedding_context_length / worst_token_char_ratio)
         prefix_overhead = self._EMBEDDING_PREFIX_LEN if embedding_prefix_enabled else 0
         safe_base = token_safe_limit - prefix_overhead
         self._effective_size_prose = max(1, min(chunk_size, safe_base))
-        self._effective_size_heading = max(1, min(chunk_size, safe_base - heading_overhead))
         # テーブルは行単位分割のため chunk_size を適用しない（仕様参照）
         self._effective_size_table = max(1, safe_base)
         # overlap が実効サイズ以上だと chunk_text が ValueError になるためクランプ
@@ -242,11 +239,14 @@ class Indexer:
         """ファイルの内容を読み取る."""
         return path.read_text(encoding="utf-8")
 
-    def _chunk_text(self, text: str) -> list[str]:
+    def _chunk_text(self, text: str) -> list[tuple[str, str]]:
         """コンテンツタイプに応じたチャンキング戦略でテキストを分割する.
 
         各チャンカーにはトークン安全上限から算出した実効サイズを渡す。
-        仕様: docs/specs/indexer.md「チャンカー別オーバーヘッドと実効サイズ」
+        仕様: docs/specs/indexer.md「オーバーヘッドと実効サイズ」
+
+        Returns:
+            (content, section_path) のタプルリスト
         """
         content_type = detect_content_type(text)
 
@@ -254,47 +254,64 @@ class Indexer:
             table_chunks = chunk_table_data(
                 text, max_chunk_size=self._effective_size_table,
             )
-            return [c.formatted_text for c in table_chunks] if table_chunks else []
+            return [
+                (c.content, c.section_path) for c in table_chunks
+            ] if table_chunks else []
 
         if content_type in (ContentType.HEADING, ContentType.MIXED):
             heading_chunks = chunk_by_headings(
                 text,
-                max_chunk_size=self._effective_size_heading,
-                min_chunk_size=max(1, self._effective_size_heading // 4),
+                max_chunk_size=self._effective_size_prose,
+                min_chunk_size=max(1, self._effective_size_prose // 4),
             )
-            return [c.formatted_text for c in heading_chunks] if heading_chunks else []
+            return [
+                (c.content, c.section_path) for c in heading_chunks
+            ] if heading_chunks else []
 
         # PROSE
-        return chunk_text(
+        prose_chunks = chunk_text(
             text,
             chunk_size=self._effective_size_prose,
             chunk_overlap=self._effective_overlap,
         )
+        return [(c, "") for c in prose_chunks]
 
     def _add_to_indices(
         self,
         source_id: str,
-        chunk_texts: list[str],
+        chunk_texts: list[tuple[str, str]],
         metadata: SourceMetadata,
     ) -> None:
-        """チャンクを ChromaDB と BM25 に追加する."""
+        """チャンクを ChromaDB と BM25 に追加する.
+
+        Args:
+            source_id: ソース識別子
+            chunk_texts: (content, section_path) のタプルリスト
+            metadata: ソースメタデータ
+        """
         total_chunks = len(chunk_texts)
 
         doc_chunks: list[DocumentChunk] = []
         bm25_docs: list[tuple[str, str, str, str]] = []
         bm25_metadata_list: list[dict[str, str | int | float | bool]] = []
 
-        for i, text in enumerate(chunk_texts):
+        for i, (content, section_path) in enumerate(chunk_texts):
             chunk_id = generate_chunk_id(source_id, i)
-            meta = build_chunk_metadata(metadata, i, total_chunks)
+            meta = build_chunk_metadata(metadata, i, total_chunks, section_path)
 
+            # ChromaDB: Embedding は本文のみ（section_path を含めない）
             doc_chunks.append(DocumentChunk(
                 id=chunk_id,
-                text=text,
+                text=content,
                 metadata=meta,
             ))
+
+            # BM25: section_path + 本文を結合（見出しキーワードでもヒットさせる）
+            bm25_text = (
+                f"{section_path}\n{content}" if section_path else content
+            )
             bm25_docs.append((
-                chunk_id, text, source_id, metadata.source_type,
+                chunk_id, bm25_text, source_id, metadata.source_type,
             ))
             bm25_metadata_list.append(meta)
 

--- a/src/rag/indexer/metadata.py
+++ b/src/rag/indexer/metadata.py
@@ -14,6 +14,7 @@ def build_chunk_metadata(
     source_metadata: SourceMetadata,
     chunk_index: int,
     total_chunks: int,
+    section_path: str = "",
 ) -> dict[str, str | int | float | bool]:
     """チャンクに付与するメタデータを構築する.
 
@@ -21,6 +22,7 @@ def build_chunk_metadata(
         source_metadata: ソースメタデータ
         chunk_index: チャンクの連番（0 始まり）
         total_chunks: 当該ソースのチャンク総数
+        section_path: 見出し階層（> 区切り）。見出しチャンカーが生成する
 
     Returns:
         ChromaDB 格納用のメタデータ辞書
@@ -32,6 +34,7 @@ def build_chunk_metadata(
         "chunk_index": chunk_index,
         "total_chunks": total_chunks,
         "collected_at": source_metadata.collected_at,
+        "section_path": section_path,
     }
 
     # カスタムフィールド: extra の各キーに custom: プレフィックスを付与

--- a/src/rag/pipeline/factory.py
+++ b/src/rag/pipeline/factory.py
@@ -79,7 +79,6 @@ def build_pipeline_controller(
         embedding_prefix_enabled=settings.embedding_prefix_enabled,
         embedding_context_length=settings.rag_embedding_context_length,
         worst_token_char_ratio=settings.rag_worst_token_char_ratio,
-        heading_overhead=settings.rag_heading_overhead,
     )
 
     return PipelineController(

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def smart_chunk(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
+def smart_chunk(
+    text: str, chunk_size: int, chunk_overlap: int,
+) -> list[tuple[str, str]]:
     """コンテンツタイプに応じた適切なチャンキング手法を選択する.
 
     仕様: docs/specs/rag-knowledge.md
@@ -47,7 +49,7 @@ def smart_chunk(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
         chunk_overlap: チャンク間のオーバーラップ文字数
 
     Returns:
-        チャンクのリスト
+        (content, section_path) のタプルリスト
     """
     if not text or not text.strip():
         return []
@@ -58,16 +60,20 @@ def smart_chunk(text: str, chunk_size: int, chunk_overlap: int) -> list[str]:
     if content_type == ContentType.TABLE:
         table_chunks = chunk_table_data(text, max_chunk_size=chunk_size)
         if table_chunks:
-            return [chunk.formatted_text for chunk in table_chunks]
+            return [(c.content, c.section_path) for c in table_chunks]
         logger.debug("Table chunking returned no results, falling back to prose")
 
     if content_type in (ContentType.HEADING, ContentType.MIXED):
         heading_chunks = chunk_by_headings(text, max_chunk_size=chunk_size)
         if heading_chunks:
-            return [chunk.formatted_text for chunk in heading_chunks]
+            return [(c.content, c.section_path) for c in heading_chunks]
         logger.debug("Heading chunking returned no results, falling back to prose")
 
-    return chunk_text(text, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    return [
+        (c, "") for c in chunk_text(
+            text, chunk_size=chunk_size, chunk_overlap=chunk_overlap,
+        )
+    ]
 
 
 @dataclass
@@ -99,6 +105,7 @@ class VectorSearchItem:
         title: コンテンツのタイトル
         source_type: ソース種別
         total_chunks: 当該ソースのチャンク総数（0はレガシーデータ）
+        section_path: 見出し階層（> 区切り）
     """
 
     text: str
@@ -109,6 +116,7 @@ class VectorSearchItem:
     source_type: str = ""
     total_chunks: int = 0
     collected_at: str = ""
+    section_path: str = ""
 
 
 @dataclass
@@ -126,6 +134,7 @@ class BM25SearchItem:
         title: コンテンツのタイトル
         source_type: ソース種別
         total_chunks: 当該ソースのチャンク総数（0はレガシーデータ）
+        section_path: 見出し階層（> 区切り）
     """
 
     text: str
@@ -137,6 +146,7 @@ class BM25SearchItem:
     source_type: str = ""
     total_chunks: int = 0
     collected_at: str = ""
+    section_path: str = ""
 
 
 @dataclass
@@ -425,10 +435,13 @@ class RAGKnowledgeService:
 
         return await self._ingest_crawled_page(page)
 
-    def _smart_chunk(self, text: str) -> list[str]:
+    def _smart_chunk(self, text: str) -> list[tuple[str, str]]:
         """コンテンツタイプに応じた適切なチャンキング手法を選択する.
 
         仕様: docs/specs/rag-knowledge.md
+
+        Returns:
+            (content, section_path) のタプルリスト
         """
         return smart_chunk(text, self._chunk_size, self._chunk_overlap)
 
@@ -458,16 +471,17 @@ class RAGKnowledgeService:
         document_chunks = [
             DocumentChunk(
                 id=f"{url_hash}_{i}",
-                text=chunk,
+                text=content,
                 metadata={
                     "source_id": normalized_url,
                     "title": page.title,
                     "chunk_index": i,
                     "crawled_at": page.crawled_at,
                     "source_type": "web",
+                    "section_path": section_path,
                 },
             )
-            for i, chunk in enumerate(chunks)
+            for i, (content, section_path) in enumerate(chunks)
         ]
         new_ids = {chunk.id for chunk in document_chunks}
 
@@ -480,10 +494,11 @@ class RAGKnowledgeService:
         # BM25インデックスにも追加（ハイブリッド検索用）
         # 注: BM25は補助的機能のため、失敗してもVectorStoreの結果は維持する
         if self._bm25_index is not None:
-            bm25_docs = [
-                (chunk.id, chunk.text, normalized_url, "web")
-                for chunk in document_chunks
-            ]
+            bm25_docs = []
+            for chunk in document_chunks:
+                sp = str(chunk.metadata.get("section_path", ""))
+                bm25_text = f"{sp}\n{chunk.text}" if sp else chunk.text
+                bm25_docs.append((chunk.id, bm25_text, normalized_url, "web"))
             try:
                 self._bm25_index.add_documents(bm25_docs)
                 logger.debug("Added %d documents to BM25 index", len(bm25_docs))
@@ -678,6 +693,7 @@ class RAGKnowledgeService:
                 result.metadata.get("collected_at")
                 or result.metadata.get("crawled_at", "")
             )
+            section_path = str(result.metadata.get("section_path", ""))
             vector_items.append(
                 VectorSearchItem(
                     text=result.text,
@@ -688,6 +704,7 @@ class RAGKnowledgeService:
                     source_type=source_type_val,
                     total_chunks=total_chunks,
                     collected_at=collected_at,
+                    section_path=section_path,
                 )
             )
 
@@ -719,6 +736,7 @@ class RAGKnowledgeService:
                 collected_at = str(
                     meta.get("collected_at") or meta.get("crawled_at", "")
                 )
+                section_path = str(meta.get("section_path", ""))
                 bm25_items.append(
                     BM25SearchItem(
                         text=bm25_result.text,
@@ -730,6 +748,7 @@ class RAGKnowledgeService:
                         source_type=bm25_source_type,
                         total_chunks=total_chunks,
                         collected_at=collected_at,
+                        section_path=section_path,
                     )
                 )
 

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -9,7 +9,7 @@ import asyncio
 import hashlib
 import logging
 import mimetypes
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -179,7 +179,7 @@ def format_raw_search_results(raw: RawSearchResults) -> str:
     if not raw.vector_results and not raw.bm25_results:
         return "該当する情報が見つかりませんでした"
 
-    sections: list[tuple[str, list[VectorSearchItem | BM25SearchItem]]] = []
+    sections: list[tuple[str, Sequence[VectorSearchItem | BM25SearchItem]]] = []
     if raw.vector_results:
         sections.append(("## ベクトル検索結果 (意味的類似度)\n", raw.vector_results))
     if raw.bm25_results:

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -167,6 +167,58 @@ class RawSearchResults:
     bm25_results: list[BM25SearchItem]
 
 
+def format_raw_search_results(raw: RawSearchResults) -> str:
+    """RawSearchResults をテキスト形式にフォーマットする.
+
+    server.py（MCP）と cli.py（CLI）で共通使用する。
+    仕様: docs/specs/search-response.md
+
+    Returns:
+        フォーマット済みテキスト。結果なしの場合は結果なしメッセージ。
+    """
+    if not raw.vector_results and not raw.bm25_results:
+        return "該当する情報が見つかりませんでした"
+
+    sections: list[tuple[str, list[VectorSearchItem | BM25SearchItem]]] = []
+    if raw.vector_results:
+        sections.append(("## ベクトル検索結果 (意味的類似度)\n", raw.vector_results))
+    if raw.bm25_results:
+        sections.append(("## BM25 検索結果 (キーワード一致)\n", raw.bm25_results))
+
+    parts: list[str] = []
+    for header, items in sections:
+        parts.append(header)
+        for i, item in enumerate(items, start=1):
+            # スコア行: ベクトルは distance、BM25 は score
+            if isinstance(item, VectorSearchItem):
+                parts.append(f"### Result {i} [distance={item.distance:.3f}]")
+            else:
+                parts.append(f"### Result {i} [score={item.score:.3f}]")
+
+            chunk_pos = _format_chunk_position(item.chunk_index, item.total_chunks)
+            parts.append(f"Source: {item.source_url}")
+            parts.append(f"Title: {item.title}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {item.source_type}")
+            if item.section_path:
+                parts.append(f"Section: {item.section_path}")
+            if item.collected_at:
+                parts.append(f"Collected: {item.collected_at}")
+            parts.append("")
+            parts.append(item.text)
+            parts.append("")
+
+    return "\n".join(parts).rstrip()
+
+
+def _format_chunk_position(chunk_index: int, total_chunks: int) -> str:
+    """チャンク位置を表示用文字列にフォーマットする."""
+    pos = chunk_index + 1
+    if total_chunks > 0:
+        return f"{pos}/{total_chunks}"
+    return f"{pos}/?"
+
+
 class RAGKnowledgeService:
     """RAGナレッジ管理サービス.
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -50,6 +50,7 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 # 問題への対策として、import 時に stdout を抑制する。
 from .config import ensure_utf8_streams
 from .filter_parser import parse_filters
+from .rag_knowledge import format_raw_search_results
 
 with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
@@ -294,22 +295,6 @@ def _get_supported_extensions() -> list[str]:
 _VALID_SOURCE_TYPES: frozenset[str] = frozenset({"web", "zenn", "bluesky", "youtube", "local", "aozora", "journal"})
 
 
-def _format_chunk_position(chunk_index: int, total_chunks: int) -> str:
-    """チャンク位置を表示用文字列にフォーマットする.
-
-    Args:
-        chunk_index: 0始まりチャンクインデックス
-        total_chunks: チャンク総数（0はレガシーデータ＝不明）
-
-    Returns:
-        "3/15" 形式、total_chunks 不明時は "3/?"
-    """
-    pos = chunk_index + 1
-    if total_chunks > 0:
-        return f"{pos}/{total_chunks}"
-    return f"{pos}/?"
-
-
 @mcp.tool()
 async def rag_search(
     query: str,
@@ -361,48 +346,7 @@ async def rag_search(
         filters=parsed_filters,
     )
 
-    if not raw.vector_results and not raw.bm25_results:
-        return "該当する情報が見つかりませんでした"
-
-    parts: list[str] = []
-
-    # ベクトル検索結果
-    if raw.vector_results:
-        parts.append("## ベクトル検索結果 (意味的類似度)\n")
-        for i, item in enumerate(raw.vector_results, start=1):
-            chunk_pos = _format_chunk_position(item.chunk_index, item.total_chunks)
-            parts.append(f"### Result {i} [distance={item.distance:.3f}]")
-            parts.append(f"Source: {item.source_url}")
-            parts.append(f"Title: {item.title}")
-            parts.append(f"Chunk: {chunk_pos}")
-            parts.append(f"Type: {item.source_type}")
-            if item.section_path:
-                parts.append(f"Section: {item.section_path}")
-            if item.collected_at:
-                parts.append(f"Collected: {item.collected_at}")
-            parts.append("")
-            parts.append(item.text)
-            parts.append("")
-
-    # BM25検索結果
-    if raw.bm25_results:
-        parts.append("## BM25 検索結果 (キーワード一致)\n")
-        for i, bm25_item in enumerate(raw.bm25_results, start=1):
-            chunk_pos = _format_chunk_position(bm25_item.chunk_index, bm25_item.total_chunks)
-            parts.append(f"### Result {i} [score={bm25_item.score:.3f}]")
-            parts.append(f"Source: {bm25_item.source_url}")
-            parts.append(f"Title: {bm25_item.title}")
-            parts.append(f"Chunk: {chunk_pos}")
-            parts.append(f"Type: {bm25_item.source_type}")
-            if bm25_item.section_path:
-                parts.append(f"Section: {bm25_item.section_path}")
-            if bm25_item.collected_at:
-                parts.append(f"Collected: {bm25_item.collected_at}")
-            parts.append("")
-            parts.append(bm25_item.text)
-            parts.append("")
-
-    return "\n".join(parts).rstrip()
+    return format_raw_search_results(raw)
 
 
 _VALID_DOCUMENT_FORMATS: frozenset[str] = frozenset({"text", "original"})

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -376,6 +376,8 @@ async def rag_search(
             parts.append(f"Title: {item.title}")
             parts.append(f"Chunk: {chunk_pos}")
             parts.append(f"Type: {item.source_type}")
+            if item.section_path:
+                parts.append(f"Section: {item.section_path}")
             if item.collected_at:
                 parts.append(f"Collected: {item.collected_at}")
             parts.append("")
@@ -392,6 +394,8 @@ async def rag_search(
             parts.append(f"Title: {bm25_item.title}")
             parts.append(f"Chunk: {chunk_pos}")
             parts.append(f"Type: {bm25_item.source_type}")
+            if bm25_item.section_path:
+                parts.append(f"Section: {bm25_item.section_path}")
             if bm25_item.collected_at:
                 parts.append(f"Collected: {bm25_item.collected_at}")
             parts.append("")

--- a/src/rag/table_chunker.py
+++ b/src/rag/table_chunker.py
@@ -20,7 +20,12 @@ class TableChunk:
     header: str  # ヘッダー行（カラム名）
     rows: list[str]  # データ行
     entity_name: str  # 行の識別子（最初のカラムの値）
-    formatted_text: str  # 検索用にフォーマットされたテキスト
+    content: str  # 検索用にフォーマットされたテキスト
+
+    @property
+    def section_path(self) -> str:
+        """テーブルチャンクの section_path（常に空文字列）."""
+        return ""
 
 
 def chunk_table_data(
@@ -42,7 +47,7 @@ def chunk_table_data(
         text: テーブルデータを含むテキスト
         header_row: 明示的なヘッダー行（Noneの場合は自動検出）
         row_context_size: 前後に含めるコンテキスト行数
-        max_chunk_size: formatted_text の最大文字数（0 の場合は制限なし）
+        max_chunk_size: content の最大文字数（0 の場合は制限なし）
 
     Returns:
         TableChunkのリスト
@@ -79,11 +84,11 @@ def chunk_table_data(
 
         # フォーマットされたテキストを生成
         main_row_index_in_context = i - start_idx
-        formatted_text = _format_table_chunk(
+        content = _format_table_chunk(
             headers, row, context_rows, entity_name, main_row_index_in_context
         )
 
-        if max_chunk_size > 0 and len(formatted_text) > max_chunk_size:
+        if max_chunk_size > 0 and len(content) > max_chunk_size:
             # 段階的削減: (1) 周辺行除去 → (2) カラム分割
             reduced = _reduce_table_chunk(
                 headers, row, entity_name, max_chunk_size,
@@ -95,7 +100,7 @@ def chunk_table_data(
                     header=", ".join(headers),
                     rows=[", ".join(r) for r in context_rows],
                     entity_name=entity_name,
-                    formatted_text=formatted_text,
+                    content=content,
                 )
             )
 
@@ -262,7 +267,7 @@ def _reduce_table_chunk(
                 header=", ".join(headers),
                 rows=[", ".join(main_row)],
                 entity_name=entity_name,
-                formatted_text=formatted_no_context,
+                content=formatted_no_context,
             )
         ]
 
@@ -322,7 +327,7 @@ def _reduce_table_chunk(
                 header=", ".join(headers),
                 rows=[", ".join(main_row)],
                 entity_name=entity_name,
-                formatted_text=ft,
+                content=ft,
             )
         )
 
@@ -334,7 +339,7 @@ def _reduce_table_chunk(
                 header=", ".join(headers),
                 rows=[", ".join(main_row)],
                 entity_name=entity_name,
-                formatted_text=ft[:max_chunk_size],
+                content=ft[:max_chunk_size],
             )
         )
 
@@ -357,7 +362,7 @@ def _flush_table_attrs(
             header=", ".join(headers),
             rows=[", ".join(main_row)],
             entity_name=entity_name,
-            formatted_text=ft,
+            content=ft,
         )
     )
 

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -203,6 +203,62 @@ class TestAdd:
         )
         assert len(result["ids"]) >= 2
 
+    def test_section_path_in_metadata(
+        self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
+    ) -> None:
+        """section_path がメタデータに含まれること."""
+        text = "# Parent\n\n## Child\n\nContent under child."
+        path = _write_text_file(tmp_path, "heading.txt", text)
+        meta = _make_metadata(source_id="src-sp")
+
+        indexer.add("src-sp", path, meta)
+
+        result = vector_store._collection.get(
+            where={"source_id": "src-sp"}, include=["metadatas"],
+        )
+        # いずれかのチャンクに section_path が設定されている
+        section_paths = [m.get("section_path", "") for m in result["metadatas"]]
+        assert any("Parent" in sp for sp in section_paths)
+
+    def test_embedding_receives_content_only(
+        self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
+    ) -> None:
+        """Embedding（ChromaDB の documents）には本文のみが格納されること."""
+        text = "# UniqueHeading\n\nBody text only."
+        path = _write_text_file(tmp_path, "heading.txt", text)
+        meta = _make_metadata(source_id="src-emb")
+
+        indexer.add("src-emb", path, meta)
+
+        result = vector_store._collection.get(
+            where={"source_id": "src-emb"},
+            include=["documents", "metadatas"],
+        )
+        # section_path はメタデータに格納されている
+        assert any(
+            m.get("section_path") == "UniqueHeading"
+            for m in result["metadatas"]
+        )
+        # documents（Embedding 入力）には見出しテキストが含まれない
+        for doc in result["documents"]:
+            assert "UniqueHeading" not in doc
+            assert "[" not in doc  # 旧形式の breadcrumb
+            assert "# " not in doc  # 旧形式の見出しプレフィックス
+
+    def test_bm25_receives_section_path_plus_content(
+        self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
+    ) -> None:
+        """BM25 には section_path + 本文が渡されること."""
+        text = "# MyHeading\n\nBody text for BM25."
+        path = _write_text_file(tmp_path, "heading.txt", text)
+        meta = _make_metadata(source_id="src-bm25-sp")
+
+        indexer.add("src-bm25-sp", path, meta)
+
+        # BM25 で見出しキーワードで検索できる
+        results = bm25_index.search("MyHeading", n_results=5)
+        assert len(results) > 0
+
     def test_table_text_uses_table_chunker(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:

--- a/tests/indexer/test_metadata.py
+++ b/tests/indexer/test_metadata.py
@@ -35,6 +35,15 @@ class TestBuildChunkMetadata:
         assert result["chunk_index"] == 0
         assert result["total_chunks"] == 5
         assert result["collected_at"] == "2025-01-01T00:00:00Z"
+        assert result["section_path"] == ""
+
+    def test_section_path_included(self) -> None:
+        meta = _make_metadata()
+        result = build_chunk_metadata(
+            meta, chunk_index=0, total_chunks=1,
+            section_path="Chapter 1 > Section 1.1",
+        )
+        assert result["section_path"] == "Chapter 1 > Section 1.1"
 
     def test_chunk_index_varies(self) -> None:
         meta = _make_metadata()

--- a/tests/test_chunk_size_enforcement.py
+++ b/tests/test_chunk_size_enforcement.py
@@ -40,16 +40,16 @@ class TestHeadingChunkerSizeEnforcement:
         text = f"# Code Section\n\n{code}"
         chunks = chunk_by_headings(text, max_chunk_size=200, min_chunk_size=50)
         assert len(chunks) > 1
-        assert all(len(c.formatted_text) <= 200 for c in chunks)
+        assert all(len(c.content) <= 200 for c in chunks)
 
-    def test_deep_nesting_formatted_text_limit(self) -> None:
-        """深い見出しネストでも formatted_text が max_chunk_size 以内であること."""
+    def test_deep_nesting_content_limit(self) -> None:
+        """深い見出しネストでも content が max_chunk_size 以内であること."""
         text = (
             "# L1\n## L2\n### L3\n#### L4\n##### L5\n###### L6\n"
             + "x" * 500
         )
         chunks = chunk_by_headings(text, max_chunk_size=200, min_chunk_size=50)
-        assert all(len(c.formatted_text) <= 200 for c in chunks)
+        assert all(len(c.content) <= 200 for c in chunks)
 
     def test_single_long_paragraph_split(self) -> None:
         """段落分割できない長いテキストが行/文字ベースで分割されること."""
@@ -58,14 +58,14 @@ class TestHeadingChunkerSizeEnforcement:
         text = f"# Section\n\n{long_para}"
         chunks = chunk_by_headings(text, max_chunk_size=100, min_chunk_size=20)
         assert len(chunks) > 1
-        assert all(len(c.formatted_text) <= 100 for c in chunks)
+        assert all(len(c.content) <= 100 for c in chunks)
 
     def test_prose_fallback_split(self) -> None:
         """見出しなしテキストで段落超過時に分割されること."""
         long_para = "x" * 500
         chunks = chunk_by_headings(long_para, max_chunk_size=200, min_chunk_size=50)
         assert len(chunks) > 1
-        assert all(len(c.formatted_text) <= 200 for c in chunks)
+        assert all(len(c.content) <= 200 for c in chunks)
 
     def test_normal_case_unchanged(self) -> None:
         """通常ケースの動作が変わらないこと."""
@@ -94,7 +94,7 @@ class TestTableChunkerSizeEnforcement:
         table = f"{headers}\n{sep}\n{row}"
         chunks = chunk_table_data(table, max_chunk_size=200)
         assert len(chunks) > 1
-        assert all(len(c.formatted_text) <= 200 for c in chunks)
+        assert all(len(c.content) <= 200 for c in chunks)
         # 全チャンクにエンティティ名が保持されている
         assert all(c.entity_name == "long_value_0" for c in chunks)
 
@@ -110,7 +110,7 @@ class TestTableChunkerSizeEnforcement:
         )
         # 周辺行付きだと超過するサイズに設定
         chunks_with_context = chunk_table_data(table, row_context_size=1)
-        max_with = max(len(c.formatted_text) for c in chunks_with_context)
+        max_with = max(len(c.content) for c in chunks_with_context)
 
         # max_chunk_size を周辺行なしなら収まるが周辺行ありだと超過する値に
         limit = max_with - 5
@@ -130,7 +130,7 @@ class TestTableChunkerLongJapaneseValues:
             "| ベクトル検索 | " + "あ" * 200 + " | " + "い" * 200 + " |"
         )
         chunks = chunk_table_data(table, max_chunk_size=300)
-        assert all(len(c.formatted_text) <= 300 for c in chunks)
+        assert all(len(c.content) <= 300 for c in chunks)
 
     def test_single_attribute_exceeds_limit(self) -> None:
         """単一セル値が max_chunk_size を超える場合でも制限内に収まること."""
@@ -141,4 +141,4 @@ class TestTableChunkerLongJapaneseValues:
         )
         chunks = chunk_table_data(table, max_chunk_size=200)
         assert len(chunks) >= 1
-        assert all(len(c.formatted_text) <= 200 for c in chunks)
+        assert all(len(c.content) <= 200 for c in chunks)

--- a/tests/test_heading_chunker.py
+++ b/tests/test_heading_chunker.py
@@ -116,12 +116,13 @@ class TestChunkByHeadings:
 
         # 複数のチャンクに分割される
         assert len(chunks) > 1
-        # すべてのチャンクが見出し情報を持つ
-        for chunk in chunks:
-            assert "見出し" in chunk.heading
+        # 最初のチャンクは見出しを持ち、2つ目以降は空
+        assert chunks[0].heading == "見出し"
+        for chunk in chunks[1:]:
+            assert chunk.heading == ""
 
-    def test_formatted_text_includes_breadcrumb(self) -> None:
-        """AC4: フォーマット済みテキストにパンくずリストが含まれる."""
+    def test_section_path_includes_breadcrumb(self) -> None:
+        """AC4: section_path に親見出しと現見出しが含まれる."""
         text = """# 親見出し
 ## 子見出し
 内容"""
@@ -130,8 +131,8 @@ class TestChunkByHeadings:
 
         # 子見出しのチャンク
         child_chunk = [c for c in chunks if c.heading == "子見出し"][0]
-        assert "[親見出し]" in child_chunk.formatted_text
-        assert "# 子見出し" in child_chunk.formatted_text
+        assert child_chunk.section_path == "親見出し > 子見出し"
+        assert child_chunk.parent_headings == ["親見出し"]
 
     def test_small_chunks_merged(self) -> None:
         """AC5: 小さすぎるチャンクは前のチャンクと結合される."""
@@ -147,3 +148,43 @@ class TestChunkByHeadings:
         # 「短い。」は前のチャンクと結合されるか、独立チャンクになる
         # 結合の条件を満たさない場合は独立チャンクとして存在
         assert len(chunks) >= 1
+
+    def test_section_path_with_deep_nesting(self) -> None:
+        """section_path が親見出し + 現見出しの > 区切りで生成されること."""
+        text = """# 第1章
+## 1.1 前処理
+### 1.1.1 正規化
+正規化の内容"""
+
+        chunks = chunk_by_headings(text)
+
+        target = [c for c in chunks if c.heading == "1.1.1 正規化"][0]
+        assert target.section_path == "第1章 > 1.1 前処理 > 1.1.1 正規化"
+
+    def test_section_path_empty_for_no_heading(self) -> None:
+        """見出しなしチャンクの section_path は空文字列."""
+        text = "見出しのないテキスト"
+        chunks = chunk_by_headings(text)
+
+        assert len(chunks) == 1
+        assert chunks[0].section_path == ""
+
+    def test_split_chunks_have_empty_heading(self) -> None:
+        """分割チャンクの2つ目以降で heading が空であること."""
+        long_content = "あ" * 500
+        text = f"# 見出し\n\n{long_content}"
+        chunks = chunk_by_headings(text, max_chunk_size=200, min_chunk_size=50)
+
+        assert len(chunks) > 1
+        assert chunks[0].heading == "見出し"
+        for c in chunks[1:]:
+            assert c.heading == ""
+
+    def test_no_tsuzuki_suffix(self) -> None:
+        """分割チャンクに (続き) サフィックスが付与されないこと."""
+        long_content = "あ" * 500
+        text = f"# 見出し\n\n{long_content}"
+        chunks = chunk_by_headings(text, max_chunk_size=200, min_chunk_size=50)
+
+        for c in chunks:
+            assert "(続き)" not in c.heading

--- a/tests/test_rag_knowledge_hybrid.py
+++ b/tests/test_rag_knowledge_hybrid.py
@@ -337,8 +337,10 @@ class TestSmartChunking:
 
         # Assert: テーブルとして処理され、各行がチャンクになる
         assert len(chunks) > 0
-        # テーブルチャンクはフォーマット済みで「名前:」を含む
-        assert any("名前:" in chunk or "魔王" in chunk for chunk in chunks)
+        # 戻り値は (content, section_path) のタプル
+        assert all(isinstance(c, tuple) and len(c) == 2 for c in chunks)
+        # テーブルチャンクは content に「名前:」を含む
+        assert any("名前:" in c[0] or "魔王" in c[0] for c in chunks)
 
     def test_smart_chunk_detects_headings(
         self,
@@ -361,8 +363,9 @@ class TestSmartChunking:
         # Act
         chunks = rag_service_hybrid._smart_chunk(heading_text)
 
-        # Assert: 見出しごとにチャンクが分割される
+        # Assert: 見出しごとにチャンクが分割される（タプルリスト）
         assert len(chunks) > 0
+        assert all(isinstance(c, tuple) and len(c) == 2 for c in chunks)
 
     def test_smart_chunk_prose_fallback(
         self,
@@ -377,8 +380,9 @@ class TestSmartChunking:
         # Act
         chunks = rag_service_hybrid._smart_chunk(prose_text)
 
-        # Assert: 何らかのチャンクが生成される
+        # Assert: 何らかのチャンクが生成される（タプルリスト）
         assert len(chunks) >= 1
+        assert all(isinstance(c, tuple) and len(c) == 2 for c in chunks)
 
 
 class TestHybridSearchEngineInitialization:

--- a/tests/test_table_chunker.py
+++ b/tests/test_table_chunker.py
@@ -27,13 +27,13 @@ class TestChunkTableData:
         assert len(chunks) == 3
         assert chunks[0].entity_name == "魔王"
         assert "HP" in chunks[0].header
-        assert "200" in chunks[0].formatted_text
+        assert "200" in chunks[0].content
 
         assert chunks[1].entity_name == "闇の王"
-        assert "500" in chunks[1].formatted_text
+        assert "500" in chunks[1].content
 
         assert chunks[2].entity_name == "ゴブリン"
-        assert "8" in chunks[2].formatted_text
+        assert "8" in chunks[2].content
 
     def test_tab_separated_table_chunks_by_row(self) -> None:
         """タブ区切りテーブルを行単位でチャンキングする."""
@@ -57,15 +57,15 @@ class TestChunkTableData:
         assert "HP" in chunks[0].header
         assert "MP" in chunks[0].header
 
-    def test_formatted_text_contains_entity_and_attributes(self) -> None:
-        """フォーマット済みテキストにエンティティと属性が含まれる."""
+    def test_content_contains_entity_and_attributes(self) -> None:
+        """content にエンティティと属性が含まれる."""
         text = """| 名前 | HP | MP |
 |------|-----|-----|
 | 魔王 | 200 | 100 |"""
 
         chunks = chunk_table_data(text)
 
-        formatted = chunks[0].formatted_text
+        formatted = chunks[0].content
         assert "魔王" in formatted
         assert "HP" in formatted
         assert "200" in formatted


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正
- [x] fix: バグ修正

## Summary

- `HeadingChunk.formatted_text` 廃止、`content` 一本化。`section_path` プロパティ追加（親見出し + 現見出しの `>` 区切り）
- `TableChunk.formatted_text` → `content` リネーム、`section_path` プロパティ追加（常に空文字列）
- Embedding は本文のみ、BM25 は `section_path` + 本文でインデックス（Embedding/BM25 分離）
- `(続き)` サフィックス廃止、分割チャンクの `heading` を空に（`section_path` は `parent_headings` 経由で維持）
- `rag_heading_overhead` 設定を全箇所から削除（全チャンカー共通 714 文字に統一）
- 検索結果表示に `Section:` メタデータ行を追加（値がある場合のみ）
- `server.py` / `cli.py` の重複フォーマットロジックを `format_raw_search_results` に共通化
- CLI の検索結果に `Section:` 行を追加、チャンク位置表示を仕様準拠（`pos/?` 形式）に統一
- `collect_evaluation_data.py` に User-Agent を追加（Wikipedia API 403 対策）
- CLAUDE.md に worktree 環境セットアップ手順と CLI 動作確認観点を追記
- `indexer.md` / `rag-knowledge.md` / `search-response.md` の仕様書修正

## Test plan

- [x] 全 1276 テストパス（`uv run pytest`）
- [x] ruff / mypy クリーン
- [x] CLI 動作確認: `crawl` で 33 ページ取り込み（468 チャンク）
- [x] ChromaDB 直接確認: `section_path` が 433/446 チャンクに正しく設定
- [x] CLI 動作確認: `search` でベクトル/BM25 両方に `Section:` 行表示
- [x] CLI 動作確認: `add` で単一ページ取り込み成功
- [x] CLI 動作確認: `init-test-db` で 101 ドキュメント / 1527 チャンク構築成功
- [x] コードレビュー・ドキュメントレビュー通過

## Related issues

Closes #376