### PR TITLE
docs(rag-knowledge): MCP 薄層アダプター化に伴う仕様書更新 (#423)

### DIFF
--- a/docs/specs/infrastructure/content-upload.md
+++ b/docs/specs/infrastructure/content-upload.md
@@ -6,7 +6,7 @@
 
 スコープ:
 
-- MCP ツール経由のコンテンツデコード・バリデーション（既存）
+- MCP ツール経由のバリデーション（encoding 許容値チェック・content 空チェック）
 - アップロードファイル名のサニタイズ（パストラバーサル防止）
 - Upload HTTP API によるファイル直接アップロード（`multipart/form-data`）
 - 全インジェスト操作の排他制御
@@ -58,9 +58,14 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
 ### インジェスト排他制御の制約
 
 - **適用対象**: 全インジェスト操作に適用する。Upload HTTP API（`/upload/document`、`/upload/journal`）、MCP ツール（`rag_add_document`、`rag_add_journal`）、CLI 直接実行の全てが対象
-- **ロック方式**: OS ファイルロックによるプロセス間排他制御。Unix では `fcntl.flock`、Windows では `msvcrt.locking` を使用する。MCP サーバー（CLI サブプロセス経由）と CLI 直接実行の間でも排他が保たれる
+- **ロック方式**: OS ファイルロックによるプロセス間排他制御。Unix では `fcntl.flock`、Windows では `msvcrt.locking` を使用する。
+  ロック取得処理の実施主体は CLI とし、MCP サーバー（`server.py`）からのインジェストも CLI サブプロセスを起動して同一のロック取得処理を利用する。
+  `server.py` 自身はロックファイルを直接操作しない
 - **ロックファイル**: source_store ディレクトリ直下に配置する。インジェストロックと rebuild ロックでそれぞれ別のロックファイルを使用する
-- **ノンブロッキング**: ロック取得を試み（`LOCK_NB` / `LK_NBLCK`）、取得できない場合は待機せず即座にエラーを返却する。Upload HTTP API では HTTP 409、MCP ツールではエラーメッセージ、CLI では標準エラー出力 + exit code 1 を返す
+- **ノンブロッキング**: CLI はロック取得を試み（`LOCK_NB` / `LK_NBLCK`）、取得できない場合は待機せず即座にエラーを返却する。
+  CLI はロック競合時に JSON Lines の error メッセージ（`type: "error"`）にロック競合である旨を含め、exit code 1 で終了する。
+  `server.py` は CLI サブプロセスの error メッセージからロック競合を判定し、Upload HTTP API では HTTP 409、MCP ツールではエラーメッセージとして返却する。
+  CLI 直接実行では標準エラー出力 + exit code 1 を返す
 - **ステールロック対策**: OS ファイルロックはプロセス終了時（SEGFAULT 含む異常終了を含む）に OS が自動解放するため、明示的なステールロック対策は不要。OS クラッシュ・電源断の場合もロックはカーネルメモリ上のみに存在し、再起動後にクリーンな状態になる
 - **Advisory lock の制約**: OS ファイルロックは advisory lock（協調ロック）であり、ロック取得のコードを経由しないアクセスは防げない。本システムでは全書き込み操作が CLI 経由（MCP サブプロセス + CLI 直接実行）のため問題ない
 - **rebuild との独立性**: インジェストロックと rebuild ロックはそれぞれ別のロックファイルを使用し、独立して動作する。rebuild 実行中のインジェスト、およびインジェスト中の rebuild は、それぞれのロックで個別に制御される
@@ -220,11 +225,14 @@ flowchart TB
 
     UD --> AUTH
     UJ --> AUTH
-    AUTH -->|一時ファイル| SAN
-    T1 -->|stdin| SAN
-    T2 -->|stdin| SAN
+    AUTH -->|filename| SAN
+    AUTH -->|content: temp file| CLI
+    T1 -->|filename| SAN
+    T1 -->|content: stdin| CLI
+    T2 -->|filename| SAN
+    T2 -->|content: stdin| CLI
 
-    SAN --> CLI
+    SAN -->|sanitized filename| CLI
     CLI --> LI
     CLI --> JI
     LI --> PIPE

--- a/docs/specs/infrastructure/content-upload.md
+++ b/docs/specs/infrastructure/content-upload.md
@@ -57,10 +57,13 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
 
 ### インジェスト排他制御の制約
 
-- **適用対象**: 全インジェスト操作に適用する。Upload HTTP API（`/upload/document`、`/upload/journal`）と MCP ツール（`rag_add_document`、`rag_add_journal`）の両方が対象
-- **ロック方式**: `asyncio.Lock` による排他制御。同一プロセス内の全インジェスト操作で 1 つのロックを共有する
-- **ノンブロッキング**: ロック取得を試み、取得できない場合は待機せず即座にエラーを返却する。Upload HTTP API では HTTP 409、MCP ツールではエラーメッセージを返す
-- **rebuild との独立性**: インジェストロックは `rag_rebuild` の既存ロック（`_rebuild_lock`）とは独立。既存の `_rebuild_lock` はスレッドロック（同期ロック）であり、新規のインジェストロックは非同期ロックである。rebuild 実行中のインジェスト、およびインジェスト中の rebuild は、それぞれのロックで個別に制御される
+- **適用対象**: 全インジェスト操作に適用する。Upload HTTP API（`/upload/document`、`/upload/journal`）、MCP ツール（`rag_add_document`、`rag_add_journal`）、CLI 直接実行の全てが対象
+- **ロック方式**: OS ファイルロックによるプロセス間排他制御。Unix では `fcntl.flock`、Windows では `msvcrt.locking` を使用する。MCP サーバー（CLI サブプロセス経由）と CLI 直接実行の間でも排他が保たれる
+- **ロックファイル**: source_store ディレクトリ直下に配置する。インジェストロックと rebuild ロックでそれぞれ別のロックファイルを使用する
+- **ノンブロッキング**: ロック取得を試み（`LOCK_NB` / `LK_NBLCK`）、取得できない場合は待機せず即座にエラーを返却する。Upload HTTP API では HTTP 409、MCP ツールではエラーメッセージ、CLI では標準エラー出力 + exit code 1 を返す
+- **ステールロック対策**: OS ファイルロックはプロセス終了時（SEGFAULT 含む異常終了を含む）に OS が自動解放するため、明示的なステールロック対策は不要。OS クラッシュ・電源断の場合もロックはカーネルメモリ上のみに存在し、再起動後にクリーンな状態になる
+- **Advisory lock の制約**: OS ファイルロックは advisory lock（協調ロック）であり、ロック取得のコードを経由しないアクセスは防げない。本システムでは全書き込み操作が CLI 経由（MCP サブプロセス + CLI 直接実行）のため問題ない
+- **rebuild との独立性**: インジェストロックと rebuild ロックはそれぞれ別のロックファイルを使用し、独立して動作する。rebuild 実行中のインジェスト、およびインジェスト中の rebuild は、それぞれのロックで個別に制御される
 
 本レイヤーは外部 API 通信を行わないため、想定プロファイル・安全制約テーブルは省略する。
 
@@ -70,16 +73,13 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
 
 #### コンテンツデコード
 
-`rag_add_document` が使用する。MCP ツールから受け取った `content` と `encoding` をバイト列に変換する。
+MCP 薄層アダプター化により、コンテンツデコード（`content` + `encoding` → バイト列変換）は CLI 側の `--stdin` + `--encoding` オプションに移行する。MCP ツール（`rag_add_document`）は `content` を CLI サブプロセスの stdin にそのまま渡し、CLI が `--encoding` フラグに基づいてデコードする。
 
-| 引数 | 型 | 説明 |
-|-----|----|------|
-| `content` | 文字列 | MCP ツールが受け取ったコンテンツ文字列 |
-| `encoding` | 文字列 | `"text"` または `"base64"` |
+MCP 側に残るバリデーション:
 
-返り値: デコード済みバイト列
-
-エラー: 不正な `encoding` 値・不正な base64 文字列・デコード後が 0 バイトの場合にバリデーションエラーを送出する
+- `encoding` の許容値チェック（`"text"` または `"base64"` のみ）
+- `content` の空チェック（空文字列の場合はバリデーションエラー）
+- `filename` のサニタイズ（後述）
 
 #### ファイル名サニタイズ
 
@@ -95,7 +95,7 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
 
 ### Upload HTTP API
 
-MCP サーバー（HTTP モード）に `custom_route()` で併設する HTTP アップロードエンドポイント。ファイルを `multipart/form-data` で直接受信し、既存インジェスターロジックを呼び出してパイプライン実行まで完結する。
+MCP サーバー（HTTP モード）に `custom_route()` で併設する HTTP アップロードエンドポイント。ファイルを `multipart/form-data` で直接受信し、一時ファイルに書き出した上で CLI サブプロセスに委譲してインジェスト処理を実行する。
 
 #### 操作一覧
 
@@ -125,11 +125,11 @@ MCP サーバー（HTTP モード）に `custom_route()` で併設する HTTP �
 処理フロー:
 
 1. API キー認証を検証する
-2. インジェストロックの取得を試みる（取得失敗時は HTTP 409）
-3. ファイル名をサニタイズし、拡張子を検証する
-4. ファイルコンテンツをバイト列として読み取る（読み取り中にファイルサイズ上限を超過した場合は即座に HTTP 413 を返す）
-5. Local インジェスターの取り込み処理を呼び出す（`upload_mode` を引き渡す）
-6. パイプラインを実行し、インジェストロックを解放する
+2. ファイル名をサニタイズし、拡張子を検証する
+3. ファイルコンテンツをバイト列として読み取る（読み取り中にファイルサイズ上限を超過した場合は即座に HTTP 413 を返す）
+4. 一時ファイルにコンテンツを書き出す
+5. CLI サブプロセスを実行する（`add-document --file <一時ファイルパス> --upload-mode <mode> --output json`）
+6. サブプロセス完了後、一時ファイルを削除する
 
 #### POST /upload/journal
 
@@ -155,11 +155,11 @@ MCP サーバー（HTTP モード）に `custom_route()` で併設する HTTP �
 処理フロー:
 
 1. API キー認証を検証する
-2. インジェストロックの取得を試みる（取得失敗時は HTTP 409）
-3. ファイル名をサニタイズし、拡張子を検証する
-4. ファイルコンテンツを UTF-8 テキストとして読み取る（読み取り中にファイルサイズ上限を超過した場合は即座に HTTP 413 を返す）
-5. Journal インジェスターの取り込み処理を呼び出す（`title`、`repository`、`entry_id` を引き渡す）
-6. パイプラインを実行し、インジェストロックを解放する
+2. ファイル名をサニタイズし、拡張子を検証する
+3. ファイルコンテンツを UTF-8 テキストとして読み取る（読み取り中にファイルサイズ上限を超過した場合は即座に HTTP 413 を返す）
+4. 一時ファイルにコンテンツを書き出す
+5. CLI サブプロセスを実行する（`add-journal --file <一時ファイルパス> --title <title> --repository <repo> --output json`）
+6. サブプロセス完了後、一時ファイルを削除する
 
 #### 共通レスポンス形式
 
@@ -207,93 +207,87 @@ flowchart TB
     end
 
     AUTH["API キー認証"]
-    LOCK["インジェストロック"]
+    SAN["ファイル名サニタイズ"]
 
-    subgraph Upload["コンテンツアップロード層"]
-        DEC["コンテンツデコード"]
-        SAN["ファイル名サニタイズ"]
+    subgraph CLISub["CLI サブプロセス"]
+        CLI["CLI コマンド"]
+        subgraph Ingesters["インジェスター"]
+            LI["Local インジェスター"]
+            JI["Journal インジェスター"]
+        end
+        PIPE["パイプライン実行"]
     end
-
-    subgraph Ingesters["インジェスター"]
-        LI["Local インジェスター"]
-        JI["Journal インジェスター"]
-    end
-
-    PIPE["パイプライン実行"]
 
     UD --> AUTH
     UJ --> AUTH
-    AUTH --> LOCK
-    T1 --> LOCK
-    T2 --> LOCK
+    AUTH -->|一時ファイル| SAN
+    T1 -->|stdin| SAN
+    T2 -->|stdin| SAN
 
-    LOCK -->|MCP: rag_add_document| DEC
-    LOCK -->|Upload / MCP| SAN
-    DEC -->|data: bytes| LI
-    SAN -->|filename: str| LI
-    SAN -->|filename: str| JI
-
-    LOCK -->|Upload: /upload/document| LI
-    LOCK -->|Upload: /upload/journal| JI
-    LOCK -->|MCP: rag_add_journal| JI
-
+    SAN --> CLI
+    CLI --> LI
+    CLI --> JI
     LI --> PIPE
     JI --> PIPE
 ```
 
 ### Upload HTTP API における呼び出し手順
 
+Upload HTTP API はリクエストボディからファイルを受信し、一時ファイルに書き出した上で CLI サブプロセスに渡す。
+
 #### /upload/document
 
 1. API キーを検証する
-2. インジェストロックを取得する（取得失敗時は HTTP 409）
-3. ファイル名をサニタイズし、拡張子が対応リストに含まれるか確認する
-4. ファイルコンテンツをバイト列として読み取る（サイズ上限超過時は HTTP 413。コンテンツデコードは不要）
-5. Local インジェスターの取り込み処理を呼び出す（`upload_mode` を引き渡す）
-6. パイプラインを実行し、インジェストロックを解放する
+2. ファイル名をサニタイズし、拡張子が対応リストに含まれるか確認する
+3. ファイルコンテンツをバイト列として読み取る（サイズ上限超過時は HTTP 413）
+4. 一時ファイルにコンテンツを書き出す
+5. CLI サブプロセスを実行する: `add-document --file <一時ファイルパス> --upload-mode <mode> --output json`
+6. サブプロセス完了後、一時ファイルを削除する
 
 #### /upload/journal
 
 1. API キーを検証する
-2. インジェストロックを取得する（取得失敗時は HTTP 409）
-3. ファイル名をサニタイズし、拡張子が `.md` であることを確認する
-4. ファイルコンテンツを UTF-8 テキストとして読み取る（サイズ上限超過時は HTTP 413）
-5. Journal インジェスターの取り込み処理を呼び出す
-6. パイプラインを実行し、インジェストロックを解放する
+2. ファイル名をサニタイズし、拡張子が `.md` であることを確認する
+3. ファイルコンテンツを UTF-8 テキストとして読み取る（サイズ上限超過時は HTTP 413）
+4. 一時ファイルにコンテンツを書き出す
+5. CLI サブプロセスを実行する: `add-journal --file <一時ファイルパス> --title <title> --repository <repo> --output json`
+6. サブプロセス完了後、一時ファイルを削除する
 
 ### MCP ツールにおける呼び出し手順
 
+MCP ツールはクライアントからコンテンツを文字列で受け取り、CLI サブプロセスの stdin に渡す。
+
 #### rag_add_document
 
-1. インジェストロックを取得する（取得失敗時はエラーメッセージを返す）
-2. ファイル名をサニタイズし、拡張子が対応リストに含まれるか確認する
-3. コンテンツをデコードしてバイト列を取得する
-4. Local インジェスターの取り込み処理を呼び出す（`upload_mode` を引き渡す）
-5. パイプラインを実行し、インジェストロックを解放する
+1. ファイル名をサニタイズし、拡張子が対応リストに含まれるか確認する
+2. CLI サブプロセスを実行する: `add-document --stdin --filename <filename> --encoding <encoding> --upload-mode <mode> --output json`
+3. `content` を subprocess の stdin に書き込み、stdin をクローズする
+4. サブプロセスの JSON Lines 出力をパースし、結果を返す
 
 #### rag_add_journal
 
-1. インジェストロックを取得する（取得失敗時はエラーメッセージを返す）
-2. ファイル名をサニタイズし、拡張子が `.md` であることを確認する
-3. `content` をそのまま本文テキストとして Journal インジェスターの取り込み処理を呼び出す（デコード不要）
-4. パイプラインを実行し、インジェストロックを解放する
+1. ファイル名をサニタイズし、拡張子が `.md` であることを確認する
+2. CLI サブプロセスを実行する: `add-journal --stdin --title <title> --repository <repo> --output json`
+3. `content` を subprocess の stdin に書き込み、stdin をクローズする
+4. サブプロセスの JSON Lines 出力をパースし、結果を返す
 
 ### 経路別比較
 
-| 経路 | コンテンツの取得方法 | コンテンツアップロード層の使用 |
-|------|---------------------|-------------------------------|
-| Upload HTTP API（/upload/document） | `multipart/form-data` でバイト列を直接受信 | ファイル名サニタイズのみ |
-| Upload HTTP API（/upload/journal） | `multipart/form-data` でテキストを直接受信 | ファイル名サニタイズのみ |
-| MCP 経由（rag_add_document） | コンテンツをデコードしてバイト列を取得 | デコード + ファイル名サニタイズ |
-| MCP 経由（rag_add_journal） | `content` 文字列をそのまま使用（デコード不要） | ファイル名サニタイズのみ |
-| CLI 経由（add-document / add-journal） | ファイルを直接読み込み | 使用しない |
+| 経路 | コンテンツの取得方法 | CLI への渡し方 | コンテンツアップロード層の使用 |
+|------|---------------------|---------------|-------------------------------|
+| Upload HTTP API（/upload/document） | `multipart/form-data` でバイト列を直接受信 | 一時ファイル → `--file` | ファイル名サニタイズのみ |
+| Upload HTTP API（/upload/journal） | `multipart/form-data` でテキストを直接受信 | 一時ファイル → `--file` | ファイル名サニタイズのみ |
+| MCP 経由（rag_add_document） | MCP ツール引数の `content` 文字列 | stdin → `--stdin` | デコード不要（CLI が `--encoding` に基づきデコード） |
+| MCP 経由（rag_add_journal） | MCP ツール引数の `content` 文字列 | stdin → `--stdin` | ファイル名サニタイズのみ |
+| CLI 直接実行（add-document / add-journal） | ファイルを直接読み込み | `--file` | 使用しない |
 
 ### 関連ファイル
 
 | ファイル | 役割 |
 |---------|------|
-| `src/rag/server.py` | MCP ツール定義 + Upload HTTP API エンドポイント定義 |
-| `src/rag/upload.py` | コンテンツデコード・ファイル名サニタイズ |
+| `src/rag/server.py` | MCP ツール定義（薄層アダプター）+ Upload HTTP API エンドポイント定義。CLI サブプロセスの起動・進捗中継を担当 |
+| `src/rag/upload.py` | ファイル名サニタイズ（MCP ツール・Upload API 共通）。コンテンツデコードは CLI 側に移行 |
+| `src/rag/cli.py` | CLI コマンド。`--stdin` オプションによる stdin 入力、`--output json` による JSON Lines 出力をサポート |
 | `src/rag/pipeline/ingesters/local.py` | Local インジェスター（ドキュメント取り込み） |
 | `src/rag/pipeline/ingesters/journal.py` | Journal インジェスター（ジャーナル取り込み） |
 | `src/rag/config.py` | `rag_upload_max_file_size_mb` 設定の定義 |
@@ -335,9 +329,11 @@ flowchart TB
 
 | ケース | 振る舞い |
 |--------|---------|
-| MCP ツールと Upload API が同時にインジェストを試みる | 先にロックを取得した方が実行され、後発はエラーを返す |
+| MCP サブプロセスと CLI 直接実行が同時にインジェストを試みる | 先にファイルロックを取得した方が実行され、後発はエラーを返す |
+| MCP ツールと Upload API が同時にインジェストを試みる | 先にファイルロックを取得した方が実行され、後発はエラーを返す |
+| インジェスト処理中にプロセスが異常終了（SEGFAULT 等） | OS がファイルロックを自動解放する。次の操作でロック取得が可能 |
 | インジェスト処理中に例外が発生 | ロックは確実に解放する（finally ブロック等） |
-| rebuild 中にインジェストを実行 | インジェストロックと rebuild ロックは独立しているため、両方が同時に実行される可能性がある。パイプラインレベルでの整合性はパイプライン制御側の責務 |
+| rebuild 中にインジェストを実行 | インジェストロックと rebuild ロックは別のロックファイルを使用し独立しているため、両方が同時に実行される可能性がある。パイプラインレベルでの整合性はパイプライン制御側の責務 |
 
 ## 関連ドキュメント
 

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -52,7 +52,7 @@
 | インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラー |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
 
-全操作は `progress_callback`（任意）を受け取り、ファイル処理完了ごとにコールバックを呼び出す。callback シグネチャ: `(processed: int, total: int, current: str) -> None`。未指定時は進捗通知なし。詳細は [rebuild-stats.md](rebuild-stats.md) のサブプロセス進捗通知セクションを参照。
+全操作は `progress_callback`（任意）を受け取り、ファイル処理完了ごとにコールバックを呼び出す。callback シグネチャ: `(processed: int, total: int, current: str) -> None`。未指定時は進捗通知なし。詳細は [rebuild-stats.md](rebuild-stats.md) の CLI サブプロセス進捗通知セクションを参照。
 
 ### 未コミット変更の扱い
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -268,23 +268,77 @@ ChromaDB は `chroma run` によるサーバーモードで動作し、MCP サ�
 
 ### MCP 薄層アダプターパターン
 
-> **TODO:#408** CLI JSON 出力モード追加、**TODO:#409** MCP 薄層アダプター化
+MCP サーバーは CLI コマンドを呼び出す薄いアダプター層として動作する。書き込み系ツールは CLI サブプロセスとして実行し、C 拡張（BM25s 等）の SEGFAULT からサーバープロセスを隔離する。検索系ツールはパフォーマンスのためインプロセス実行を維持する。
 
-MCP サーバーは CLI コマンドを呼び出す薄いアダプター層として動作する。検索系ツールはパフォーマンスのためインプロセス実行を維持する。
+#### ツール分類
 
 | ツール分類 | 実行方式 | 対象 |
 |-----------|---------|------|
-| 検索系 | インプロセス（RAGKnowledgeService 直接呼び出し） | `rag_search`, `rag_get_document`, `rag_stats`, `rag_crawl_preview`, `rag_search_aozora` |
+| 検索系 | インプロセス（RAGKnowledgeService 直接呼び出し） | `rag_search`, `rag_get_document`, `rag_stats`, `rag_crawl_preview`, `rag_search_aozora`, `rag_list_recent` |
 | 書き込み系 | CLI サブプロセス（`--output json` で結果をパース） | `rag_add`, `rag_crawl`, `rag_crawl_zenn`, `rag_crawl_bluesky`, `rag_add_youtube`, `rag_crawl_youtube`, `rag_add_document`, `rag_crawl_documents`, `rag_add_journal`, `rag_add_aozora`, `rag_crawl_aozora`, `rag_update_aozora_catalog`, `rag_delete`, `rag_rebuild` |
+| Upload HTTP API | CLI サブプロセス（書き込み系と同一方式） | `/upload/document`, `/upload/journal` |
 | 特殊 | Scrapy サブプロセス + Bridge（現行維持） | `rag_site_ingest` |
 
-CLI の JSON 出力は JSON Lines 形式で、既存の `rag.pipeline.worker` モジュール（`src/rag/pipeline/worker.py`）のサブプロセス出力プロトコルを踏襲する:
+#### MCP ツール → CLI コマンドマッピング
+
+| MCP ツール / エンドポイント | CLI コマンド | 備考 |
+|---------------------------|------------|------|
+| `rag_add` | `add` | |
+| `rag_crawl` | `crawl` | |
+| `rag_crawl_zenn` | `crawl-zenn` | |
+| `rag_crawl_bluesky` | `crawl-bluesky` | |
+| `rag_add_youtube` | `ingest-youtube` | |
+| `rag_crawl_youtube` | `ingest-youtube-playlist` | |
+| `rag_add_document` | `add-document` | stdin 入力（後述） |
+| `rag_crawl_documents` | `crawl-documents` | |
+| `rag_add_journal` | `add-journal` | stdin 入力（後述） |
+| `rag_add_aozora` | `ingest-aozora` | |
+| `rag_crawl_aozora` | `ingest-aozora-author` | |
+| `rag_update_aozora_catalog` | `update-aozora-catalog` | |
+| `rag_delete` | `delete` | |
+| `rag_rebuild` | `rebuild` | |
+| `/upload/document` | `add-document` | 一時ファイル経由 |
+| `/upload/journal` | `add-journal` | 一時ファイル経由 |
+
+#### CLI サブプロセス実行方式
+
+MCP サーバーは `_run_cli_subprocess` で CLI コマンドを実行する:
+
+1. コマンド構築: `python -m rag.cli <command> --output json [args...]`
+2. `asyncio.create_subprocess_exec` でサブプロセスを起動
+3. stdout を行単位で非同期に読み取り、各行を JSON パース:
+   - `type: "progress"` → `ctx.info()` でログ通知 + `ctx.report_progress()` で数値通知
+   - `type: "result"` → 結果として返却
+   - `type: "error"` → エラーとして処理
+4. stderr はプロセス終了後に読み取る
+5. SEGFAULT 検出: exit code が SEGFAULT シグナル（Unix: -11/139、Windows: -1073741819/3221225477）の場合、エラーメッセージを返却
+6. サブプロセス完了後、RAGKnowledgeService と PipelineController のキャッシュをリセットする（サブプロセスが ChromaDB・source_store を更新するため、インプロセスのキャッシュが古くなる）
+
+CLI の JSON 出力は JSON Lines 形式:
 
 | メッセージ種別 | 用途 |
 |-------------|------|
-| `{"type": "progress", ...}` | 進捗報告（MCP `ctx.report_progress` に中継） |
-| `{"type": "result", ...}` | コマンド結果 |
-| `{"type": "error", ...}` | エラー報告 |
+| `{"type": "progress", "processed": N, "total": M, "current": "..."}` | 進捗報告（MCP `ctx.report_progress` に中継） |
+| `{"type": "result", ...}` | コマンド結果（コマンド固有のフィールドを含む） |
+| `{"type": "error", "error": true, "message": "..."}` | エラー報告（exit code 1） |
+
+#### CLI stdin 入力プロトコル
+
+`rag_add_journal` と `rag_add_document` は MCP クライアントからコンテンツを文字列で受け取る。CLI コマンドはファイルパスを期待するため、`--stdin` オプションで stdin からコンテンツを読み取る方式を提供する。
+
+| MCP ツール | CLI コマンド | stdin の内容 | 追加引数 |
+|-----------|------------|------------|---------|
+| `rag_add_journal` | `add-journal --stdin --title T --repository R` | UTF-8 テキスト（Markdown 本文） | `--title`, `--repository`, `--entry-id`（任意） |
+| `rag_add_document` | `add-document --stdin --filename F --encoding E` | encoding に応じたデータ（`text`: UTF-8 テキスト、`base64`: base64 文字列） | `--filename`, `--encoding`（デフォルト: `text`）、`--upload-mode` |
+
+MCP 側の処理フロー:
+
+1. MCP ツールが `content` パラメータを受け取る
+2. `_run_cli_subprocess` でサブプロセスを起動し、stdin パイプを確保する
+3. `content` を subprocess の stdin に書き込み、stdin をクローズする
+4. CLI が stdin からコンテンツを読み取り、通常のファイル読み取りと同様に処理する
+
+Upload HTTP API（`/upload/document`, `/upload/journal`）はリクエストボディからファイルを受信し、一時ファイルに書き出した上で CLI の `--file` オプション経由で渡す。stdin は使用しない。
 
 ### 取り込みフロー（3段パイプライン）
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -145,7 +145,7 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
 | `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `skipped`, `errors`, `elapsed` 等） |
-| `error` | エラー時（最終行） | `message`（str） |
+| `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`message`（str） |
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -32,7 +32,7 @@
 - **パイプライン制御への委譲**: 再構築の実行ロジックはパイプライン制御に委譲する。本コンポーネントは MCP/CLI インターフェースの提供とパラメータの検証のみを担当する
 - **再構築中の排他制御**: 再構築処理は同時に1つのみ実行可能とする。実行中に別の再構築要求を受けた場合はエラーを返す
 - **全再構築のコスト認知**: 全再構築およびインデックスのみ再構築は Embedding API を呼び出すため、データ量に比例したコストが発生する。MCP ツール・CLI の説明文にこの旨を明記し、利用者が意図せず大量の API 呼び出しを行わないようにする
-- **MCP サーバーのクラッシュ耐性**: MCP 経由のパイプライン処理（再構築・取り込み後のインデックス構築・削除）は `pipeline/worker.py` をサブプロセスとして実行する。C 拡張（BM25s 等）の SEGFAULT が発生しても MCP サーバープロセスは生存し、エラーメッセージをクライアントに返却する。CLI は独立プロセスのため対策不要
+- **MCP サーバーのクラッシュ耐性**: MCP 経由のパイプライン処理（再構築・取り込み後のインデックス構築・削除）は CLI を別プロセスとして実行する（MCP 薄層アダプターパターン）。C 拡張（BM25s 等）の SEGFAULT が発生しても MCP サーバープロセスは生存し、エラーメッセージをクライアントに返却する。CLI 直接実行は独立プロセスのため対策不要
 
 本コンポーネント自体は外部 API 通信を行わないが、再構築実行時にパイプラインを通じて Embedding API 等の外部通信が発生する。外部 API の安全制約は各ステージの仕様に従うため、想定プロファイル・安全制約セクションは省略する。
 
@@ -101,7 +101,7 @@ flowchart TD
     VALIDATE["パラメータ検証"]
     LOCK["排他ロック取得"]
     LOCK_FAIL["エラー: 別の再構築が実行中"]
-    WORKER["pipeline worker（サブプロセス）"]
+    CLI_SUB["CLI サブプロセス"]
     DELEGATE["パイプライン制御に委譲"]
     CRASH["クラッシュ検出（exit code）"]
     RESULT["処理結果サマリを返却"]
@@ -111,20 +111,20 @@ flowchart TD
     VALIDATE -->|不正| ERROR["エラー返却"]
     VALIDATE -->|正常| LOCK
     LOCK -->|取得失敗| LOCK_FAIL
-    LOCK -->|取得成功 MCP| WORKER
+    LOCK -->|取得成功 MCP| CLI_SUB
     LOCK -->|取得成功 CLI| DELEGATE
-    WORKER --> DELEGATE
+    CLI_SUB --> DELEGATE
     DELEGATE -->|正常終了| RESULT
     DELEGATE -->|処理エラー| ERROR_PROC["エラー返却（処理エラー）"]
-    WORKER -->|クラッシュ| CRASH
+    CLI_SUB -->|クラッシュ| CRASH
     CRASH --> ERROR_CRASH["エラー返却（サーバー生存）"]
 ```
 
-MCP 経由の場合、パイプライン処理（再構築・取り込み後のインデックス構築・削除）は `pipeline/worker.py` をサブプロセスとして実行する。C 拡張の SEGFAULT が発生してもサーバープロセスは生存し、exit code からエラーメッセージを返却する。CLI は独立プロセスのためサブプロセス化は不要。
+MCP 経由の場合、パイプライン処理（再構築・取り込み後のインデックス構築・削除）は CLI を別プロセスとして実行する（MCP 薄層アダプターパターン、詳細は [rag-knowledge.md](rag-knowledge.md) を参照）。C 拡張の SEGFAULT が発生してもサーバープロセスは生存し、exit code からエラーメッセージを返却する。CLI 直接実行は独立プロセスのためサブプロセス化は不要。
 
-### サブプロセス進捗通知
+### CLI サブプロセス進捗通知
 
-MCP ツール経由のパイプライン処理中、サブプロセスの進捗をリアルタイムで MCP クライアントに通知する。
+MCP ツール経由のパイプライン処理中、CLI サブプロセスの進捗をリアルタイムで MCP クライアントに通知する。
 
 #### 通知方式
 
@@ -137,29 +137,29 @@ MCP ツール経由のパイプライン処理中、サブプロセスの進捗�
 
 FastMCP の `Context` オブジェクト経由で送信する。ツール関数に `ctx: Context` パラメータを追加する。
 
-#### Worker stdout プロトコル
+#### CLI stdout プロトコル
 
-worker.py は処理中に JSON Lines 形式で stdout に出力する。各行は `type` フィールドで識別する。
+CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する。各行は `type` フィールドで識別する。
 
 | `type` 値 | 出力タイミング | フィールド |
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
-| `result` | 処理完了時（最終行） | 既存の結果 JSON と同一（`mode`, `total_files`, `processed`, `skipped`, `errors`, `elapsed`） |
+| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `skipped`, `errors`, `elapsed` 等） |
 | `error` | エラー時（最終行） | `message`（str） |
 
-親プロセス（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
+MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
 
 #### サーバー側の処理
 
-`_run_worker_subprocess` を行単位ストリーミングに変更する:
+`_run_cli_subprocess` で CLI コマンドを実行し、stdout を行単位でストリーミングする:
 
-1. `asyncio.create_subprocess_exec` で subprocess を起動（従来通り）
-2. stdout を行単位で非同期に読み取る（`communicate()` → `readline()` ループ）
+1. `asyncio.create_subprocess_exec` で CLI サブプロセスを起動
+2. stdout を行単位で非同期に読み取る（`readline()` ループ）
 3. 各行を JSON パースし:
    - `type: "progress"` → `ctx.info()` でログ通知 + `ctx.report_progress()` で数値通知
    - `type: "result"` → 結果として返却
    - `type: "error"` → エラーとして処理
-4. stderr は従来通りプロセス終了後に読み取る
+4. stderr はプロセス終了後に読み取る
 
 #### PipelineController の変更
 
@@ -176,13 +176,13 @@ callback シグネチャ: `(processed: int, total: int, current: str) -> None`
 
 `ingest_and_index` および `run_incremental` も `progress_callback` パラメータを受け取り、内部的に `_process_changes` に中継する。
 
-worker.py はこの callback 内で進捗 JSON を stdout に出力する。CLI は現時点では callback を使用しない（将来対応予定）。callback 未指定時は従来通り無出力。
+CLI は `--output json` 指定時にこの callback 内で進捗 JSON を stdout に出力する。callback 未指定時は従来通り無出力。
 
 | ファイル | 役割 |
 |-------------|------|
-| `src/rag/pipeline/worker.py` | MCP 用サブプロセスエントリポイント。`rebuild` / `ingest-and-index` / `delete` のサブコマンドを受け取りパイプライン処理を実行。処理中は進捗 JSON（type: progress）、完了時は結果 JSON（type: result）を stdout に JSON Lines 形式で出力 |
-| `src/rag/server.py` | MCP ツール。パラメータ検証・排他制御を行い worker をサブプロセスで起動。stdout を行単位でストリーミングし、進捗を MCP 通知として転送 |
-| `src/rag/cli.py` | CLI コマンド。パイプライン制御を直接呼び出す（サブプロセス化なし） |
+| `src/rag/cli.py` | CLI コマンド。`--output json` 指定時に JSON Lines 形式で進捗・結果を出力。MCP 薄層アダプターからサブプロセスとして呼び出される際のエントリポイント |
+| `src/rag/server.py` | MCP ツール（薄層アダプター）。パラメータ検証を行い CLI をサブプロセスで起動。stdout を行単位でストリーミングし、進捗を MCP 通知として転送 |
+| `src/rag/pipeline/worker.py` | パイプライン処理の薄いエントリポイント。CLI から呼び出される内部モジュール |
 
 ### rag_stats 出力項目
 

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -368,7 +368,7 @@ sequenceDiagram
     BRIDGE->>SS: ファイル配置 + .meta 生成
     BRIDGE->>CMD: 配置結果
     alt download_only = false
-        CMD->>PC: パイプライン処理（git commit + converter + indexer、MCP: サブプロセス経由）
+        CMD->>PC: パイプライン処理（git commit + converter + indexer、MCP: CLI サブプロセス経由）
         PC->>CMD: パイプライン処理結果
     else download_only = true
         CMD->>PC: git commit（source_store のみ）


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [ ] fix: バグ修正
- [ ] docs: ドキュメント更新
- [x] docs(pre-impl): 設計書先行更新（実装は後続フェーズ） ★
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

<!-- docs(pre-impl) を選択: 現在のコードとの不整合は意図的です。#409 の実装で反映予定 -->

## Summary

- `rag-knowledge.md`: 薄層アダプターセクション拡充（CLIコマンドマッピング、`_run_cli_subprocess` 仕様、stdin プロトコル、Upload HTTP API 含む）
- `content-upload.md`: 排他制御を `asyncio.Lock` → OS ファイルロック（fcntl/msvcrt）に変更、Upload API を CLI サブプロセス経由に更新、コンポーネント構成図・処理フロー更新
- `rebuild-stats.md`: worker.py → CLI サブプロセスへの参照更新（制約・Mermaid図・進捗通知セクション・ファイル構成テーブル）
- `pipeline-controller.md`: サブプロセス進捗通知の参照テキスト更新
- `site-ingest.md`: Mermaid シーケンス図の参照更新

## Test plan

- [x] markdownlint: 違反なし
- [x] mermaid-lint（構文チェック）: 違反なし
- [x] mermaid-lint（GitHub 互換チェック）: 違反なし
- [x] doc-review: 初回指摘 5 件を全て修正し再チェック通過

## Related issues

Closes #423