### PR TITLE
feat(content-listing): コンテンツ一覧取得機能の実装 (#414)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,6 +46,9 @@ rag_url_safety_timeout = 5.0
 # rag_max_response_chars = (未設定時は None)
 rag_stats_max_sources = 100
 
+# rag_list_recent / list-recent のデフォルト取得件数
+rag_list_recent_limit = 20
+
 # Zenn インジェスター
 rag_zenn_max_articles = 100
 rag_zenn_request_timeout = 30

--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -120,7 +120,7 @@ flowchart TD
     MCP["MCP rag_list_recent"]
     CLI["CLI list-recent"]
     VALIDATE["パラメータ検証"]
-    SERVICE["RAGKnowledgeService"]
+    SERVICE["共通関数 (rag_knowledge.py)"]
     METADB["MetadataDB"]
     FORMAT["テキストフォーマット"]
     RESPONSE["レスポンス返却"]
@@ -139,7 +139,7 @@ flowchart TD
 
 1. MCP ツールまたは CLI からパラメータを受け取る
 2. `source_type` と `limit` のバリデーションを実行する（1〜100 の範囲チェック含む）
-3. `RAGKnowledgeService` の共通関数を呼び出す
+3. `rag_knowledge.py` の共通関数 `list_recent_sources` を呼び出す
 4. `MetadataDB` から以下の 2 クエリを発行する:
    - 一覧取得: `source_type` + `status = 'active'` でフィルタし、`collected_at` 降順で `limit` 件取得
    - 総件数取得: 同条件の `COUNT(*)` で該当 source_type の全件数を取得
@@ -149,7 +149,7 @@ flowchart TD
 
 | ファイル | 役割 |
 |---------|------|
-| `src/rag/server.py` | MCP ツール定義。パラメータ検証と `RAGKnowledgeService` 呼び出し |
+| `src/rag/server.py` | MCP ツール定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/cli.py` | CLI サブコマンド定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/rag_knowledge.py` | 共通ロジック。MetadataDB へのクエリとフォーマット処理 |
 | `src/rag/store/metadata_db.py` | MetadataDB。`source_type` フィルタ + `collected_at` 降順ソートのクエリ |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -303,6 +303,30 @@ def main() -> None:
     # stats サブコマンド
     subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
 
+    # list-recent サブコマンド
+    list_recent_parser = subparsers.add_parser(
+        "list-recent", help="指定 source_type のソースを新しい順で一覧取得",
+    )
+    list_recent_parser.add_argument(
+        "--source-type",
+        required=True,
+        choices=["web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"],
+        help="ソース種別",
+    )
+    def _validate_list_recent_limit(value: str) -> int:
+        n = int(value)
+        if n < 1 or n > 100:
+            raise argparse.ArgumentTypeError(
+                f"--limit must be 1-100 (got {n})"
+            )
+        return n
+    list_recent_parser.add_argument(
+        "--limit",
+        type=_validate_list_recent_limit,
+        default=None,
+        help="取得件数（1〜100、未指定時は設定値を使用）",
+    )
+
     # search サブコマンド
     search_parser = subparsers.add_parser("search", help="ナレッジベースを検索")
     search_parser.add_argument("--query", required=True, help="検索クエリ")
@@ -447,6 +471,7 @@ def main() -> None:
         "get-document": run_get_document,
         "rebuild": run_rebuild,
         "stats": run_stats,
+        "list-recent": run_list_recent,
         "search": run_search,
         "delete": run_delete,
         "search-aozora": run_search_aozora,
@@ -1280,6 +1305,22 @@ def run_stats(args: argparse.Namespace) -> None:
     print("\n".join(parts))
 
 
+def run_list_recent(args: argparse.Namespace) -> None:
+    """指定 source_type のソースを新しい順で一覧取得する.
+
+    MCP ツール rag_list_recent と同等の一覧取得を CLI で実行する。
+
+    Args:
+        args: コマンドライン引数
+    """
+    from .config import get_settings
+    from .rag_knowledge import list_recent_sources
+
+    settings = get_settings()
+    limit: int = args.limit if args.limit is not None else settings.rag_list_recent_limit
+    print(list_recent_sources(settings.source_store_dir, args.source_type, limit))
+
+
 def run_search(args: argparse.Namespace) -> None:
     """ナレッジベースを検索する.
 
@@ -1460,13 +1501,9 @@ def run_migrate_journal(args: argparse.Namespace) -> None:
 
 def _format_cli_size(size_bytes: int) -> str:
     """バイト数を人間が読みやすい単位に変換する."""
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    if size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    if size_bytes < 1024 * 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+    from .rag_knowledge import format_file_size
+
+    return format_file_size(size_bytes)
 
 
 # --- インジェスト系 CLI コマンド ---

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -161,6 +161,9 @@ class RAGSettings(BaseModel):
     # rag_stats ソース一覧の最大表示件数
     rag_stats_max_sources: int = Field(ge=1)
 
+    # rag_list_recent デフォルト取得件数
+    rag_list_recent_limit: int = Field(ge=1, le=100)
+
     # Zenn インジェスター
     rag_zenn_max_articles: int = Field(ge=1, le=100)
     rag_zenn_request_timeout: int = Field(ge=1, le=120)

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -1151,3 +1151,59 @@ def format_document_response(result: DocumentResult) -> str:
     lines.append("")
     lines.append(result.content)
     return "\n".join(lines)
+
+
+def list_recent_sources(
+    source_store_dir: str,
+    source_type: str,
+    limit: int,
+) -> str:
+    """指定 source_type のソースを新しい順で一覧取得する（MCP/CLI 共通ロジック）.
+
+    仕様: docs/specs/infrastructure/content-listing.md
+
+    Args:
+        source_store_dir: source_store のルートディレクトリパス
+        source_type: ソース種別
+        limit: 取得件数
+
+    Returns:
+        フォーマット済みテキスト
+    """
+    from .store.metadata_db import MetadataDB
+
+    db_path = Path(source_store_dir) / "metadata.db"
+    if not db_path.exists():
+        return f"source_type: {source_type}（0件 / 全0件）"
+
+    db = MetadataDB(db_path)
+    try:
+        db.initialize()
+        sources = db.list_sources(source_type=source_type, limit=limit)  # type: ignore[arg-type]
+        total = db.count_sources_by_type(source_type=source_type)  # type: ignore[arg-type]
+    finally:
+        db.close()
+
+    lines: list[str] = [
+        f"source_type: {source_type}（{len(sources)}件 / 全{total}件）",
+    ]
+
+    for i, src in enumerate(sources, 1):
+        lines.append("")
+        lines.append(f"{i}. {src.title}")
+        lines.append(f"   Source: {src.source_id}")
+        lines.append(f"   Collected: {src.collected_at}")
+        lines.append(f"   Size: {format_file_size(src.file_size)}")
+
+    return "\n".join(lines)
+
+
+def format_file_size(size_bytes: int) -> str:
+    """バイト数を人間が読みやすい単位に変換する."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    if size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    if size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -12,7 +12,7 @@ import mimetypes
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urldefrag
 
 from .chunker import chunk_text
@@ -1179,8 +1179,11 @@ def list_recent_sources(
     db = MetadataDB(db_path)
     try:
         db.initialize()
-        sources = db.list_sources(source_type=source_type, limit=limit)  # type: ignore[arg-type]
-        total = db.count_sources_by_type(source_type=source_type)  # type: ignore[arg-type]
+        from .store.models import SourceType
+
+        st = cast(SourceType, source_type)
+        sources = db.list_sources(source_type=st, limit=limit)
+        total = db.count_sources_by_type(source_type=st)
     finally:
         db.close()
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -3,7 +3,7 @@
 仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md
 独立リポジトリとして動作する。
 
-FastMCP を使用して 20 個の RAG ツールを公開する:
+FastMCP を使用して 21 個の RAG ツールを公開する:
 - rag_search: ナレッジベース検索（チャンク単位返却）
 - rag_get_document: ソース全文取得
 - rag_add: 単一ページをナレッジベースに取り込み
@@ -21,6 +21,7 @@ FastMCP を使用して 20 個の RAG ツールを公開する:
 - rag_search_aozora: 青空文庫カタログ検索
 - rag_add_aozora: 青空文庫作品の単一取り込み
 - rag_crawl_aozora: 青空文庫著者作品の一括取り込み
+- rag_list_recent: 指定 source_type のソースを新しい順で一覧取得
 - rag_delete: ソースURL指定でナレッジから論理削除
 - rag_rebuild: ナレッジベースの再構築
 - rag_stats: ナレッジベースの統計情報を表示
@@ -50,7 +51,7 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 # 問題への対策として、import 時に stdout を抑制する。
 from .config import ensure_utf8_streams
 from .filter_parser import parse_filters
-from .rag_knowledge import format_raw_search_results
+from .rag_knowledge import format_file_size, format_raw_search_results
 
 with contextlib.redirect_stdout(io.StringIO()):
     from .bm25_index import BM25Index
@@ -1600,15 +1601,7 @@ _VALID_PIPELINE_SOURCE_TYPES: frozenset[str] = frozenset({
 _rebuild_lock = threading.Lock()
 
 
-def _format_size(size_bytes: int) -> str:
-    """バイト数を人間が読みやすい単位に変換する."""
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    if size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    if size_bytes < 1024 * 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+_format_size = format_file_size
 
 
 def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
@@ -2057,6 +2050,44 @@ async def _run_rebuild_subprocess(
     elapsed = result.get("elapsed", 0)
 
     return _format_rebuild_summary(summary, elapsed)
+
+
+@mcp.tool()
+async def rag_list_recent(
+    source_type: str,
+    limit: int | None = None,
+) -> str:
+    """[rag-knowledge] List recent sources - 指定した source_type のソースを新しい順で一覧取得する.
+
+    content listing, recent sources, source list, browse.
+    ナレッジベースに取り込んだコンテンツを source_type 別に一覧で確認できる。
+    最近取り込んだコンテンツの確認や、ナレッジベースの内容把握に使用する。
+
+    Args:
+        source_type: ソース種別: "web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"
+        limit: 取得件数（1〜100、未指定時は設定値を使用）
+
+    Returns:
+        ソース一覧テキスト（タイトル、source_id、collected_at、ファイルサイズ）
+    """
+    if source_type not in _VALID_SOURCE_TYPES:
+        valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
+        return f"無効な source_type: {source_type!r}（有効値: {valid}）"
+
+    settings = get_settings()
+    if limit is None:
+        limit = settings.rag_list_recent_limit
+    if limit < 1 or limit > 100:
+        return "エラー: limit は 1〜100 の範囲で指定してください"
+
+    from .rag_knowledge import list_recent_sources
+
+    return await asyncio.to_thread(
+        list_recent_sources,
+        settings.source_store_dir,
+        source_type,
+        limit,
+    )
 
 
 @mcp.tool()

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -311,6 +311,31 @@ class MetadataDB:
             ).fetchone()
         return int(row["cnt"]) if row else 0
 
+    def list_sources(
+        self,
+        *,
+        source_type: SourceType,
+        limit: int,
+    ) -> list[SourceRecord]:
+        """指定 source_type の active ソースを collected_at 降順で取得する."""
+        rows = self._connection.execute(
+            "SELECT * FROM sources"
+            " WHERE source_type = ? AND status = 'active'"
+            " ORDER BY collected_at DESC"
+            " LIMIT ?",
+            (source_type, limit),
+        ).fetchall()
+        return [_row_to_source_record(r) for r in rows]
+
+    def count_sources_by_type(self, *, source_type: SourceType) -> int:
+        """指定 source_type の active ソース件数を返す."""
+        row = self._connection.execute(
+            "SELECT COUNT(*) as cnt FROM sources"
+            " WHERE source_type = ? AND status = 'active'",
+            (source_type,),
+        ).fetchone()
+        return int(row["cnt"]) if row else 0
+
 
 def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
     """sqlite3.Row を SourceRecord に変換する."""

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -321,7 +321,7 @@ class MetadataDB:
         rows = self._connection.execute(
             "SELECT * FROM sources"
             " WHERE source_type = ? AND status = 'active'"
-            " ORDER BY collected_at DESC"
+            " ORDER BY datetime(collected_at) DESC"
             " LIMIT ?",
             (source_type, limit),
         ).fetchall()

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -1,0 +1,214 @@
+"""コンテンツ一覧取得のテスト.
+
+仕様: docs/specs/infrastructure/content-listing.md
+
+テスト方針:
+- MetadataDB の list_sources / count_sources_by_type メソッドの単体テスト
+- list_recent_sources 共通関数のフォーマット・統合テスト
+- エッジケース: 0件、limit > 該当件数、論理削除除外、ソート順
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.store.metadata_db import MetadataDB
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> MetadataDB:
+    """テスト用 MetadataDB インスタンス."""
+    mdb = MetadataDB(tmp_path / "metadata.db")
+    mdb.initialize()
+    return mdb
+
+
+def _register(
+    db: MetadataDB,
+    source_id: str,
+    source_type: str = "web",
+    title: str = "Test",
+    collected_at: str = "2026-01-01T00:00:00Z",
+    file_size: int = 1024,
+    status: str = "active",
+) -> None:
+    """テスト用ソース登録ヘルパー."""
+    db.register_source(
+        source_id=source_id,
+        source_type=source_type,
+        file_path=f"{source_type}/{source_id.replace('/', '_')}",
+        title=title,
+        content_hash="hash",
+        file_size=file_size,
+        collected_at=collected_at,
+        updated_at=collected_at,
+    )
+    if status == "deleted":
+        db.set_status(source_id, "deleted")
+
+
+class TestListSources:
+    """MetadataDB.list_sources のテスト."""
+
+    def test_empty(self, db: MetadataDB) -> None:
+        """0件の場合は空リストを返す."""
+        result = db.list_sources(source_type="web", limit=10)
+        assert result == []
+
+    def test_filter_by_source_type(self, db: MetadataDB) -> None:
+        """source_type でフィルタされる."""
+        _register(db, "web1", source_type="web")
+        _register(db, "local1", source_type="local")
+
+        result = db.list_sources(source_type="web", limit=10)
+        assert len(result) == 1
+        assert result[0].source_id == "web1"
+
+    def test_order_by_collected_at_desc(self, db: MetadataDB) -> None:
+        """collected_at 降順でソートされる."""
+        _register(db, "old", collected_at="2026-01-01T00:00:00Z")
+        _register(db, "mid", collected_at="2026-01-15T00:00:00Z")
+        _register(db, "new", collected_at="2026-02-01T00:00:00Z")
+
+        result = db.list_sources(source_type="web", limit=10)
+        assert [r.source_id for r in result] == ["new", "mid", "old"]
+
+    def test_limit(self, db: MetadataDB) -> None:
+        """limit で取得件数が制限される."""
+        for i in range(5):
+            _register(db, f"web{i}", collected_at=f"2026-01-{i+1:02d}T00:00:00Z")
+
+        result = db.list_sources(source_type="web", limit=2)
+        assert len(result) == 2
+        assert result[0].source_id == "web4"
+        assert result[1].source_id == "web3"
+
+    def test_limit_larger_than_count(self, db: MetadataDB) -> None:
+        """limit が該当件数より大きい場合は全件返す."""
+        _register(db, "web1")
+        result = db.list_sources(source_type="web", limit=100)
+        assert len(result) == 1
+
+    def test_excludes_deleted(self, db: MetadataDB) -> None:
+        """論理削除済みソースは除外される."""
+        _register(db, "active1")
+        _register(db, "deleted1", status="deleted")
+
+        result = db.list_sources(source_type="web", limit=10)
+        assert len(result) == 1
+        assert result[0].source_id == "active1"
+
+
+class TestCountSourcesByType:
+    """MetadataDB.count_sources_by_type のテスト."""
+
+    def test_empty(self, db: MetadataDB) -> None:
+        assert db.count_sources_by_type(source_type="web") == 0
+
+    def test_counts_only_active(self, db: MetadataDB) -> None:
+        _register(db, "a1")
+        _register(db, "a2")
+        _register(db, "d1", status="deleted")
+
+        assert db.count_sources_by_type(source_type="web") == 2
+
+    def test_counts_by_type(self, db: MetadataDB) -> None:
+        _register(db, "web1", source_type="web")
+        _register(db, "local1", source_type="local")
+
+        assert db.count_sources_by_type(source_type="web") == 1
+        assert db.count_sources_by_type(source_type="local") == 1
+
+
+class TestListRecentSources:
+    """list_recent_sources 共通関数のテスト."""
+
+    def _setup_db(self, tmp_path: Path) -> Path:
+        """source_store_dir に metadata.db を準備する."""
+        source_store_dir = tmp_path / "source_store"
+        source_store_dir.mkdir()
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        return source_store_dir
+
+    def test_format_output(self, tmp_path: Path) -> None:
+        """出力フォーマットが仕様に準拠する."""
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        _register(
+            db, "https://example.com/page", title="Sample Page",
+            collected_at="2026-06-15T10:30:00+09:00", file_size=46285,
+        )
+        db.close()
+
+        result = list_recent_sources(str(source_store_dir), "web", 10)
+
+        assert "source_type: web（1件 / 全1件）" in result
+        assert "1. Sample Page" in result
+        assert "Source: https://example.com/page" in result
+        assert "Collected: 2026-06-15T10:30:00+09:00" in result
+        assert "Size: 45.2 KB" in result
+
+    def test_zero_results(self, tmp_path: Path) -> None:
+        """0件の場合のフォーマット."""
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        result = list_recent_sources(str(source_store_dir), "web", 10)
+        assert result == "source_type: web（0件 / 全0件）"
+
+    def test_db_not_exists(self, tmp_path: Path) -> None:
+        """metadata.db が存在しない場合."""
+        from rag.rag_knowledge import list_recent_sources
+
+        result = list_recent_sources(str(tmp_path / "nonexistent"), "web", 10)
+        assert result == "source_type: web（0件 / 全0件）"
+
+    def test_partial_display(self, tmp_path: Path) -> None:
+        """limit で表示件数を制限し、総件数は全件数を表示."""
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        for i in range(5):
+            _register(
+                db, f"https://example.com/p{i}", title=f"Page {i}",
+                collected_at=f"2026-01-{i+1:02d}T00:00:00Z",
+            )
+        db.close()
+
+        result = list_recent_sources(str(source_store_dir), "web", 2)
+        assert "source_type: web（2件 / 全5件）" in result
+        assert "1. Page 4" in result
+        assert "2. Page 3" in result
+        assert "3." not in result
+
+
+class TestFormatFileSize:
+    """format_file_size のテスト."""
+
+    def test_bytes(self) -> None:
+        from rag.rag_knowledge import format_file_size
+
+        assert format_file_size(500) == "500 B"
+
+    def test_kilobytes(self) -> None:
+        from rag.rag_knowledge import format_file_size
+
+        assert format_file_size(46285) == "45.2 KB"
+
+    def test_megabytes(self) -> None:
+        from rag.rag_knowledge import format_file_size
+
+        assert format_file_size(5 * 1024 * 1024) == "5.0 MB"
+
+    def test_gigabytes(self) -> None:
+        from rag.rag_knowledge import format_file_size
+
+        assert format_file_size(2 * 1024 * 1024 * 1024) == "2.0 GB"


### PR DESCRIPTION
## Change type

- [x] feat

## Summary

- MCP ツール `rag_list_recent` を追加（指定 source_type のソースを collected_at 降順で一覧取得）
- CLI サブコマンド `list-recent` を追加（同等機能）
- MetadataDB に `list_sources` / `count_sources_by_type` メソッドを追加
- `rag_knowledge.py` に共通関数 `list_recent_sources` / `format_file_size` を追加し、server.py / cli.py の重複サイズフォーマット関数を統一
- `rag_list_recent_limit` 設定を config.toml + config.py に追加（デフォルト: 20、範囲: 1-100）
- 仕様書のコンポーネント構成図を実装に合わせて修正

## Test plan

- [x] MetadataDB 単体テスト（0件、フィルタ、ソート順、limit、論理削除除外）
- [x] 共通関数統合テスト（フォーマット、0件、DB不在、部分表示）
- [x] format_file_size ユニットテスト（B/KB/MB/GB）
- [x] ruff / mypy クリア
- [x] 全17テスト通過

## Related issues

Closes #414

> QA スキルへの検証ステップ追加は #417 に分離