### PR TITLE
refactor(source-store): MetadataDB の created_at カラムを collected_at にリネーム (#397)

### DIFF
--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -715,11 +715,11 @@ class PipelineController:
 
         existing = self.db.get_source(source_id)
         if existing:
-            created_at = existing.created_at
+            collected_at = existing.collected_at
         elif meta_dict and "collected_at" in meta_dict:
-            created_at = str(meta_dict["collected_at"])
+            collected_at = str(meta_dict["collected_at"])
         else:
-            created_at = now
+            collected_at = now
 
         self.db.register_source(
             source_id=source_id,
@@ -728,7 +728,7 @@ class PipelineController:
             title=title,
             content_hash=content_hash,
             file_size=len(data),
-            created_at=created_at,
+            collected_at=collected_at,
             updated_at=now,
         )
 
@@ -815,10 +815,10 @@ class PipelineController:
         source_id = record.source_id
         source_type = record.source_type
         title = record.title
-        created_at = record.created_at
+        collected_at_db = record.collected_at
 
         meta_dict = self._read_meta_dict(file_path) or {}
-        collected_at = str(meta_dict.get("collected_at", created_at))
+        collected_at = str(meta_dict.get("collected_at", collected_at_db))
 
         extra = dict(meta_dict)
         for key in ("source_id", "source_type", "title", "collected_at"):

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS sources (
     status       TEXT NOT NULL DEFAULT 'active',
     content_hash TEXT NOT NULL,
     file_size    INTEGER NOT NULL,
-    created_at   TEXT NOT NULL,
+    collected_at TEXT NOT NULL,
     updated_at   TEXT NOT NULL
 );
 
@@ -90,7 +90,7 @@ class MetadataDB:
         title: str,
         content_hash: str,
         file_size: int,
-        created_at: str,
+        collected_at: str,
         updated_at: str,
     ) -> None:
         """ソースを登録する.
@@ -101,8 +101,8 @@ class MetadataDB:
         旧レコードを削除してから登録する。
 
         Note:
-            created_at は新規 INSERT 時のみ使用される。既存レコードの
-            更新時は元の created_at が保持される（ON CONFLICT で更新対象外）。
+            collected_at は新規 INSERT 時のみ使用される。既存レコードの
+            更新時は元の collected_at が保持される（ON CONFLICT で更新対象外）。
             local 媒体の git 由来時刻への補正は、パイプライン制御層が
             update_source() で後から実施する。
         """
@@ -115,7 +115,7 @@ class MetadataDB:
             """\
             INSERT INTO sources
                 (source_id, source_type, file_path, title, status,
-                 content_hash, file_size, created_at, updated_at)
+                 content_hash, file_size, collected_at, updated_at)
             VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)
             ON CONFLICT(source_id) DO UPDATE SET
                 source_type = excluded.source_type,
@@ -133,7 +133,7 @@ class MetadataDB:
                 title,
                 content_hash,
                 file_size,
-                created_at,
+                collected_at,
                 updated_at,
             ),
         )
@@ -161,7 +161,7 @@ class MetadataDB:
             "status",
             "content_hash",
             "file_size",
-            "created_at",
+            "collected_at",
             "updated_at",
         }
         invalid = set(fields.keys()) - allowed
@@ -221,7 +221,7 @@ class MetadataDB:
 
         where = " AND ".join(conditions) if conditions else "1=1"
         rows = self._connection.execute(
-            f"SELECT * FROM sources WHERE {where} ORDER BY created_at",  # noqa: S608
+            f"SELECT * FROM sources WHERE {where} ORDER BY collected_at",  # noqa: S608
             params,
         ).fetchall()
         return [_row_to_source_record(r) for r in rows]
@@ -322,6 +322,6 @@ def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
         status=row["status"],
         content_hash=row["content_hash"],
         file_size=row["file_size"],
-        created_at=row["created_at"],
+        collected_at=row["collected_at"],
         updated_at=row["updated_at"],
     )

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -26,7 +26,7 @@ class SourceRecord:
     status: SourceStatus
     content_hash: str
     file_size: int
-    created_at: str
+    collected_at: str
     updated_at: str
 
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -122,14 +122,14 @@ class SourceStore:
         source_id = self._resolve_source_id(source_type, rel_path, metadata)
         title = self._resolve_title(source_type, rel_path, metadata)
 
-        # created_at: 既存レコード > metadata['collected_at'] > now の優先順
+        # collected_at: 既存レコード > metadata['collected_at'] > now の優先順
         existing = self._db.get_source(source_id)
         if existing:
-            created_at = existing.created_at
+            collected_at = existing.collected_at
         elif metadata and "collected_at" in metadata:
-            created_at = str(metadata["collected_at"])
+            collected_at = str(metadata["collected_at"])
         else:
-            created_at = now
+            collected_at = now
 
         self._db.register_source(
             source_id=source_id,
@@ -138,7 +138,7 @@ class SourceStore:
             title=title,
             content_hash=content_hash,
             file_size=len(data),
-            created_at=created_at,
+            collected_at=collected_at,
             updated_at=now,
         )
 
@@ -178,7 +178,7 @@ class SourceStore:
     def _build_metadata(self, record: SourceRecord) -> SourceMetadata:
         """SourceRecord と .meta ファイルから SourceMetadata を構築する.
 
