### PR TITLE
refactor(rag-knowledge,web): Safe Browsing 安全性チェックの設計見直し (#381)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,10 +37,9 @@ rag_robots_txt_cache_ttl = 3600
 
 # URL 安全性チェック (Google Safe Browsing API)
 # true にするには keyring に GOOGLE_SAFE_BROWSING_API_KEY の登録が必要
-# 未登録の場合はチェックが無効化され警告ログが出力される
+# 未登録・空・不正の場合は SafeBrowsingConfigError で即時中断する
 rag_url_safety_check = true
 rag_url_safety_cache_ttl = 300
-rag_url_safety_fail_open = true
 rag_url_safety_timeout = 5.0
 
 # レスポンス制御

--- a/docs/specs/ingesters/web.md
+++ b/docs/specs/ingesters/web.md
@@ -81,7 +81,7 @@ Web ページを HTTP 経由で取得し、source_store にファイルを配置
 3. 全ての IP アドレスがブロック対象に該当しないことを検証する
 4. いずれかが該当する場合は `ValueError` を送出する
 
-リダイレクト追従は SSRF 防止のため無効化する。リダイレクトレスポンス（3xx）はエラーとして扱う。
+リダイレクト追従は SSRF 防止のため無効化する。リダイレクトレスポンス（3xx）はブロックし、スキップ扱い（エラーカウント対象外）とする。
 
 ### robots.txt
 
@@ -95,12 +95,11 @@ Web ページを HTTP 経由で取得し、source_store にファイルを配置
 
 - `rag_url_safety_check` が `true`（デフォルト）の場合、Google Safe Browsing API で URL の安全性を検証する
 - API キーは OS セキュアストレージ（keyring）から取得する（サービス名: `rag-knowledge`、キー名: `GOOGLE_SAFE_BROWSING_API_KEY`）
-- API キーが未登録の場合、チェックを無効化し警告ログを出力する
+- API キーが未登録・空・不正（400 応答）の場合は設定エラー（`SafeBrowsingConfigError`）として即時中断する
+- API キーは `x-goog-api-key` ヘッダーで送信する（URL パラメータではログに漏洩するため）
 - 検出する脅威タイプ: MALWARE、SOCIAL_ENGINEERING、UNWANTED_SOFTWARE、POTENTIALLY_HARMFUL_APPLICATION
 - チェック結果は TTL ベースでキャッシュする（デフォルト: 300 秒、最大 1000 エントリ）
-- フェイルオープン/フェイルクローズ:
-  - `rag_url_safety_fail_open=true`（デフォルト）: API 障害時は URL を許可する
-  - `rag_url_safety_fail_open=false`: API 障害時は URL をブロックする
+- 常にフェイルクローズ: API 障害時（429/500/タイムアウト等）は URL をブロックしエラーとする
 
 ### 保存形式
 
@@ -125,7 +124,7 @@ Web ページを HTTP 経由で取得し、source_store にファイルを配置
 |--------|------|---------|
 | Google Safe Browsing API v4 | URL 安全性チェック | REST API（ConstrainedClient 経由、オプション） |
 
-Safe Browsing API はオプション機能。API キーが未登録の場合は機能が無効化される。
+Safe Browsing API はオプション機能。`rag_url_safety_check=false` で無効化できる。有効時に API キーが未登録・空・不正の場合は `SafeBrowsingConfigError` で即時中断する。
 
 ## 想定プロファイル
 
@@ -141,7 +140,7 @@ Safe Browsing API はオプション機能。API キーが未登録の場合は�
 
 | 項目 | 内容 |
 |------|------|
-| 最悪ケースリクエスト数 | 1（インデックスページ）+ 1（robots.txt）+ 1（Safe Browsing 一括チェック。Lookup API v4 は最大 500 URL を 1 リクエストで検査可能）+ 497（個別ページ。バジェット 500 から先行リクエスト分を差し引き）= 500。バジェットトラッカー上限 500 で打ち切り |
+| 最悪ケースリクエスト数 | 1（起点 URL の Safe Browsing チェック）+ 1（インデックスページ）+ 1（robots.txt）+ 1（Safe Browsing 一括チェック。Lookup API v4 は 1 リクエストあたり最大 500 URL。500 URL 超の場合はバッチ分割する）+ 496（個別ページ。バジェット 500 から先行リクエスト分を差し引き）= 500。バジェットトラッカー上限 500 で打ち切り |
 | 最悪ケース所要時間 | 500 × 0.1 秒（ハードリミット最小間隔での理論最短）= 50 秒。デフォルト設定（1.0 秒間隔）では 500 秒。per-request タイムアウト・処理時間は含まない。操作全体タイムアウト 600 秒で打ち切り |
 | 想定エラー率 | 外部 Web サイト依存。リトライ機構なし（失敗ページはスキップし処理を続行）。累計エラー数が閾値に達した場合、またはサーキットブレーカー（5 回連続 HTTP 失敗）が発動した場合に操作中断 |
 
@@ -172,7 +171,7 @@ Safe Browsing API はオプション機能。API キーが未登録の場合は�
 | クロール対象ページ数上限 | ハードリミット | 500 ページ | 引き上げ不可（引き下げ可） |
 | クロール深度上限 | ハードリミット | 10 | 引き上げ不可（引き下げ可） |
 | SSRF 対策 | ハードリミット | プライベート IP・ローカルホストへのリクエスト拒否 | 無効化不可 |
-| リダイレクト追従無効化 | ハードリミット | HTTP リダイレクト（3xx）をエラーとして扱う | 無効化不可 |
+| リダイレクト追従無効化 | ハードリミット | HTTP リダイレクト（3xx）をブロックしスキップ扱いとする | 無効化不可 |
 | HTTP エラーレスポンス拒否 | ハードリミット | HTTP 4xx/5xx レスポンスをエラーとして扱い、コンテンツを保存しない | 無効化不可 |
 | クロール対象ページ数 | 設定値 | 許容範囲 1〜500、デフォルト 50 | 範囲内で変更可 |
 | クロール遅延（リクエスト間隔） | 設定値 | 許容範囲 0.1〜60 秒、デフォルト 1.0 秒 | 範囲内で変更可 |
@@ -234,7 +233,6 @@ Safe Browsing API はオプション機能。API キーが未登録の場合は�
 | `rag_robots_txt_cache_ttl` | int | `config.toml` | 3600 | 0 以上 | robots.txt キャッシュの有効期間（秒） |
 | `rag_url_safety_check` | bool | `config.toml` | true | — | Google Safe Browsing API による URL 安全性チェックを有効にするか |
 | `rag_url_safety_cache_ttl` | int | `config.toml` | 300 | 0 以上 | Safe Browsing チェック結果のキャッシュ有効期間（秒） |
-| `rag_url_safety_fail_open` | bool | `config.toml` | true | — | Safe Browsing API 障害時に URL を許可するか |
 | `rag_url_safety_timeout` | float | `config.toml` | 5.0 | 0 より大きい | Safe Browsing API のリクエストタイムアウト（秒） |
 | `rag_crawl_request_timeout` | int | `config.toml` | 30 | 1〜120 | ページ取得時の per-request タイムアウト（秒） |
 | `rag_crawl_default_depth` | int | `config.toml` | 1 | 1〜10 | クロールのデフォルト深度。1 = 従来動作（インデックスページの直接リンクのみ） |
@@ -327,6 +325,7 @@ flowchart TD
 flowchart TD
     START["rag_crawl(url, pattern, depth)"]
     VALIDATE["URL バリデーション + depth > 1 なら pattern 必須チェック"]
+    SAFETY_ORIGIN["起点 URL の Safe Browsing チェック（有効時）"]
     DEPTH_LOOP["depth ループ開始（現在の depth = 1）"]
     FETCH_INDEX["対象ページ群を取得"]
     EXTRACT["各ページの HTML からリンク抽出（同一ドメインのみ）"]
@@ -347,7 +346,8 @@ flowchart TD
     ABORT["エラー閾値到達: 操作中断"]
 
     START --> VALIDATE
-    VALIDATE --> DEPTH_LOOP
+    VALIDATE --> SAFETY_ORIGIN
+    SAFETY_ORIGIN --> DEPTH_LOOP
     DEPTH_LOOP --> FETCH_INDEX
     FETCH_INDEX --> EXTRACT
     EXTRACT --> FILTER
@@ -561,7 +561,7 @@ source_id の決定方式は [source-store.md](../source-store.md) の「source_
 | URL のスキームが http/https 以外 | バリデーションエラーとして拒否する |
 | URL のホスト名がない | バリデーションエラーとして拒否する |
 | プライベート IP・localhost へのアクセス | SSRF 対策としてリクエストを拒否する |
-| HTTP リダイレクト（3xx） | SSRF 防止のためリダイレクト追従を無効化し、エラーとして扱う |
+| HTTP リダイレクト（3xx） | SSRF 防止のためリダイレクト追従を無効化し、スキップ扱い（エラーカウント対象外）とする |
 | HTTP 404（Not Found） | リンク切れとして扱い、スキップする（エラーカウント対象外）。一括クロール（`rag_crawl` / `rag_crawl_preview`）では該当ページをスキップし、処理を続行する |
 | HTTP クライアントエラー（403/429 等、404 以外の 4xx） | エラーカウント対象として扱い、レスポンスボディを保存しない。単一ページ取得（`rag_add`）では ValueError を発生させる。一括クロールでは該当ページをスキップし、累計エラー数に加算する |
 | HTTP サーバーエラー（5xx） | 403/429 と同様にエラーカウント対象として扱う |
@@ -569,8 +569,8 @@ source_id の決定方式は [source-store.md](../source-store.md) の「source_
 | robots.txt の Disallow に該当する URL | クロールをスキップする |
 | robots.txt の取得に失敗した場合 | フェイルオープンでクロールを許可する |
 | Safe Browsing API で危険と判定された URL | 該当ページをスキップし、警告ログを出力する |
-| Safe Browsing API の障害時 | `rag_url_safety_fail_open` の設定に従い、URL を許可またはブロックする |
-| `GOOGLE_SAFE_BROWSING_API_KEY` が未登録 | URL 安全性チェックを無効化し、警告ログを出力して処理を続行する |
+| Safe Browsing API の障害時（429/500/タイムアウト等） | 常にフェイルクローズ: URL をブロックしエラーとする |
+| `GOOGLE_SAFE_BROWSING_API_KEY` が未登録・空・不正 | 設定エラー（`SafeBrowsingConfigError`）として即時中断する |
 | URL にフラグメント（`#section`）が含まれる場合 | フラグメント部分を除去してから処理する。フラグメント違いの URL は同一ファイルとして扱う |
 | URL にクエリパラメータが含まれる場合 | クエリパラメータも含めてパスに変換する（`?` → `？` の全角変換）。同一パスで異なるクエリの URL は異なるファイルとして扱う |
 | クロール時の個別ページエラー | ページ単位でエラーを隔離し、成功したページの処理を続行する。404 はリンク切れとしてスキップ（エラーカウント対象外）。403/429/5xx は累計エラー数に加算し、`rag_crawl_max_errors` に達した場合は操作を中断する |

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -55,7 +55,7 @@ MCP サーバーとして独立動作し、16 個のツールを提供する。
 | ハイブリッド検索 | `rag_hybrid_search_enabled`, `rag_vector_weight`, `rag_bm25_k1`, `rag_bm25_b`, `rag_min_combined_score` |
 | クロール | `rag_max_crawl_pages`, `rag_crawl_delay_sec` |
 | robots.txt | `rag_respect_robots_txt`, `rag_robots_txt_cache_ttl` |
-| URL 安全性 | `rag_url_safety_check`, `rag_url_safety_cache_ttl`, `rag_url_safety_fail_open`, `rag_url_safety_timeout` |
+| URL 安全性 | `rag_url_safety_check`, `rag_url_safety_cache_ttl`, `rag_url_safety_timeout` |
 | レスポンス制御 | `rag_max_response_chars`（rag_get_document のトランケーション）, `rag_stats_max_sources` |
 | Zenn インジェスター | `rag_zenn_max_articles`, `rag_zenn_request_timeout`, `rag_zenn_request_interval` |
 | BlueSky インジェスター | `rag_bluesky_appview_url`, `rag_bluesky_max_posts`, `rag_bluesky_request_timeout`, `rag_bluesky_request_interval`, `rag_bluesky_include_reposts` |
@@ -418,7 +418,7 @@ flowchart LR
 | BM25 インデックスの破損 | 空インデックスで起動する（フェイルセーフ） |
 | Embedding プロバイダー接続不可 | 疎通確認で検出し、エラーを返す |
 | `OPENAI_API_KEY` が未登録 | オンライン Embedding プロバイダーの初期化に失敗し、エラーを返す |
-| `GOOGLE_SAFE_BROWSING_API_KEY` が未登録 | URL 安全性チェックを無効化し、警告ログを出力して処理を続行する |
+| `GOOGLE_SAFE_BROWSING_API_KEY` が未登録・空・不正 | 設定エラー（`SafeBrowsingConfigError`）として即時中断する |
 | クロールプレビュー時のタイトル取得失敗 | タイトルを空文字列とし、URL のみ返す。他のページの処理は続行する |
 | rag_get_document レスポンスサイズ超過 | MCP 経由で `RAG_MAX_RESPONSE_CHARS` 超過時はトランケーションし、末尾に CLI `--output` オプションでの全文取得を案内する。CLI の `--output` 指定時はトランケーションなし |
 | バジェット上限到達 | 取得済みデータを返し、上限到達の旨をログ出力する |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from .pipeline.controller import PipelineController
     from .pipeline.ingesters._common import IngestResult
     from .pipeline.ingesters.web import WebIngester
+    from .safe_browsing import SafeBrowsingClient
     from .pipeline.ingesters.youtube import YoutubeIngester
     from .pipeline.models import PipelineSummary
     from .rag_knowledge import RAGKnowledgeService
@@ -1551,17 +1552,20 @@ def _build_cli_pipeline_controller() -> tuple[
     return controller, settings
 
 
-def _get_safe_browsing_api_key_for_cli(settings: "Settings") -> str:
-    """CLI 用: Safe Browsing API キーを取得する."""
-    from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
+def _create_safe_browsing_client_cli(
+    settings: "Settings",
+) -> "SafeBrowsingClient | None":
+    """CLI 用: SafeBrowsingClient を生成する.
 
-    if not settings.rag_url_safety_check:
-        return ""
+    SafeBrowsingConfigError 時はエラーメッセージを表示して終了する。
+    """
+    from .safe_browsing import SafeBrowsingConfigError, create_safe_browsing_client
+
     try:
-        return get_secret("GOOGLE_SAFE_BROWSING_API_KEY", service="rag-knowledge") or ""
-    except (SecretNotFoundError, SecretStoreError):
-        logger.warning("Safe Browsing API key not available")
-        return ""
+        return create_safe_browsing_client(settings)
+    except SafeBrowsingConfigError as e:
+        logger.error("Safe Browsing 設定エラー: %s", e)
+        sys.exit(1)
 
 
 def _print_ingest_result(
@@ -1585,18 +1589,15 @@ async def run_add(args: argparse.Namespace) -> None:
     from py_common_lib.httpx import ConstrainedClient  # safety:allowed
 
     controller, settings = _build_cli_pipeline_controller()
+    sb_client = _create_safe_browsing_client_cli(settings)
     web_ingester = WebIngester(
         controller.source_store,
         max_crawl_pages=settings.rag_max_crawl_pages,
         crawl_request_timeout=settings.rag_crawl_request_timeout,
         respect_robots_txt=settings.rag_respect_robots_txt,
         robots_txt_cache_ttl=settings.rag_robots_txt_cache_ttl,
-        url_safety_check=settings.rag_url_safety_check,
-        url_safety_cache_ttl=settings.rag_url_safety_cache_ttl,
-        url_safety_fail_open=settings.rag_url_safety_fail_open,
-        url_safety_timeout=settings.rag_url_safety_timeout,
+        safe_browsing_client=sb_client,
     )
-    api_key = _get_safe_browsing_api_key_for_cli(settings)
 
     try:
         async with ConstrainedClient(
@@ -1604,7 +1605,7 @@ async def run_add(args: argparse.Namespace) -> None:
             request_interval=settings.rag_crawl_delay_sec,
         ) as client:
             ingest_result = await web_ingester.add(
-                args.url, client=client, safe_browsing_api_key=api_key,
+                args.url, client=client,
             )
     except ValueError as e:
         logger.error("エラー: %s", e)
@@ -1640,6 +1641,7 @@ async def run_crawl(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    sb_client = _create_safe_browsing_client_cli(settings)
     web_ingester = WebIngester(
         controller.source_store,
         max_crawl_pages=settings.rag_max_crawl_pages,
@@ -1647,12 +1649,8 @@ async def run_crawl(args: argparse.Namespace) -> None:
         crawl_max_errors=settings.rag_crawl_max_errors,
         respect_robots_txt=settings.rag_respect_robots_txt,
         robots_txt_cache_ttl=settings.rag_robots_txt_cache_ttl,
-        url_safety_check=settings.rag_url_safety_check,
-        url_safety_cache_ttl=settings.rag_url_safety_cache_ttl,
-        url_safety_fail_open=settings.rag_url_safety_fail_open,
-        url_safety_timeout=settings.rag_url_safety_timeout,
+        safe_browsing_client=sb_client,
     )
-    api_key = _get_safe_browsing_api_key_for_cli(settings)
 
     try:
         async with ConstrainedClient(
@@ -1661,7 +1659,6 @@ async def run_crawl(args: argparse.Namespace) -> None:
         ) as client:
             ingest_result = await web_ingester.crawl(
                 args.url, pattern=args.pattern, depth=depth, client=client,
-                safe_browsing_api_key=api_key,
             )
     except ValueError as e:
         logger.error("エラー: %s", e)
@@ -1739,7 +1736,9 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
 
 
 def _create_web_ingester_cli(
-    source_store: SourceStore, settings: Settings,
+    source_store: SourceStore,
+    settings: Settings,
+    safe_browsing_client: SafeBrowsingClient | None = None,
 ) -> WebIngester:
     """CLI 用 WebIngester を生成する."""
     from .pipeline.ingesters.web import WebIngester
@@ -1751,10 +1750,7 @@ def _create_web_ingester_cli(
         crawl_max_errors=settings.rag_crawl_max_errors,
         respect_robots_txt=settings.rag_respect_robots_txt,
         robots_txt_cache_ttl=settings.rag_robots_txt_cache_ttl,
-        url_safety_check=settings.rag_url_safety_check,
-        url_safety_cache_ttl=settings.rag_url_safety_cache_ttl,
-        url_safety_fail_open=settings.rag_url_safety_fail_open,
-        url_safety_timeout=settings.rag_url_safety_timeout,
+        safe_browsing_client=safe_browsing_client,
     )
 
 
@@ -1809,14 +1805,16 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             # 投稿内 URL の自動取り込み
             url_stats: dict[str, int] = {}
             if placed_items:
-                web_ingester = _create_web_ingester_cli(controller.source_store, settings)
+                sb_client = _create_safe_browsing_client_cli(settings)
+                web_ingester = _create_web_ingester_cli(
+                    controller.source_store, settings, sb_client,
+                )
                 youtube_ingester = _create_youtube_ingester_cli(controller.source_store, settings)
                 url_stats = await bluesky_ingester.follow_urls(
                     placed_items,
                     client=client,
                     web_ingester=web_ingester,
                     youtube_ingester=youtube_ingester,
-                    safe_browsing_api_key=_get_safe_browsing_api_key_for_cli(settings),
                 )
     except (ValueError, TypeError) as e:
         logger.error("エラー: %s", e)

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -153,7 +153,6 @@ class RAGSettings(BaseModel):
     # URL安全性チェック (Google Safe Browsing API)
     rag_url_safety_check: bool
     rag_url_safety_cache_ttl: int = Field(ge=0)
-    rag_url_safety_fail_open: bool
     rag_url_safety_timeout: float = Field(gt=0)
 
     # レスポンスサイズ制限

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -391,7 +391,6 @@ class BlueskyIngester:
         client: ConstrainedClient | None = None,
         web_ingester: WebIngester | None = None,
         youtube_ingester: YoutubeIngester | None = None,
-        safe_browsing_api_key: str = "",
     ) -> dict[str, int]:
         """配置済み投稿から URL を抽出し、Web/YouTube インジェスターに委譲する.
 
@@ -402,7 +401,6 @@ class BlueskyIngester:
             client: ConstrainedClient（Web インジェスターに共有）
             web_ingester: WebIngester インスタンス
             youtube_ingester: YoutubeIngester インスタンス
-            safe_browsing_api_key: Google Safe Browsing API キー
 
         Returns:
             {"web_placed": N, "youtube_placed": N, "skipped": N, "errors": N}
@@ -464,7 +462,6 @@ class BlueskyIngester:
                 try:
                     web_result = await web_ingester.add(
                         url=url, client=client,
-                        safe_browsing_api_key=safe_browsing_api_key,
                     )
                     stats["web_placed"] += web_result.placed
                     if web_result.errors > 0:

--- a/src/rag/pipeline/ingesters/web.py
+++ b/src/rag/pipeline/ingesters/web.py
@@ -21,6 +21,7 @@ from bs4 import BeautifulSoup
 from pathlib import PurePosixPath
 
 from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.safe_browsing import SafeBrowsingClient
 from rag.utils.url import check_ssrf, validate_url
 
 # converter が認識する拡張子（変換対象 + パススルー対象）
@@ -55,10 +56,6 @@ _CRAWL_ALLOWED_EXTENSIONS: frozenset[str] = frozenset(
 _CRAWL_ALLOWED_CONTENT_TYPES: frozenset[str] = frozenset(
     {"text/html", "application/pdf"},
 )
-
-# Safe Browsing キャッシュ最大エントリ数
-SAFE_BROWSING_CACHE_MAX_ENTRIES = 1000
-
 
 def _decode_html_bytes(data: bytes) -> str:
     """HTML バイト列をテキストにデコードする.
@@ -188,10 +185,7 @@ class WebIngester:
         crawl_max_errors: int = 5,
         respect_robots_txt: bool = True,
         robots_txt_cache_ttl: int = 3600,
-        url_safety_check: bool = True,
-        url_safety_cache_ttl: int = 300,
-        url_safety_fail_open: bool = True,
-        url_safety_timeout: float = 5.0,
+        safe_browsing_client: SafeBrowsingClient | None = None,
     ) -> None:
         self._store = source_store
         self._max_crawl_pages = min(max_crawl_pages, MAX_CRAWL_PAGES_HARD_LIMIT)
@@ -202,30 +196,22 @@ class WebIngester:
         )
         self._respect_robots_txt = respect_robots_txt
         self._robots_txt_cache_ttl = robots_txt_cache_ttl
-        self._url_safety_check = url_safety_check
-        self._url_safety_cache_ttl = url_safety_cache_ttl
-        self._url_safety_fail_open = url_safety_fail_open
-        self._url_safety_timeout = url_safety_timeout
+        self._safe_browsing_client = safe_browsing_client
 
         # robots.txt キャッシュ: key = scheme://hostname:port
         self._robots_cache: dict[str, tuple[RobotFileParser | None, float]] = {}
-
-        # Safe Browsing キャッシュ: key = url, value = (is_safe, timestamp)
-        self._safety_cache: dict[str, tuple[bool, float]] = {}
 
     async def add(
         self,
         url: str,
         *,
         client: Any | None = None,
-        safe_browsing_api_key: str = "",
     ) -> IngestResult:
         """単一ページを取得して source_store に配置する.
 
         Args:
             url: 取り込み対象ページの URL
             client: ConstrainedClient インスタンス
-            safe_browsing_api_key: Safe Browsing API キー
 
         Returns:
             配置結果
@@ -239,13 +225,10 @@ class WebIngester:
             raise ValueError("client (ConstrainedClient) が必要です")
 
         # Safe Browsing チェック
-        if self._url_safety_check and not safe_browsing_api_key:
-            logger.warning("Safe Browsing が有効ですが API キーが未指定です。チェックをスキップします")
-        if self._url_safety_check and safe_browsing_api_key:
-            is_safe = await self._check_safe_browsing(
-                [url], safe_browsing_api_key, client
-            )
-            if not is_safe.get(url, True):
+        if self._safe_browsing_client is not None:
+            sb_results = await self._safe_browsing_client.check_urls([url])
+            sb_result = sb_results.get(url)
+            if sb_result is not None and not sb_result.is_safe:
                 logger.warning("Safe Browsing で危険と判定された URL: %s", url)
                 result.errors += 1
                 result.error_details.append(f"Unsafe URL: {url}")
@@ -305,7 +288,6 @@ class WebIngester:
         pattern: str = "",
         depth: int = 1,
         client: Any | None = None,
-        safe_browsing_api_key: str = "",
     ) -> IngestResult:
         """リンク集ページから一括クロールして source_store に配置する.
 
@@ -317,7 +299,6 @@ class WebIngester:
             pattern: リンクをフィルタする正規表現パターン
             depth: クロール深度（1〜10。デフォルト: 1 = 従来動作）
             client: ConstrainedClient インスタンス
-            safe_browsing_api_key: Safe Browsing API キー
 
         Returns:
             配置結果
@@ -349,11 +330,15 @@ class WebIngester:
                 result.error_details.append(f"無効な正規表現パターン: {e}")
                 return result
 
-        # Safe Browsing 警告（1回のみ）
-        if self._url_safety_check and not safe_browsing_api_key:
-            logger.warning(
-                "Safe Browsing が有効ですが API キーが未指定です。チェックをスキップします"
-            )
+        # Safe Browsing チェック（起点 URL）
+        if self._safe_browsing_client is not None:
+            sb_results = await self._safe_browsing_client.check_urls([url])
+            sb_result = sb_results.get(url)
+            if sb_result is not None and not sb_result.is_safe:
+                logger.warning("Safe Browsing で危険と判定された URL: %s", url)
+                result.errors += 1
+                result.error_details.append(f"Unsafe URL: {url}")
+                return result
 
         # インデックスページ取得
         resp = await client.get(url, follow_redirects=False)
@@ -413,17 +398,12 @@ class WebIngester:
                 pending_links = filtered
 
             # Safe Browsing 一括チェック
-            if (
-                self._url_safety_check
-                and safe_browsing_api_key
-                and pending_links
-            ):
-                safety_results = await self._check_safe_browsing(
-                    pending_links, safe_browsing_api_key, client
-                )
+            if self._safe_browsing_client is not None and pending_links:
+                sb_results = await self._safe_browsing_client.check_urls(pending_links)
                 safe_links: list[str] = []
                 for link in pending_links:
-                    if safety_results.get(link, True):
+                    sb_result = sb_results.get(link)
+                    if sb_result is None or sb_result.is_safe:
                         safe_links.append(link)
                     else:
                         logger.warning("Safe Browsing で除外: %s", link)
@@ -461,9 +441,10 @@ class WebIngester:
 
                     page_resp = await client.get(link, follow_redirects=False)
                     if 300 <= page_resp.status_code < 400:
-                        logger.warning("リダイレクト（SSRF 防止）: %s", link)
-                        result.errors += 1
-                        result.error_details.append(f"Redirect blocked: {link}")
+                        # リダイレクトは SSRF 防止でブロックするが、
+                        # 正常な応答（301/302）なのでスキップ扱い（エラーカウント対象外）
+                        logger.info("リダイレクト（SSRF 防止でスキップ）: %s", link)
+                        result.skipped += 1
                         continue
                     if page_resp.status_code == 404:
                         # 404 はリンク切れ（スキップ扱い、エラーカウント対象外）
@@ -656,8 +637,7 @@ class WebIngester:
                         link, follow_redirects=False
                     )
                     if 300 <= page_resp.status_code < 400:
