### PR TITLE
feat(rag-knowledge): ChromaDB Server Manager 実装 (#407)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ CONVERTED_STORE_DIR=./converted_store
 # ChromaDB サーバー接続
 CHROMADB_SERVER_HOST=localhost
 CHROMADB_SERVER_PORT=8000
-# 未実装 (#407 対応予定)。現在はこの設定値は使用されません。
-CHROMADB_AUTO_START=false
+# MCP サーバー起動時に ChromaDB サーバーを自動起動 (true/false)
+CHROMADB_AUTO_START=true
 
 # トランスポート (stdio or http)
 RAG_TRANSPORT=stdio

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,7 @@
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
 | `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・DocumentIngester・BlueskyIngester） |
+| `src/rag/infrastructure/` | インフラ基盤（ChromaDB サーバーのライフサイクル管理） |
 | `src/rag/pipeline/` | パイプライン制御（git 操作・差分検知・ステージ間連携・4モード実行） |
 | `src/rag/pipeline/worker.py` | MCP 用サブプロセスエントリポイント（`python -m rag.pipeline.worker` で起動、クラッシュ耐性確保） |
 | `src/rag/pipeline/factory.py` | PipelineController のファクトリ関数（server/cli/worker 共通） |

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -247,8 +247,6 @@ flowchart TB
 
 ### ChromaDB client/server 構成
 
-> **TODO:#406** VectorStore HttpClient 化、**TODO:#407** ChromaDB Server Manager 実装
-
 ChromaDB は `chroma run` によるサーバーモードで動作し、MCP サーバー・CLI の両方が `HttpClient` で接続する。これにより、`PersistentClient` の単一プロセス制約を解消し、MCP と CLI の同時アクセスを可能にする。
 
 | 項目 | 仕様 |
@@ -443,6 +441,7 @@ flowchart LR
 | ConstrainedClient (py-common-lib) | 全外部 HTTP リクエストのゲートウェイ。ハードリミット・バジェット・サーキットブレーカーを統合し、httpx.AsyncClient をラップする |
 | BudgetTracker (py-common-lib) | 操作あたりのリクエスト総数を追跡し、上限到達で BudgetExhaustedError を送出する |
 | CircuitBreaker (py-common-lib) | 連続失敗回数を監視し、閾値超過で CircuitBreakerOpenError を送出する |
+| ChromaDB Server Manager | MCP サーバー起動時に ChromaDB サーバーのヘルスチェック・自動起動を行う。グレースフルデグレードにより起動失敗時も MCP は稼働継続する |
 | 評価ツール | Precision、Recall、F1、NDCG、MRR の計算とベースライン比較 |
 
 ## 外部連携
@@ -477,6 +476,7 @@ flowchart LR
 | 設定値がハードリミット超過 | ハードリミット値にクランプし、警告ログを出力する |
 | AsciiDoc デリミタブロックが閉じられていない | ファイル末尾までをブロック内とみなし、ブロック内での見出し分割を行わない |
 | ネストしたデリミタブロック（AsciiDoc モード） | AsciiDoc 仕様に従い、同一種類のデリミタはネスト不可。最初の閉じデリミタで終了する |
+| ChromaDB サーバー自動起動失敗（chroma コマンド未検出・起動タイムアウト・プロセス異常終了） | 警告ログを出力し、MCP サーバーは稼働を継続する（グレースフルデグレード）。ツール呼び出し時に接続エラーを返す |
 | ChromaDB サーバーがダウンしている状態でのツール呼び出し | 接続エラーを検出し、エラーメッセージを返す。MCP サーバー自体は稼働を継続する |
 
 ## 関連ドキュメント

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -66,9 +66,9 @@ class _EnvLoader(BaseSettings):
     # ChromaDB サーバー接続
     chromadb_server_host: str = "localhost"
     chromadb_server_port: int = Field(default=8000, ge=1, le=65535)
-    # auto_start は #407 (ChromaDB Server Manager) で参照実装予定。
-    # 未実装のため現時点ではデフォルト False。#407 完了後に True に変更する。
-    chromadb_auto_start: bool = False
+    # MCP サーバー起動時に ChromaDB サーバーを自動起動するか。
+    # ChromaDBServerManager (infrastructure/chromadb_manager.py) が参照する。
+    chromadb_auto_start: bool = True
 
     # トランスポート
     rag_transport: Literal["stdio", "http"]
@@ -113,8 +113,7 @@ class RAGSettings(BaseModel):
     converted_store_dir: str
     chromadb_server_host: str
     chromadb_server_port: int = Field(ge=1, le=65535)
-    # auto_start は #407 (ChromaDB Server Manager) で参照実装予定
-    # 未実装のため _EnvLoader のデフォルトは False
+    # MCP サーバー起動時に ChromaDB サーバーを自動起動するか
     chromadb_auto_start: bool
     rag_transport: Literal["stdio", "http"]
     rag_http_host: str

--- a/src/rag/infrastructure/chromadb_manager.py
+++ b/src/rag/infrastructure/chromadb_manager.py
@@ -161,8 +161,15 @@ class ChromaDBServerManager:
                 _SHUTDOWN_TIMEOUT,
             )
             self._process.kill()
-            self._process.wait(timeout=_SHUTDOWN_TIMEOUT)
-            logger.info("ChromaDB server killed")
+            try:
+                self._process.wait(timeout=_SHUTDOWN_TIMEOUT)
+                logger.info("ChromaDB server killed")
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "ChromaDB server did not exit even after kill() "
+                    "within %.0fs; giving up without further waiting",
+                    _SHUTDOWN_TIMEOUT,
+                )
 
         self._process = None
         self._started_by_us = False
@@ -187,7 +194,7 @@ class ChromaDBServerManager:
 
         popen_kwargs: dict[str, Any] = {
             "stdout": subprocess.DEVNULL,
-            "stderr": subprocess.PIPE,
+            "stderr": subprocess.DEVNULL,
             "stdin": subprocess.DEVNULL,
             "text": True,
         }
@@ -229,14 +236,10 @@ class ChromaDBServerManager:
         while time.monotonic() - start < timeout:
             # プロセスが予期せず終了していないか確認
             if self._process is not None and self._process.poll() is not None:
-                stderr_output = ""
-                if self._process.stderr:
-                    stderr_output = self._process.stderr.read()
                 logger.error(
                     "ChromaDB server process exited unexpectedly "
-                    "(code: %d): %s",
+                    "(code: %d)",
                     self._process.returncode,
-                    stderr_output[:500] if stderr_output else "(no output)",
                 )
                 return False
 

--- a/src/rag/infrastructure/chromadb_manager.py
+++ b/src/rag/infrastructure/chromadb_manager.py
@@ -1,0 +1,253 @@
+"""ChromaDB サーバーのライフサイクル管理.
+
+仕様: docs/specs/rag-knowledge.md (ChromaDB client/server 構成)
+
+MCP サーバー起動時にヘルスチェック → 未起動なら自動起動を行う。
+MCP サーバー終了時は、自分が起動したプロセスのみ停止する
+（既存サーバーに接続した場合は停止しない）。
+CLI からの接続は既存サーバーへの接続のみ（手動起動 or MCP 経由で起動済み前提）。
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx  # safety:allowed — ChromaDB サーバーへのローカルヘルスチェック用
+
+logger = logging.getLogger(__name__)
+
+# ヘルスチェックのデフォルトタイムアウト（秒）
+_HEALTH_CHECK_TIMEOUT = 5.0
+
+# 起動待機のデフォルトタイムアウト（秒）
+_WAIT_FOR_READY_TIMEOUT = 30.0
+
+# 起動待機のリトライ間隔（秒）
+_WAIT_RETRY_INTERVAL = 1.0
+
+# shutdown 時の terminate → kill 待機タイムアウト（秒）
+_SHUTDOWN_TIMEOUT = 5.0
+
+
+class ChromaDBServerManager:
+    """ChromaDB サーバーのライフサイクル管理.
+
+    MCP サーバー起動時に使用する。ヘルスチェックで既存サーバーの存在を確認し、
+    未起動かつ auto_start が有効な場合は `chroma run` でサブプロセス起動する。
+    自分が起動したプロセスのみ shutdown() で停止する。
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 8000,
+        persist_dir: str = "./chroma_db",
+        auto_start: bool = True,
+    ) -> None:
+        """ChromaDBServerManager を初期化する.
+
+        Args:
+            host: ChromaDB サーバーのホスト
+            port: ChromaDB サーバーのポート
+            persist_dir: ChromaDB の永続化ディレクトリ
+            auto_start: 未起動時に自動起動するか
+        """
+        self._host = host
+        self._port = port
+        self._persist_dir = persist_dir
+        self._auto_start = auto_start
+        self._process: subprocess.Popen[str] | None = None
+        self._started_by_us = False
+
+    @property
+    def _base_url(self) -> str:
+        """ChromaDB サーバーのベース URL."""
+        return f"http://{self._host}:{self._port}"
+
+    def health_check(self, timeout: float = _HEALTH_CHECK_TIMEOUT) -> bool:
+        """ChromaDB サーバーの HTTP ヘルスチェック.
+
+        Args:
+            timeout: リクエストタイムアウト（秒）
+
+        Returns:
+            サーバーが応答すれば True
+        """
+        try:
+            resp = httpx.get(  # safety:allowed — ローカルヘルスチェック
+                f"{self._base_url}/api/v1/heartbeat",
+                timeout=timeout,
+            )
+            return resp.status_code == 200
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return False
+        except Exception:
+            logger.warning(
+                "Health check failed unexpectedly",
+                exc_info=True,
+            )
+            return False
+
+    def ensure_server_running(self) -> bool:
+        """ChromaDB サーバーが稼働していることを保証する.
+
+        1. ヘルスチェックで既存サーバーの存在を確認
+        2. 未起動かつ auto_start 有効なら自動起動
+        3. 起動待機（タイムアウト付き）
+
+        Returns:
+            サーバーが利用可能なら True。
+            False でも MCP サーバーは稼働を継続し、ツール呼び出し時にエラーを返す
+            （グレースフルデグレード）。
+        """
+        if self.health_check():
+            logger.info(
+                "ChromaDB server is already running at %s:%d",
+                self._host,
+                self._port,
+            )
+            return True
+
+        if not self._auto_start:
+            logger.warning(
+                "ChromaDB server is not running at %s:%d and auto_start is disabled. "
+                "Start manually with: chroma run --path <persist_dir> --port %d",
+                self._host,
+                self._port,
+                self._port,
+            )
+            return False
+
+        logger.info(
+            "ChromaDB server not found at %s:%d, starting...",
+            self._host,
+            self._port,
+        )
+        return self._start_server()
+
+    def shutdown(self) -> None:
+        """自分が起動した ChromaDB サーバープロセスを停止する.
+
+        既存サーバーに接続した場合（自分が起動していない場合）は何もしない。
+        """
+        if not self._started_by_us or self._process is None:
+            return
+
+        if self._process.poll() is not None:
+            logger.info(
+                "ChromaDB server process already exited (code: %d)",
+                self._process.returncode,
+            )
+            self._process = None
+            self._started_by_us = False
+            return
+
+        logger.info(
+            "Shutting down ChromaDB server (PID: %d)...",
+            self._process.pid,
+        )
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=_SHUTDOWN_TIMEOUT)
+            logger.info("ChromaDB server stopped gracefully")
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "ChromaDB server did not stop within %.0fs, killing...",
+                _SHUTDOWN_TIMEOUT,
+            )
+            self._process.kill()
+            self._process.wait(timeout=_SHUTDOWN_TIMEOUT)
+            logger.info("ChromaDB server killed")
+
+        self._process = None
+        self._started_by_us = False
+
+    def _start_server(self) -> bool:
+        """ChromaDB サーバーをサブプロセスとして起動する.
+
+        Returns:
+            サーバーの起動待機が成功すれば True
+        """
+        persist_path = str(Path(self._persist_dir).resolve())
+        cmd = [
+            "chroma",
+            "run",
+            "--path",
+            persist_path,
+            "--port",
+            str(self._port),
+            "--host",
+            self._host,
+        ]
+
+        popen_kwargs: dict[str, Any] = {
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.PIPE,
+            "stdin": subprocess.DEVNULL,
+            "text": True,
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
+        try:
+            self._process = subprocess.Popen(cmd, **popen_kwargs)
+            self._started_by_us = True
+            logger.info(
+                "Started ChromaDB server process (PID: %d, path: %s)",
+                self._process.pid,
+                persist_path,
+            )
+        except FileNotFoundError:
+            logger.error(
+                "'chroma' command not found. "
+                "Ensure chromadb is installed: pip install chromadb"
+            )
+            return False
+        except OSError:
+            logger.exception("Failed to start ChromaDB server")
+            return False
+
+        return self._wait_for_ready()
+
+    def _wait_for_ready(
+        self, timeout: float = _WAIT_FOR_READY_TIMEOUT
+    ) -> bool:
+        """サーバーが応答するまでリトライする.
+
+        Args:
+            timeout: 最大待機時間（秒）
+
+        Returns:
+            サーバーが応答すれば True
+        """
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            # プロセスが予期せず終了していないか確認
+            if self._process is not None and self._process.poll() is not None:
+                stderr_output = ""
+                if self._process.stderr:
+                    stderr_output = self._process.stderr.read()
+                logger.error(
+                    "ChromaDB server process exited unexpectedly "
+                    "(code: %d): %s",
+                    self._process.returncode,
+                    stderr_output[:500] if stderr_output else "(no output)",
+                )
+                return False
+
+            if self.health_check(timeout=2.0):
+                elapsed = time.monotonic() - start
+                logger.info("ChromaDB server ready (%.1fs)", elapsed)
+                return True
+
+            time.sleep(_WAIT_RETRY_INTERVAL)
+
+        logger.error(
+            "ChromaDB server did not become ready within %.0fs", timeout
+        )
+        return False

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -178,8 +178,8 @@ def _build_rag_service() -> RAGKnowledgeService:
 
     with contextlib.redirect_stdout(io.StringIO()):
         # HttpClient で ChromaDB サーバーに接続。
-        # chromadb_persist_dir はサーバー側の永続化パス（chroma run --path）で使用。
-        # auto_start による自動起動は #407 で実装予定。
+        # ChromaDB サーバーの起動確保は _configure_and_run() の
+        # ChromaDBServerManager.ensure_server_running() で実施済み。
         vector_store = VectorStore.create_http(
             embedding_provider=embedding_provider,
             host=settings.chromadb_server_host,
@@ -2486,6 +2486,21 @@ async def upload_journal(request: Request) -> Response:
 def _configure_and_run() -> None:
     """トランスポート設定に基づいて MCP サーバーを起動する."""
     settings = get_settings()
+
+    # ChromaDB サーバーの起動確保（グレースフルデグレード: 失敗しても MCP は稼働継続）
+    import atexit
+
+    from .infrastructure.chromadb_manager import ChromaDBServerManager
+
+    chromadb_manager = ChromaDBServerManager(
+        host=settings.chromadb_server_host,
+        port=settings.chromadb_server_port,
+        persist_dir=settings.chromadb_persist_dir,
+        auto_start=settings.chromadb_auto_start,
+    )
+    chromadb_manager.ensure_server_running()
+    atexit.register(chromadb_manager.shutdown)
+
     transport = settings.rag_transport
 
     if transport == "http":

--- a/tests/test_chromadb_manager.py
+++ b/tests/test_chromadb_manager.py
@@ -1,0 +1,339 @@
+"""ChromaDB Server Manager のテスト (Issue #407).
+
+仕様: docs/specs/rag-knowledge.md (ChromaDB client/server 構成)
+
+テスト方針:
+- ヘルスチェック: httpx.get をモックし、成功/接続エラー/タイムアウトを検証
+- 自動起動: subprocess.Popen をモックし、起動シーケンスを検証
+- 起動待機: タイムアウト・プロセス異常終了時の動作を検証
+- 自動起動フラグ OFF: サーバー未起動時に起動を試みないことを検証
+- シャットダウン: 自分が起動したプロセスのみ停止、既存サーバーは停止しないことを検証
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from rag.infrastructure.chromadb_manager import ChromaDBServerManager
+
+
+@pytest.fixture
+def manager() -> ChromaDBServerManager:
+    """デフォルト設定の ChromaDBServerManager."""
+    return ChromaDBServerManager(
+        host="localhost",
+        port=8000,
+        persist_dir="./test_chroma_db",
+        auto_start=True,
+    )
+
+
+@pytest.fixture
+def manager_no_autostart() -> ChromaDBServerManager:
+    """auto_start=False の ChromaDBServerManager."""
+    return ChromaDBServerManager(
+        host="localhost",
+        port=8000,
+        persist_dir="./test_chroma_db",
+        auto_start=False,
+    )
+
+
+class TestHealthCheck:
+    """health_check() のテスト."""
+
+    def test_success(self, manager: ChromaDBServerManager) -> None:
+        """サーバーが正常応答する場合 True を返す."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("rag.infrastructure.chromadb_manager.httpx.get", return_value=mock_response):
+            assert manager.health_check() is True
+
+    def test_connection_error(self, manager: ChromaDBServerManager) -> None:
+        """接続エラー時に False を返す."""
+        with patch(
+            "rag.infrastructure.chromadb_manager.httpx.get",
+            side_effect=httpx.ConnectError("Connection refused"),
+        ):
+            assert manager.health_check() is False
+
+    def test_timeout(self, manager: ChromaDBServerManager) -> None:
+        """タイムアウト時に False を返す."""
+        with patch(
+            "rag.infrastructure.chromadb_manager.httpx.get",
+            side_effect=httpx.TimeoutException("Timeout"),
+        ):
+            assert manager.health_check() is False
+
+    def test_non_200_status(self, manager: ChromaDBServerManager) -> None:
+        """200 以外のステータスコードで False を返す."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        with patch("rag.infrastructure.chromadb_manager.httpx.get", return_value=mock_response):
+            assert manager.health_check() is False
+
+    def test_unexpected_exception(self, manager: ChromaDBServerManager) -> None:
+        """予期しない例外時に False を返す."""
+        with patch(
+            "rag.infrastructure.chromadb_manager.httpx.get",
+            side_effect=RuntimeError("Unexpected"),
+        ):
+            assert manager.health_check() is False
+
+    def test_requests_correct_url(self, manager: ChromaDBServerManager) -> None:
+        """正しい URL にリクエストする."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("rag.infrastructure.chromadb_manager.httpx.get", return_value=mock_response) as mock_get:
+            manager.health_check(timeout=3.0)
+            mock_get.assert_called_once_with(
+                "http://localhost:8000/api/v1/heartbeat",
+                timeout=3.0,
+            )
+
+
+class TestEnsureServerRunning:
+    """ensure_server_running() のテスト."""
+
+    def test_server_already_running(self, manager: ChromaDBServerManager) -> None:
+        """サーバーが既に稼働中なら True を返し、起動しない."""
+        with patch.object(manager, "health_check", return_value=True):
+            with patch.object(manager, "_start_server") as mock_start:
+                assert manager.ensure_server_running() is True
+                mock_start.assert_not_called()
+
+    def test_auto_start_disabled_server_not_running(
+        self, manager_no_autostart: ChromaDBServerManager
+    ) -> None:
+        """auto_start=False でサーバー未起動時に False を返す."""
+        with patch.object(manager_no_autostart, "health_check", return_value=False):
+            with patch.object(manager_no_autostart, "_start_server") as mock_start:
+                assert manager_no_autostart.ensure_server_running() is False
+                mock_start.assert_not_called()
+
+    def test_auto_start_enabled_starts_server(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """auto_start=True でサーバー未起動時に _start_server を呼ぶ."""
+        with patch.object(manager, "health_check", return_value=False):
+            with patch.object(manager, "_start_server", return_value=True) as mock_start:
+                assert manager.ensure_server_running() is True
+                mock_start.assert_called_once()
+
+    def test_auto_start_server_fails(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """サーバー起動に失敗した場合 False を返す."""
+        with patch.object(manager, "health_check", return_value=False):
+            with patch.object(manager, "_start_server", return_value=False):
+                assert manager.ensure_server_running() is False
+
+
+class TestStartServer:
+    """_start_server() のテスト."""
+
+    def test_command_not_found(self, manager: ChromaDBServerManager) -> None:
+        """chroma コマンドが見つからない場合 False を返す."""
+        with patch(
+            "rag.infrastructure.chromadb_manager.subprocess.Popen",
+            side_effect=FileNotFoundError("chroma not found"),
+        ):
+            assert manager._start_server() is False
+
+    def test_popen_exception(self, manager: ChromaDBServerManager) -> None:
+        """Popen で予期しない例外が発生した場合 False を返す."""
+        with patch(
+            "rag.infrastructure.chromadb_manager.subprocess.Popen",
+            side_effect=OSError("Permission denied"),
+        ):
+            assert manager._start_server() is False
+
+    def test_successful_start(self, manager: ChromaDBServerManager) -> None:
+        """正常にプロセス起動 → 起動待機に進む."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        with patch(
+            "rag.infrastructure.chromadb_manager.subprocess.Popen",
+            return_value=mock_process,
+        ):
+            with patch.object(manager, "_wait_for_ready", return_value=True):
+                assert manager._start_server() is True
+
+    def test_start_command_includes_host_and_port(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """起動コマンドに host と port が含まれる."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        with patch(
+            "rag.infrastructure.chromadb_manager.subprocess.Popen",
+            return_value=mock_process,
+        ) as mock_popen:
+            with patch.object(manager, "_wait_for_ready", return_value=True):
+                manager._start_server()
+                call_args = mock_popen.call_args
+                cmd = call_args[0][0]
+                assert "chroma" == cmd[0]
+                assert "run" == cmd[1]
+                assert "--port" in cmd
+                assert "8000" in cmd
+                assert "--host" in cmd
+                assert "localhost" in cmd
+
+
+class TestWaitForReady:
+    """_wait_for_ready() のテスト."""
+
+    def test_immediately_ready(self, manager: ChromaDBServerManager) -> None:
+        """最初のヘルスチェックで成功する場合."""
+        manager._process = MagicMock()
+        manager._process.poll.return_value = None
+        with patch.object(manager, "health_check", return_value=True):
+            assert manager._wait_for_ready(timeout=5.0) is True
+
+    def test_ready_after_retries(self, manager: ChromaDBServerManager) -> None:
+        """数回のリトライ後に成功する場合."""
+        manager._process = MagicMock()
+        manager._process.poll.return_value = None
+        call_count = 0
+
+        def health_check_side_effect(timeout: float = 5.0) -> bool:
+            nonlocal call_count
+            call_count += 1
+            return call_count >= 3
+
+        with patch.object(manager, "health_check", side_effect=health_check_side_effect):
+            with patch("rag.infrastructure.chromadb_manager.time.sleep"):
+                assert manager._wait_for_ready(timeout=30.0) is True
+
+    def test_timeout(self, manager: ChromaDBServerManager) -> None:
+        """タイムアウトまでサーバーが応答しない場合 False を返す."""
+        manager._process = MagicMock()
+        manager._process.poll.return_value = None
+        with patch.object(manager, "health_check", return_value=False):
+            with patch("rag.infrastructure.chromadb_manager.time.sleep"):
+                with patch(
+                    "rag.infrastructure.chromadb_manager.time.monotonic",
+                    side_effect=[0.0, 0.0, 1.0, 2.0, 31.0],
+                ):
+                    assert manager._wait_for_ready(timeout=30.0) is False
+
+    def test_process_exits_unexpectedly(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """プロセスが予期せず終了した場合 False を返す."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 1
+        mock_process.returncode = 1
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = "Error: port already in use"
+        mock_process.stderr = mock_stderr
+        manager._process = mock_process
+
+        with patch(
+            "rag.infrastructure.chromadb_manager.time.monotonic",
+            side_effect=[0.0, 0.0],
+        ):
+            assert manager._wait_for_ready(timeout=30.0) is False
+
+    def test_process_exits_no_stderr(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """プロセスが予期せず終了し stderr が None の場合."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 1
+        mock_process.returncode = 1
+        mock_process.stderr = None
+        manager._process = mock_process
+
+        with patch(
+            "rag.infrastructure.chromadb_manager.time.monotonic",
+            side_effect=[0.0, 0.0],
+        ):
+            assert manager._wait_for_ready(timeout=30.0) is False
+
+
+class TestShutdown:
+    """shutdown() のテスト."""
+
+    def test_not_started_by_us(self, manager: ChromaDBServerManager) -> None:
+        """自分が起動していない場合は何もしない."""
+        manager._started_by_us = False
+        manager._process = MagicMock()
+        manager.shutdown()
+        manager._process.terminate.assert_not_called()
+
+    def test_no_process(self, manager: ChromaDBServerManager) -> None:
+        """プロセスが None の場合は何もしない."""
+        manager._started_by_us = True
+        manager._process = None
+        manager.shutdown()
+
+    def test_process_already_exited(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """プロセスが既に終了している場合は terminate しない."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 0
+        mock_process.returncode = 0
+        manager._process = mock_process
+        manager._started_by_us = True
+
+        manager.shutdown()
+        mock_process.terminate.assert_not_called()
+        assert manager._process is None
+        assert manager._started_by_us is False
+
+    def test_graceful_shutdown(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """正常にプロセスを停止できる場合."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 12345
+        manager._process = mock_process
+        manager._started_by_us = True
+
+        manager.shutdown()
+        mock_process.terminate.assert_called_once()
+        mock_process.wait.assert_called_once()
+        mock_process.kill.assert_not_called()
+        assert manager._process is None
+        assert manager._started_by_us is False
+
+    def test_force_kill_on_timeout(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """terminate 後にタイムアウトした場合 kill する."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 12345
+        mock_process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="chroma", timeout=5.0),
+            None,
+        ]
+        manager._process = mock_process
+        manager._started_by_us = True
+
+        manager.shutdown()
+        mock_process.terminate.assert_called_once()
+        mock_process.kill.assert_called_once()
+        assert manager._process is None
+        assert manager._started_by_us is False
+
+    def test_existing_server_not_terminated(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """既存サーバーに接続した場合（_started_by_us=False）は停止しない."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        manager._process = mock_process
+        manager._started_by_us = False
+
+        manager.shutdown()
+        mock_process.terminate.assert_not_called()
+        mock_process.kill.assert_not_called()

--- a/tests/test_chromadb_manager.py
+++ b/tests/test_chromadb_manager.py
@@ -229,25 +229,6 @@ class TestWaitForReady:
         mock_process = MagicMock()
         mock_process.poll.return_value = 1
         mock_process.returncode = 1
-        mock_stderr = MagicMock()
-        mock_stderr.read.return_value = "Error: port already in use"
-        mock_process.stderr = mock_stderr
-        manager._process = mock_process
-
-        with patch(
-            "rag.infrastructure.chromadb_manager.time.monotonic",
-            side_effect=[0.0, 0.0],
-        ):
-            assert manager._wait_for_ready(timeout=30.0) is False
-
-    def test_process_exits_no_stderr(
-        self, manager: ChromaDBServerManager
-    ) -> None:
-        """プロセスが予期せず終了し stderr が None の場合."""
-        mock_process = MagicMock()
-        mock_process.poll.return_value = 1
-        mock_process.returncode = 1
-        mock_process.stderr = None
         manager._process = mock_process
 
         with patch(
@@ -315,6 +296,26 @@ class TestShutdown:
         mock_process.wait.side_effect = [
             subprocess.TimeoutExpired(cmd="chroma", timeout=5.0),
             None,
+        ]
+        manager._process = mock_process
+        manager._started_by_us = True
+
+        manager.shutdown()
+        mock_process.terminate.assert_called_once()
+        mock_process.kill.assert_called_once()
+        assert manager._process is None
+        assert manager._started_by_us is False
+
+    def test_kill_also_times_out(
+        self, manager: ChromaDBServerManager
+    ) -> None:
+        """kill 後もタイムアウトした場合、例外を握りつぶして終了する."""
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 12345
+        mock_process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="chroma", timeout=5.0),
+            subprocess.TimeoutExpired(cmd="chroma", timeout=5.0),
         ]
         manager._process = mock_process
         manager._started_by_us = True


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] test: テスト追加・修正
- [x] docs: ドキュメント更新

## Summary

- ChromaDB サーバーのライフサイクル管理コンポーネント `ChromaDBServerManager` を新規実装
- MCP サーバー起動時にヘルスチェック → 未起動なら `chroma run` で自動起動
- グレースフルデグレード: 起動失敗時も MCP サーバーは稼働継続
- MCP サーバー終了時に自分が起動したプロセスのみ `atexit` で停止（既存サーバーは影響なし）
- `chromadb_auto_start` のデフォルトを `True` に変更
- ユニットテスト 25 件追加（全パス）
- 仕様書の TODO 削除、コンポーネント一覧・エッジケース・ARCHITECTURE.md 更新

## Test plan

- [x] `uv run pytest tests/test_chromadb_manager.py` — 25 passed
- [x] `uv run pytest tests/test_rag_config.py` — 20 passed
- [x] `uv run ruff check` — All checks passed
- [x] `uv run mypy src/rag/infrastructure/` — Success

## Related issues

Closes #407