### PR TITLE
fix(rag-knowledge): ChromaDB v2 API 対応・ロックファイル除外 (#430)

### DIFF
--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -207,6 +207,18 @@ sequenceDiagram
 
 変換不要なファイル（md/txt/adoc）はコンバーターが source_store から converted_store にそのままコピーする。これによりインデクサーは常に converted_store のみを参照すればよく、フォールバックロジックは不要。
 
+### パイプライン処理対象外ファイル
+
+source_store 内の以下のファイルは、git diff で検出されてもパイプライン処理をスキップする。
+
+| ファイル | 理由 |
+|---------|------|
+| `.gitignore` | git メタデータ |
+| `.ingest.lock` | インジェスト排他制御用ロックファイル |
+| `.rebuild.lock` | 再構築排他制御用ロックファイル |
+| `aozora/catalog.csv` | 青空文庫カタログ（検索用、インデックス対象外） |
+| `aozora/catalog.csv.meta` | カタログのメタデータ |
+
 ### 変更種別と処理の対応
 
 | git diff status | 変更種別 | コンバーター | インデクサー | metadata.db |

--- a/src/rag/infrastructure/chromadb_manager.py
+++ b/src/rag/infrastructure/chromadb_manager.py
@@ -80,7 +80,7 @@ class ChromaDBServerManager:
         """
         try:
             resp = httpx.get(  # safety:allowed — ローカルヘルスチェック
-                f"{self._base_url}/api/v1/heartbeat",
+                f"{self._base_url}/api/v2/heartbeat",
                 timeout=timeout,
             )
             return resp.status_code == 200

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -47,6 +47,8 @@ _NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})
 # パイプライン処理対象外のファイル（git メタデータ等）
 _PIPELINE_EXCLUDE_FILES: frozenset[str] = frozenset({
     ".gitignore",
+    ".ingest.lock",
+    ".rebuild.lock",
     "aozora/catalog.csv",
     "aozora/catalog.csv.meta",
 })

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from rag.converter.converter import get_converted_rel_path
+from rag.infrastructure.file_lock import INGEST_LOCK_FILENAME, REBUILD_LOCK_FILENAME
 from rag.pipeline.git_ops import GitOperations
 from rag.pipeline.models import (
     ChangeEntry,
@@ -47,8 +48,8 @@ _NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})
 # パイプライン処理対象外のファイル（git メタデータ等）
 _PIPELINE_EXCLUDE_FILES: frozenset[str] = frozenset({
     ".gitignore",
-    ".ingest.lock",
-    ".rebuild.lock",
+    INGEST_LOCK_FILENAME,
+    REBUILD_LOCK_FILENAME,
     "aozora/catalog.csv",
     "aozora/catalog.csv.meta",
 })

--- a/tests/test_chromadb_manager.py
+++ b/tests/test_chromadb_manager.py
@@ -91,7 +91,7 @@ class TestHealthCheck:
         with patch("rag.infrastructure.chromadb_manager.httpx.get", return_value=mock_response) as mock_get:
             manager.health_check(timeout=3.0)
             mock_get.assert_called_once_with(
-                "http://localhost:8000/api/v1/heartbeat",
+                "http://localhost:8000/api/v2/heartbeat",
                 timeout=3.0,
             )
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新

## Summary

QA 初回実行（#430）で発見されたブロッカーバグ 2 件を修正。

- ChromaDB health_check のエンドポイントを `/api/v1/heartbeat` → `/api/v2/heartbeat` に変更（バグ 4）
- `.ingest.lock` / `.rebuild.lock` を `_PIPELINE_EXCLUDE_FILES` に追加し、パイプラインでの誤処理を防止（バグ 1）
- テスト（`test_chromadb_manager.py`）の期待 URL を v2 に更新
- `pipeline-controller.md` にパイプライン処理対象外ファイル一覧を追加

#430 の部分修正（バグ 1, 4 のみ）。残りのバグ（5, 6, 7, 8）は別途対応。

## Test plan

- [x] pytest: 65 passed（test_chromadb_manager, test_pipeline_controller）
- [x] ruff: 違反なし
- [x] mypy: 型エラーなし

## Related issues

Ref #430