### PR TITLE
docs(qa-skill): QA スキル手順バグ 8 件を修正 (#429)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -52,11 +52,13 @@ QA 検証グループ:
 2. worktree を作成する: `git worktree add -b qa/qa-skill-<Issue番号> <worktree-path> develop`
    - 配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`
 3. メインリポジトリから `.env` をコピーする
-4. `.env` のストレージパスを worktree 内の**絶対パス**に変更する（相対パスだとメインリポジトリのストレージを参照してしまう）。`CHROMADB_SERVER_PORT=8001` を追加する（メインリポジトリの MCP サーバーとのポート競合回避）
+4. `.env` のストレージパスを worktree 内の**絶対パス**に変更する（相対パスだとメインリポジトリのストレージを参照してしまう）。以下も設定する:
+   - `CHROMADB_SERVER_PORT=8001`（メインリポジトリの MCP サーバーとのポート競合回避）
+   - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する
 7. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
-8. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
+8. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
@@ -64,7 +66,7 @@ QA 検証グループ:
 
 - 現在のブランチ・作業ディレクトリを表示
 - MCP サーバーの状態確認（CLI 検証時は disabled 推奨、MCP 検証時は enabled であることを確認）
-- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v1/heartbeat` で応答を確認。「MCP のみ」選択時はスキップ
+- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認。「MCP のみ」選択時はスキップ
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認
 - 問題があればユーザーに報告し、解決してから続行
@@ -173,7 +175,7 @@ NG を検出した場合、Issue 起票を提案する。
 | 1 | `add-document --file README.md` | Markdown 取り込み成功 | `ingest` |
 | 2 | `add-document --file .qa/pdf_add_test.pdf` | PDF 取り込み成功 | `ingest` |
 | 3 | `add-document --file README.md --upload-mode replace` | 上書き成功、エラーなし | `none` |
-| 4 | `crawl-documents docs/specs/` | ディレクトリ一括取り込み成功 | `ingest` |
+| 4 | `crawl-documents docs/specs/`（`dir_path` は positional 引数） | ディレクトリ一括取り込み成功 | `ingest` |
 | 5 | `add-journal --title "コンテンツ一覧取得機能の実装" --file .qa/journal_add_test.md --repository rag-knowledge` | ジャーナル登録成功 | `ingest` |
 | 6a | `migrate-journal --dir .qa/journals --repository rag-knowledge` | ジャーナル一括配置成功 | `none` |
 | 6b | `rebuild --mode incremental` | 再構築成功、migrate 分がインデックスに反映 | `ingest` |
@@ -230,14 +232,16 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
 HTTP モードで MCP サーバーを起動して実行:
 
+ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
+
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `POST /upload/document` で `README.md` をアップロード | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `POST /upload/document` で同ファイルを再アップロード（`upload_mode=fail`） | HTTP 409（重複検出エラー） | `none` |
-| 3 | `POST /upload/document` で `upload_mode=replace` で上書き | HTTP 200 | `none` |
-| 4 | `POST /upload/journal` で `.qa/journal_upload_test.md` をアップロード（`title: "QA スキルの仕様書・スキル定義作成"` `repository: rag-knowledge`） | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `POST /upload/journal` で title なしアップロード | HTTP 400（必須フィールド欠落） | `none` |
-| 6 | `curl -X POST ... &` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+| 1 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 6 | ステップ 1 のコマンドを `&` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
 
 ### G) Eval（CLI 固定）
 
@@ -258,13 +262,40 @@ A〜G の取り込みデータを使ってパイプライン基盤を検証す�
 | 2 | `list-recent --source-type local` | 取り込み済み local ソースが一覧に表示される | `none` |
 | 3 | `list-recent --source-type journal` | 取り込み済み journal ソースが一覧に表示される | `none` |
 | 4 | `search --query <取り込み内容に関連するワード>` | ベクトル検索・BM25 の両方で結果が返る | `none` |
-| 5a | `get-document <source_id> --format text` | A) の README.md の全文がテキスト形式で取得できる | `none` |
+| 5a | `get-document <source_id> --format text`（`source_id` は positional 引数） | A) の README.md の全文がテキスト形式で取得できる | `none` |
 | 5b | `get-document <source_id> --format original` | A) の README.md の全文がオリジナル形式で取得できる | `none` |
-| 6 | `delete <source_id>` | A) の README.md が削除される | `delete` |
+| 6 | `delete <source_id>`（`source_id` は positional 引数） | A) の README.md が削除される | `delete` |
 | 7 | `rebuild --mode incremental` | 差分再構築が成功する | `none` |
 | 8 | `stats` | 再構築後の統計が更新されている | `none` |
 
 MCP 対応: `rag_stats` / `rag_list_recent` / `rag_search` / `rag_get_document` / `rag_delete` / `rag_rebuild`
