### PR TITLE
fix(site-ingest): ルート URL パス・ページカウント・DFS の問題を修正 (#431)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ reports/
 scheduled_tasks.lock
 aidlc-archive/
 .pr-creation-authorized
+.claude/scheduled_tasks.lock

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -61,7 +61,13 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 ### ページ数上限
 
 - `site_ingest_max_pages`（config.toml）でクロール対象ページ数を制限する（デフォルト: 10,000）
-- Scrapy の `CLOSESPIDER_PAGECOUNT` 設定で制御する
+- Spider 内で 200 OK レスポンスのみをカウントし、上限に達したら `close_spider` で自前クローズする
+- 404 等の非 200 レスポンスはカウントに含めない（Scrapy の `CLOSESPIDER_PAGECOUNT` は全レスポンスをカウントするため使用しない）
+
+### クロール順序
+
+- BFS（幅優先探索）でクロールする。同一 depth のページを優先的に取得するため、`max_pages` に達した際にトップページ付近のページが網羅される
+- Scrapy の `DEPTH_PRIORITY = 1` + FIFO キュー設定で制御する
 
 ### リクエスト間隔
 
@@ -215,6 +221,7 @@ flowchart TD
 | `allowed_domains` | ドメイン制約（初回 URL から自動導出） |
 | `url_pattern` | URL フィルタ（正規表現、任意） |
 | `output_dir` | HTML ファイルの保存先ディレクトリ |
+| `max_pages` | ページ数上限（200 OK カウント、0 = 無制限） |
 
 Spider の振る舞い:
 
@@ -226,6 +233,7 @@ Spider の振る舞い:
 - `start_requests` をオーバーライドし `dont_filter=False` でリクエストを発行する。これにより start_url のフィンガープリントが重複フィルタに記録され、リンク辿りでの再取得を防止する
 - FEEDS 機能で JSONL にメタデータ（url, title, status, depth, collected_at）を出力する
 - 非テキストレスポンス（Content-Type がテキスト系でない場合）はスキップする
+- 200 OK レスポンスのみをページ数としてカウントし、`max_pages` に達したら `close_spider` で自前クローズする
 
 ### Runner
 
@@ -248,7 +256,9 @@ Scrapy に渡す設定:
 | `ROBOTSTXT_OBEY` | `True`（固定） |
 | `DOWNLOAD_DELAY` | `site_ingest_delay_sec`（config.toml） |
 | `DOWNLOAD_TIMEOUT` | `site_ingest_download_timeout`（config.toml） |
-| `CLOSESPIDER_PAGECOUNT` | `max_pages` パラメータまたは `site_ingest_max_pages`（config.toml） |
+| `DEPTH_PRIORITY` | `1`（固定、BFS） |
+| `SCHEDULER_DISK_QUEUE` | `scrapy.squeues.PickleFifoDiskQueue`（固定、BFS） |
+| `SCHEDULER_MEMORY_QUEUE` | `scrapy.squeues.FifoMemoryQueue`（固定、BFS） |
 | `CLOSESPIDER_TIMEOUT` | `site_ingest_timeout_sec`（config.toml） |
 | `CLOSESPIDER_ERRORCOUNT` | `site_ingest_error_count`（config.toml） |
 | `JOBDIR` | クロールディレクトリ内の `jobdir/`（`{domain}/{crawl_key}/jobdir/`） |

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -221,7 +221,7 @@ flowchart TD
 | `allowed_domains` | ドメイン制約（初回 URL から自動導出） |
 | `url_pattern` | URL フィルタ（正規表現、任意） |
 | `output_dir` | HTML ファイルの保存先ディレクトリ |
-| `max_pages` | ページ数上限（200 OK カウント、0 = 無制限） |
+| `max_pages` | ページ数上限（200 OK カウント）。外部インターフェースでは許容範囲 1〜50,000 でクランプされる。Spider 内部では 0 を無制限として扱うが、CLI/MCP からは入力されない |
 
 Spider の振る舞い:
 

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -254,7 +254,10 @@ settings = {{
     }},
     'DOWNLOAD_DELAY': params['delay_sec'],
     'DOWNLOAD_TIMEOUT': params['download_timeout'],
-    'CLOSESPIDER_PAGECOUNT': params['max_pages'],
+    # BFS: 同一 depth のページを優先的に取得する
+    'DEPTH_PRIORITY': 1,
+    'SCHEDULER_DISK_QUEUE': 'scrapy.squeues.PickleFifoDiskQueue',
+    'SCHEDULER_MEMORY_QUEUE': 'scrapy.squeues.FifoMemoryQueue',
     'LOG_LEVEL': 'INFO',
 }}
 if params.get('timeout_sec'):
