### PR TITLE
feat(zenn): Zenn インジェスターにスキップモードを追加 (#386)

### DIFF
--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -208,7 +208,7 @@ flowchart TB
 |------|-----------|----------------|-------------|
 | web | URL | URL パス変換規則で一意に決定 | 上書き |
 | bluesky | AT URI | DID + 年月 + rkey で一意に決定 | スキップ |
-| zenn | Zenn URL | username + slug で一意に決定 | 上書き |
+| zenn | Zenn URL | username + slug で一意に決定 | スキップ（force 指定時は上書き） |
 | youtube | YouTube 動画 URL | channel_id + video_id で一意に決定 | 上書き |
 | aozora | 青空文庫 URL | person_id + book_id で一意に決定 | スキップ |
 | local | 相対パス | ユーザー指定パスで一意に決定 | 上書き |

--- a/docs/specs/ingesters/zenn.md
+++ b/docs/specs/ingesters/zenn.md
@@ -240,10 +240,12 @@ flowchart TD
     PAGE["ページ取得"]
     CHECK_NEXT{"next_page が null?"}
     CHECK_LIMIT{"走査上限 or 記事数上限?"}
+    LOOP["各 slug をループ"]
     CHECK_EXIST{"既存ファイルあり and not force?"}
-    SKIP["スキップ"]
-    FETCH["各記事の詳細を取得"]
+    SKIP["スキップ（次の slug へ）"]
+    FETCH["記事の詳細を取得"]
     PLACE["source_store にファイル配置 + .meta 生成"]
+    LOOP_END{"次の slug あり?"}
     NOTIFY["パイプライン制御に取り込み完了通知"]
     RESULT["配置結果サマリーを返却"]
 
@@ -251,15 +253,18 @@ flowchart TD
     VALIDATE --> DISCOVER
     DISCOVER --> PAGE
     PAGE --> CHECK_NEXT
-    CHECK_NEXT -->|"はい"| CHECK_EXIST
+    CHECK_NEXT -->|"はい"| LOOP
     CHECK_NEXT -->|"いいえ"| CHECK_LIMIT
-    CHECK_LIMIT -->|"はい（上限到達）"| CHECK_EXIST
+    CHECK_LIMIT -->|"はい（上限到達）"| LOOP
     CHECK_LIMIT -->|"いいえ"| PAGE
+    LOOP --> CHECK_EXIST
     CHECK_EXIST -->|"はい"| SKIP
     CHECK_EXIST -->|"いいえ"| FETCH
     FETCH --> PLACE
-    SKIP --> NOTIFY
-    PLACE --> NOTIFY
+    SKIP --> LOOP_END
+    PLACE --> LOOP_END
+    LOOP_END -->|"はい"| CHECK_EXIST
+    LOOP_END -->|"いいえ"| NOTIFY
     NOTIFY --> RESULT
 ```
 

--- a/docs/specs/ingesters/zenn.md
+++ b/docs/specs/ingesters/zenn.md
@@ -63,7 +63,9 @@ Zenn（zenn.dev）の記事およびスクラップを API 経由で取得し、
 
 ### 重複検出
 
-[インジェスター共通仕様](common.md) のファイルシステムベース方式に従う。source_id（Zenn 記事 URL）からファイルパスを導出し、ファイルの存在有無で判定する。既存ファイルが存在する場合は上書きする。
+[インジェスター共通仕様](common.md) のファイルシステムベース方式に従う。source_id（Zenn 記事 URL）からファイルパスを導出し、ファイルの存在有無で判定する。
+
+デフォルト動作はスキップモード（既存ファイルがあれば上書きしない）。明示的に `force` を指定した場合のみ上書きする。定期的な取り込み運用では記事の更新頻度は低く、毎回上書き → 変換 → インデックス再構築の無駄を避ける。
 
 ## 想定プロファイル
 
@@ -103,7 +105,7 @@ Zenn（zenn.dev）の記事およびスクラップを API 経由で取得し、
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| `rag_crawl_zenn` | username、max_articles（任意）、content_type（任意） | 指定ユーザーの Zenn コンテンツを API 経由で取得し、source_store にファイルを配置する。取り込み完了後、パイプライン制御に通知する |
+| `rag_crawl_zenn` | username、max_articles（任意）、content_type（任意）、force（任意） | 指定ユーザーの Zenn コンテンツを API 経由で取得し、source_store にファイルを配置する。取り込み完了後、パイプライン制御に通知する |
 
 ツール入力パラメータ:
 
@@ -112,6 +114,7 @@ Zenn（zenn.dev）の記事およびスクラップを API 経由で取得し、
 | `username` | 文字列 | はい | Zenn ユーザー名 |
 | `max_articles` | 整数 | いいえ | 取得する最大コンテンツ数。デフォルト: 50、許容範囲: 1〜100 |
 | `content_type` | 文字列 | いいえ | 取得対象のフィルタ: `articles`（記事のみ）、`scraps`（スクラップのみ）、`all`（両方）。デフォルト: `all`。ツール入力では複数形（`articles`/`scraps`）、.meta の `content_type` フィールドでは単数形（`article`/`scrap`）を使用する |
+| `force` | 真偽値 | いいえ | 既存ファイルを上書きするか。デフォルト: `false`（スキップモード） |
 
 ツール出力: source_store への配置結果（配置ファイル数、スキップ数、エラー数）のサマリーテキスト。記事とスクラップの内訳も含む。
 
@@ -121,7 +124,7 @@ Zenn（zenn.dev）の記事およびスクラップを API 経由で取得し、
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
+| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意）、`--force`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
 
 ### 設定項目
 
@@ -231,12 +234,14 @@ username: "alice"
 
 ```mermaid
 flowchart TD
-    START["rag_crawl_zenn(username, max_articles, content_type)"]
+    START["rag_crawl_zenn(username, max_articles, content_type, force)"]
     VALIDATE["入力バリデーション"]
     DISCOVER["コンテンツ一覧 API を走査（content_type に応じて記事/スクラップ/両方）"]
     PAGE["ページ取得"]
     CHECK_NEXT{"next_page が null?"}
     CHECK_LIMIT{"走査上限 or 記事数上限?"}
+    CHECK_EXIST{"既存ファイルあり and not force?"}
+    SKIP["スキップ"]
     FETCH["各記事の詳細を取得"]
     PLACE["source_store にファイル配置 + .meta 生成"]
     NOTIFY["パイプライン制御に取り込み完了通知"]
@@ -246,11 +251,14 @@ flowchart TD
     VALIDATE --> DISCOVER
     DISCOVER --> PAGE
     PAGE --> CHECK_NEXT
-    CHECK_NEXT -->|"はい"| FETCH
+    CHECK_NEXT -->|"はい"| CHECK_EXIST
     CHECK_NEXT -->|"いいえ"| CHECK_LIMIT
-    CHECK_LIMIT -->|"はい（上限到達）"| FETCH
+    CHECK_LIMIT -->|"はい（上限到達）"| CHECK_EXIST
     CHECK_LIMIT -->|"いいえ"| PAGE
+    CHECK_EXIST -->|"はい"| SKIP
+    CHECK_EXIST -->|"いいえ"| FETCH
     FETCH --> PLACE
+    SKIP --> NOTIFY
     PLACE --> NOTIFY
     NOTIFY --> RESULT
 ```
@@ -275,20 +283,20 @@ flowchart TD
 
 ### 個別記事取得とファイル配置の処理手順
 
-1. 記事詳細 API（`/api/articles/{slug}`）にリクエストを送信する
-2. レスポンスから `article` オブジェクトを取得する
-3. `article` オブジェクトをそのまま JSON として source_store に配置する（配置先: `zenn/{username}/articles/{slug}.json`）
-4. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/articles/{slug}.json.meta`）
-5. 重複検出: 配置先パスにファイルが既に存在する場合は上書きする
+1. 重複検出: 配置先パス（`zenn/{username}/articles/{slug}.json`）にファイルが既に存在し、`force` が指定されていなければスキップする
+2. 記事詳細 API（`/api/articles/{slug}`）にリクエストを送信する
+3. レスポンスから `article` オブジェクトを取得する
+4. `article` オブジェクトをそのまま JSON として source_store に配置する（配置先: `zenn/{username}/articles/{slug}.json`）
+5. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/articles/{slug}.json.meta`）
 
 ### スクラップ取得とファイル配置の処理手順
 
 1. スクラップ一覧 API（`/api/scraps?username={username}&order=latest&page={page}`）を走査する。走査手順は記事一覧走査と同様（ページネーション上限・コンテンツ数上限で終了）
 2. 各スクラップの `slug` を収集する
-3. スクラップ詳細 API（`/api/scraps/{slug}`）にリクエストを送信する
-4. レスポンスの `scrap` オブジェクト（`comments` 配列を含む）をそのまま JSON として source_store に配置する（配置先: `zenn/{username}/scraps/{slug}.json`）
-5. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/scraps/{slug}.json.meta`）
-6. 重複検出: 配置先パスにファイルが既に存在する場合は上書きする
+3. 重複検出: 配置先パス（`zenn/{username}/scraps/{slug}.json`）にファイルが既に存在し、`force` が指定されていなければスキップする
+4. スクラップ詳細 API（`/api/scraps/{slug}`）にリクエストを送信する
+5. レスポンスの `scrap` オブジェクト（`comments` 配列を含む）をそのまま JSON として source_store に配置する（配置先: `zenn/{username}/scraps/{slug}.json`）
+6. .meta サイドカーファイルを同階層に生成する（配置先: `zenn/{username}/scraps/{slug}.json.meta`）
 
 ### パイプライン制御との連携
 
@@ -418,7 +426,8 @@ Zenn は公式の API ドキュメントを公開していない。以下は観�
 | `article` オブジェクトが空 | 該当記事をスキップする。空の JSON ファイルは source_store に配置しない |
 | 下書き・非公開記事 | API が公開記事のみを返すため、考慮不要 |
 | 大量記事ユーザー（480 件超 = 10 ページ超） | ページネーション走査上限（10 ページ）で打ち切る。取得済み記事を処理し、上限到達の旨を警告ログに出力する |
-| 同一記事の再取り込み | source_id（記事の公開 URL）からファイルパスを導出し、既存ファイルを上書きする |
+| 同一記事の再取り込み（デフォルト） | source_id（記事の公開 URL）からファイルパスを導出し、既存ファイルがあればスキップする |
+| 同一記事の再取り込み（`force` 指定時） | source_id（記事の公開 URL）からファイルパスを導出し、既存ファイルを上書きする |
 | バジェット上限到達 | 取得済みデータを配置し、上限到達の旨をログ出力する |
 | サーキットブレーカー発動 | 操作を中断し、取得済みデータを配置する。エラーの詳細をログ出力する |
 | 操作全体タイムアウト | 操作を中断し、取得済みデータを配置する |
@@ -428,7 +437,8 @@ Zenn は公式の API ドキュメントを公開していない。以下は観�
 | `content_type` に無効な値を指定 | バリデーションエラーとして拒否する。有効値: `articles`, `scraps`, `all` |
 | スクラップのコメントが 0 件 | raw JSON をそのまま source_store に保存する（インジェスターは無加工保存）。コンバーターが空テキストとして変換をスキップする |
 | スクラップのコメント `body_html` が全て空 | raw JSON をそのまま source_store に保存する。コンバーターが空テキストとして変換をスキップする |
-| 同一スクラップの再取り込み | source_id（スクラップの公開 URL）からファイルパスを導出し、既存ファイルを上書きする |
+| 同一スクラップの再取り込み（デフォルト） | source_id（スクラップの公開 URL）からファイルパスを導出し、既存ファイルがあればスキップする |
+| 同一スクラップの再取り込み（`force` 指定時） | source_id（スクラップの公開 URL）からファイルパスを導出し、既存ファイルを上書きする |
 | Zenn API のレート制限（429） | ConstrainedClient のサーキットブレーカーで検出される。連続失敗として計上し、閾値超過で操作を中断する |
 | .meta ファイルの書き込みに失敗した場合 | ファイル物理削除禁止制約により、配置済みデータファイルのロールバックは行わない。エラーログを出力して処理を続行する |
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1868,7 +1868,7 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
 
     if ingest_result.placed == 0 and ingest_result.errors == 0:
         if ingest_result.skipped > 0:
-            print(f"全 {ingest_result.skipped} 件のコンテンツが既に取り込み済みです（ユーザー: {args.username}）。上書きするには --force を指定してください")
+            print(f"全 {ingest_result.skipped} 件のコンテンツがスキップされました（ユーザー: {args.username}）。上書きするには --force を指定してください")
         else:
             print(f"コンテンツが見つかりませんでした（ユーザー: {args.username}）")
         return

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -366,6 +366,7 @@ def main() -> None:
     zenn_parser.add_argument("username", help="Zenn ユーザー名")
     zenn_parser.add_argument("--max-articles", type=int, default=None, help="取得する最大コンテンツ数")
     zenn_parser.add_argument("--content-type", choices=["articles", "scraps", "all"], default="all", help="取得対象")
+    zenn_parser.add_argument("--force", action="store_true", default=False, help="既存ファイルを上書きする（デフォルト: スキップ）")
 
     # add-document: 単一ドキュメント取り込み
     adddoc_parser = subparsers.add_parser("add-document", help="ドキュメントファイルをナレッジベースに取り込む")
@@ -1858,11 +1859,19 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 args.username,
                 max_articles=max_articles,
                 content_type=args.content_type,
+                force=args.force,
                 client=client,
             )
     except (ValueError, TypeError) as e:
         logger.error("エラー: %s", e)
         sys.exit(1)