-                        # リダイレクト: エラーカウント（crawl と統一）
-                        error_count += 1
+                        # リダイレクト: スキップ扱い（crawl と統一）
                         continue
                     if page_resp.status_code == 404:
                         # リンク切れ: スキップ（エラーカウント対象外）
@@ -737,86 +717,3 @@ class WebIngester:
             self._robots_cache[key] = (None, now)
             return True
 
-    # --- Safe Browsing ---
-
-    async def _check_safe_browsing(
-        self,
-        urls: list[str],
-        api_key: str,
-        client: Any,
-    ) -> dict[str, bool]:
-        """Safe Browsing API で URL の安全性をチェックする.
-
-        Returns:
-            URL -> is_safe の辞書
-        """
-        results: dict[str, bool] = {}
-        unchecked: list[str] = []
-        now = time.time()
-
-        # キャッシュから取得
-        for url in urls:
-            if url in self._safety_cache:
-                is_safe, cached_at = self._safety_cache[url]
-                if now - cached_at < self._url_safety_cache_ttl:
-                    results[url] = is_safe
-                    continue
-            unchecked.append(url)
-
-        if not unchecked:
-            return results
-
-        # API 呼び出し
-        try:
-            sb_url = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
-            body = {
-                "client": {"clientId": "rag-knowledge", "clientVersion": "1.0"},
-                "threatInfo": {
-                    "threatTypes": [
-                        "MALWARE",
-                        "SOCIAL_ENGINEERING",
-                        "UNWANTED_SOFTWARE",
-                        "POTENTIALLY_HARMFUL_APPLICATION",
-                    ],
-                    "platformTypes": ["ANY_PLATFORM"],
-                    "threatEntryTypes": ["URL"],
-                    "threatEntries": [{"url": u} for u in unchecked],
-                },
-            }
-
-            resp = await client.post(
-                sb_url,
-                params={"key": api_key},
-                json=body,
-                timeout=self._url_safety_timeout,
-            )
-            data = resp.json()
-
-            # 脅威検出された URL を特定
-            threat_urls: set[str] = set()
-            for match in data.get("matches", []):
-                threat_url = match.get("threat", {}).get("url", "")
-                if threat_url:
-                    threat_urls.add(threat_url)
-
-            for u in unchecked:
-                is_safe = u not in threat_urls
-                results[u] = is_safe
-                # キャッシュ更新（TTL 切れエントリを先に削除してから追加）
-                if len(self._safety_cache) >= SAFE_BROWSING_CACHE_MAX_ENTRIES:
-                    expired = [
-                        k for k, (_, ts) in self._safety_cache.items()
-                        if now - ts >= self._url_safety_cache_ttl
-                    ]
-                    for k in expired:
-                        del self._safety_cache[k]
-                if len(self._safety_cache) < SAFE_BROWSING_CACHE_MAX_ENTRIES:
-                    self._safety_cache[u] = (is_safe, now)
-
-        except Exception:
-            logger.warning("Safe Browsing API の呼び出しに失敗しました")
-            # フェイルオープン/フェイルクローズ
-            for u in unchecked:
-                results[u] = self._url_safety_fail_open
-
-        return results

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -323,8 +323,7 @@ class RAGKnowledgeService:
             {"pages_crawled": N, "chunks_stored": M, "errors": E, "unsafe_urls": U}
 
         Raises:
