### PR TITLE
docs(qa-skill): QA スキルの確認観点を新アーキテクチャに対応 (#427)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -50,17 +50,20 @@ QA 検証グループ:
 2. worktree を作成する: `git worktree add -b qa/qa-skill-<Issue番号> <worktree-path> develop`
    - 配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`
 3. メインリポジトリから `.env` をコピーする
-4. `.env` のストレージパスを worktree 内の**絶対パス**に変更する（相対パスだとメインリポジトリのストレージを参照してしまう）
+4. `.env` のストレージパスを worktree 内の**絶対パス**に変更する（相対パスだとメインリポジトリのストレージを参照してしまう）。`CHROMADB_SERVER_PORT=8001` を追加する（メインリポジトリの MCP サーバーとのポート競合回避）
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する
 7. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
+8. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
 ### 4. 環境確認
 
 - 現在のブランチ・作業ディレクトリを表示
-- MCP サーバーの状態確認（CLI 検証時は disabled、MCP 検証時は enabled であることを確認）
+- MCP サーバーの状態確認（CLI 検証時は disabled 推奨、MCP 検証時は enabled であることを確認）
+- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v1/heartbeat` で応答を確認。「MCP のみ」選択時はスキップ
+- LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認
 - 問題があればユーザーに報告し、解決してから続行
 
@@ -91,6 +94,13 @@ YouTube 検証を実行します。
 YouTube API へのアクセスにより IP ブロックのリスクがあります。
 実行しますか？ (y/n)
 ```
+
+**MCP フェーズでの追加確認:**
+
+MCP フェーズで書き込み系ツール（取り込み・削除・再構築）を実行する際、以下を追加で確認する:
+
+- MCP ツールの実行結果が正常に返されること（CLI サブプロセス経由の JSON パースが成功していることの間接確認）
+- エラー発生時にエラーメッセージが適切に返されること
 
 **取り込み後の共通検証フロー:**
 
@@ -199,10 +209,11 @@ NG を検出した場合、Issue 起票を提案する。
 HTTP モードで MCP サーバーを起動して実行:
 
 1. `POST /upload/document` で `README.md` をアップロード（正常系）+ 共通検証
-2. `POST /upload/document` で同ファイルを再アップロード（同名エラー、409）
+2. `POST /upload/document` で同ファイルを再アップロード（同名エラー、409 — 重複検出エラー。ロック競合の 409 とは異なる）
 3. `POST /upload/document` で `upload_mode=replace` で上書き（200）
 4. `POST /upload/journal` で `.qa/journal_upload_test.md` をアップロード（`title: "QA スキルの仕様書・スキル定義作成"` `repository: rag-knowledge`）+ 共通検証
 5. `POST /upload/journal` で title なしアップロード（必須フィールド欠落、400）
+6. **ロック競合検証**: `curl -X POST ... &` でバックグラウンド送信した直後に同一コマンドをフォアグラウンドで実行し、いずれか一方が HTTP 409 Conflict（ロック競合）を返すことを確認。エラーレスポンスにロック競合を示すメッセージが含まれることを確認
 
 ### G) Eval（CLI 固定）
 
@@ -234,3 +245,4 @@ A〜G の取り込みデータを使ってパイプライン基盤を検証す�
 - テストデータの作成時、実在の著作物・キャラクター情報を使用しない（`~/.claude/rules/invariants.md`）
 - 各グループの実行中にエラーが発生した場合、そのステップを NG として記録し、次のステップに進む。グループ全体を中断しない
 - MCP ツールの検証では、MCP サーバーが enabled であることを確認してから実行する。disabled の場合はユーザーに `/mcp` での状態変更を依頼する
+- **MCP と CLI の共存**: HttpClient + ファイルベースロックにより MCP と CLI の同時アクセスは技術的に可能だが、QA では検証環境の単純化のため CLI 検証時は MCP disabled を推奨する

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -25,7 +25,7 @@ MCP ツール・CLI コマンド・HTTP API の機能を実際に実行し、正
 ## 制約
 
 - **worktree 環境での実行**: 本番ストレージに影響を与えないよう、worktree 環境で実行する。ストレージパスは worktree 内の絶対パスを使用する
-- **MCP サーバーの排他**: MCP ツール検証時は MCP サーバーを enabled にする。CLI 検証時は disabled にする。同時アクセスは禁止
+- **MCP サーバーの分離**: MCP ツール検証時は MCP サーバーを enabled にする。CLI 検証時は disabled を推奨する（HttpClient + ファイルベースロックにより同時アクセスは技術的に可能だが、検証環境の単純化のため分離する）
 - **YouTube の実行制限**: YouTube グループ（D）を選択した場合、実行直前にユーザー確認を必ず挟む。IP ブロックリスクがあるため
 - **外部 API への最小アクセス**: 外部 API を使用するグループでは、取り込み件数を最小限に制限する（具体値は検証リソース定義に従う）
 - **エラー時の継続動作**: 各ステップでエラーが発生した場合、NG として記録し次のステップに進む。グループ全体を中断しない
@@ -107,17 +107,19 @@ QA 検証グループ:
 
 1. ベースブランチ（develop）を最新に更新する
 2. worktree を作成する（配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`）
-3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する
+3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する。`CHROMADB_SERVER_PORT=8001` を追加する（メインリポジトリの MCP サーバーとのポート競合回避）
 4. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 5. `.tmp` ディレクトリを作成する
 6. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
+7. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
 ### ステップ 4: 環境確認
 
 - 現在のブランチ・ディレクトリを確認する
-- MCP サーバーの状態を確認する（CLI 検証時は disabled であることを確認）
+- MCP サーバーの状態を確認する（CLI 検証時は disabled 推奨）
+- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v1/heartbeat` で応答を確認する。「MCP のみ」選択時はスキップする
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認する
 
@@ -133,6 +135,11 @@ QA 検証グループ:
   1. **CLI フェーズ**: MCP disabled を確認し、全グループを CLI で実行する
   2. **切り替え**: ユーザーに `/mcp` で MCP サーバーを enabled に切り替えてもらう
   3. **MCP フェーズ**: MCP enabled を確認し、全グループを MCP で実行する
+
+MCP フェーズでの追加確認（書き込み系ツール実行時）:
+
+- MCP ツールの実行結果が正常に返されること（CLI サブプロセス経由の JSON パースが成功していることの間接確認）
+- エラー発生時にエラーメッセージが適切に返されること
 
 YouTube（D）選択時は、グループ実行直前に以下を表示してユーザー確認を取る:
 
@@ -286,10 +293,11 @@ CLI 対応コマンド:
 手順:
 
 1. **POST /upload/document（正常系）** — ファイルをアップロード。レスポンスの `status: ok` と `source_id` を確認。共通検証フローを実行
-2. **POST /upload/document（同名エラー）** — 同じファイルを再度アップロード（`upload_mode=fail`）。HTTP 409 が返ること
+2. **POST /upload/document（同名エラー）** — 同じファイルを再度アップロード（`upload_mode=fail`）。HTTP 409 が返ること（重複検出エラー。ロック競合の 409 とは異なる）
 3. **POST /upload/document（上書き）** — `upload_mode=replace` で上書き。HTTP 200 が返ること
 4. **POST /upload/journal（正常系）** — ジャーナルをアップロード。レスポンスの `status: ok` と `source_id` を確認。共通検証フローを実行
 5. **POST /upload/journal（必須フィールド欠落）** — title なしでアップロード。HTTP 400 が返ること
+6. **ロック競合検証** — `curl -X POST ... &` でバックグラウンド送信した直後に同一コマンドをフォアグラウンドで実行し、いずれか一方が HTTP 409 Conflict（ロック競合）を返すことを確認する。エラーレスポンスにロック競合を示すメッセージが含まれることを確認する
 
 ### G) Eval
 
@@ -349,5 +357,6 @@ CLI 対応コマンド:
 - 品質ゲート（`~/.claude/rules/quality-gate.md`）— QA フェーズの位置づけ
 - 仕様駆動開発（`~/.claude/rules/spec-driven.md`）— QA フェーズの原則
 - [RAG Knowledge 全体仕様](../../overview.md) — 機能一覧
+- [RAG ナレッジ](../../rag-knowledge.md) — ChromaDB client/server 構成、MCP 薄層アダプターパターン
 - [content-upload](../../infrastructure/content-upload.md) — Upload HTTP API 仕様
 - [content-listing](../../infrastructure/content-listing.md) — コンテンツ一覧取得仕様


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- QA スキル（`/qa`）の確認観点を ChromaDB client/server 化・MCP 薄層アダプター化に対応
- worktree セットアップに ChromaDB サーバーポート設定・起動手順を追加
- 環境確認に ChromaDB サーバー疎通確認（heartbeat）を追加
- 制約セクションの MCP 排他制約を「分離推奨」に変更（HttpClient + ファイルベースロックで共存可能）
- MCP フェーズでの CLI サブプロセス経由の結果伝達確認を追加
- F グループ（Upload API）にロック競合検証ステップ追加、409 の区別を明確化
- 関連ドキュメントに rag-knowledge.md への参照を追加

## Test plan

- [x] markdownlint 違反なし
- [x] doc-reviewer によるドキュメントレビュー通過
- [x] 仕様書（qa-skill.md）とスキル定義（SKILL.md）の同期確認済み

## Related issues

Closes #427