### PR TITLE
fix(content-upload,rag-knowledge): Upload API 日本語文字化け修正・bm25s 警告抑制 (#430)

### DIFF
--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -5,11 +5,13 @@
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import re
 import shutil
 import tempfile
+from contextlib import redirect_stdout
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -338,7 +340,8 @@ class BM25Index:
     def _rebuild_index(self) -> None:
         """BM25インデックスを再構築する."""
         try:
-            import bm25s
+            with redirect_stdout(io.StringIO()):
+                import bm25s
         except ImportError:
             logger.warning("bm25s not installed, BM25 search disabled")
             self._bm25 = None
@@ -508,7 +511,8 @@ class BM25Index:
                 self._doc_metadata_map = {}
                 return
 
-            import bm25s as bm25s_lib
+            with redirect_stdout(io.StringIO()):
+                import bm25s as bm25s_lib
 
             self._bm25 = bm25s_lib.BM25.load(str(bm25s_dir))
             self._needs_rebuild = False

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1760,6 +1760,30 @@ def _upload_success(message: str, source_id: str) -> JSONResponse:
     )
 
 
+def _decode_form_value(value: str) -> str:
+    """Starlette の Latin-1 フォールバックで壊れたフォーム値を UTF-8/cp932 に復元する.
+
+    Starlette の MultiPartParser は非 UTF-8 バイト列を受信すると UTF-8 デコードに
+    失敗し Latin-1 にフォールバックする。この関数は Latin-1 文字列をバイト列に戻し、
+    UTF-8 → cp932 の順で再デコードすることで元の文字列を復元する。
+
+    主な発生パターン:
+    - Windows curl（cp932 コンソール）から日本語を送信した場合
+    - UTF-8 バイト列が Latin-1 にフォールバックした場合
+    """
+    try:
+        raw_bytes = value.encode("latin-1")
+    except UnicodeEncodeError:
+        return value
+    # UTF-8 を優先（cp932 の一部バイト列が偶然 UTF-8 として解釈されるのを防ぐ）
+    for codec in ("utf-8", "cp932"):
+        try:
+            return raw_bytes.decode(codec)
+        except (UnicodeDecodeError, ValueError):
+            continue
+    return value
+
+
 async def _read_upload_file(
     request: Request,
     max_size_bytes: int,
@@ -1787,7 +1811,7 @@ async def _read_upload_file(
     if file_field is None or not hasattr(file_field, "read"):
         return _upload_error(400, "file フィールドが未指定です")
 
-    filename = getattr(file_field, "filename", "") or ""
+    filename = _decode_form_value(getattr(file_field, "filename", "") or "")
 
     # ストリーミング読み取りでサイズチェック
     data = bytearray()
@@ -1929,10 +1953,10 @@ async def upload_journal(request: Request) -> Response:
 
         # フォームフィールド取得
         form = await request.form()
-        title = str(form.get("title", "")).strip()
-        repository = str(form.get("repository", "")).strip()
+        title = _decode_form_value(str(form.get("title", ""))).strip()
+        repository = _decode_form_value(str(form.get("repository", ""))).strip()
         entry_id = form.get("entry_id")
-        entry_id_str = str(entry_id).strip() if entry_id else None
+        entry_id_str = _decode_form_value(str(entry_id)).strip() if entry_id else None
 
         if not title:
             return _upload_error(400, "title が未指定です")

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -35,6 +35,7 @@ import io
 import json
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -1760,6 +1761,10 @@ def _upload_success(message: str, source_id: str) -> JSONResponse:
     )
 
 
+_CJK_PATTERN = re.compile(r"[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]")
+"""ひらがな・カタカナ・CJK 漢字の検出パターン."""
+
+
 def _decode_form_value(value: str) -> str:
     """Starlette の Latin-1 フォールバックで壊れたフォーム値を UTF-8/cp932 に復元する.
 
@@ -1770,17 +1775,27 @@ def _decode_form_value(value: str) -> str:
     主な発生パターン:
     - Windows curl（cp932 コンソール）から日本語を送信した場合
     - UTF-8 バイト列が Latin-1 にフォールバックした場合
+
+    cp932 誤判定の防止:
+    - cp932 デコード後に日本語文字（ひらがな・カタカナ・CJK 漢字）が含まれない場合、
+      正当な Latin-1 入力（例: "¡Hola!"）と判断し元の値を返す。
     """
     try:
         raw_bytes = value.encode("latin-1")
     except UnicodeEncodeError:
         return value
     # UTF-8 を優先（cp932 の一部バイト列が偶然 UTF-8 として解釈されるのを防ぐ）
-    for codec in ("utf-8", "cp932"):
-        try:
-            return raw_bytes.decode(codec)
-        except (UnicodeDecodeError, ValueError):
-            continue
+    try:
+        return raw_bytes.decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        pass
+    # cp932: デコード成功しても日本語文字が含まれなければ誤判定とみなす
+    try:
+        decoded = raw_bytes.decode("cp932")
+        if _CJK_PATTERN.search(decoded):
+            return decoded
+    except (UnicodeDecodeError, ValueError):
+        pass
     return value
 
 

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -18,6 +18,7 @@ import pytest
 
 from rag.server import (
     CLISubprocessError,
+    _decode_form_value,
     _reset_pipeline_controller,
     _reset_rag_service,
     mcp,
@@ -244,6 +245,84 @@ class TestUploadJournalIntegration:
         assert body["status"] == "ok"
         assert "source_id" in body
 
+    @pytest.mark.asyncio
+    async def test_japanese_title_passed_to_cli(self, client: httpx.AsyncClient) -> None:
+        """日本語タイトルが CLI サブプロセスに正しく渡される."""
+        mock_cli_result = {"entry_id": "20260327-test"}
+        captured_args: list[list[str]] = []
+
+        async def capture_cli(cmd: str, args: list[str], **kwargs: object) -> dict:
+            captured_args.append(args)
+            return mock_cli_result
+
+        japanese_title = "QA \u30c6\u30b9\u30c8\u30bb\u30c3\u30b7\u30e7\u30f3\u8a18\u9332"  # "QA テストセッション記録"
+
+        with patch("rag.server._run_cli_subprocess", side_effect=capture_cli):
+            resp = await client.post(
+                "/upload/journal",
+                files={"file": ("session.md", b"# Test", "text/plain")},
+                data={
+                    "title": japanese_title,
+                    "repository": "rag-knowledge",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        title_idx = args.index("--title")
+        assert args[title_idx + 1] == japanese_title
+
+    @pytest.mark.asyncio
+    async def test_cp932_encoded_japanese_title_restored(
+        self, app: object
+    ) -> None:
+        """Windows curl の cp932 エンコードで送信された日本語タイトルが復元される."""
+        mock_cli_result = {"entry_id": "20260327-cp932"}
+        captured_args: list[list[str]] = []
+
+        async def capture_cli(cmd: str, args: list[str], **kwargs: object) -> dict:
+            captured_args.append(args)
+            return mock_cli_result
+
+        japanese_title = "QA \u30c6\u30b9\u30c8\u30bb\u30c3\u30b7\u30e7\u30f3\u8a18\u9332"
+        # cp932 エンコードされたバイト列で raw multipart body を構築
+        title_cp932 = japanese_title.encode("cp932")
+        boundary = "----Cp932TestBoundary"
+        file_content = b"# Test journal"
+        raw_body = (
+            b"--" + boundary.encode() + b"\r\n"
+            b'Content-Disposition: form-data; name="title"\r\n\r\n'
+            + title_cp932 + b"\r\n"
+            b"--" + boundary.encode() + b"\r\n"
+            b'Content-Disposition: form-data; name="repository"\r\n\r\n'
+            b"test-repo\r\n"
+            b"--" + boundary.encode() + b"\r\n"
+            b'Content-Disposition: form-data; name="file"; filename="test.md"\r\n'
+            b"Content-Type: text/markdown\r\n\r\n"
+            + file_content + b"\r\n"
+            b"--" + boundary.encode() + b"--\r\n"
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as raw_client:
+            with patch("rag.server._run_cli_subprocess", side_effect=capture_cli):
+                resp = await raw_client.post(
+                    "/upload/journal",
+                    content=raw_body,
+                    headers={
+                        "Content-Type": f"multipart/form-data; boundary={boundary}",
+                    },
+                )
+
+        assert resp.status_code == 200
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        title_idx = args.index("--title")
+        assert args[title_idx + 1] == japanese_title
+
 
 # --- インジェスト排他制御テスト ---
 
@@ -441,3 +520,51 @@ class TestUploadMaxFileSizeConfig:
 
         with pytest.raises(ValidationError):
             RAGSettings(**{**TEST_SETTINGS_DEFAULTS, "rag_upload_max_file_size_mb": 501})
+
+
+# --- _decode_form_value テスト ---
+
+
+class TestDecodeFormValue:
+    """Starlette Latin-1 フォールバック文字列の復元テスト."""
+
+    def test_ascii_string_unchanged(self) -> None:
+        """ASCII 文字列はそのまま返される."""
+        assert _decode_form_value("hello") == "hello"
+
+    def test_utf8_string_unchanged(self) -> None:
+        """正しい UTF-8 文字列はそのまま返される."""
+        assert _decode_form_value("日本語テキスト") == "日本語テキスト"
+
+    def test_cp932_latin1_fallback_restored(self) -> None:
+        """cp932 → Latin-1 フォールバック文字列が cp932 として復元される."""
+        # Starlette が cp932 バイト列を Latin-1 にフォールバックした文字列を模擬
+        original = "QA スキルの仕様書・スキル定義作成"
+        cp932_bytes = original.encode("cp932")
+        latin1_garbled = cp932_bytes.decode("latin-1")
+        assert _decode_form_value(latin1_garbled) == original
+
+    def test_utf8_latin1_fallback_restored(self) -> None:
+        """UTF-8 バイト列が Latin-1 フォールバックされた場合に正しく復元される."""
+        original = "日本語テキスト"
+        utf8_bytes = original.encode("utf-8")
+        latin1_garbled = utf8_bytes.decode("latin-1")
+        assert _decode_form_value(latin1_garbled) == original
+
+    def test_empty_string(self) -> None:
+        """空文字列はそのまま返される."""
+        assert _decode_form_value("") == ""
+
+    def test_mixed_ascii_and_non_ascii(self) -> None:
+        """ASCII と非 ASCII が混在する UTF-8 Latin-1 フォールバック文字列が復元される."""
+        original = "Title: テスト"
+        utf8_bytes = original.encode("utf-8")
+        latin1_garbled = utf8_bytes.decode("latin-1")
+        assert _decode_form_value(latin1_garbled) == original
+
+    def test_cp932_mixed_ascii_restored(self) -> None:
+        """ASCII と日本語が混在する cp932 Latin-1 フォールバックが復元される."""
+        original = "QA テストセッション記録"
+        cp932_bytes = original.encode("cp932")
+        latin1_garbled = cp932_bytes.decode("latin-1")
+        assert _decode_form_value(latin1_garbled) == original

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -568,3 +568,15 @@ class TestDecodeFormValue:
         cp932_bytes = original.encode("cp932")
         latin1_garbled = cp932_bytes.decode("latin-1")
         assert _decode_form_value(latin1_garbled) == original
+
+    def test_latin1_text_not_misidentified_as_cp932(self) -> None:
+        """正当な Latin-1 テキストが cp932 に誤変換されない."""
+        # \xa1 は Latin-1 では ¡ だが cp932 では ｡（半角句点）
+        # 日本語文字を含まないため cp932 デコード結果は採用されない
+        latin1_text = "\u00a1Hola!"  # "¡Hola!"
+        assert _decode_form_value(latin1_text) == latin1_text
+
+    def test_latin1_accented_text_unchanged(self) -> None:
+        """アクセント付き Latin-1 テキストがそのまま返される."""
+        latin1_text = "caf\u00e9 r\u00e9sum\u00e9"  # "café résumé"
+        assert _decode_form_value(latin1_text) == latin1_text


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正

## Summary

- Upload API で multipart/form-data の日本語メタデータが文字化けする問題を修正（バグ5）
  - Starlette の Latin-1 フォールバックで壊れた文字列を UTF-8/cp932 で復元する `_decode_form_value()` を追加
  - title, repository, entry_id, filename の全フォームフィールドに適用
- bm25s import 時の `resource module not available on Windows` 警告を抑制（バグ8）
  - `bm25_index.py` の `_rebuild_index()` と `_load()` 内で `redirect_stdout` ガードを集約
- バグ6（Embedding 初回リトライ）は現環境で再現せず、修正を破棄

## Test plan

- [x] `_decode_form_value` 単体テスト 7 件（ASCII, UTF-8, cp932, 空文字列, 混在）
- [x] 結合テスト 2 件（日本語タイトル CLI 伝搬, cp932 raw body 復元）
- [x] bm25_index テスト 19 件 PASS
- [x] ruff / mypy クリーン
- [x] 実機確認: HTTP サーバー + curl で日本語タイトル送信 → 文字化けなし
- [x] 実機確認: bm25s import 直接→警告あり、bm25_index.py 経由→抑制

## Related issues

Ref #430