+
+### 7. クリーンアップ
+
+QA 完了後、worktree 環境を片付ける。ChromaDB や MCP サーバーのプロセスがファイルをロックしているため、先にプロセスを停止する必要がある。
+
+1. バックグラウンドの ChromaDB サーバーを停止する:
+
+   ```bash
+   # worktree のプロセスを特定（Windows）
+   wmic process where "CommandLine like '%<worktree-path>%'" get ProcessId,CommandLine
+   # または、ポートで特定
+   netstat -ano | grep <CHROMADB_SERVER_PORT>
+   # 停止
+   taskkill //PID <pid> //F
+   ```
+
+2. worktree ディレクトリを削除する:
+
+   ```bash
+   git worktree remove <worktree-path>
+   ```
+
+3. worktree の参照をクリーンアップする:
+
+   ```bash
+   git worktree prune
+   ```
 
 ## 制約
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ ChromaDB は HttpClient 経由でサーバーに接続するため、MCP と CLI
 
 ### DB 破損時の復旧
 
-MCP を disable → ChromaDB サーバーが起動していることを確認（停止していれば `chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。
+MCP を disable → ChromaDB サーバーが起動していることを確認（停止していれば `uv run chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。
 
 ### worktree 環境セットアップ
 
@@ -66,10 +66,10 @@ worktree で CLI 操作・動作確認を行う場合、以下のセットアッ
    mkdir -p <worktree-path>/.tmp
    ```
 
-5. ChromaDB サーバーを起動する（メインリポジトリの MCP が enabled の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）:
+5. ChromaDB サーバーを起動する（メインリポジトリの MCP が enabled の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
 
    ```bash
-   chroma run --path <worktree-path>/.tmp/test_chroma_db --port <別ポート>
+   uv run chroma run --path <worktree-path>/.tmp/test_chroma_db --port <別ポート>
    ```
 
 ### CLI 動作確認の確認観点

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ API キーは py-common-lib の `get_secret` で OS セキュアストレージ�
 MCP サーバー起動時に ChromaDB サーバーが自動起動される（`CHROMADB_AUTO_START=true`、デフォルト）。CLI 単体で使用する場合は手動起動が必要:
 
 ```bash
-chroma run --path <CHROMADB_PERSIST_DIR>
+uv run chroma run --path <CHROMADB_PERSIST_DIR>
 ```
 
 ### MCP サーバー / CLI

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -108,11 +108,13 @@ QA 検証グループ:
 
 1. ベースブランチ（develop）を最新に更新する
 2. worktree を作成する（配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`）
-3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する。`CHROMADB_SERVER_PORT=8001` を追加する（メインリポジトリの MCP サーバーとのポート競合回避）
+3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する。以下も設定する:
+   - `CHROMADB_SERVER_PORT=8001`（メインリポジトリの MCP サーバーとのポート競合回避）
+   - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
 4. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 5. `.tmp` ディレクトリを作成する
 6. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
-7. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
+7. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
@@ -120,7 +122,7 @@ QA 検証グループ:
 
 - 現在のブランチ・ディレクトリを確認する
 - MCP サーバーの状態を確認する（CLI 検証時は disabled 推奨）
-- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v1/heartbeat` で応答を確認する。「MCP のみ」選択時はスキップする
+- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する。「MCP のみ」選択時はスキップする
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認する
 
@@ -188,7 +190,7 @@ NG が検出された場合、Issue 起票を提案する。
 | 1 | `add-document --file README.md` | Markdown 取り込み成功 | `ingest` |
 | 2 | `add-document --file .qa/pdf_add_test.pdf` | PDF 取り込み成功 | `ingest` |
 | 3 | `add-document --file README.md --upload-mode replace` | 上書き成功、エラーなし | `none` |
-| 4 | `crawl-documents docs/specs/` | ディレクトリ一括取り込み成功 | `ingest` |
+| 4 | `crawl-documents docs/specs/`（`dir_path` は positional 引数） | ディレクトリ一括取り込み成功 | `ingest` |
 | 5 | `add-journal --title "コンテンツ一覧取得機能の実装" --file .qa/journal_add_test.md --repository rag-knowledge` | ジャーナル登録成功 | `ingest` |
 | 6a | `migrate-journal --dir .qa/journals --repository rag-knowledge` | ジャーナル一括配置成功 | `none` |
 | 6b | `rebuild --mode incremental` | 再構築成功、migrate 分がインデックスに反映 | `ingest` |
@@ -255,14 +257,16 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
 前提: MCP サーバーを HTTP モードで起動する（`.env` で `RAG_TRANSPORT=http` を設定）。
 
+ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
+
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `POST /upload/document` で `README.md` をアップロード | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `POST /upload/document` で同ファイルを再アップロード（`upload_mode=fail`） | HTTP 409（重複検出エラー） | `none` |
-| 3 | `POST /upload/document` で `upload_mode=replace` で上書き | HTTP 200 | `none` |
-| 4 | `POST /upload/journal` で `.qa/journal_upload_test.md` をアップロード（`title: "QA スキルの仕様書・スキル定義作成"` `repository: rag-knowledge`） | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `POST /upload/journal` で title なしアップロード | HTTP 400（必須フィールド欠落） | `none` |
-| 6 | `curl -X POST ... &` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+| 1 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 6 | ステップ 1 のコマンドを `&` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
 
 ### G) Eval
 
@@ -287,13 +291,21 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 | 2 | `list-recent --source-type local` | 取り込み済み local ソースが一覧に表示される | `none` |
 | 3 | `list-recent --source-type journal` | 取り込み済み journal ソースが一覧に表示される | `none` |
 | 4 | `search --query <取り込み内容に関連するワード>` | ベクトル検索・BM25 の両方で結果が返る | `none` |
-| 5a | `get-document <source_id> --format text` | A) の README.md の全文がテキスト形式で取得できる | `none` |
+| 5a | `get-document <source_id> --format text`（`source_id` は positional 引数） | A) の README.md の全文がテキスト形式で取得できる | `none` |
 | 5b | `get-document <source_id> --format original` | A) の README.md の全文がオリジナル形式で取得できる | `none` |
-| 6 | `delete <source_id>` | A) の README.md が削除される | `delete` |
+| 6 | `delete <source_id>`（`source_id` は positional 引数） | A) の README.md が削除される | `delete` |
 | 7 | `rebuild --mode incremental` | 差分再構築が成功する | `none` |
 | 8 | `stats` | 再構築後の統計が更新されている | `none` |
 
 CLI / MCP 対応: `rag_stats` / `rag_list_recent` / `rag_search` / `rag_get_document` / `rag_delete` / `rag_rebuild`
+
+### ステップ 7: クリーンアップ
+
+QA 完了後、worktree 環境を片付ける。ChromaDB や MCP サーバーのプロセスがファイルをロックしているため、先にプロセスを停止する必要がある。
+
+1. バックグラウンドの ChromaDB サーバーを停止する（プロセス特定: `wmic process where "CommandLine like '%<worktree-path>%'"` または `netstat -ano | grep <port>`）
+2. worktree ディレクトリを削除する: `git worktree remove <worktree-path>`
+3. worktree の参照をクリーンアップする: `git worktree prune`
 
 ## 入出力
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -247,12 +247,12 @@ flowchart TB
 
 ### ChromaDB client/server 構成
 
-ChromaDB は `chroma run` によるサーバーモードで動作し、MCP サーバー・CLI の両方が `HttpClient` で接続する。これにより、`PersistentClient` の単一プロセス制約を解消し、MCP と CLI の同時アクセスを可能にする。
+ChromaDB は `uv run chroma run` によるサーバーモードで動作し、MCP サーバー・CLI の両方が `HttpClient` で接続する。これにより、`PersistentClient` の単一プロセス制約を解消し、MCP と CLI の同時アクセスを可能にする。
 
 | 項目 | 仕様 |
 |------|------|
 | ChromaDB クライアント | `chromadb.HttpClient`（`PersistentClient` から移行） |
-| ChromaDB サーバー | `chroma run --path <persist_dir> --port <port>` |
+| ChromaDB サーバー | `uv run chroma run --path <persist_dir> --port <port>` |
 | ライフサイクル管理 | MCP サーバー起動時にヘルスチェック → 未起動なら自動起動 |
 | CLI からの接続 | 既存サーバーに接続（手動起動 or MCP 経由で起動済み前提） |
 | テスト時 | `EphemeralClient` を使用（ChromaDB サーバー不要） |


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [x] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

QA スキル初回実行で発見された手順・仕様の問題 8 件を修正。

- `chroma run` → `uv run chroma run` に統一（SKILL.md, qa-skill.md, CLAUDE.md, README.md, rag-knowledge.md）
- ChromaDB heartbeat URL を `/api/v1/` → `/api/v2/` に更新
- worktree 初回 `uv run` 時の venv 構築待機時間の注記を追加
- `crawl-documents`, `get-document`, `delete` の positional 引数を明記
- Upload グループ（F）に具体的な curl コマンド例を追記
- worktree `.env` に `CHROMADB_AUTO_START=false` の設定を追記
- QA 完了後のクリーンアップ手順（プロセス停止 → worktree 削除 → prune）を追加

## Test plan

- [x] markdownlint クリア（0 error）
- [x] doc-reviewer によるドキュメントレビュー通過
- [x] SKILL.md と qa-skill.md の整合性確認済み

## Related issues

Closes #429