@@ -270,6 +273,7 @@ process.crawl(
     allowed_domains=params['allowed_domains'],
     url_pattern=params['url_pattern'],
     output_dir=params['output_dir'],
+    max_pages=params['max_pages'],
 )
 process.start()
 """

--- a/src/rag/scrapy/spider.py
+++ b/src/rag/scrapy/spider.py
@@ -53,6 +53,7 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
         allowed_domains: str = "",
         url_pattern: str = "",
         output_dir: str = "",
+        max_pages: int = 0,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -85,6 +86,9 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
         self._output_dir = Path(output_dir)
         self._output_dir.mkdir(parents=True, exist_ok=True)
 
+        # ページ数上限（0 = 無制限）
+        self._max_pages = int(max_pages)
+
         # 統計
         self._page_count = 0
         self._error_count = 0
@@ -113,7 +117,10 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
             )
             return
 
-        self._page_count += 1
+        # 200 OK のみカウント（404 等を除外して正確なページ数制限を実現）
+        if response.status == 200:
+            self._page_count += 1
+
         self.logger.info(
             "[%d] Crawled: %s (status=%d, size=%d)",
             self._page_count,
@@ -142,6 +149,10 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
 
         # リンクを辿る
         yield from self._follow_links(response)
+
+        # 200 OK ページ数が上限に達したら Spider をクローズ
+        if self._max_pages and self._page_count >= self._max_pages:
+            self.crawler.engine.close_spider(self, "max_pages_reached")
 
     def _is_text_response(self, content_type: str) -> bool:
         """Content-Type がテキスト系かどうか判定する."""

--- a/src/rag/scrapy/spider.py
+++ b/src/rag/scrapy/spider.py
@@ -129,11 +129,18 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
             len(response.body),
         )
 
+        # 200 OK ページ数が上限に達したら Spider をクローズ
+        # リンク追跡より前に判定し、上限到達後は新規リクエストをスケジュールしない
+        max_reached = self._max_pages and self._page_count >= self._max_pages
+
         # HTML ファイルを保存
         filepath = self._save_html(response)
         if filepath is None:
             # 保存失敗時はメタデータを yield しない（JSONL に不整合な行を書かない）
-            yield from self._follow_links(response)
+            if not max_reached:
+                yield from self._follow_links(response)
+            if max_reached:
+                self.crawler.engine.close_spider(self, "max_pages_reached")
             return
 
         # JSONL 用メタデータを yield（FEEDS 機能で自動出力）
@@ -147,11 +154,11 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
             "filepath": str(filepath.relative_to(self._output_dir.resolve())),
         }
 
-        # リンクを辿る
-        yield from self._follow_links(response)
+        # 上限未到達時のみリンクを辿る
+        if not max_reached:
+            yield from self._follow_links(response)
 
-        # 200 OK ページ数が上限に達したら Spider をクローズ
-        if self._max_pages and self._page_count >= self._max_pages:
+        if max_reached:
             self.crawler.engine.close_spider(self, "max_pages_reached")
 
     def _is_text_response(self, content_type: str) -> bool:

--- a/src/rag/store/path_converter.py
+++ b/src/rag/store/path_converter.py
@@ -72,6 +72,12 @@ def url_to_path(url: str) -> str:
     # コンバーターが ".html" 拡張子を付与した際に "path/.html" となる
     path = parsed.path.strip("/")
 
+    # ルート URL（パスが空）の場合は "index" を設定
+    # そのまま空だとホスト名がファイル名になり、
+    # ".html" 付与で "host.html" となってサブページと不整合になる
+    if not path:
+        path = "index"
+
     # クエリパラメータ（? を全角に置換して結合）
     query = parsed.query
     if query:

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -153,8 +153,9 @@ class TestBuildSpiderScript:
         # JSON から設定を読み込む構造
         assert "params['delay_sec']" in script
         assert "params['download_timeout']" in script
-        assert "params['max_pages']" in script
         assert "'LOG_LEVEL': 'INFO'" in script
+        # max_pages は Spider パラメータとして渡される（CLOSESPIDER_PAGECOUNT ではない）
+        assert "max_pages=params['max_pages']" in script
 
     def test_script_contains_spider_args(self, tmp_path: Path) -> None:
         """スクリプトに Spider 引数が JSON 経由で渡される構造を含むこと."""
@@ -199,6 +200,24 @@ class TestBuildSpiderScript:
 
         assert "json.load(f)" in script
         assert str(params_path).replace("\\", "/") in script
+
+    def test_script_contains_bfs_settings(self, tmp_path: Path) -> None:
+        """スクリプトに BFS 設定が含まれること."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+        params_path = _write_params(tmp_path)
+        script = runner._build_spider_script(params_path=params_path)
+
+        assert "'DEPTH_PRIORITY': 1" in script
+        assert "PickleFifoDiskQueue" in script
+        assert "FifoMemoryQueue" in script
+
+    def test_script_does_not_contain_closespider_pagecount(self, tmp_path: Path) -> None:
+        """スクリプトに CLOSESPIDER_PAGECOUNT が含まれないこと."""
+        runner = ScrapyRunner(temp_dir=tmp_path)
+        params_path = _write_params(tmp_path)
+        script = runner._build_spider_script(params_path=params_path)
+
+        assert "CLOSESPIDER_PAGECOUNT" not in script
 
     def test_script_contains_closespider_timeout_conditional(self, tmp_path: Path) -> None:
         """スクリプトに CLOSESPIDER_TIMEOUT の条件分岐が含まれること."""

