### PR TITLE
docs(rag-knowledge): MCP 薄層アダプター化に伴うドキュメント更新 (#410)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@
 |---|---|
 | `src/rag/embedding/` | Embedding プロバイダー抽象化（ローカル / OpenAI）とファクトリ |
 | `src/rag/ingesters/` | インジェスタープラグイン（BaseIngester 抽象基底・IngestedContent 共通モデル・WebIngester・ZennIngester・DocumentIngester・BlueskyIngester） |
-| `src/rag/infrastructure/` | インフラ基盤（ChromaDB サーバーのライフサイクル管理） |
+| `src/rag/infrastructure/` | インフラ基盤（ChromaDB サーバーのライフサイクル管理・ファイルベースロック） |
 | `src/rag/pipeline/` | パイプライン制御（git 操作・差分検知・ステージ間連携・4モード実行） |
 | `src/rag/pipeline/factory.py` | PipelineController のファクトリ関数（server/cli 共通） |
 | `src/rag/pipeline/ingesters/` | 新アーキテクチャ用インジェスター（source_store へのファイル配置 + .meta 生成） |
@@ -32,8 +32,8 @@
 
 | ファイル | 責務 |
 |---|---|
-| `src/rag/server.py` | MCP サーバー（FastMCP）エントリーポイント・ツール定義 |
-| `src/rag/cli.py` | CLI エントリーポイント（評価・DB 初期化） |
+| `src/rag/server.py` | MCP 薄層アダプター（書き込み系は CLI サブプロセス委譲、検索系はインプロセス） |
+| `src/rag/cli.py` | CLI エントリーポイント（取り込み・検索・評価・DB 初期化、JSON 出力モード対応） |
 | `src/rag/config.py` | pydantic-settings による環境変数・設定管理 |
 | `src/rag/rag_knowledge.py` | ナレッジサービス（取り込み・検索・削除のオーケストレーション） |
 | `src/rag/markdown.py` | RAG 用 Markdown コンバーター（リンク・画像 URL 除去） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,29 +7,32 @@
 
 ## MCP サーバー運用ルール
 
-本リポジトリは MCP サーバーの実装リポジトリであり、`.mcp.json` で Claude Code の MCP サーバーとして登録されている。MCP サーバーが enabled の場合、Claude Code セッション中はサーバープロセスが常駐し、ChromaDB・BM25 等のリソースを占有する。
+本リポジトリは MCP サーバーの実装リポジトリであり、`.mcp.json` で Claude Code の MCP サーバーとして登録されている。MCP サーバーが enabled の場合、Claude Code セッション中はサーバープロセスが常駐する。
 
 ### セッション開始時の状態確認
 
 作業開始時に MCP サーバーの状態を確認すること。前回セッションの状態が引き継がれるため、意図しない状態で作業を始めるリスクがある。
 
-- **enabled の場合**: MCP サーバーが DB を占有している。CLI や テストで DB にアクセスする作業は競合する
+- **enabled の場合**: MCP サーバーが稼働中。CLI 操作はファイルベースロックにより共存可能だが、テスト実行は DB 分離のため disabled 推奨
 - **disabled の場合**: MCP ツールは使用できないが、CLI・テスト・開発作業は自由に行える
 
 状態に応じて必要なら、ユーザーに `/mcp` での状態変更を依頼する。`/mcp` での状態変更はエージェントからは実行できない。
 
-### MCP サーバーと他プロセスの排他
+### MCP サーバーと他プロセスの共存
 
-MCP サーバー enabled 中は、**同じ DB に対する CLI 操作・テスト実行・別プロセスからのアクセスを行わないこと**。ChromaDB の PersistentClient は単一プロセスアクセスを前提としており、複数プロセスからの同時アクセスでインデックスが破損する。
+ChromaDB は HttpClient 経由でサーバーに接続するため、MCP と CLI の同時アクセスが可能。書き込み操作はファイルベースロック（fcntl/msvcrt）でプロセス間排他制御される。
 
 | 作業 | 必要な MCP 状態 |
 |------|---------------|
-| 通常開発・CLI 操作・テスト実行 | disabled |
+| 通常開発・CLI 操作 | enabled / disabled どちらでも可 |
+| テスト実行 | disabled 推奨（テスト用 DB との分離のため） |
 | MCP ツールの動作確認 | enabled |
+
+**注意**: BM25 インデックスは単一プロセス前提のインメモリキャッシュを持つ。MCP 経由の書き込み後はキャッシュが自動リセットされるが、CLI 直接実行で BM25 を更新した場合、MCP 側の検索結果に反映されるのは次回のサービスリセット後となる。
 
 ### DB 破損時の復旧
 
-MCP を disable → CLI `rebuild --mode full` で復旧する。
+MCP を disable → ChromaDB サーバーが起動していることを確認（停止していれば `chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。
 
 ### worktree 環境セットアップ
 
@@ -48,6 +51,7 @@ worktree で CLI 操作・動作確認を行う場合、以下のセットアッ
    BM25_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_bm25_index
    SOURCE_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_source_store
    CONVERTED_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_converted_store
+   CHROMADB_SERVER_PORT=8001
    ```
 
 3. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する:
@@ -60,6 +64,12 @@ worktree で CLI 操作・動作確認を行う場合、以下のセットアッ
 
    ```bash
    mkdir -p <worktree-path>/.tmp
+   ```
+
+5. ChromaDB サーバーを起動する（メインリポジトリの MCP が enabled の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）:
+
+   ```bash
+   chroma run --path <worktree-path>/.tmp/test_chroma_db --port <別ポート>
    ```
 
 ### CLI 動作確認の確認観点

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | **ベクトル検索** | ChromaDB による類似度検索 |
 | **ハイブリッド検索** | ベクトル検索 + BM25 のスコア統合 |
 | **全文取得** | ソースドキュメントの全文取得（変換済みテキスト/オリジナル） |
-| **MCP サーバー** | FastMCP による stdio/HTTP インターフェース |
+| **MCP サーバー** | FastMCP による stdio/HTTP インターフェース（CLI 薄層アダプター） |
 | **評価 CLI** | 検索精度の評価パイプライン |
 | **URL 安全性チェック** | Google Safe Browsing API による URL 検証 |
 | **クロールプレビュー** | クロール対象ページのタイトル・URL 一覧を事前確認 |
@@ -41,7 +41,7 @@
 | MCP SDK | FastMCP |
 | HTTP クライアント | httpx |
 | 制約付き HTTP クライアント | py-common-lib (ConstrainedClient) |
-| ベクトル DB | ChromaDB |
+| ベクトル DB | ChromaDB（client/server 構成、HttpClient 接続） |
 | キーワード検索 | BM25s |
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
@@ -53,6 +53,7 @@
 | Web クローラー（大規模サイト） | Scrapy |
 | multipart フォーム解析 | python-multipart |
 | YAML パーサー | PyYAML |
+| プロセス間排他制御 | ファイルベースロック（fcntl/msvcrt） |
 
 ## セットアップ
 
@@ -92,6 +93,16 @@ API キーは py-common-lib の `get_secret` で OS セキュアストレージ�
 新しい設定値を追加する際は、上記の判断基準に従って適切な層に配置すること。詳細は [設定管理仕様](docs/specs/rag-knowledge.md#設定管理) を参照。
 
 ## 起動
+
+### ChromaDB サーバー
+
+MCP サーバー起動時に ChromaDB サーバーが自動起動される（`CHROMADB_AUTO_START=true`、デフォルト）。CLI 単体で使用する場合は手動起動が必要:
+
+```bash
+chroma run --path <CHROMADB_PERSIST_DIR>
+```
+
+### MCP サーバー / CLI
 
 ```bash
 # MCP サーバー (stdio モード、デフォルト)

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -12,7 +12,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 2 | チャンキング | テキストを適切なサイズに分割（見出し・テーブル対応） | [rag-knowledge.md](rag-knowledge.md) |
 | 3 | ベクトル検索 | ChromaDB による類似度検索 | [rag-knowledge.md](rag-knowledge.md) |
 | 4 | ハイブリッド検索 | ベクトル検索 + BM25 のスコア統合 | [rag-knowledge.md](rag-knowledge.md) |
-| 5 | MCP サーバー | FastMCP による stdio/HTTP インターフェース | [rag-knowledge.md](rag-knowledge.md) |
+| 5 | MCP サーバー | FastMCP による stdio/HTTP インターフェース（CLI 薄層アダプター） | [rag-knowledge.md](rag-knowledge.md) |
 | 6 | 評価 CLI | 検索精度の評価パイプライン | [rag-knowledge.md](rag-knowledge.md) |
 | 7 | URL 安全性チェック | Google Safe Browsing API による URL 検証 | [rag-knowledge.md](rag-knowledge.md) |
 | 8 | クロールプレビュー | クロール対象ページのタイトル・URL 一覧を事前確認 | [rag-knowledge.md](rag-knowledge.md) |
@@ -32,6 +32,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 22 | 青空文庫インジェスター | 青空文庫の著作権切れ作品を取り込み | [ingesters/aozora.md](ingesters/aozora.md) |
 | 23 | Journal インジェスター | 開発ジャーナルの登録・検索 | [ingesters/journal.md](ingesters/journal.md) |
 | 24 | コンテンツ一覧取得 | source_type 別の最新ソース一覧取得 | [infrastructure/content-listing.md](infrastructure/content-listing.md) |
+| 25 | コンテンツアップロード | HTTP モードでのファイル直接アップロード（multipart/form-data） | [infrastructure/content-upload.md](infrastructure/content-upload.md) |
 
 ## 3. 技術スタック
 
@@ -42,12 +43,13 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | MCP SDK | FastMCP |
 | HTTP クライアント | httpx |
 | 制約付き HTTP クライアント | py-common-lib (ConstrainedClient) |
-| ベクトル DB | ChromaDB |
+| ベクトル DB | ChromaDB（client/server 構成、HttpClient 接続） |
 | キーワード検索 | BM25s |
 | Embedding | OpenAI SDK / LM Studio (OpenAI 互換 API) |
 | HTML 解析 | BeautifulSoup4 |
 | HTML→Markdown 変換 | markdownify |
 | PDF テキスト抽出 | pymupdf4llm / MinerU（CUDA 環境、未インストール時は pymupdf4llm にフォールバック） |
+| プロセス間排他制御 | ファイルベースロック（fcntl/msvcrt） |
 | 設定管理 | pydantic-settings (.env + config.toml) |
 
 ## 4. 開発方針

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -107,9 +107,9 @@ _init_lock = asyncio.Lock()
 def _reset_rag_service() -> None:
     """グローバルな RAGKnowledgeService をリセットする.
 
-    SharedSystemClient キャッシュをクリアしてから破棄する。
-    サブプロセスが ChromaDB を更新した後、キャッシュが残っていると
-    古い HNSW インメモリ状態が再利用され where フィルタ付き検索が失敗する。
+    CLI サブプロセスが BM25 インデックスをディスク上で更新した後、
+    MCP プロセス内のインメモリ BM25 キャッシュが陳腐化するためリセットが必要。
+    ChromaDB は HttpClient 経由のためクライアント側キャッシュの問題はない。
     """
     global _rag_service
     if _rag_service is not None:
@@ -858,6 +858,9 @@ async def rag_site_ingest(
     knowledge base, bulk ingest, site crawl, large scale, scrapy.
     数千ページ規模の大規模サイトを Scrapy subprocess で一括取り込みする。
     既存の rag_crawl（上限500ページ）では足りない大規模サイト向け。
+
+    並行実行非対応: Bridge が source_store へのファイル配置をロック保護外で
+    実行するため、同一サイトに対する同時実行はデータ競合のリスクがある。
 
     Args:
         url: クロール開始 URL


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- CLAUDE.md: MCP/CLI 排他制約を緩和（HttpClient + ファイルベースロック反映、worktree セットアップに ChromaDB サーバー起動手順追加）
- README.md: ChromaDB サーバー起動手順追加、技術スタックにファイルベースロック追加、MCP サーバー概要に薄層アダプター追記
- ARCHITECTURE.md: server.py を薄層アダプターとして記述更新、infrastructure にファイルベースロック追加
- docs/specs/overview.md: Upload HTTP API を機能一覧に追加、技術スタック更新（ChromaDB client/server 構成、ファイルベースロック）
- src/rag/server.py: `_reset_rag_service` docstring を BM25 陳腐化ベースに更新、`rag_site_ingest` に並行実行非対応制約を追記

## Test plan

- [x] ruff check 通過
- [x] mypy 通過
- [x] markdownlint 通過

## Related issues

Closes #410

マージ後に親 Issue #403 をクローズする（全 Phase 完了）