-            SafetyCheckError: Safe Browsing APIでfail_open=False設定時、
-                API障害が発生した場合に送出される
+            SafetyCheckError: Safe Browsing API障害時に送出される
         """
         return await self._ingest_from_index_impl(
             index_url, url_pattern, progress_callback

--- a/src/rag/safe_browsing.py
+++ b/src/rag/safe_browsing.py
@@ -24,10 +24,17 @@ _SERVICE_NAME = "rag-knowledge"
 logger = logging.getLogger(__name__)
 
 
+class SafeBrowsingConfigError(Exception):
+    """Safe Browsing の設定エラー.
+
+    API キー未登録・空・不正（400 応答）、keyring アクセス失敗時に送出される。
+    """
+
+
 class SafetyCheckError(Exception):
     """URL安全性チェック失敗時の例外.
 
-    危険なURLが検出された場合、またはfail_close設定時にAPI障害が発生した場合に送出される。
+    危険なURLが検出された場合、またはAPI障害が発生した場合に送出される。
     """
 
     def __init__(self, url: str, message: str, threats: list[str] | None = None) -> None:
@@ -81,7 +88,6 @@ class SafeBrowsingResult:
     url: str
     is_safe: bool
     threats: list[ThreatMatch] = field(default_factory=list)
-    error: str | None = None
     cached: bool = False
 
 
@@ -109,13 +115,13 @@ class SafeBrowsingClient:
     API_URL = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
     DEFAULT_CACHE_TTL = 300  # 5分（デフォルトTTL）
     MAX_CACHE_SIZE = 1000  # キャッシュの最大エントリ数
+    MAX_URLS_PER_REQUEST = 500  # Lookup API v4 の 1 リクエストあたり URL 上限
 
     def __init__(
         self,
         api_key: str,
         timeout: float = 10.0,
         cache_ttl: float | None = None,
-        fail_open: bool = True,
         client_id: str = "rag-knowledge",
         client_version: str = "1.0.0",
         max_cache_size: int | None = None,
@@ -127,7 +133,6 @@ class SafeBrowsingClient:
             api_key: Google Safe Browsing API キー
             timeout: APIリクエストのタイムアウト秒数
             cache_ttl: キャッシュのTTL秒数（None の場合はデフォルトTTLを使用）
-            fail_open: API障害時の動作（True: URLを許可, False: URLを拒否）
             client_id: クライアント識別子
             client_version: クライアントバージョン
             max_cache_size: キャッシュの最大エントリ数（None の場合はデフォルト値を使用）
@@ -137,7 +142,6 @@ class SafeBrowsingClient:
         self._api_key = api_key
         self._timeout = httpx.Timeout(timeout)
         self._cache_ttl = cache_ttl
-        self._fail_open = fail_open
         self._client_id = client_id
         self._client_version = client_version
         self._max_cache_size = max_cache_size if max_cache_size is not None else self.MAX_CACHE_SIZE
@@ -165,7 +169,6 @@ class SafeBrowsingClient:
                 url=result.url,
                 is_safe=result.is_safe,
                 threats=list(result.threats),
-                error=result.error,
                 cached=True,
             )
 
@@ -286,64 +289,86 @@ class SafeBrowsingClient:
         if not urls_to_check:
             return results
 
-        # API呼び出し
+        # API呼び出し（常にフェイルクローズ: エラー時は例外送出）
         try:
             api_results = await self._call_api(urls_to_check)
             for url, result in api_results.items():
                 results[url] = result
                 # キャッシュに保存
                 await self._set_cache(url, result)
+        except SafeBrowsingConfigError:
+            raise
         except Exception as e:
             logger.exception("Safe Browsing API error")
-            if self._fail_open:
-                # fail-open: API障害時はURLを許可
-                for url in urls_to_check:
-                    results[url] = SafeBrowsingResult(
-                        url=url,
-                        is_safe=True,
-                        error=str(e),
-                    )
-            else:
-                # fail-close: API障害時はURLを拒否（例外を送出）
-                raise SafetyCheckError(
-                    url=urls_to_check[0] if len(urls_to_check) == 1 else "",
-                    message=f"Safe Browsing API障害のためURL安全性を確認できません: {e}",
-                ) from e
+            raise SafetyCheckError(
+                url=urls_to_check[0] if len(urls_to_check) == 1 else "",
+                message=f"Safe Browsing API障害のためURL安全性を確認できません: {e}",
+            ) from e
 
         return results
 
     async def _call_api(self, urls: list[str]) -> dict[str, SafeBrowsingResult]:
-        """Safe Browsing API を呼び出す."""
+        """Safe Browsing API を呼び出す.
+
+        URL 数が MAX_URLS_PER_REQUEST を超える場合はバッチ分割して呼び出す。
+        """
+        # バッチ分割
+        if len(urls) > self.MAX_URLS_PER_REQUEST:
+            all_results: dict[str, SafeBrowsingResult] = {}
+            for i in range(0, len(urls), self.MAX_URLS_PER_REQUEST):
+                batch = urls[i : i + self.MAX_URLS_PER_REQUEST]
+                batch_results = await self._call_api_single(batch)
+                all_results.update(batch_results)
+            return all_results
+
+        return await self._call_api_single(urls)
+
+    async def _call_api_single(self, urls: list[str]) -> dict[str, SafeBrowsingResult]:
+        """Safe Browsing API を 1 回呼び出す."""
         from py_common_lib.httpx import ConstrainedClient
 
         request_body = self._build_request_body(urls)
+        headers = {"x-goog-api-key": self._api_key}
 
         if self._cc_kwargs is not None:
             # 都度生成: 再入・並行利用による状態干渉を防ぐ
-            cc = ConstrainedClient(**self._cc_kwargs)
+            cc_kwargs = {**self._cc_kwargs, "headers": headers}
+            cc = ConstrainedClient(**cc_kwargs)
             async with cc as client:
                 resp = await client.post(
                     self.API_URL,
-                    params={"key": self._api_key},
                     json=request_body,
                 )
-                if resp.status_code != 200:
-                    raise RuntimeError(
-                        f"Safe Browsing API error: {resp.status_code} - {resp.text}"
-                    )
+                self._check_response_status(resp.status_code, resp.text)
                 response_data = resp.json()
         else:
-            async with httpx.AsyncClient(timeout=self._timeout) as session:  # safety:allowed
+            async with httpx.AsyncClient(timeout=self._timeout, headers=headers) as session:  # safety:allowed
                 resp = await session.post(
-                    self.API_URL, params={"key": self._api_key}, json=request_body
+                    self.API_URL, json=request_body,
                 )
-                if resp.status_code != 200:
-                    raise RuntimeError(
-                        f"Safe Browsing API error: {resp.status_code} - {resp.text}"
-                    )
+                self._check_response_status(resp.status_code, resp.text)
                 response_data = resp.json()
 
         return self._parse_response(response_data, urls)
+
+    def _check_response_status(self, status_code: int, text: str) -> None:
+        """APIレスポンスのステータスコードを検証する."""
+        if status_code == 200:
+            return
+        if status_code == 400:
+            # バッチ分割により URL 数超過は通常発生しない。
+            # 400 は API キー不正またはリクエスト不正として設定エラーとする。
+            raise SafeBrowsingConfigError(
+                f"Safe Browsing API 設定エラー（400 Bad Request）: {text}"
+            )
+        if status_code == 429:
+            raise RuntimeError(
+                "Safe Browsing API レートリミット超過（429）。"
+                "1日あたりのリクエスト上限に達しました。時間を置いてから再試行してください"
+            )
+        raise RuntimeError(
+            f"Safe Browsing API エラー（{status_code}）: {text}"
+        )
 
     async def is_url_safe(self, url: str) -> bool:
         """URLが安全かどうかを判定する（シンプルなインターフェース）.