--- a/tests/test_scrapy_spider.py
+++ b/tests/test_scrapy_spider.py
@@ -196,6 +196,140 @@ class TestSpiderInit:
         assert spider._max_pages == 20
 
 
+# --- parse() の max_pages クローズテスト ---
+
+
+class TestParseMaxPages:
+    """parse() の max_pages 到達時の close_spider テスト."""
+
+    @staticmethod
+    def _make_spider(tmp_path: Path, max_pages: int) -> SiteSpider:
+        """テスト用 Spider インスタンスを作成する."""
+        from unittest.mock import MagicMock
+
+        spider = SiteSpider.__new__(SiteSpider)
+        spider.name = "site_spider"
+        spider._url_pattern = None
+        spider._output_dir = tmp_path
+        spider._max_pages = max_pages
+        spider._page_count = 0
+        spider._error_count = 0
+        # crawler.engine.close_spider のモック
+        spider.crawler = MagicMock()
+        # logger は Scrapy の property のためモック不要（crawler モックにより動作する）
+        return spider
+
+    @staticmethod
+    def _make_response(url: str, status: int = 200) -> "MagicMock":
+        """テスト用モック Response を作成する."""
+        from unittest.mock import MagicMock
+
+        mock_headers = MagicMock()
+        mock_headers.get.return_value = b"text/html; charset=utf-8"
+        mock_response = MagicMock()
+        mock_response.url = url
+        mock_response.status = status
+        mock_response.body = b"<html><title>Test</title></html>"
+        mock_response.headers = mock_headers
+        mock_response.meta = {"depth": 0}
+        mock_response.css.return_value.get.return_value = "Test"
+        mock_response.css.return_value.getall.return_value = []
+        return mock_response
+
+    def test_close_spider_called_on_max_pages(self, tmp_path: Path) -> None:
+        """200 OK が max_pages に達したら close_spider が呼ばれること."""
+        from unittest.mock import patch
+
+        spider = self._make_spider(tmp_path, max_pages=2)
+        resolved_file = (tmp_path / "page.html").resolve()
+        resolved_file.parent.mkdir(parents=True, exist_ok=True)
+        resolved_file.write_text("<html></html>", encoding="utf-8")
+
+        resp1 = self._make_response("https://example.com/page1")
+        resp2 = self._make_response("https://example.com/page2")
+
+        with patch.object(spider, "_save_html", return_value=resolved_file):
+            list(spider.parse(resp1))
+            list(spider.parse(resp2))
+
+        spider.crawler.engine.close_spider.assert_called_once_with(
+            spider, "max_pages_reached",
+        )
+
+    def test_close_spider_not_called_below_max(self, tmp_path: Path) -> None:
+        """200 OK が max_pages 未満なら close_spider は呼ばれないこと."""
+        from unittest.mock import patch
+
+        spider = self._make_spider(tmp_path, max_pages=3)
+        resolved_file = (tmp_path / "page.html").resolve()
+        resolved_file.parent.mkdir(parents=True, exist_ok=True)
+        resolved_file.write_text("<html></html>", encoding="utf-8")
+
+        resp = self._make_response("https://example.com/page1")
+        with patch.object(spider, "_save_html", return_value=resolved_file):
+            list(spider.parse(resp))
+
+        spider.crawler.engine.close_spider.assert_not_called()
+
+    def test_404_not_counted_for_max_pages(self, tmp_path: Path) -> None:
+        """404 レスポンスは max_pages のカウントに含まれないこと."""
+        from unittest.mock import patch
+
+        spider = self._make_spider(tmp_path, max_pages=1)
+        resolved_file = (tmp_path / "page.html").resolve()
+        resolved_file.parent.mkdir(parents=True, exist_ok=True)
+        resolved_file.write_text("<html></html>", encoding="utf-8")
+
+        # 404 → close_spider は呼ばれない
+        resp_404 = self._make_response("https://example.com/missing", status=404)
+        with patch.object(spider, "_save_html", return_value=resolved_file):
+            list(spider.parse(resp_404))
+
+        spider.crawler.engine.close_spider.assert_not_called()
+        assert spider._page_count == 0
+
+        # 200 → close_spider が呼ばれる
+        resp_200 = self._make_response("https://example.com/page1")
+        with patch.object(spider, "_save_html", return_value=resolved_file):
+            list(spider.parse(resp_200))
+
+        spider.crawler.engine.close_spider.assert_called_once()
+
+    def test_no_follow_links_after_max_pages(self, tmp_path: Path) -> None:
+        """max_pages 到達後はリンク追跡しないこと."""
+        from unittest.mock import MagicMock, patch
+
+        spider = self._make_spider(tmp_path, max_pages=1)
+        resolved_file = (tmp_path / "page.html").resolve()
+        resolved_file.parent.mkdir(parents=True, exist_ok=True)
+        resolved_file.write_text("<html></html>", encoding="utf-8")
+
+        resp = self._make_response("https://example.com/page1")
+        mock_follow = MagicMock(return_value=iter([]))
+
+        with (
+            patch.object(spider, "_save_html", return_value=resolved_file),
+            patch.object(spider, "_follow_links", mock_follow),
+        ):
+            list(spider.parse(resp))
+
+        mock_follow.assert_not_called()
+
+    def test_close_spider_on_save_html_failure(self, tmp_path: Path) -> None:
+        """_save_html 失敗時でも max_pages 到達なら close_spider が呼ばれること."""
+        from unittest.mock import patch
+
+        spider = self._make_spider(tmp_path, max_pages=1)
+
+        resp = self._make_response("https://example.com/page1")
+        with patch.object(spider, "_save_html", return_value=None):
+            list(spider.parse(resp))
+
+        spider.crawler.engine.close_spider.assert_called_once_with(
+            spider, "max_pages_reached",
+        )
+
+
 # --- parse() の filepath 回帰テスト ---
 
 