-        .meta の collected_at を優先し、なければ DB の created_at を使用する。
+        .meta の collected_at を優先し、なければ DB の collected_at を使用する。
         共通フィールド（source_id, source_type, title）を除いた残りを extra に格納する。
 
         Args:
@@ -188,7 +188,7 @@ class SourceStore:
             SourceMetadata
         """
         extra: dict[str, Any] = {}
-        collected_at = record.created_at
+        collected_at = record.collected_at
         if record.source_type not in _NO_META_TYPES:
             file_path = self._root / record.file_path
             meta_file = meta_path_for(file_path)
@@ -394,7 +394,7 @@ class SourceStore:
                 title=title,
                 content_hash=content_hash,
                 file_size=len(data),
-                created_at=collected_at,
+                collected_at=collected_at,
                 updated_at=now,
             )
             count += 1

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -533,7 +533,7 @@ class TestClear:
             title="Web Page",
             content_hash="abc",
             file_size=100,
-            created_at="2025-01-01T00:00:00Z",
+            collected_at="2025-01-01T00:00:00Z",
             updated_at="2025-01-01T00:00:00Z",
         )
         metadata_db.register_source(
@@ -543,7 +543,7 @@ class TestClear:
             title="Zenn Article",
             content_hash="def",
             file_size=200,
-            created_at="2025-01-01T00:00:00Z",
+            collected_at="2025-01-01T00:00:00Z",
             updated_at="2025-01-01T00:00:00Z",
         )
 

--- a/tests/test_get_document.py
+++ b/tests/test_get_document.py
@@ -294,6 +294,6 @@ def _setup_source_with_db(
             title=title,
             content_hash=content_hash,
             file_size=len(content),
-            created_at=now,
+            collected_at=now,
             updated_at=now,
         )

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -481,7 +481,7 @@ class TestDeleteAndReAdd:
             title="a",
             content_hash="dummy",
             file_size=len(content),
-            created_at="2026-01-01T00:00:00+00:00",
+            collected_at="2026-01-01T00:00:00+00:00",
             updated_at="2026-01-01T00:00:00+00:00",
         )
         ctrl.commit("readd a")
@@ -525,7 +525,7 @@ class TestDeleteAndReAdd:
             title="b",
             content_hash="dummy2",
             file_size=11,
-            created_at="2026-01-01T00:00:00+00:00",
+            collected_at="2026-01-01T00:00:00+00:00",
             updated_at="2026-01-01T00:00:00+00:00",
         )
         ctrl.commit("readd b with new content")
@@ -563,7 +563,7 @@ class TestRemoveFile:
             title="Test",
             content_hash="dummy",
             file_size=17,
-            created_at="2026-01-01T00:00:00+00:00",
+            collected_at="2026-01-01T00:00:00+00:00",
             updated_at="2026-01-01T00:00:00+00:00",
         )
 
@@ -606,7 +606,7 @@ class TestRemoveFile:
             title="ghost",
             content_hash="dummy",
             file_size=0,
-            created_at="2026-01-01T00:00:00+00:00",
+            collected_at="2026-01-01T00:00:00+00:00",
             updated_at="2026-01-01T00:00:00+00:00",
         )
 

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -248,7 +248,7 @@ class TestCollectPipelineStats:
             title="Test",
             content_hash="abc",
             file_size=100,
-            created_at="2026-01-01",
+            collected_at="2026-01-01",
             updated_at="2026-01-01",
         )
         db.set_status("src1", "deleted")

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -32,7 +32,7 @@ class TestSourcesCRUD:
             title="Test Page",
             content_hash="abc123",
             file_size=1024,
-            created_at="2026-01-15T10:00:00Z",
+            collected_at="2026-01-15T10:00:00Z",
             updated_at="2026-01-15T10:00:00Z",
         )
 
@@ -53,7 +53,7 @@ class TestSourcesCRUD:
             title="Old Title",
             content_hash="old",
             file_size=100,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.register_source(
@@ -63,7 +63,7 @@ class TestSourcesCRUD:
             title="New Title",
             content_hash="new",
             file_size=200,
-            created_at="2026-01-02T00:00:00Z",
+            collected_at="2026-01-02T00:00:00Z",
             updated_at="2026-01-02T00:00:00Z",
         )
 
@@ -82,7 +82,7 @@ class TestSourcesCRUD:
             title="Test",
             content_hash="hash1",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.set_status("test", "deleted")
@@ -94,7 +94,7 @@ class TestSourcesCRUD:
             title="Test Updated",
             content_hash="hash2",
             file_size=20,
-            created_at="2026-01-02T00:00:00Z",
+            collected_at="2026-01-02T00:00:00Z",
             updated_at="2026-01-02T00:00:00Z",
         )
 
@@ -114,7 +114,7 @@ class TestSourcesCRUD:
             title="Test",
             content_hash="hash",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
 
@@ -130,7 +130,7 @@ class TestSourcesCRUD:
             title="Old",
             content_hash="hash",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
 
@@ -156,7 +156,7 @@ class TestSourcesCRUD:
             title="Test",
             content_hash="hash",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         with pytest.raises(ValueError, match="不正なフィールド"):
@@ -170,7 +170,7 @@ class TestSourcesCRUD:
             title="Web1",
             content_hash="h1",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.register_source(
@@ -180,7 +180,7 @@ class TestSourcesCRUD:
             title="Local1",
             content_hash="h2",
             file_size=20,
-            created_at="2026-01-02T00:00:00Z",
+            collected_at="2026-01-02T00:00:00Z",
             updated_at="2026-01-02T00:00:00Z",
         )
 
@@ -196,7 +196,7 @@ class TestSourcesCRUD:
             title="Active",
             content_hash="h1",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.register_source(
@@ -206,7 +206,7 @@ class TestSourcesCRUD:
             title="Deleted",
             content_hash="h2",
             file_size=20,
-            created_at="2026-01-02T00:00:00Z",
+            collected_at="2026-01-02T00:00:00Z",
             updated_at="2026-01-02T00:00:00Z",
         )
         db.set_status("deleted1", "deleted")
@@ -223,7 +223,7 @@ class TestSourcesCRUD:
             title="Test",
             content_hash="hash",
             file_size=10,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
 
@@ -251,7 +251,7 @@ class TestSourcesCRUD:
             title="S1",
             content_hash="h",
             file_size=1,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.register_source(
@@ -261,7 +261,7 @@ class TestSourcesCRUD:
             title="S2",
             content_hash="h",
             file_size=1,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.set_status("s2", "deleted")
@@ -341,7 +341,7 @@ class TestDeleteAllSources:
             title="S1",
             content_hash="h",
             file_size=1,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
         db.register_source(
@@ -351,7 +351,7 @@ class TestDeleteAllSources:
             title="S2",
             content_hash="h",
             file_size=1,
-            created_at="2026-01-01T00:00:00Z",
+            collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
 


### PR DESCRIPTION
## Change type

- [x] ★ refactor: リファクタリング

## Summary

- `sources` テーブルの `created_at` カラムを `collected_at` にリネーム（DDL・SQL・メソッドパラメータ）
- `SourceRecord` dataclass のフィールド名を `collected_at` に変更
- 呼び出し元（`source_store.py`, `controller.py`）のローカル変数名・キーワード引数を更新
- 全テストフィクスチャのキーワード引数名を更新（5テストファイル）
- 外部 API フィールド（BlueSky `createdAt`、Zenn `created_at`）は変更対象外

## Test plan

- [x] pytest 156 件全パス
- [x] ruff check 違反なし
- [x] mypy 型エラーなし
- [x] CLI 動作確認（add-document / stats / search）
- [x] MCP ツール動作確認（rag_stats / rag_search）
- [x] コードレビュー 指摘 0 件
- [x] ドキュメントレビュー 指摘 0 件（仕様書との整合性確認済み）

## Related issues

Closes #397