### PR TITLE
docs: README の YouTube インジェスター注意セクションを仕様書に移動 (#447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ uv run python -m rag.server
 # CLI
 uv run python -m rag.cli --help
 ```
+
 ## Journal CLI
 
 ### 単一エントリ登録

--- a/README.md
+++ b/README.md
@@ -115,24 +115,6 @@ uv run python -m rag.server
 # CLI
 uv run python -m rag.cli --help
 ```
-
-## YouTube インジェスター利用時の注意
-
-YouTube インジェスターは非公式 API（youtube-transcript-api）を使用して字幕を取得する。短時間に多数のリクエストを送ると YouTube に IP をブロックされる場合がある。
-
-**実測データ（ローカル PC 環境）:**
-
-- 約 20 動画を 30 分間で取り込んだ時点で字幕取得 API（youtube-transcript-api）の IP ブロックが発生
-- ブロックは字幕取得 API（youtube-transcript-api）のみに影響し、メタデータ取得・音声ダウンロード（yt-dlp）は継続動作
-- IP ブロック時は Whisper フォールバックせずエラーとしてスキップされる（品質低下防止のため）
-- ブロックは一時的（通常は数十分〜数時間で解除）
-
-**推奨運用:**
-
-- プレイリスト一括取り込み時は `--max-videos` で段階的に取り込む（1 回あたり 10〜20 動画推奨）
-- `rag_youtube_request_interval`（デフォルト: 5.0 秒）を短くしすぎない
-- IP ブロックが発生した場合は時間を置いて再実行する
-
 ## Journal CLI
 
 ### 単一エントリ登録

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -60,6 +60,16 @@ youtube-transcript-api と yt-dlp はそれぞれ独自の HTTP クライアン�
 - **タイムアウト**: yt-dlp の `socket_timeout` オプションで制御する
 - **サーキットブレーカー**: インジェスター側で連続失敗をカウントし、5 回連続失敗で操作を中断する
 
+### IP ブロックリスク
+
+youtube-transcript-api は非公式 API を使用しており、短時間に多数のリクエストを送ると YouTube に IP をブロックされる場合がある。
+
+- IP ブロックは youtube-transcript-api のみに影響し、yt-dlp（メタデータ取得・音声ダウンロード）は継続動作する
+- ブロックは一時的で、通常は数十分〜数時間で解除される
+- プレイリスト一括取り込み時は `--max-videos` で段階的に取り込む（1 回あたり 10〜20 動画推奨）
+- `rag_youtube_request_interval`（デフォルト: 5.0 秒）を短くしすぎない
+- IP ブロックが発生した場合は時間を置いて再実行する
+
 ### 外部ツール依存
 
 - **FFmpeg**: yt-dlp の音声変換（`FFmpegExtractAudio`）に必要。Whisper フォールバック時に音声を WAV 形式に変換する際に使用する。未インストールの場合、音声文字起こしが失敗する


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- README.md から「YouTube インジェスター利用時の注意」セクションを削除
- `docs/specs/ingesters/youtube.md` の制約セクションに「IP ブロックリスク」サブセクションとして転記
- 実測データはスタイルガイド 6.6 により仕様書の記載対象外とした

## Test plan

- [x] markdownlint 通過
- [x] mermaid-lint（構文チェック）通過
- [x] mermaid-lint（GitHub 互換チェック）通過

## Related issues

Closes #447