--- a/tests/test_scrapy_spider.py
+++ b/tests/test_scrapy_spider.py
@@ -82,6 +82,7 @@ class TestIsTextResponse:
         spider = SiteSpider.__new__(SiteSpider)
         spider._url_pattern = None
         spider._output_dir = tmp_path
+        spider._max_pages = 0
         spider._page_count = 0
         spider._error_count = 0
         return spider
@@ -177,6 +178,23 @@ class TestSpiderInit:
         )
         assert out.exists()
 
+    def test_max_pages_default_zero(self, tmp_path: Path) -> None:
+        """max_pages 未指定時は 0（無制限）になること."""
+        spider = SiteSpider(
+            start_url="https://example.com",
+            output_dir=str(tmp_path),
+        )
+        assert spider._max_pages == 0
+
+    def test_max_pages_set(self, tmp_path: Path) -> None:
+        """max_pages が設定されること."""
+        spider = SiteSpider(
+            start_url="https://example.com",
+            output_dir=str(tmp_path),
+            max_pages=20,
+        )
+        assert spider._max_pages == 20
+
 
 # --- parse() の filepath 回帰テスト ---
 
@@ -201,6 +219,7 @@ class TestParseFilepathRegression:
         spider.name = "site_spider"
         spider._url_pattern = None
         spider._output_dir = output_dir