+
+    if ingest_result.placed == 0 and ingest_result.errors == 0:
+        if ingest_result.skipped > 0:
+            print(f"全 {ingest_result.skipped} 件のコンテンツが既に取り込み済みです（ユーザー: {args.username}）。上書きするには --force を指定してください")
+        else:
+            print(f"コンテンツが見つかりませんでした（ユーザー: {args.username}）")
+        return
 
     pipeline_summary = controller.ingest_and_index(f"ingest(zenn): {args.username}")
     _print_ingest_result(ingest_result, pipeline_summary, context=f"ユーザー: {args.username}")

--- a/src/rag/pipeline/ingesters/zenn.py
+++ b/src/rag/pipeline/ingesters/zenn.py
@@ -52,6 +52,7 @@ class ZennIngester:
         *,
         max_articles: int | None = None,
         content_type: str = "all",
+        force: bool = False,
         client: Any | None = None,
     ) -> IngestResult:
         """Zenn コンテンツを取得し source_store に配置する.
@@ -60,6 +61,7 @@ class ZennIngester:
             username: Zenn ユーザー名
             max_articles: 取得する最大コンテンツ数（None の場合はインスタンス設定を使用）
             content_type: 取得対象（``articles``, ``scraps``, ``all``）
+            force: 既存ファイルを上書きするか（デフォルト: False＝スキップモード）
             client: ConstrainedClient インスタンス
 
         Returns:
@@ -86,11 +88,11 @@ class ZennIngester:
         # content_type に応じて処理
         if content_type in ("articles", "all"):
             await self._crawl_articles(
-                username, effective_max, client, result
+                username, effective_max, client, result, force=force
             )
         if content_type in ("scraps", "all"):
             await self._crawl_scraps(
-                username, effective_max, client, result
+                username, effective_max, client, result, force=force
             )
 
         return result
@@ -101,6 +103,8 @@ class ZennIngester:
         max_articles: int,
         client: Any,
         result: IngestResult,
+        *,
+        force: bool = False,
     ) -> None:
         """記事を取得して配置する."""
         # 一覧走査
@@ -110,6 +114,15 @@ class ZennIngester:
 
         for slug in slugs:
             try:
+                # スキップ判定: 既存ファイルがあり force でなければスキップ
+                rel_path = f"zenn/{username}/articles/{slug}.json"
+                if not force:
+                    dest = self._store.root_dir / rel_path
+                    if dest.exists():
+                        logger.debug("既存ファイルのためスキップ: %s", rel_path)
+                        result.skipped += 1
+                        continue
+
                 # 記事詳細取得
                 url = f"{ZENN_API_BASE}/articles/{slug}"
                 resp = await client.get(url)
@@ -122,7 +135,6 @@ class ZennIngester:
                     continue
 
                 # JSON として保存
-                rel_path = f"zenn/{username}/articles/{slug}.json"
                 json_data = json.dumps(article, ensure_ascii=False, indent=2)
                 json_bytes = json_data.encode("utf-8")
 
@@ -166,6 +178,8 @@ class ZennIngester:
         max_articles: int,
         client: Any,
         result: IngestResult,
+        *,
+        force: bool = False,
     ) -> None:
         """スクラップを取得して配置する."""
         # 一覧走査
@@ -175,14 +189,20 @@ class ZennIngester:
 
         for slug in slugs:
             try:
+                # スキップ判定: 既存ファイルがあり force でなければスキップ
+                rel_path = f"zenn/{username}/scraps/{slug}.json"
+                if not force:
+                    dest = self._store.root_dir / rel_path
+                    if dest.exists():
+                        logger.debug("既存ファイルのためスキップ: %s", rel_path)
+                        result.skipped += 1
+                        continue
+
                 # スクラップ詳細取得
                 url = f"{ZENN_API_BASE}/scraps/{slug}"
                 resp = await client.get(url)
                 data = resp.json()
                 scrap = data.get("scrap", data)
-
-                # JSON として保存
-                rel_path = f"zenn/{username}/scraps/{slug}.json"
                 json_data = json.dumps(scrap, ensure_ascii=False, indent=2)
                 json_bytes = json_data.encode("utf-8")
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -662,7 +662,7 @@ async def rag_crawl_zenn(
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
             if ingest_result.skipped > 0:
-                return f"全 {ingest_result.skipped} 件のコンテンツが既に取り込み済みです（ユーザー: {username}）。上書きするには force=true を指定してください"
+                return f"全 {ingest_result.skipped} 件のコンテンツがスキップされました（ユーザー: {username}）。上書きするには force=true を指定してください"
             return f"コンテンツが見つかりませんでした（ユーザー: {username}）"
 
         pipeline_summary = await _run_ingest_and_index_subprocess(

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -606,18 +606,20 @@ async def rag_crawl_zenn(
     username: str,
     max_articles: int | None = None,
     content_type: str = "all",
+    force: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Zenn - Zenn コンテンツを API 経由で取得し一括取り込み.
 
     knowledge base, Zenn, ingest, articles, scraps, API.
     指定ユーザーの Zenn 記事・スクラップを API 経由で取得し、ナレッジベースに取り込む。
-    同一コンテンツの再取り込み時は既存の知識を最新に置き換える。
+    デフォルトでは既存コンテンツはスキップする。force=True で上書き取り込み。
 
     Args:
         username: Zenn ユーザー名
         max_articles: 取得する最大コンテンツ数（未指定時は設定値を使用、許容範囲: 1〜100）
         content_type: 取得対象（"articles": 記事のみ、"scraps": スクラップのみ、"all": 両方。デフォルト: "all"）
+        force: 既存ファイルを上書きするか（デフォルト: false＝スキップモード）
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -654,10 +656,13 @@ async def rag_crawl_zenn(
                 username.strip(),
                 max_articles=max_articles,
                 content_type=content_type,
+                force=force,
                 client=client,
             )
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
+            if ingest_result.skipped > 0:
+                return f"全 {ingest_result.skipped} 件のコンテンツが既に取り込み済みです（ユーザー: {username}）。上書きするには force=true を指定してください"
             return f"コンテンツが見つかりませんでした（ユーザー: {username}）"
 
         pipeline_summary = await _run_ingest_and_index_subprocess(

--- a/tests/test_pipeline_ingesters_zenn.py
+++ b/tests/test_pipeline_ingesters_zenn.py
@@ -415,3 +415,125 @@ class TestCrawlAll:
 
         assert result.placed == 0
         assert result.errors == 0
+
+
+@pytest.mark.asyncio()
+class TestSkipMode:
+    """スキップモード（デフォルト）のテスト."""
+
+    async def test_skip_existing_article(self, source_store: SourceStore) -> None:
+        """既存ファイルがある記事はスキップされること."""
+        # 事前に記事ファイルを配置
+        rel_path = source_store.root_dir / "zenn" / "testuser" / "articles" / "existing.json"
+        rel_path.parent.mkdir(parents=True, exist_ok=True)
+        rel_path.write_text('{"slug": "existing"}', encoding="utf-8")
+
+        # 一覧 API は "existing" を返すが、詳細 API は呼ばれないはず
+        client = _make_mock_client([
+            _make_article_list_response(["existing"]),
+        ])
+
+        ingester = ZennIngester(source_store, max_articles=3)
+        result = await ingester.crawl_zenn(
+            "testuser",
+            content_type="articles",
+            client=client,
+        )
+
+        assert result.placed == 0
+        assert result.skipped == 1
+        # 詳細 API は呼ばれない（一覧 API の 1 回のみ）
+        assert client.get.call_count == 1
+
+    async def test_skip_existing_scrap(self, source_store: SourceStore) -> None:
+        """既存ファイルがあるスクラップはスキップされること."""
+        rel_path = source_store.root_dir / "zenn" / "testuser" / "scraps" / "existing.json"
+        rel_path.parent.mkdir(parents=True, exist_ok=True)
+        rel_path.write_text('{"slug": "existing"}', encoding="utf-8")
+
+        client = _make_mock_client([
+            _make_scrap_list_response(["existing"]),
+        ])
+
+        ingester = ZennIngester(source_store, max_articles=3)
+        result = await ingester.crawl_zenn(
+            "testuser",
+            content_type="scraps",
+            client=client,
+        )
+
+        assert result.placed == 0
+        assert result.skipped == 1
+        assert client.get.call_count == 1
+
+    async def test_force_overwrites_existing(self, source_store: SourceStore) -> None:
+        """force=True で既存ファイルが上書きされること."""
+        rel_path = source_store.root_dir / "zenn" / "testuser" / "articles" / "existing.json"
+        rel_path.parent.mkdir(parents=True, exist_ok=True)
+        rel_path.write_text('{"slug": "old"}', encoding="utf-8")
+
+        client = _make_mock_client([
+            _make_article_list_response(["existing"]),
+            _make_article_detail_response("existing"),
+        ])
+
+        ingester = ZennIngester(source_store, max_articles=3)
+        result = await ingester.crawl_zenn(
+            "testuser",
+            content_type="articles",
+            force=True,
+            client=client,
+        )
+
+        assert result.placed == 1
+        assert result.skipped == 0
+        # 上書きされた内容を確認
+        data = json.loads(rel_path.read_text(encoding="utf-8"))
+        assert data["slug"] == "existing"
+        assert "body_html" in data
+
+    async def test_force_overwrites_existing_scrap(self, source_store: SourceStore) -> None:
+        """force=True で既存スクラップが上書きされること."""
+        rel_path = source_store.root_dir / "zenn" / "testuser" / "scraps" / "existing.json"
+        rel_path.parent.mkdir(parents=True, exist_ok=True)
+        rel_path.write_text('{"slug": "old"}', encoding="utf-8")
+
+        client = _make_mock_client([
+            _make_scrap_list_response(["existing"]),
+            _make_scrap_detail_response("existing"),
+        ])
+
+        ingester = ZennIngester(source_store, max_articles=3)
+        result = await ingester.crawl_zenn(
+            "testuser",
+            content_type="scraps",
+            force=True,
+            client=client,
+        )
+
+        assert result.placed == 1
+        assert result.skipped == 0
+        data = json.loads(rel_path.read_text(encoding="utf-8"))
+        assert data["comments_count"] == 2
+
+    async def test_mixed_new_and_existing(self, source_store: SourceStore) -> None:
+        """新規と既存が混在する場合、既存のみスキップされること."""
+        existing_path = source_store.root_dir / "zenn" / "testuser" / "articles" / "old.json"
+        existing_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_path.write_text('{"slug": "old"}', encoding="utf-8")
+
+        client = _make_mock_client([
+            _make_article_list_response(["old", "new-article"]),
+            # "old" はスキップされるので詳細 API は "new-article" のみ
+            _make_article_detail_response("new-article"),
+        ])
+
+        ingester = ZennIngester(source_store, max_articles=3)
+        result = await ingester.crawl_zenn(
+            "testuser",
+            content_type="articles",
+            client=client,
+        )
+
+        assert result.placed == 1
+        assert result.skipped == 1


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- Zenn インジェスターのデフォルト動作をスキップモードに変更（既存ファイルがあれば上書きしない）
- CLI に `--force` オプション、MCP ツールに `force` パラメータを追加（指定時のみ上書き）
- 全件スキップ時はパイプライン処理を省略（CLI/MCP 共通）
- 仕様書（zenn.md, common.md）を更新: 重複検出の動作、フローチャート、処理手順
- スキップモードのテストを5件追加（記事/スクラップのスキップ、force上書き、混在ケース）

## Test plan

- [x] pytest 75件パス（Zenn 19件含む）
- [x] ruff lint クリーン
- [x] mypy 型チェッククリーン
- [x] markdownlint / mermaid-lint クリーン

## Related issues

Closes #386