### PR TITLE
feat(site-ingest): 正常完了後の一時ディレクトリ自動クリーンアップ (#442)

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -354,6 +354,18 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 
 `SITE_INGEST_TEMP_DIR` のデフォルト値は `.tmp/site_ingest`。`crawl_key` の詳細は「JOBDIR の分離」セクションを参照。
 
+### 正常完了後のクリーンアップ
+
+Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）全体を削除する。bridge 完了後は全データが source_store に配置済みであり、一時ファイルは不要。大規模サイトのクロールを繰り返すとディスクを圧迫するため、自動削除する。`download_only` の場合も bridge は完了しているため同様に削除する。
+
+クリーンアップの実行条件:
+
+| 条件 | クリーンアップ |
+|------|-------------|
+| Scrapy 正常完了 + bridge 完了 | 実行する（`download_only` の有無を問わない。bridge 完了時点で source_store に配置済み） |
+| Scrapy 異常終了（exit_code != 0） | 実行しない（JOBDIR によるレジュームを維持） |
+| クリーンアップ自体が失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする |
+
 ### 処理フロー
 
 ```mermaid
@@ -384,6 +396,7 @@ sequenceDiagram
         CMD->>PC: git commit（source_store のみ）
         Note over CMD: パイプライン処理（converter + indexer）をスキップ
     end
+    CMD->>CMD: クロールディレクトリ削除（Scrapy 正常完了時）
     CMD->>USER: 結果サマリー
 ```
 
@@ -430,6 +443,7 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
 | `download_only` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
 | 同一ドメインへの異なるパラメータでの複数回クロール | クロールキー（`start_url` + effective `url_pattern` のハッシュ）により JOBDIR が分離されるため、前回クロールの URL キューが残留しない |
+| 正常完了後のクリーンアップ失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする。一時ディレクトリは手動削除が必要 |
 
 ## 関連ドキュメント
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2417,6 +2417,10 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
         # download_only でもコミットは実行する（パイプライン処理のみスキップ）
         controller.commit(f"ingest(web): site-ingest {url} (download_only)")
 
+    # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
+    if crawl_result.success:
+        crawl_result.cleanup()
+
     # 操作全体の所要時間（クロール + Bridge + パイプライン）
     elapsed = time_mod.monotonic() - start_time
 

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -51,18 +51,22 @@ class CrawlResult:
         仕様: docs/specs/site-ingest.md「正常完了後のクリーンアップ」
         削除失敗時は警告ログを出力し、例外を送出しない。
         """
-        if not self.crawl_dir:
+        crawl_dir = self.crawl_dir
+        if not crawl_dir or not crawl_dir.exists():
             return
         try:
-            shutil.rmtree(self.crawl_dir)
+            shutil.rmtree(crawl_dir)
             # 親ディレクトリ（ドメイン）が空なら削除
-            parent = self.crawl_dir.parent
+            parent = crawl_dir.parent
             if parent.exists() and not any(parent.iterdir()):
                 parent.rmdir()
+        except FileNotFoundError:
+            # 競合状態などで既に削除されていた場合は正常扱い
+            return
         except OSError:
             logger.warning(
                 "クロールディレクトリの削除に失敗しました: %s",
-                self.crawl_dir,
+                crawl_dir,
                 exc_info=True,
             )
 

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -42,7 +42,29 @@ class CrawlResult:
     output_dir: Path
     jsonl_path: Path
     success: bool
+    crawl_dir: Path | None = None
     stderr_tail: str = ""
+
+    def cleanup(self) -> None:
+        """クロールディレクトリを削除する（正常完了後のクリーンアップ）.
+
+        仕様: docs/specs/site-ingest.md「正常完了後のクリーンアップ」
+        削除失敗時は警告ログを出力し、例外を送出しない。
+        """
+        if not self.crawl_dir:
+            return
+        try:
+            shutil.rmtree(self.crawl_dir)
+            # 親ディレクトリ（ドメイン）が空なら削除
+            parent = self.crawl_dir.parent
+            if parent.exists() and not any(parent.iterdir()):
+                parent.rmdir()
+        except OSError:
+            logger.warning(
+                "クロールディレクトリの削除に失敗しました: %s",
+                self.crawl_dir,
+                exc_info=True,
+            )
 
 
 class ScrapyRunner:
@@ -203,6 +225,7 @@ class ScrapyRunner:
             output_dir=html_dir,
             jsonl_path=jsonl_path,
             success=success,
+            crawl_dir=crawl_dir,
             stderr_tail=stderr_tail,
         )
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -969,7 +969,7 @@ async def rag_site_ingest(
 
         # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
         if crawl_result.success:
-            crawl_result.cleanup()
+            await asyncio.to_thread(crawl_result.cleanup)
 
         # 操作全体の所要時間（クロール + Bridge + パイプライン）
         elapsed = time_mod.monotonic() - start_time

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -967,6 +967,10 @@ async def rag_site_ingest(
                 controller.commit, f"ingest(web): site-ingest {url} (download_only)",
             )
 
+        # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
+        if crawl_result.success:
+            crawl_result.cleanup()
+
         # 操作全体の所要時間（クロール + Bridge + パイプライン）
         elapsed = time_mod.monotonic() - start_time
 

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -97,6 +97,7 @@ class TestCrawlResult:
         assert result.success is True
         assert result.exit_code == 0
         assert result.stderr_tail == ""
+        assert result.crawl_dir is None
 
     def test_failure_result(self, tmp_path: Path) -> None:
         """異常終了の CrawlResult."""
@@ -110,6 +111,56 @@ class TestCrawlResult:
         assert result.success is False
         assert result.exit_code == 1
         assert result.stderr_tail == "Error occurred"
+
+    def test_crawl_dir_field(self, tmp_path: Path) -> None:
+        """crawl_dir フィールドが設定できること."""
+        crawl_dir = tmp_path / "domain" / "key123"
+        result = CrawlResult(
+            exit_code=0,
+            output_dir=crawl_dir / "html",
+            jsonl_path=crawl_dir / "metadata.jsonl",
+            success=True,
+            crawl_dir=crawl_dir,
+        )
+        assert result.crawl_dir == crawl_dir
+
+    def test_cleanup_deletes_crawl_dir(self, tmp_path: Path) -> None:
+        """cleanup() がクロールディレクトリを削除すること."""
+        domain_dir = tmp_path / "domain"
+        crawl_dir = domain_dir / "key123"
+        crawl_dir.mkdir(parents=True)
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        result = CrawlResult(
+            exit_code=0, output_dir=crawl_dir / "html",
+            jsonl_path=crawl_dir / "metadata.jsonl",
+            success=True, crawl_dir=crawl_dir,
+        )
+        result.cleanup()
+        assert not crawl_dir.exists()
+        # 空の親ディレクトリも削除される
+        assert not domain_dir.exists()
+
+    def test_cleanup_noop_when_crawl_dir_none(self) -> None:
+        """crawl_dir が None の場合 cleanup() は何もしないこと."""
+        result = CrawlResult(
+            exit_code=0, output_dir=Path("/tmp/html"),
+            jsonl_path=Path("/tmp/metadata.jsonl"),
+            success=True, crawl_dir=None,
+        )
+        result.cleanup()  # 例外が発生しないこと
+
+    def test_cleanup_warns_on_oserror(self, tmp_path: Path) -> None:
+        """削除失敗時に警告ログを出力し例外を送出しないこと."""
+        crawl_dir = tmp_path / "domain" / "key123"
+        # crawl_dir を作成しない（rmtree が失敗する）
+        result = CrawlResult(
+            exit_code=0, output_dir=crawl_dir / "html",
+            jsonl_path=crawl_dir / "metadata.jsonl",
+            success=True, crawl_dir=crawl_dir,
+        )
+        # 例外が発生しないこと
+        result.cleanup()
 
 
 # --- _build_spider_script テスト ---

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -312,6 +312,156 @@ class TestMcpSiteIngestFlow:
             mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_cleanup_on_success(self, tmp_path: Path) -> None:
+        """正常完了時にクロールディレクトリが削除されること."""
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        crawl_dir = tmp_path / "crawl"
+        crawl_dir.mkdir()
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/page", "title": "Test", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "page.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+            crawl_dir=crawl_dir,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=1, skipped=0, errors=0),
+            total_lines=1,
+            parse_errors=0,
+        )
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+
+        mock_cli_result: dict[str, object] = {
+            "type": "result", "mode": "incremental",
+            "total_files": 1, "processed": 1, "skipped": 0, "errors": [], "elapsed": 0.1,
+        }
+
+        mod = import_module("rag.server")
+        with (
+            patch.object(mod, "get_settings", return_value=_make_mock_settings()),
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch.object(mod, "_get_pipeline_controller", new_callable=AsyncMock, return_value=mock_controller),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+            patch.object(mod, "_run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result),
+        ):
+            await mod.rag_site_ingest(url="https://example.com", url_pattern="", max_pages=10, force=False)
+            assert not crawl_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_no_cleanup_on_scrapy_failure(self, tmp_path: Path) -> None:
+        """Scrapy 異常終了時にクロールディレクトリが残ること."""
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        crawl_dir = tmp_path / "crawl"
+        crawl_dir.mkdir()
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/page", "title": "Test", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "page.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=1,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=False,
+            crawl_dir=crawl_dir,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=1, skipped=0, errors=0),
+            total_lines=1,
+            parse_errors=0,
+        )
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+
+        mock_cli_result: dict[str, object] = {
+            "type": "result", "mode": "incremental",
+            "total_files": 1, "processed": 1, "skipped": 0, "errors": [], "elapsed": 0.1,
+        }
+
+        mod = import_module("rag.server")
+        with (
+            patch.object(mod, "get_settings", return_value=_make_mock_settings()),
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch.object(mod, "_get_pipeline_controller", new_callable=AsyncMock, return_value=mock_controller),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+            patch.object(mod, "_run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result),
+        ):
+            await mod.rag_site_ingest(url="https://example.com", url_pattern="", max_pages=10, force=False)
+            assert crawl_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_download_only(self, tmp_path: Path) -> None:
+        """download_only 時もクロールディレクトリが削除されること."""
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        crawl_dir = tmp_path / "crawl"
+        crawl_dir.mkdir()
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/page", "title": "Test", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "page.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+            crawl_dir=crawl_dir,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=1, skipped=0, errors=0),
+            total_lines=1,
+            parse_errors=0,
+        )
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+
+        mod = import_module("rag.server")
+        with (
+            patch.object(mod, "get_settings", return_value=_make_mock_settings()),
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch.object(mod, "_get_pipeline_controller", new_callable=AsyncMock, return_value=mock_controller),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            await mod.rag_site_ingest(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=True)
+            assert not crawl_dir.exists()
+
+    @pytest.mark.asyncio
     async def test_partial_result_with_scrapy_failure(self, tmp_path: Path) -> None:
         """Scrapy が非0終了コードでも部分結果が返ること."""
         import json
@@ -589,6 +739,107 @@ class TestCliSiteIngestFlow:
             assert "2件スキップ" in captured.out
             assert "1件エラー" in captured.out
             assert "パイプライン: 5件処理" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_success(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """正常完了時にクロールディレクトリが削除されること."""
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        crawl_dir = tmp_path / "crawl"
+        crawl_dir.mkdir()
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+            crawl_dir=crawl_dir,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=1, skipped=0, errors=0),
+            total_lines=1,
+            parse_errors=0,
+        )
+
+        mock_pipeline_summary = MagicMock()
+        mock_pipeline_summary.processed = 1
+        mock_pipeline_summary.errors = []
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+        mock_controller.ingest_and_index.return_value = mock_pipeline_summary
+
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=False)
+
+        with (
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            from rag.cli import run_site_ingest
+
+            await run_site_ingest(args)
+            assert not crawl_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_download_only(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """download_only 時もクロールディレクトリが削除されること."""
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        crawl_dir = tmp_path / "crawl"
+        crawl_dir.mkdir()
+        (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+            crawl_dir=crawl_dir,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=1, skipped=0, errors=0),
+            total_lines=1,
+            parse_errors=0,
+        )
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+
+        args = argparse.Namespace(url="https://example.com", url_pattern="", max_pages=10, force=False, download_only=True)
+
+        with (
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            from rag.cli import run_site_ingest
+
+            await run_site_ingest(args)
+            assert not crawl_dir.exists()
 
     @pytest.mark.asyncio
     async def test_no_pipeline_when_zero_placed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- site-ingest（CLI / MCP）の正常完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）を自動削除する機能を追加
- `CrawlResult` に `crawl_dir` フィールドと `cleanup()` メソッドを追加し、削除ロジックを共通化
- Scrapy 異常終了時はレジューム用に一時ディレクトリを残す
- `download_only` 時も bridge 完了後は source_store に配置済みのため削除する
- 仕様書（site-ingest.md）にクリーンアップの実行条件テーブル・シーケンス図を追記

## Test plan

- [x] pytest 71 passed（test_scrapy_runner.py, test_scrapy_site_ingest.py）
- [x] ruff / mypy クリーン
- [x] CLI 動作確認: site-ingest 後に一時ディレクトリが削除されることを確認

## Related issues

Closes #442