+        spider._max_pages = 0
         spider._page_count = 0
         spider._error_count = 0
 

--- a/tests/test_store_path_converter.py
+++ b/tests/test_store_path_converter.py
@@ -47,12 +47,14 @@ class TestUrlToPath:
             url_to_path("ftp://example.com/file")
 
     def test_root_url(self) -> None:
+        """ルート URL は {host}/index に配置されること."""
         result = url_to_path("https://example.com/")
-        assert result == "web/https/example.com"
+        assert result == "web/https/example.com/index"
 
     def test_host_only(self) -> None:
+        """ホストのみの URL は {host}/index に配置されること."""
         result = url_to_path("https://example.com")
-        assert result == "web/https/example.com"
+        assert result == "web/https/example.com/index"
 
     def test_trailing_slash(self) -> None:
         """末尾 / が除去されること（ディレクトリ扱い回避）."""
@@ -129,3 +131,9 @@ class TestRoundTrip:
         path = url_to_path(url)
         restored = path_to_url(path)
         assert restored == "https://example.com/page"
+
+    def test_roundtrip_root_url_gets_index(self) -> None:
+        """ルート URL は往復で /index が付加される（既知の制限）."""
+        path = url_to_path("https://example.com/")
+        restored = path_to_url(path)
+        assert restored == "https://example.com/index"


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `url_to_path` でルート URL（パスが空）の場合に `index` を設定し、`{host}/index.html` に配置されるよう修正
- `CLOSESPIDER_PAGECOUNT` を廃止し、Spider 内で 200 OK レスポンスのみカウントして `max_pages` 到達時に自前クローズする方式に変更
- BFS（`DEPTH_PRIORITY=1` + FIFO キュー）をデフォルトのクロール順序に設定し、同一 depth のページを優先的に取得

## Test plan

- [x] path_converter: ルート URL が `web/https/example.com/index` に変換されるテスト
- [x] path_converter: ルート URL のラウンドトリップで `/index` が付加されることを明示するテスト
- [x] spider: `max_pages` パラメータの初期化テスト
- [x] runner: BFS 設定が含まれるテスト
- [x] runner: `CLOSESPIDER_PAGECOUNT` が含まれないテスト
- [x] runner: `max_pages` が Spider パラメータとして渡されるテスト
- [x] 既存テスト 84 件全て PASSED
- [x] ruff / mypy / markdownlint 全て通過

## Related issues

Closes #431