### PR TITLE
feat(content-upload): コンテンツアップロード型の実装（add_document / add_journal） (#392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,13 @@ YouTube インジェスターは非公式 API（youtube-transcript-api）を使�
 ### 単一エントリ登録
 
 ```bash
-# インライン本文
-uv run python -m rag.cli add-journal --title "セッション記録" --body "本文..." --repository rag-knowledge
-
-# ファイルから本文読み込み（長文推奨）
-uv run python -m rag.cli add-journal --title "セッション記録" --body @path/to/journal.md --repository rag-knowledge
+uv run python -m rag.cli add-journal --title "セッション記録" --file path/to/journal.md --repository rag-knowledge
 ```
 
 | パラメータ | 短縮 | 必須 | 説明 |
 |-----------|------|------|------|
 | `--title` | `-t` | Yes | エントリタイトル |
-| `--body` | `-b` | Yes | 本文（Markdown）。`@ファイルパス` でファイルから読み込み |
+| `--file` | `-f` | Yes | 本文 Markdown ファイルのパス。CLI がファイルを読み込んでコンテンツをインジェスターに渡す |
 | `--repository` | `-r` | Yes | リポジトリ名 |
 | `--entry-id` | `-e` | No | エントリ識別子（省略時は自動生成） |
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -413,7 +413,7 @@ def main() -> None:
     # add-journal: 単一ジャーナルエントリの登録
     aj_parser = subparsers.add_parser("add-journal", help="ジャーナルエントリをナレッジベースに登録")
     aj_parser.add_argument("--title", "-t", required=True, help="エントリタイトル")
-    aj_parser.add_argument("--body", "-b", required=True, help="本文（Markdown）。@ファイルパス で本文をファイルから読み込み")
+    aj_parser.add_argument("--file", "-f", required=True, help="本文 Markdown ファイルのパス。CLI がファイルを読み込んでコンテンツをインジェスターに渡す")
     aj_parser.add_argument("--repository", "-r", required=True, help="リポジトリ名")
     aj_parser.add_argument("--entry-id", "-e", default=None, help="エントリ識別子（省略時は自動生成）")
 
@@ -1387,7 +1387,7 @@ async def run_add_journal(args: argparse.Namespace) -> None:
     """単一ジャーナルエントリを登録する.
 
     Args:
-        args: コマンドライン引数（--title, --body, --repository, --entry-id）
+        args: コマンドライン引数（--title, --file, --repository, --entry-id）
     """
     from .pipeline.ingesters.journal import JournalIngester
 
@@ -1395,14 +1395,12 @@ async def run_add_journal(args: argparse.Namespace) -> None:
 
     ingester = JournalIngester(controller.source_store)
 
-    # --body が @ファイルパス の場合、ファイルから読み込む
-    body = args.body
-    if body.startswith("@"):
-        file_path = Path(body[1:])
-        if not file_path.is_file():
-            print(f"エラー: ファイルが見つかりません: {file_path}", file=sys.stderr)
-            raise SystemExit(1)
-        body = file_path.read_text(encoding="utf-8")
+    # --file で指定したファイルを読み込む
+    file_path = Path(args.file)
+    if not file_path.is_file():
+        print(f"エラー: ファイルが見つかりません: {file_path}", file=sys.stderr)
+        raise SystemExit(1)
+    body = file_path.read_text(encoding="utf-8")
 
     ingest_result = ingester.add_entry(
         title=args.title,
@@ -1888,24 +1886,43 @@ async def run_add_document(args: argparse.Namespace) -> None:
         for ext in settings.rag_document_supported_extensions.split(",")
         if ext.strip()
     ]
+
+    # CLI でのバリデーション: パス → バイト列取得
+    file_path_str = args.file_path
+    if not file_path_str or not file_path_str.strip():
+        print("エラー: file_path が空です", file=sys.stderr)
+        raise SystemExit(1)
+    resolved = Path(file_path_str.strip()).resolve()
+    if not resolved.exists():
+        print(f"エラー: ファイルが見つかりません: {resolved}", file=sys.stderr)
+        raise SystemExit(1)
+    if resolved.is_dir():
+        print(f"エラー: パスはファイルではなくディレクトリです: {resolved}", file=sys.stderr)
+        raise SystemExit(1)
+    ext = resolved.suffix.lower()
+    if ext not in supported_extensions:
+        print(f"エラー: 対応していないファイル形式です: {ext!r}（対応: {', '.join(supported_extensions)}）", file=sys.stderr)
+        raise SystemExit(1)
+    data = resolved.read_bytes()
+
     local_ingester = LocalIngester(
         controller.source_store,
         supported_extensions=supported_extensions,
     )
 
     ingest_result = local_ingester.add_document(
-        args.file_path, upload_mode=args.upload_mode,
+        data, resolved.name, upload_mode=args.upload_mode,
     )
 
     if ingest_result.placed == 0 and ingest_result.errors == 0:
-        print(f"取り込み対象がありませんでした: {args.file_path}")
+        print(f"取り込み対象がありませんでした: {file_path_str}")
         return
     if ingest_result.errors > 0:
         print(f"エラー: {ingest_result.error_details[0]}", file=sys.stderr)
         raise SystemExit(1)
 
-    pipeline_summary = controller.ingest_and_index(f"ingest(local): add {args.file_path}")
-    _print_ingest_result(ingest_result, pipeline_summary, context=args.file_path)
+    pipeline_summary = controller.ingest_and_index(f"ingest(local): add {resolved.name}")
+    _print_ingest_result(ingest_result, pipeline_summary, context=file_path_str)
 
 
 async def run_crawl_documents(args: argparse.Namespace) -> None:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1882,7 +1882,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
     controller, settings = _build_cli_pipeline_controller()
 
     supported_extensions = [
-        ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
+        (ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}").lower()
         for ext in settings.rag_document_supported_extensions.split(",")
         if ext.strip()
     ]
@@ -1932,7 +1932,7 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
     controller, settings = _build_cli_pipeline_controller()
 
     supported_extensions = [
-        ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
+        (ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}").lower()
         for ext in settings.rag_document_supported_extensions.split(",")
         if ext.strip()
     ]

--- a/src/rag/pipeline/ingesters/local.py
+++ b/src/rag/pipeline/ingesters/local.py
@@ -40,35 +40,38 @@ class LocalIngester:
 
     def add_document(
         self,
-        file_path: str,
+        data: bytes,
+        filename: str,
         *,
         upload_mode: UploadMode = "fail",
     ) -> IngestResult:
-        """単一ドキュメントファイルを source_store に配置する.
+        """単一ドキュメントのバイト列を source_store に配置する.
 
         Args:
-            file_path: 取り込み対象ファイルのパス
+            data: ファイルのバイト列（MCP 経由はデコード済み、CLI 経由は直接読み込み）
+            filename: 配置先命名に使用するファイル名（サニタイズ済みであること）
             upload_mode: 同名ファイル存在時の動作
                 ``fail`` — エラー（デフォルト）、``replace`` — 上書き
         """
         result = IngestResult()
         try:
-            resolved = self._validate_single_file(file_path)
-            rel_path = self._upload_rel_path(resolved.name)
+            if len(data) == 0:
+                raise ValueError(f"ファイルが空です (0 バイト): {filename}")
+
+            rel_path = self._upload_rel_path(filename)
 
             if upload_mode == "fail" and self._file_exists(rel_path):
                 raise ValueError(
                     f"同名ファイルが既に存在します: {rel_path}"
                 )
 
-            data = resolved.read_bytes()
             self._store.place_file(source_type="local", data=data, rel_path=rel_path)
             result.placed = 1
         except ValueError as e:
             result.errors = 1
             result.error_details.append(str(e))
         except OSError as e:
-            logger.exception("Failed to copy file: %s", file_path)
+            logger.exception("Failed to place file: %s", filename)
             result.errors = 1
             result.error_details.append(str(e))
         return result

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -67,6 +67,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     # パイプライン関連
     from .pipeline.controller import PipelineController
     from .pipeline.ingesters._common import IngestResult
+    from .upload import decode_upload_content, sanitize_filename as sanitize_upload_filename
     from .pipeline.ingesters.aozora import AozoraIngester as PipelineAozoraIngester
     from .pipeline.ingesters.bluesky import BlueskyIngester as PipelineBlueskyIngester
     from .pipeline.ingesters.journal import JournalIngester as PipelineJournalIngester
@@ -946,70 +947,87 @@ _VALID_UPLOAD_MODES: frozenset[str] = frozenset({"fail", "replace"})
 
 @mcp.tool()
 async def rag_add_document(
-    file_path: str,
+    content: str,
+    filename: str,
+    encoding: str = "text",
     upload_mode: str = "fail",
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add document - ドキュメントファイルをナレッジベースに取り込む.
 
-    knowledge base, ingest, document, file, text.
-    ドキュメントファイル（Markdown、テキスト、PDF、AsciiDoc）を読み取り、
-    ナレッジベースに取り込む。
-    stdio モード専用。HTTP モードでは無効。
+    knowledge base, ingest, document, file, text, upload.
+    ドキュメントファイル（Markdown、テキスト、PDF、AsciiDoc）のコンテンツを受け取り、
+    ナレッジベースに取り込む。stdio・HTTP 両モードで使用可能。
 
     Args:
-        file_path: 取り込み対象ファイルのパス（絶対パスまたは相対パス）
+        content: ファイルのコンテンツ。encoding=text の場合は UTF-8 文字列、
+            encoding=base64 の場合は base64 エンコードされた文字列
+        filename: 元ファイルのファイル名（例: resume.pdf, notes.md）。
+            拡張子バリデーションおよびファイル配置先の命名に使用する
+        encoding: コンテンツのエンコーディング。"text"（デフォルト）または "base64"。
+            テキストファイルは "text"、バイナリファイル（PDF 等）は "base64" を使用する
         upload_mode: 同名ファイル存在時の動作。"fail"（エラー、デフォルト）または "replace"（上書き）
 
     Returns:
         取り込み結果のメッセージ
     """
-    if get_settings().rag_transport == "http":
-        return "エラー: rag_add_document は HTTP モードでは無効です（セキュリティ上の制約）"
-
     if upload_mode not in _VALID_UPLOAD_MODES:
         valid = ", ".join(sorted(_VALID_UPLOAD_MODES))
         return f"エラー: 無効な upload_mode: {upload_mode!r}（有効値: {valid}）"
 
+    try:
+        sanitized_filename = sanitize_upload_filename(filename)
+    except ValueError as e:
+        return f"エラー: {e}"
+
+    supported_extensions = _get_supported_extensions()
+    ext = Path(sanitized_filename).suffix.lower()
+    if not ext or ext not in supported_extensions:
+        return f"エラー: 対応していないファイル形式です: {sanitized_filename!r}（対応: {', '.join(supported_extensions)}）"
+
+    try:
+        data = decode_upload_content(content, encoding)
+    except ValueError as e:
+        return f"エラー: {e}"
+
     controller = await _get_pipeline_controller()
     local_ingester = PipelineLocalIngester(
         controller.source_store,
-        supported_extensions=_get_supported_extensions(),
+        supported_extensions=supported_extensions,
     )
 
     try:
         ingest_result = await asyncio.to_thread(
-            local_ingester.add_document, file_path,
+            local_ingester.add_document, data, sanitized_filename,
             upload_mode=upload_mode,  # type: ignore[arg-type]
         )
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
-            return f"エラー: ファイルの取り込みに失敗しました。パス: {file_path}"
+            return f"エラー: ファイルの取り込みに失敗しました: {sanitized_filename}"
 
         if ingest_result.errors > 0:
             return f"エラー: {ingest_result.error_details[0]}"
 
         pipeline_summary = await _run_ingest_and_index_subprocess(
-            f"ingest(local): add {file_path}",
+            f"ingest(local): add {sanitized_filename}",
             ctx=ctx,
         )
         _reset_pipeline_controller()
         _reset_rag_service()
 
         return _format_ingest_response(
-            ingest_result, pipeline_summary, context=file_path,
+            ingest_result, pipeline_summary, context=sanitized_filename,
         )
-    except ValueError as e:
-        return f"エラー: {e}"
     except Exception:
-        logger.exception("Failed to add document file: %s", file_path)
-        return f"エラー: ファイルの取り込みに失敗しました。パス: {file_path}"
+        logger.exception("Failed to add document: %s", sanitized_filename)
+        return f"エラー: ファイルの取り込みに失敗しました: {sanitized_filename}"
 
 
 @mcp.tool()
 async def rag_add_journal(
     title: str,
-    body: str,
+    content: str,
+    filename: str,
     repository: str,
     entry_id: str | None = None,
     ctx: MCPContext | None = None,
@@ -1018,19 +1036,25 @@ async def rag_add_journal(
 
     journal, session log, work record, development diary.
     セッションごとの作業記録（ジャーナル）をナレッジベースに追加する。
-    stdio モード専用。HTTP モードでは無効。
+    stdio・HTTP 両モードで使用可能。
 
     Args:
         title: エントリタイトル
-        body: 本文（Markdown）
+        content: ジャーナル本文（Markdown）。MCP クライアントがファイルを読み込んでテキスト文字列として渡す
+        filename: 元ファイルのファイル名（例: session-summary.md）。.md 拡張子であることの確認に使用する
         repository: リポジトリ名（例: rag-knowledge）
         entry_id: エントリ識別子（更新時に使用。未指定時は自動生成。命名規則: YYYYMMDD-HHMMSS-topic）
 
     Returns:
         取り込み結果のメッセージ
     """
-    if get_settings().rag_transport == "http":
-        return "エラー: rag_add_journal は HTTP モードでは無効です（セキュリティ上の制約）"
+    try:
+        sanitized_filename = sanitize_upload_filename(filename)
+    except ValueError as e:
+        return f"エラー: {e}"
+
+    if not sanitized_filename.lower().endswith(".md"):
+        return f"エラー: filename の拡張子が .md ではありません: {sanitized_filename!r}"
 
     controller = await _get_pipeline_controller()
     journal_ingester = PipelineJournalIngester(controller.source_store)
@@ -1039,7 +1063,7 @@ async def rag_add_journal(
         ingest_result = await asyncio.to_thread(
             journal_ingester.add_entry,
             title,
-            body,
+            content,
             repository,
             entry_id=entry_id,
         )

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -285,7 +285,7 @@ def _get_supported_extensions() -> list[str]:
     """設定からサポート拡張子リストを取得する."""
     settings = get_settings()
     return [
-        ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
+        (ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}").lower()
         for ext in settings.rag_document_supported_extensions.split(",")
         if ext.strip()
     ]

--- a/src/rag/upload.py
+++ b/src/rag/upload.py
@@ -1,0 +1,68 @@
+"""コンテンツアップロード層 — MCP ツール経由ファイル受け取り用ユーティリティ.
+
+仕様: docs/specs/infrastructure/content-upload.md
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from pathlib import Path
+
+
+def decode_upload_content(content: str, encoding: str) -> bytes:
+    """MCP ツールから受け取ったコンテンツ文字列をバイト列に変換する.
+
+    Args:
+        content: MCP ツールが受け取ったコンテンツ文字列
+        encoding: ``"text"`` または ``"base64"``
+
+    Returns:
+        デコード済みバイト列
+
+    Raises:
+        ValueError: 不正な encoding 値、不正な base64 文字列、デコード後が 0 バイトの場合
+    """
+    if encoding == "text":
+        data = content.encode("utf-8")
+    elif encoding == "base64":
+        try:
+            data = base64.b64decode(content, validate=True)
+        except binascii.Error as e:
+            raise ValueError(f"不正な base64 文字列です: {e}") from e
+    else:
+        raise ValueError(
+            f"encoding の値が不正です: {encoding!r}（許容値: 'text', 'base64'）"
+        )
+
+    if len(data) == 0:
+        raise ValueError("コンテンツが空です（デコード後 0 バイト）")
+
+    return data
+
+
+def sanitize_filename(filename: str) -> str:
+    """ファイル名をサニタイズしてファイル名部分のみを返す.
+
+    ディレクトリセパレータ（``/``、``\\``）や ``..`` を含む場合、
+    ``Path(filename).name`` でファイル名部分のみを採用する。
+
+    Args:
+        filename: MCP ツールから受け取ったファイル名
+
+    Returns:
+        サニタイズ済みファイル名（ディレクトリ部分を除いたファイル名のみ）
+
+    Raises:
+        ValueError: filename が空文字列またはサニタイズ後のファイル名が空・``..`` の場合
+    """
+    if not filename:
+        raise ValueError("filename が空文字列です")
+
+    name = Path(filename).name
+    if not name or name == "..":
+        raise ValueError(
+            f"filename からファイル名部分を取得できません: {filename!r}"
+        )
+
+    return name

--- a/src/rag/upload.py
+++ b/src/rag/upload.py
@@ -59,7 +59,8 @@ def sanitize_filename(filename: str) -> str:
     if not filename:
         raise ValueError("filename が空文字列です")
 
-    name = Path(filename).name
+    # バックスラッシュを統一して OS 非依存にする
+    name = Path(filename.replace("\\", "/")).name
     if not name or name == "..":
         raise ValueError(
             f"filename からファイル名部分を取得できません: {filename!r}"

--- a/tests/test_pipeline_ingesters_local.py
+++ b/tests/test_pipeline_ingesters_local.py
@@ -44,13 +44,6 @@ def ingester(source_store: SourceStore) -> LocalIngester:
 
 
 @pytest.fixture()
-def sample_file(tmp_path: Path) -> Path:
-    f = tmp_path / "sample.md"
-    f.write_text("# Test\nHello world", encoding="utf-8")
-    return f
-
-
-@pytest.fixture()
 def sample_dir(tmp_path: Path) -> Path:
     d = tmp_path / "docs"
     d.mkdir()
@@ -64,65 +57,46 @@ def sample_dir(tmp_path: Path) -> Path:
 
 
 class TestAddDocument:
-    def test_add_single_file(self, ingester: LocalIngester, sample_file: Path, source_store: SourceStore) -> None:
-        result = ingester.add_document(str(sample_file))
+    def test_add_single_file(self, ingester: LocalIngester, source_store: SourceStore) -> None:
+        data = b"# Test\nHello world"
+        result = ingester.add_document(data, "sample.md")
         assert result.placed == 1
         assert result.errors == 0
         placed = source_store.root_dir / "local" / _UPLOAD_DIR / _today_prefix() / "sample.md"
         assert placed.exists()
+        assert placed.read_bytes() == data
 
-    def test_add_nonexistent_file(self, ingester: LocalIngester) -> None:
-        result = ingester.add_document("/nonexistent/path.md")
+    def test_add_empty_data_raises_error(self, ingester: LocalIngester) -> None:
+        result = ingester.add_document(b"", "empty.md")
         assert result.errors == 1
 
-    def test_add_empty_path(self, ingester: LocalIngester) -> None:
-        result = ingester.add_document("")
-        assert result.errors == 1
+    def test_add_binary_content(self, ingester: LocalIngester, source_store: SourceStore) -> None:
+        data = b"%PDF-1.4 binary content \x00\x01\x02"
+        result = ingester.add_document(data, "doc.pdf")
+        assert result.placed == 1
+        placed = source_store.root_dir / "local" / _UPLOAD_DIR / _today_prefix() / "doc.pdf"
+        assert placed.read_bytes() == data
 
-    def test_add_unsupported_extension(self, ingester: LocalIngester, tmp_path: Path) -> None:
-        f = tmp_path / "test.xyz"
-        f.write_text("test")
-        result = ingester.add_document(str(f))
-        assert result.errors == 1
-
-    def test_add_directory_path(self, ingester: LocalIngester, tmp_path: Path) -> None:
-        d = tmp_path / "adir"
-        d.mkdir()
-        result = ingester.add_document(str(d))
-        assert result.errors == 1
-
-    def test_add_empty_file(self, ingester: LocalIngester, tmp_path: Path) -> None:
-        f = tmp_path / "empty.md"
-        f.write_text("")
-        result = ingester.add_document(str(f))
-        assert result.errors == 1
-
-    def test_add_replace_mode(self, ingester: LocalIngester, tmp_path: Path, source_store: SourceStore) -> None:
+    def test_add_replace_mode(self, ingester: LocalIngester, source_store: SourceStore) -> None:
         """replace モード: 同名ファイルを上書きできること."""
-        f = tmp_path / "overwrite.md"
-        f.write_text("v1", encoding="utf-8")
-        ingester.add_document(str(f), upload_mode="replace")
-        f.write_text("v2", encoding="utf-8")
-        result = ingester.add_document(str(f), upload_mode="replace")
+        ingester.add_document(b"v1", "overwrite.md", upload_mode="replace")
+        result = ingester.add_document(b"v2", "overwrite.md", upload_mode="replace")
         assert result.placed == 1
         placed = source_store.root_dir / "local" / _UPLOAD_DIR / _today_prefix() / "overwrite.md"
-        assert placed.read_text(encoding="utf-8") == "v2"
+        assert placed.read_bytes() == b"v2"
 
-    def test_add_fail_mode_duplicate(self, ingester: LocalIngester, tmp_path: Path) -> None:
+    def test_add_fail_mode_duplicate(self, ingester: LocalIngester) -> None:
         """fail モード（デフォルト）: 同名ファイルが既にある場合にエラーになること."""
-        f = tmp_path / "dup.md"
-        f.write_text("first", encoding="utf-8")
-        result1 = ingester.add_document(str(f))
+        result1 = ingester.add_document(b"first", "dup.md")
         assert result1.placed == 1
 
-        f.write_text("second", encoding="utf-8")
-        result2 = ingester.add_document(str(f))
+        result2 = ingester.add_document(b"second", "dup.md")
         assert result2.placed == 0
         assert result2.errors == 1
         assert "同名ファイル" in result2.error_details[0]
 
-    def test_no_meta_for_local(self, ingester: LocalIngester, sample_file: Path, source_store: SourceStore) -> None:
-        ingester.add_document(str(sample_file))
+    def test_no_meta_for_local(self, ingester: LocalIngester, source_store: SourceStore) -> None:
+        ingester.add_document(b"# Test", "sample.md")
         meta = source_store.root_dir / "local" / _UPLOAD_DIR / _today_prefix() / "sample.md.meta"
         assert not meta.exists()
 
@@ -205,9 +179,9 @@ class TestCrawlDocuments:
 class TestUploadPath:
     """アップロードパスの構造テスト."""
 
-    def test_upload_path_structure(self, ingester: LocalIngester, sample_file: Path, source_store: SourceStore) -> None:
-        """MCP 経由のファイルが .upload/yyyy/MM/dd/ に配置されること."""
-        ingester.add_document(str(sample_file))
+    def test_upload_path_structure(self, ingester: LocalIngester, source_store: SourceStore) -> None:
+        """ファイルが .upload/yyyy/MM/dd/ に配置されること."""
+        ingester.add_document(b"# Test content", "sample.md")
         upload_base = source_store.root_dir / "local" / _UPLOAD_DIR
         assert upload_base.exists()
         # 日付ディレクトリの存在確認（_FIXED_DATE で固定）
@@ -216,34 +190,22 @@ class TestUploadPath:
         assert (date_dir / "sample.md").exists()
 
 
-class TestHttpModeRestriction:
-    def test_http_mode_no_allowed_dirs(self, source_store: SourceStore, tmp_path: Path) -> None:
+class TestCrawlHttpModeRestriction:
+    """crawl_documents の HTTP モード制限テスト."""
+
+    def test_crawl_http_mode_no_allowed_dirs(self, source_store: SourceStore, sample_dir: Path) -> None:
         ingester = LocalIngester(source_store, http_mode_enabled=True, allowed_dirs=[])
-        f = tmp_path / "test.md"
-        f.write_text("test content")
-        result = ingester.add_document(str(f))
+        result = ingester.crawl_documents(str(sample_dir))
         assert result.errors == 1
 
-    def test_http_mode_allowed_dir(self, source_store: SourceStore, tmp_path: Path) -> None:
-        allowed = tmp_path / "allowed"
-        allowed.mkdir()
-        f = allowed / "test.md"
-        f.write_text("test content")
-        ingester = LocalIngester(source_store, http_mode_enabled=True, allowed_dirs=[str(allowed)])
-        result = ingester.add_document(str(f))
-        assert result.placed == 1
+    def test_crawl_http_mode_allowed_dir(self, source_store: SourceStore, sample_dir: Path) -> None:
+        ingester = LocalIngester(source_store, http_mode_enabled=True, allowed_dirs=[str(sample_dir)])
+        result = ingester.crawl_documents(str(sample_dir))
+        assert result.placed > 0
 
-    def test_http_mode_denied_dir(self, source_store: SourceStore, tmp_path: Path) -> None:
-        allowed = tmp_path / "allowed"
+    def test_crawl_http_mode_denied_dir(self, source_store: SourceStore, tmp_path: Path, sample_dir: Path) -> None:
+        allowed = tmp_path / "allowed_other"
         allowed.mkdir()
-        denied = tmp_path / "denied"
-        denied.mkdir()
-        f = denied / "test.md"
-        f.write_text("test content")
         ingester = LocalIngester(source_store, http_mode_enabled=True, allowed_dirs=[str(allowed)])
-        result = ingester.add_document(str(f))
+        result = ingester.crawl_documents(str(sample_dir))
         assert result.errors == 1
-
-    def test_stdio_mode_no_restriction(self, ingester: LocalIngester, sample_file: Path) -> None:
-        result = ingester.add_document(str(sample_file))
-        assert result.placed == 1

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,107 @@
+"""コンテンツアップロード層のテスト.
+
+仕様: docs/specs/infrastructure/content-upload.md
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from rag.upload import decode_upload_content, sanitize_filename
+
+
+class TestDecodeUploadContent:
+    def test_text_encoding_decodes_to_utf8_bytes(self) -> None:
+        result = decode_upload_content("hello world", "text")
+        assert result == b"hello world"
+
+    def test_text_encoding_with_japanese(self) -> None:
+        result = decode_upload_content("日本語テキスト", "text")
+        assert result == "日本語テキスト".encode("utf-8")
+
+    def test_base64_encoding_decodes_correctly(self) -> None:
+        original = b"binary content \x00\x01\x02"
+        encoded = base64.b64encode(original).decode("ascii")
+        result = decode_upload_content(encoded, "base64")
+        assert result == original
+
+    def test_base64_encoding_with_pdf_like_content(self) -> None:
+        pdf_like = b"%PDF-1.4 some content"
+        encoded = base64.b64encode(pdf_like).decode("ascii")
+        result = decode_upload_content(encoded, "base64")
+        assert result == pdf_like
+
+    def test_invalid_encoding_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="encoding"):
+            decode_upload_content("content", "utf-8")
+
+    def test_invalid_encoding_hex_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="encoding"):
+            decode_upload_content("content", "hex")
+
+    def test_invalid_base64_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="base64"):
+            decode_upload_content("not-valid-base64!!!", "base64")
+
+    def test_base64_without_padding_raises_value_error(self) -> None:
+        # 正しいパディングなし（validate=True で拒否される）
+        no_padding = base64.b64encode(b"test").decode("ascii").rstrip("=")
+        with pytest.raises(ValueError, match="base64"):
+            decode_upload_content(no_padding, "base64")
+
+    def test_empty_content_text_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="空"):
+            decode_upload_content("", "text")
+
+    def test_empty_content_base64_raises_value_error(self) -> None:
+        # base64 で空バイト列になるケース: base64.b64encode(b"") == b""
+        with pytest.raises(ValueError, match="空"):
+            decode_upload_content("", "base64")
+
+    def test_base64_single_missing_padding_raises_value_error(self) -> None:
+        # b"ab" → "YWI=" → パディング1つ除去で "YWI" → Incorrect padding
+        no_padding = "YWI"
+        with pytest.raises(ValueError, match="base64"):
+            decode_upload_content(no_padding, "base64")
+
+
+class TestSanitizeFilename:
+    def test_plain_filename_is_returned_as_is(self) -> None:
+        assert sanitize_filename("resume.pdf") == "resume.pdf"
+
+    def test_filename_with_extension_is_returned(self) -> None:
+        assert sanitize_filename("notes.md") == "notes.md"
+
+    def test_path_with_directory_separator_extracts_filename(self) -> None:
+        assert sanitize_filename("/home/user/docs/resume.pdf") == "resume.pdf"
+
+    def test_windows_path_extracts_filename(self) -> None:
+        assert sanitize_filename("C:\\Users\\user\\docs\\resume.pdf") == "resume.pdf"
+
+    def test_relative_path_extracts_filename(self) -> None:
+        assert sanitize_filename("docs/notes.md") == "notes.md"
+
+    def test_dotdot_path_extracts_filename_part(self) -> None:
+        # ../../etc/passwd → basename は "passwd"
+        assert sanitize_filename("../../etc/passwd") == "passwd"
+
+    def test_dotdot_alone_raises_value_error(self) -> None:
+        # ".." 単体はファイル名部分も ".." になるため拒否
+        with pytest.raises(ValueError, match="filename"):
+            sanitize_filename("..")
+
+    def test_empty_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="空"):
+            sanitize_filename("")
+
+    def test_root_path_raises_value_error(self) -> None:
+        # "/" → Path("/").name == "" → 拒否
+        with pytest.raises(ValueError, match="filename"):
+            sanitize_filename("/")
+
+    def test_windows_drive_root_raises_value_error(self) -> None:
+        # "C:\" → Path("C:\\").name == "" → 拒否
+        with pytest.raises(ValueError, match="filename"):
+            sanitize_filename("C:\\")


### PR DESCRIPTION
## Change type

- [x] feat

## Summary

- `src/rag/upload.py` を新規作成し、`decode_upload_content` / `sanitize_filename` を実装
- `rag_add_document` / `rag_add_journal` MCP ツールをコンテンツアップロード型に変更（ローカルパス参照からコンテンツ受け取りへ）
- `LocalIngester.add_document` のインターフェースを `(data: bytes, filename: str)` に変更
- `rag_add_document` / `rag_add_journal` の HTTP モードガードを削除（HTTP モードでも使用可能に）
- CLI `add-journal` の `--body` を `--file` に変更（CLI がファイルを読み込んでインジェスターに渡す）
- `tests/test_upload.py` を新規作成（upload ユーティリティの単体テスト）
- `tests/test_pipeline_ingesters_local.py` を新インターフェースに合わせて更新
- `README.md` の Journal CLI セクションを更新

## Test plan

- [x] 品質チェック通過済み（コードレビュー・ドキュメントレビュー・テスト実行）
- [x] `tests/test_upload.py` 追加（decode_upload_content / sanitize_filename の単体テスト）
- [x] `tests/test_pipeline_ingesters_local.py` 更新済み

## Related issues

Closes #392