@@ -352,7 +377,7 @@ class SafeBrowsingClient:
             url: チェックするURL
 
         Returns:
-            True: 安全（または判定不能）, False: 危険
+            True: 安全, False: 危険
         """
         result = await self.check_url(url)
         return result.is_safe
@@ -394,6 +419,9 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
 
     Returns:
         SafeBrowsingClient または None（無効時）
+
+    Raises:
+        SafeBrowsingConfigError: API キー未登録・空・keyring アクセス失敗時
     """
     if not settings.rag_url_safety_check:
         logger.debug("URL safety check is disabled")
@@ -401,26 +429,22 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
 
     try:
         api_key = get_secret("GOOGLE_SAFE_BROWSING_API_KEY", service=_SERVICE_NAME)
-    except SecretNotFoundError:
-        logger.warning(
+    except SecretNotFoundError as e:
+        raise SafeBrowsingConfigError(
             "URL safety check is enabled but GOOGLE_SAFE_BROWSING_API_KEY is not "
-            "registered in the secret store. Skipping Safe Browsing integration."
-        )
-        return None
-    except SecretStoreError:
-        logger.warning(
-            "URL safety check is enabled but failed to access the secret store. "
-            "Skipping Safe Browsing integration.",
-            exc_info=True,
-        )
-        return None
+            "registered in the secret store. Register the key or set "
+            "rag_url_safety_check=false in config.toml."
+        ) from e
+    except SecretStoreError as e:
+        raise SafeBrowsingConfigError(
+            "URL safety check is enabled but failed to access the secret store."
+        ) from e
 
     if not api_key:
-        logger.warning(
+        raise SafeBrowsingConfigError(
             "URL safety check is enabled but GOOGLE_SAFE_BROWSING_API_KEY is empty. "
-            "Skipping Safe Browsing integration."
+            "Register a valid key or set rag_url_safety_check=false in config.toml."
         )
-        return None
 
     cache_ttl: float | None = None
     if settings.rag_url_safety_cache_ttl > 0:
@@ -430,7 +454,6 @@ def create_safe_browsing_client(settings: RAGSettings) -> SafeBrowsingClient | N
         api_key=api_key,
         timeout=settings.rag_url_safety_timeout,
         cache_ttl=cache_ttl,
-        fail_open=settings.rag_url_safety_fail_open,
         constrained_client_kwargs={
             "request_timeout": settings.rag_url_safety_timeout,
             "max_requests": 10,

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -80,7 +80,12 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .store.source_store import SourceStore
 
 from py_common_lib.httpx import ConstrainedClient  # safety:allowed
-from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
+
+from .safe_browsing import (
+    SafeBrowsingClient,
+    SafeBrowsingConfigError,
+    create_safe_browsing_client,
+)
 
 from mcp.server.fastmcp import Context, FastMCP
 
@@ -94,9 +99,6 @@ ensure_utf8_streams()
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("rag")
-
-# シークレットサービス名
-_SECRET_SERVICE_NAME = "rag-knowledge"
 
 # --- 遅延初期化: RAGKnowledgeService（検索用） ---
 
@@ -214,32 +216,29 @@ def _build_pipeline_controller() -> PipelineController:
     return build_pipeline_controller()
 
 
-_safe_browsing_api_key_cache: str | None = None
+_safe_browsing_client_cache: SafeBrowsingClient | None = None
+_safe_browsing_client_initialized = False
 
 
-def _get_safe_browsing_api_key() -> str:
-    """Safe Browsing API キーを取得する（プロセス内キャッシュ）.
+def _get_safe_browsing_client() -> SafeBrowsingClient | None:
+    """SafeBrowsingClient を取得する（プロセス内キャッシュ）.
 
     Returns:
-        API キー。取得できない場合は空文字列。
+        SafeBrowsingClient または None（無効時）
+
+    Raises:
+        SafeBrowsingConfigError: API キー未登録・空・keyring アクセス失敗時
     """
-    global _safe_browsing_api_key_cache
-    if _safe_browsing_api_key_cache is not None:
-        return _safe_browsing_api_key_cache
+    global _safe_browsing_client_cache, _safe_browsing_client_initialized
+    if _safe_browsing_client_initialized:
+        return _safe_browsing_client_cache
+    # SafeBrowsingConfigError 時は initialized を True にしない
+    # （設定修正まで毎回エラー送出）
 
     settings = get_settings()
-    if not settings.rag_url_safety_check:
-        _safe_browsing_api_key_cache = ""
-        return ""
-    try:
-        key = get_secret(
-            "GOOGLE_SAFE_BROWSING_API_KEY", service=_SECRET_SERVICE_NAME,
-        )
-        _safe_browsing_api_key_cache = key or ""
-    except (SecretNotFoundError, SecretStoreError):
-        logger.warning("Safe Browsing API key not available")
-        _safe_browsing_api_key_cache = ""
-    return _safe_browsing_api_key_cache
+    _safe_browsing_client_cache = create_safe_browsing_client(settings)
+    _safe_browsing_client_initialized = True
+    return _safe_browsing_client_cache
 
 
 # --- レスポンスフォーマッタ ---
@@ -263,7 +262,10 @@ def _format_ingest_response(
 # --- ファクトリヘルパー ---
 
 
-def _create_web_ingester(source_store: SourceStore) -> PipelineWebIngester:
+def _create_web_ingester(
+    source_store: SourceStore,
+    safe_browsing_client: SafeBrowsingClient | None = None,
+) -> PipelineWebIngester:
     """設定に基づいて PipelineWebIngester を生成する."""
     settings = get_settings()
     return PipelineWebIngester(
@@ -273,10 +275,7 @@ def _create_web_ingester(source_store: SourceStore) -> PipelineWebIngester:
         crawl_max_errors=settings.rag_crawl_max_errors,
         respect_robots_txt=settings.rag_respect_robots_txt,
         robots_txt_cache_ttl=settings.rag_robots_txt_cache_ttl,
-        url_safety_check=settings.rag_url_safety_check,
-        url_safety_cache_ttl=settings.rag_url_safety_cache_ttl,
-        url_safety_fail_open=settings.rag_url_safety_fail_open,
-        url_safety_timeout=settings.rag_url_safety_timeout,
+        safe_browsing_client=safe_browsing_client,
     )
 
 
@@ -414,17 +413,20 @@ async def rag_add(url: str, ctx: MCPContext | None = None) -> str:
         取り込み結果のメッセージ
     """
     controller = await _get_pipeline_controller()
-    web_ingester = _create_web_ingester(controller.source_store)
+    try:
+        sb_client = _get_safe_browsing_client()
+    except SafeBrowsingConfigError as e:
+        return f"Safe Browsing 設定エラー: {e}"
+    web_ingester = _create_web_ingester(controller.source_store, sb_client)
     settings = get_settings()
 
     try:
-        api_key = _get_safe_browsing_api_key()
         async with ConstrainedClient(
             request_timeout=settings.rag_crawl_request_timeout,
             request_interval=settings.rag_crawl_delay_sec,
         ) as client:
             ingest_result = await web_ingester.add(
-                url, client=client, safe_browsing_api_key=api_key,
+                url, client=client,
             )
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
@@ -486,17 +488,19 @@ async def rag_crawl(
         )
 
     controller = await _get_pipeline_controller()
-    web_ingester = _create_web_ingester(controller.source_store)
+    try:
+        sb_client = _get_safe_browsing_client()
+    except SafeBrowsingConfigError as e:
+        return f"Safe Browsing 設定エラー: {e}"
+    web_ingester = _create_web_ingester(controller.source_store, sb_client)
 
     try:
-        api_key = _get_safe_browsing_api_key()
         async with ConstrainedClient(
             request_timeout=settings.rag_crawl_request_timeout,
             request_interval=settings.rag_crawl_delay_sec,
         ) as client:
             ingest_result = await web_ingester.crawl(
                 url, pattern=pattern, depth=depth, client=client,
-                safe_browsing_api_key=api_key,
             )
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
@@ -734,7 +738,11 @@ async def rag_crawl_bluesky(
             # 投稿内 URL の自動取り込み
             url_stats: dict[str, int] = {}
             if placed_items:
-                web_ingester = _create_web_ingester(controller.source_store)
+                try:
+                    sb_client = _get_safe_browsing_client()
+                except SafeBrowsingConfigError as e:
+                    return f"Safe Browsing 設定エラー: {e}"
+                web_ingester = _create_web_ingester(controller.source_store, sb_client)
                 youtube_ingester = PipelineYoutubeIngester(
                     controller.source_store,
                     max_videos=settings.rag_youtube_max_videos,
@@ -745,13 +753,11 @@ async def rag_crawl_bluesky(
                     transcript_languages=settings.rag_youtube_transcript_languages,
                     max_duration=settings.rag_youtube_max_duration,
                 )
-                api_key = _get_safe_browsing_api_key()
                 url_stats = await bluesky_ingester.follow_urls(
                     placed_items,
                     client=client,
                     web_ingester=web_ingester,
                     youtube_ingester=youtube_ingester,
-                    safe_browsing_api_key=api_key,
                 )
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -84,6 +84,7 @@ from py_common_lib.httpx import ConstrainedClient  # safety:allowed
 from .safe_browsing import (
     SafeBrowsingClient,
     SafeBrowsingConfigError,
+    SafetyCheckError,
     create_safe_browsing_client,
 )
 
@@ -440,6 +441,8 @@ async def rag_add(url: str, ctx: MCPContext | None = None) -> str:
         _reset_rag_service()
 
         return _format_ingest_response(ingest_result, pipeline_summary, context=url)
+    except (SafetyCheckError, SafeBrowsingConfigError) as e:
+        return f"Safe Browsing エラー: {e}"
     except ValueError as e:
         return f"エラー: {e}"
     except Exception:
@@ -514,6 +517,8 @@ async def rag_crawl(
         _reset_rag_service()
 
         return _format_ingest_response(ingest_result, pipeline_summary, context=url)
+    except (SafetyCheckError, SafeBrowsingConfigError) as e:
+        return f"Safe Browsing エラー: {e}"
     except ValueError as e:
         return f"エラー: {e}"
     except Exception:
@@ -784,6 +789,8 @@ async def rag_crawl_bluesky(
                 parts.append(f"エラー {err_n}件")
             summary += " ".join(parts)
         return summary
+    except (SafetyCheckError, SafeBrowsingConfigError) as e:
+        return f"Safe Browsing エラー: {e}"
     except (ValueError, TypeError) as e:
         return f"エラー: {e}"
     except Exception:

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -39,7 +39,6 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_robots_txt_cache_ttl": 3600,
     "rag_url_safety_check": False,
     "rag_url_safety_cache_ttl": 300,
-    "rag_url_safety_fail_open": True,
     "rag_url_safety_timeout": 5.0,
     "rag_stats_max_sources": 100,
     "rag_zenn_max_articles": 50,

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -484,7 +484,6 @@ class TestFollowUrls:
 
         mock_web.add.assert_called_once_with(
             url="https://example.com/article", client=mock_client,
-            safe_browsing_api_key="",
         )
         assert stats["web_placed"] == 1
 

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -241,7 +241,6 @@ class TestAdd:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.add(
@@ -272,7 +271,6 @@ class TestAdd:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         with pytest.raises(ValueError, match="リダイレクト"):
@@ -294,7 +292,6 @@ class TestAddExtension:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.add(
@@ -322,7 +319,6 @@ class TestAddExtension:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.add(
@@ -351,7 +347,6 @@ class TestAddExtension:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.add(
@@ -394,7 +389,6 @@ class TestCrawlExtension:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -432,7 +426,6 @@ class TestCrawl:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -459,7 +452,6 @@ class TestCrawl:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -491,7 +483,6 @@ class TestCrawlPreview:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         previews = await ingester.crawl_preview(
@@ -526,7 +517,6 @@ class TestCrawlPreview:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl_preview(
@@ -574,7 +564,6 @@ class TestCrawlDepth:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -611,7 +600,6 @@ class TestCrawlDepth:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -648,7 +636,6 @@ class TestCrawlDepth:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -681,7 +668,6 @@ class TestCrawlDepth:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -720,7 +706,6 @@ class TestCrawlDepth:
         ingester = WebIngester(
             source_store,
             max_crawl_pages=2,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -764,7 +749,6 @@ class TestCrawlMaxErrors:
         ingester = WebIngester(
             source_store,
             crawl_max_errors=5,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(
@@ -783,7 +767,6 @@ class TestCrawlMaxErrors:
         ingester = WebIngester(
             source_store,
             crawl_max_errors=1,  # 1 は下限 5 にクランプ
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         assert ingester._crawl_max_errors == 5
@@ -819,7 +802,6 @@ class TestCrawlPreviewDepth:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         previews = await ingester.crawl_preview(
@@ -966,7 +948,6 @@ class TestCrawlContentTypeFilter:
 
         ingester = WebIngester(
             source_store,
-            url_safety_check=False,
             respect_robots_txt=False,
         )
         result = await ingester.crawl(

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -183,7 +183,6 @@ rag_respect_robots_txt = true
 rag_robots_txt_cache_ttl = 3600
 rag_url_safety_check = false
 rag_url_safety_cache_ttl = 300
-rag_url_safety_fail_open = true
 rag_url_safety_timeout = 5.0
 rag_stats_max_sources = 100
 rag_zenn_max_articles = 50

--- a/tests/test_safe_browsing.py
+++ b/tests/test_safe_browsing.py
@@ -10,11 +10,12 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from py_common_lib.secrets import SecretNotFoundError
+from py_common_lib.secrets import SecretNotFoundError, SecretStoreError
 
 from rag.safe_browsing import (
     CacheEntry,
     SafeBrowsingClient,
+    SafeBrowsingConfigError,
     SafeBrowsingResult,
     SafetyCheckError,
     ThreatType,
@@ -149,7 +150,7 @@ class TestSafeBrowsingClientAsync:
 
     @pytest.mark.asyncio
     async def test_check_url_unsafe(self) -> None:
-        """AC3: 危険なURLのチェックでis_safe=Falseが返ること."""
+        """危険なURLのチェックでis_safe=Falseが返ること."""
         client = SafeBrowsingClient(api_key="test-key")
         mock_response = MockResponse(
             200,
@@ -230,7 +231,7 @@ class TestSafeBrowsingCache:
 
     @pytest.mark.asyncio
     async def test_cache_hit(self) -> None:
-        """AC8: キャッシュヒット時にAPIが呼ばれないこと."""
+        """キャッシュヒット時にAPIが呼ばれないこと."""
         client = SafeBrowsingClient(api_key="test-key", cache_ttl=300)
 
         # 最初のリクエスト
@@ -323,11 +324,11 @@ class TestSafeBrowsingCache:
 
 
 class TestSafeBrowsingErrorHandling:
-    """SafeBrowsingClient のエラーハンドリングテスト."""
+    """SafeBrowsingClient のエラーハンドリングテスト（常にフェイルクローズ）."""
 
     @pytest.mark.asyncio
-    async def test_api_error_fail_open(self) -> None:
-        """AC6: API障害時にfail-open（URLを許可）すること."""
+    async def test_api_error_raises_safety_check_error(self) -> None:
+        """API障害時にSafetyCheckErrorが送出されること."""
         client = SafeBrowsingClient(api_key="test-key")
         mock_response = MockResponse(500, {"error": "Internal Server Error"})
 
@@ -335,51 +336,33 @@ class TestSafeBrowsingErrorHandling:
             "rag.safe_browsing.httpx.AsyncClient",
             return_value=MockAsyncClient(mock_response),
         ):
-            result = await client.check_url("https://unknown-site.com")
-
-        # fail-open: エラー時も安全と判定
-        assert result.is_safe is True
-        assert result.error is not None
-        assert "500" in result.error
+            with pytest.raises(SafetyCheckError, match="API障害"):
+                await client.check_url("https://unknown-site.com")
 
     @pytest.mark.asyncio
-    async def test_network_error_fail_open(self) -> None:
-        """AC6: ネットワークエラー時にfail-open（URLを許可）すること."""
-        client = SafeBrowsingClient(api_key="test-key", fail_open=True)
+    async def test_network_error_raises_safety_check_error(self) -> None:
+        """ネットワークエラー時にSafetyCheckErrorが送出されること."""
+        client = SafeBrowsingClient(api_key="test-key")
 
         with patch(
             "rag.safe_browsing.httpx.AsyncClient",
             side_effect=Exception("Network error"),
         ):
-            result = await client.check_url("https://unknown-site.com")
-
-        assert result.is_safe is True
-        assert result.error is not None
+            with pytest.raises(SafetyCheckError, match="API障害"):
+                await client.check_url("https://unknown-site.com")
 
     @pytest.mark.asyncio
-    async def test_api_error_fail_close(self) -> None:
-        """AC7: fail_close設定時にAPI障害で例外が送出されること."""
-        client = SafeBrowsingClient(api_key="test-key", fail_open=False)
-        mock_response = MockResponse(500, {"error": "Internal Server Error"})
+    async def test_400_response_raises_config_error(self) -> None:
+        """400応答時にSafeBrowsingConfigErrorが送出されること."""
+        client = SafeBrowsingClient(api_key="invalid-key")
+        mock_response = MockResponse(400, {"error": "API key not valid"})
 
         with patch(
             "rag.safe_browsing.httpx.AsyncClient",
             return_value=MockAsyncClient(mock_response),
         ):
-            with pytest.raises(SafetyCheckError, match="API障害"):
-                await client.check_url("https://unknown-site.com")
-
-    @pytest.mark.asyncio
-    async def test_network_error_fail_close(self) -> None:
-        """AC7: fail_close設定時にネットワークエラーで例外が送出されること."""
-        client = SafeBrowsingClient(api_key="test-key", fail_open=False)
-
-        with patch(
-            "rag.safe_browsing.httpx.AsyncClient",
-            side_effect=Exception("Network error"),
-        ):
-            with pytest.raises(SafetyCheckError, match="API障害"):
-                await client.check_url("https://unknown-site.com")
+            with pytest.raises(SafeBrowsingConfigError, match="400 Bad Request"):
+                await client.check_url("https://example.com")
 
 
 class TestSafetyCheckError:
@@ -444,15 +427,15 @@ class TestCreateSafeBrowsingClient:
     """ファクトリ関数のテスト."""
 
     def test_create_client_disabled(self) -> None:
-        """AC4: RAG_URL_SAFETY_CHECK=false の場合、チェックがスキップされること."""
+        """rag_url_safety_check=false の場合、None が返ること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = False
 
         client = create_safe_browsing_client(mock_settings)
         assert client is None
 
-    def test_create_client_no_api_key(self) -> None:
-        """AC5: GOOGLE_SAFE_BROWSING_API_KEY 未登録の場合、スキップ."""
+    def test_create_client_no_api_key_raises_config_error(self) -> None:
+        """API キー未登録の場合、SafeBrowsingConfigError が送出されること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
 
@@ -460,24 +443,35 @@ class TestCreateSafeBrowsingClient:
             "rag.safe_browsing.get_secret",
             side_effect=SecretNotFoundError("not found"),
         ):
-            client = create_safe_browsing_client(mock_settings)
-        assert client is None
+            with pytest.raises(SafeBrowsingConfigError, match="not registered"):
+                create_safe_browsing_client(mock_settings)
 
-    def test_create_client_empty_api_key(self) -> None:
-        """GOOGLE_SAFE_BROWSING_API_KEY が空文字列の場合、スキップ."""
+    def test_create_client_empty_api_key_raises_config_error(self) -> None:
+        """API キーが空文字列の場合、SafeBrowsingConfigError が送出されること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
 
         with patch("rag.safe_browsing.get_secret", return_value=""):
-            client = create_safe_browsing_client(mock_settings)
-        assert client is None
+            with pytest.raises(SafeBrowsingConfigError, match="empty"):
+                create_safe_browsing_client(mock_settings)
+
+    def test_create_client_secret_store_error_raises_config_error(self) -> None:
+        """keyring アクセス失敗時に SafeBrowsingConfigError が送出されること."""
+        mock_settings = MagicMock()
+        mock_settings.rag_url_safety_check = True
+
+        with patch(
+            "rag.safe_browsing.get_secret",
+            side_effect=SecretStoreError("keyring error"),
+        ):
+            with pytest.raises(SafeBrowsingConfigError, match="secret store"):
+                create_safe_browsing_client(mock_settings)
 
     def test_create_client_enabled(self) -> None:
         """有効な設定でクライアントが作成されること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
         mock_settings.rag_url_safety_cache_ttl = 300
-        mock_settings.rag_url_safety_fail_open = True
         mock_settings.rag_url_safety_timeout = 5.0
 
         with patch("rag.safe_browsing.get_secret", return_value="test-api-key"):
@@ -490,7 +484,6 @@ class TestCreateSafeBrowsingClient:
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
         mock_settings.rag_url_safety_cache_ttl = 600
-        mock_settings.rag_url_safety_fail_open = True
         mock_settings.rag_url_safety_timeout = 5.0
 
         with patch("rag.safe_browsing.get_secret", return_value="test-api-key"):
@@ -503,7 +496,6 @@ class TestCreateSafeBrowsingClient:
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
         mock_settings.rag_url_safety_cache_ttl = 0
-        mock_settings.rag_url_safety_fail_open = True
         mock_settings.rag_url_safety_timeout = 5.0
 
         with patch("rag.safe_browsing.get_secret", return_value="test-api-key"):
@@ -511,25 +503,11 @@ class TestCreateSafeBrowsingClient:
         assert client is not None
         assert client._cache_ttl is None  # APIレスポンスに従う
 
-    def test_create_client_with_fail_open_false(self) -> None:
-        """fail_open=Falseで作成されること."""
-        mock_settings = MagicMock()
-        mock_settings.rag_url_safety_check = True
-        mock_settings.rag_url_safety_cache_ttl = 300
-        mock_settings.rag_url_safety_fail_open = False
-        mock_settings.rag_url_safety_timeout = 5.0
-
-        with patch("rag.safe_browsing.get_secret", return_value="test-api-key"):
-            client = create_safe_browsing_client(mock_settings)
-        assert client is not None
-        assert client._fail_open is False
-
     def test_create_client_has_constrained_client_kwargs(self) -> None:
         """ファクトリ関数で ConstrainedClient kwargs が設定されること."""
         mock_settings = MagicMock()
         mock_settings.rag_url_safety_check = True
         mock_settings.rag_url_safety_cache_ttl = 300
-        mock_settings.rag_url_safety_fail_open = True
         mock_settings.rag_url_safety_timeout = 5.0
 
         with patch("rag.safe_browsing.get_secret", return_value="test-api-key"):
@@ -544,8 +522,8 @@ class TestSafeBrowsingWithConstrainedClient:
     """ConstrainedClient 経由での SafeBrowsingClient テスト."""
 
     @pytest.mark.asyncio
-    async def test_call_api_via_constrained_client(self) -> None:
-        """ConstrainedClient 経由で API が呼び出されること."""
+    async def test_call_api_via_constrained_client_uses_header(self) -> None:
+        """ConstrainedClient 経由で API キーがヘッダーで送信されること."""
         client = SafeBrowsingClient(
             api_key="test-key",
             constrained_client_kwargs={
@@ -561,27 +539,39 @@ class TestSafeBrowsingWithConstrainedClient:
 
         with patch.object(
             ConstrainedClient,
+            "__init__",
+            return_value=None,
+        ) as mock_init, patch.object(
+            ConstrainedClient,
             "post",
             new_callable=AsyncMock,
             return_value=mock_resp,
-        ) as mock_post:
+        ) as mock_post, patch.object(
+            ConstrainedClient,
+            "__aenter__",
+            new_callable=AsyncMock,
+            return_value=MagicMock(post=mock_post),
+        ), patch.object(
+            ConstrainedClient,
+            "__aexit__",
+            new_callable=AsyncMock,
+        ):
             result = await client.check_url("https://safe-site.com")
-            mock_post.assert_called_once()
-            call_kwargs = mock_post.call_args
-            assert call_kwargs.kwargs["params"] == {"key": "test-key"}
+            # ConstrainedClient の init に x-goog-api-key ヘッダーが渡されていること
+            init_kwargs = mock_init.call_args
+            assert init_kwargs.kwargs.get("headers", {}).get("x-goog-api-key") == "test-key"
 
         assert result.is_safe is True
 
     @pytest.mark.asyncio
-    async def test_call_api_via_constrained_client_error(self) -> None:
-        """ConstrainedClient 経由でのエラーが fail-open で処理されること."""
+    async def test_call_api_via_constrained_client_error_raises(self) -> None:
+        """ConstrainedClient 経由でのエラーが SafetyCheckError で処理されること."""
         client = SafeBrowsingClient(
             api_key="test-key",
             constrained_client_kwargs={
                 "request_timeout": 5.0,
                 "request_interval": 0.5,
             },
-            fail_open=True,
         )
 
         mock_resp = MagicMock()
@@ -595,7 +585,52 @@ class TestSafeBrowsingWithConstrainedClient:
             new_callable=AsyncMock,
             return_value=mock_resp,
         ):
-            result = await client.check_url("https://test-site.com")
+            with pytest.raises(SafetyCheckError):
+                await client.check_url("https://test-site.com")
 
-        assert result.is_safe is True
-        assert result.error is not None
+
+class TestHeaderAuthentication:
+    """API キーのヘッダー認証テスト."""
+
+    @pytest.mark.asyncio
+    async def test_httpx_client_uses_header(self) -> None:
+        """httpx.AsyncClient が x-goog-api-key ヘッダーで認証すること."""
+        client = SafeBrowsingClient(api_key="my-secret-key")
+        mock_response = MockResponse(200, {})
+
+        with patch(
+            "rag.safe_browsing.httpx.AsyncClient",
+        ) as mock_client_cls:
+            mock_instance = MockAsyncClient(mock_response)
+            mock_client_cls.return_value = mock_instance
+
+            await client.check_url("https://example.com")
+
+            # AsyncClient にヘッダーが渡されていること
+            call_kwargs = mock_client_cls.call_args.kwargs
+            assert "headers" in call_kwargs
+            assert call_kwargs["headers"]["x-goog-api-key"] == "my-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_httpx_client_no_api_key_in_params(self) -> None:
+        """httpx.AsyncClient が URL パラメータに API キーを含まないこと."""
+        client = SafeBrowsingClient(api_key="my-secret-key")
+        mock_response = MockResponse(200, {})
+
+        class TrackingMockAsyncClient(MockAsyncClient):
+            """POST のパラメータを追跡するモック."""
+
+            last_kwargs: dict[str, object] = {}
+
+            async def post(self, url: str, **kwargs: object) -> MockResponse:
+                TrackingMockAsyncClient.last_kwargs = kwargs
+                return self._response
+
+        with patch(
+            "rag.safe_browsing.httpx.AsyncClient",
+            return_value=TrackingMockAsyncClient(mock_response),
+        ):
+            await client.check_url("https://example.com")
+
+        # post() に params が渡されていないこと
+        assert "params" not in TrackingMockAsyncClient.last_kwargs


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング ★
- [x] docs: ドキュメント更新

## Summary

- `fail_open` 設定を廃止し、Safe Browsing チェック失敗時は常にフェイルクローズ（即時中断）に統一
- API キーの送信方式を URL パラメータから `x-goog-api-key` ヘッダーに変更（ログへの漏洩防止）
- `web.py` のインライン Safe Browsing 実装を削除し、`SafeBrowsingClient` に一本化
- `SafeBrowsingConfigError` を追加し、API キー未登録・空・不正（400応答）時は設定エラーとして即時中断
- `create_safe_browsing_client()` ファクトリ関数のエラーハンドリングを強化
- `server.py` / `cli.py` のエントリポイントを `SafeBrowsingClient` 注入方式に変更
- crawl 起点 URL への Safe Browsing チェックを追加（設計漏れ修正）
- リダイレクト（301/302）をエラーカウントからスキップ扱いに変更
- 500 URL 超時のバッチ分割対応（Lookup API v4 の 1 リクエスト上限）
- 429（レートリミット）応答時の明示的エラーメッセージを追加
- `SafeBrowsingResult.error` デッドフィールドを削除
- 仕様書（web.md, rag-knowledge.md）を実装と整合するよう更新

## Test plan

- [x] ruff / mypy エラーなし
- [x] 全 1277 テスト通過
- [x] CLI add: Safe Browsing 200 OK、正常取り込み確認
- [x] CLI crawl depth=2: 起点 + リンク群の Safe Browsing チェック正常（67件配置）
- [x] CLI bluesky 10件: 投稿内 URL の Safe Browsing チェック正常（Web 2件 + YouTube 1件）
- [x] MCP rag_add: Safe Browsing チェック経由で正常取り込み・検索確認
- [x] コードレビュー・ドキュメントレビュー通過

## Related issues

Closes #381