### PR TITLE
feat(scheduled-rebuild): 定期 index rebuild バッチの導入 (#445, #455)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ git-flow ベースのブランチ戦略を採用。詳細は `~/.claude/docs/spe
 - [コンテンツ一覧取得](docs/specs/infrastructure/content-listing.md)
 - [コンテンツアップロード](docs/specs/infrastructure/content-upload.md)
 - [Upload HTTP API 認証](docs/specs/infrastructure/upload-auth.md)
+- [定期 index rebuild](docs/specs/infrastructure/scheduled-rebuild.md)
 
 ### インジェスター仕様
 

--- a/docs/specs/infrastructure/scheduled-rebuild.md
+++ b/docs/specs/infrastructure/scheduled-rebuild.md
@@ -1,0 +1,200 @@
+# 定期 index rebuild
+
+## 概要
+
+HNSW インデックスの品質劣化対策として、前回の index rebuild 以降に更新があった場合にのみ `rebuild --mode index` を自動実行する仕組みを提供する。
+
+スコープ:
+
+- `rebuild` コマンドの `--if-needed` オプション（条件付き実行）
+- `pipeline_history` テーブルへの `mode` 列追加（rebuild モード識別）
+- エラー時の Windows ダイアログ通知
+- Windows タスクスケジューラによる定期実行のセットアップ手順
+
+スコープ外:
+
+- rebuild の実行ロジック自体（パイプライン制御の範疇）
+- MCP/CLI の rebuild インターフェース定義（rebuild-stats.md の範疇）
+- HNSW インデックスの劣化メカニズム（Issue #443 で対応済み）
+
+## 背景
+
+逐次 upsert により HNSW グラフの接続品質が劣化し、ベクトル検索のリコールが低下する。パラメータ引き上げで軽減されるが、tombstone フラグメンテーションや到達不能ノードの問題はインデックス再構築でしかリセットできない。
+
+HNSW グラフの劣化はインデックス側の問題であり、ソースファイルの再変換は不要。`rebuild --mode index` で converted_store からインデックスのみ再構築すれば十分。
+
+手動での定期実行は運用負荷が高く忘れやすいため、タスクスケジューラによる自動化が必要。
+
+## 制約
+
+- **index モード限定**: 定期バッチで実行するのは `rebuild --mode index` のみ。full rebuild は手動実行とする
+- **更新判定の基準**: `pipeline_history` の `mode` 列を参照し、最後の `index` または `full` モードの実行以降に新しい `pipeline_history` レコード（`incremental` 等）が存在するかで判定する
+- **スキップ時の挙動**: 更新がない場合は rebuild を実行せず、正常終了する（exit code 0）
+- **排他制御**: 既存の rebuild ロック機構を使用する。ロック取得失敗時はエラーとする
+- **実行環境**: Windows 11 の開発マシンを前提とする
+
+本コンポーネント自体は外部 API 通信を行わないが、rebuild 実行時にパイプラインを通じて Embedding API 等の外部通信が発生する。外部 API の安全制約は各ステージの仕様に従うため、想定プロファイル・安全制約セクションは省略する。
+
+## インターフェース
+
+### `--if-needed` オプション
+
+既存の `rebuild` CLI コマンドに `--if-needed` フラグを追加する。
+
+```
+uv run python -m rag.cli rebuild --mode index --if-needed
+```
+
+| オプション | 型 | 必須 | 内容 |
+|-----------|-----|------|------|
+| `--if-needed` | flag | いいえ | 前回の index/full rebuild 以降に更新がなければスキップする |
+
+振る舞い:
+
+1. `pipeline_history` から最後の `index` または `full` モードのレコードを取得する
+2. そのレコードより後に他のモードのレコード（`incremental` 等）が存在するか確認する
+3. 存在すれば rebuild を実行、存在しなければスキップして正常終了する
+4. `pipeline_history` が空の場合（初回）は rebuild を実行する
+
+`--if-needed` は `--mode` が `index` または `full` の場合のみ有効。それ以外のモードで指定された場合はパラメータ検証エラーとする。
+
+### 所要時間の表示形式
+
+rebuild コマンドの所要時間表示を秒単位から時分秒表記に変更する。
+
+| 所要時間 | 表示例 |
+|---------|--------|
+| 60 秒未満 | `3.2 秒` |
+| 60 秒以上 60 分未満 | `2 分 15.0 秒` |
+| 60 分以上 | `1 時間 5 分 30.0 秒` |
+
+JSON 出力の `elapsed` フィールドは秒単位（数値）を維持する（機械処理向け）。テキスト出力のみ時分秒表記に変更する。
+
+### エラー通知
+
+rebuild 実行中にエラーが発生した場合、ログ出力に加えて Windows ダイアログを表示する。
+
+| 項目 | 内容 |
+|------|------|
+| 表示条件 | rebuild がエラーで終了した場合 |
+| ダイアログタイトル | `RAG Knowledge - Rebuild Error` |
+| ダイアログ内容 | エラーメッセージの要約 |
+| ダイアログ種別 | エラーアイコン付きメッセージボックス |
+
+ダイアログ表示は `--if-needed` 指定時のみ有効とする（対話的な手動実行ではターミナルで確認できるため不要）。
+
+非 Windows 環境ではダイアログ表示をスキップし、ログ出力のみとする。
+
+## コンポーネント構成
+
+### `--if-needed` の判定フロー
+
+```mermaid
+flowchart TD
+    START["rebuild --mode index --if-needed"]
+    GET_LAST["pipeline_history から最後の index/full レコードを取得"]
+    CHECK_EXIST{"レコードが存在する?"}
+    CHECK_NEWER{"それ以降に他のレコードがある?"}
+    SKIP["スキップ（正常終了）"]
+    EXEC["rebuild --mode index を実行"]
+    RESULT{"実行結果"}
+    SUCCESS["正常終了"]
+    ERROR_LOG["エラーログ出力"]
+    ERROR_DIALOG["Windows ダイアログ表示"]
+
+    START --> GET_LAST
+    GET_LAST --> CHECK_EXIST
+    CHECK_EXIST -- No --> EXEC
+    CHECK_EXIST -- Yes --> CHECK_NEWER
+    CHECK_NEWER -- No --> SKIP
+    CHECK_NEWER -- Yes --> EXEC
+    EXEC --> RESULT
+    RESULT -- 成功 --> SUCCESS
+    RESULT -- エラー --> ERROR_LOG
+    ERROR_LOG --> ERROR_DIALOG
+```
+
+### `pipeline_history` テーブルの拡張
+
+`mode` 列を追加し、rebuild 実行時のモードを記録する。
+
+| カラム | 型 | 制約 | 内容 |
+|--------|-----|------|------|
+| `mode` | TEXT | NOT NULL | 実行モード: `full`, `convert`, `index`, `incremental` |
+
+既存レコード（`mode` 列追加前）のマイグレーション: `ALTER TABLE pipeline_history ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'`。既存レコードは `incremental` として扱う（安全側に倒す: index rebuild が必要と判定される）。
+
+最後の index/full rebuild の取得:
+
+```
+SELECT id FROM pipeline_history
+WHERE mode IN ('index', 'full')
+ORDER BY id DESC LIMIT 1
+```
+
+それ以降のレコード存在確認:
+
+```
+SELECT EXISTS(
+  SELECT 1 FROM pipeline_history
+  WHERE id > :last_index_rebuild_id
+)
+```
+
+### 関連ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/rag/cli.py` | `--if-needed` オプション追加、所要時間の時分秒表記、エラー時 Windows ダイアログ |
+| `src/rag/store/metadata_db.py` | `pipeline_history` への `mode` 列追加、マイグレーション、判定クエリ |
+| `src/rag/pipeline/controller.py` | `pipeline_history` 記録時に `mode` を渡す |
+
+## タスクスケジューラ設定手順
+
+Windows タスクスケジューラで深夜に定期実行する設定手順。
+
+### 前提条件
+
+- ChromaDB サーバーが稼働していること（MCP サーバーが enabled であれば自動起動済み）
+- LM Studio が起動していること（Embedding API に必要）
+
+### 登録手順
+
+1. タスクスケジューラを開く（`taskschd.msc`）
+2. 「タスクの作成」を選択
+3. 以下の設定を行う:
+
+| タブ | 設定項目 | 値 |
+|------|---------|-----|
+| 全般 | 名前 | `RAG Knowledge - Index Rebuild` |
+| 全般 | ユーザーがログオンしているかどうかにかかわらず実行する | 有効 |
+| トリガー | スケジュール | 毎日、開始時刻は深夜帯（例: 3:00） |
+| 操作 | プログラム/スクリプト | プロジェクトの uv 実行パス |
+| 操作 | 引数の追加 | `run python -m rag.cli rebuild --mode index --if-needed` |
+| 操作 | 開始（オプション） | プロジェクトのルートディレクトリ |
+| 設定 | タスクを停止するまでの時間 | 1 時間 |
+
+### 確認方法
+
+手動でタスクを実行し、以下を確認する:
+
+- 更新がある場合: rebuild が実行され、所要時間が表示される
+- 更新がない場合: スキップされ、正常終了する
+- エラーの場合: ログ出力と Windows ダイアログが表示される
+
+## エッジケース
+
+| ケース | 振る舞い |
+|--------|---------|
+| `--if-needed` を `--mode incremental` と組み合わせた場合 | パラメータ検証エラーを返す |
+| `--if-needed` を `--mode convert` と組み合わせた場合 | パラメータ検証エラーを返す |
+| `pipeline_history` が空（初回実行）の場合 | rebuild を実行する |
+| ChromaDB サーバーが停止している場合 | rebuild エラー → ログ出力 + Windows ダイアログ |
+| LM Studio が停止している場合 | Embedding API エラー → ログ出力 + Windows ダイアログ |
+| 別の rebuild が実行中の場合 | ロック取得失敗 → エラー |
+
+## 関連ドキュメント
+
+- [rebuild-stats.md](../rebuild-stats.md) — 再構築 MCP/CLI インターフェース
+- [pipeline-controller.md](../pipeline-controller.md) — パイプライン制御仕様
+- [source-store.md](../source-store.md) — source_store 仕様（`pipeline_history` テーブル定義）

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -34,6 +34,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 24 | コンテンツ一覧取得 | source_type 別の最新ソース一覧取得 | [infrastructure/content-listing.md](infrastructure/content-listing.md) |
 | 25 | コンテンツアップロード | HTTP モードでのファイル直接アップロード（multipart/form-data） | [infrastructure/content-upload.md](infrastructure/content-upload.md) |
 | 26 | Upload HTTP API 認証 | API キー認証・バインドアドレス制約 | [infrastructure/upload-auth.md](infrastructure/upload-auth.md) |
+| 27 | 定期 index rebuild | 条件付き index rebuild の自動実行 | [infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) |
 
 ## 3. 技術スタック
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -87,8 +87,9 @@ uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>]
 |-----------|-----|------|------|
 | `--mode` | str | はい | 再構築モード: `full`、`convert`、`index`、`incremental` |
 | `--source-type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`local` |
+| `--if-needed` | flag | いいえ | 前回の index/full rebuild 以降に更新がなければスキップする。`--mode` が `index` または `full` の場合のみ有効 |
 
-MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適用する。
+MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適用する。`--if-needed` の詳細は [infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) を参照。
 
 ## コンポーネント構成
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -90,7 +90,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | ソース登録 | ソースメタデータ | なし | sources テーブルにレコードを挿入する |
 | ソース更新 | source_id、更新フィールド | なし | 指定レコードを更新する |
 | ソース検索 | 検索条件 | ソースメタデータのリスト | 条件に合致するレコードを返す |
-| パイプライン履歴追加 | from_commit_id、to_commit_id | なし | pipeline_history テーブルに実行履歴を追加する |
+| パイプライン履歴追加 | from_commit_id、to_commit_id、mode | なし | pipeline_history テーブルに実行履歴を追加する |
 | 最終コミット ID 取得 | なし | コミット ID | pipeline_history の最新行の `to_commit_id` を返す。履歴がない場合は null commit hash を返す |
 | DB 再構築 | なし | なし | source_store のファイルと .meta をスキャンし、metadata.db を再構築する |
 
@@ -415,6 +415,7 @@ source_store 内の全ファイルのメタデータ索引。
 | `from_commit_id` | TEXT | NOT NULL | 処理前のコミット ID。初回は null commit hash（40文字ゼロ） |
 | `to_commit_id` | TEXT | NOT NULL | 処理後のコミット ID |
 | `processed_at` | TEXT | NOT NULL | 処理日時（ISO 8601） |
+| `mode` | TEXT | NOT NULL | 実行モード: `full`, `convert`, `index`, `incremental` |
 
 - `last_commit_id` の取得: `SELECT to_commit_id FROM pipeline_history ORDER BY id DESC LIMIT 1`
 - 初回実行時の `from_commit_id` には git の null commit hash `0000000000000000000000000000000000000000`（40文字ゼロ）を使用する

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -90,7 +90,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | ソース登録 | ソースメタデータ | なし | sources テーブルにレコードを挿入する |
 | ソース更新 | source_id、更新フィールド | なし | 指定レコードを更新する |
 | ソース検索 | 検索条件 | ソースメタデータのリスト | 条件に合致するレコードを返す |
-| パイプライン履歴追加 | from_commit_id、to_commit_id、mode | なし | pipeline_history テーブルに実行履歴を追加する |
+| パイプライン履歴追加 | from_commit_id、to_commit_id、mode、processed_at | なし | pipeline_history テーブルに実行履歴を追加する |
 | 最終コミット ID 取得 | なし | コミット ID | pipeline_history の最新行の `to_commit_id` を返す。履歴がない場合は null commit hash を返す |
 | DB 再構築 | なし | なし | source_store のファイルと .meta をスキャンし、metadata.db を再構築する |
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1328,6 +1328,8 @@ def run_rebuild(args: argparse.Namespace) -> None:
         if json_out:
             _output_error(msg)
         print(f"エラー: {msg}", file=sys.stderr)
+        if if_needed:
+            _show_error_dialog(msg)
         raise SystemExit(1)
 
     has_error = False

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -371,6 +371,12 @@ def main() -> None:
         default=None,
         help="再構築前に source_store を git commit するメッセージ",
     )
+    rebuild_parser.add_argument(
+        "--if-needed",
+        action="store_true",
+        default=False,
+        help="前回 index/full rebuild 以降に更新がなければスキップ（index/full のみ有効）",
+    )
     _add_output_option(rebuild_parser)
     # stats サブコマンド
     subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
@@ -1198,6 +1204,43 @@ def run_get_document(args: argparse.Namespace) -> None:
         print(response)
 
 
+def _format_elapsed(seconds: float) -> str:
+    """所要時間を時分秒表記にフォーマットする.
+
+    仕様: docs/specs/infrastructure/scheduled-rebuild.md
+    """
+    if seconds < 60:
+        return f"{seconds:.1f} 秒"
+    minutes = int(seconds // 60)
+    secs = seconds % 60
+    if minutes < 60:
+        return f"{minutes} 分 {secs:.1f} 秒"
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours} 時間 {mins} 分 {secs:.1f} 秒"
+
+
+def _show_error_dialog(message: str) -> None:
+    """Windows エラーダイアログを表示する.
+
+    仕様: docs/specs/infrastructure/scheduled-rebuild.md
+
+    非 Windows 環境ではスキップする。
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        ctypes.windll.user32.MessageBoxW(
+            0,
+            message,
+            "RAG Knowledge - Rebuild Error",
+            0x10,  # MB_ICONERROR
+        )
+    except Exception:
+        logger.warning("Windows ダイアログの表示に失敗しました")
+
+
 def run_rebuild(args: argparse.Namespace) -> None:
     """再構築を実行する.
 
@@ -1216,6 +1259,7 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     mode: str = args.mode
     source_type: SourceType | None = args.source_type
+    if_needed: bool = args.if_needed
 
     # incremental + source_type のバリデーション
     if mode == "incremental" and source_type is not None:
@@ -1224,6 +1268,14 @@ def run_rebuild(args: argparse.Namespace) -> None:
         logger.error(
             "incremental モードでは source_type を指定できません"
         )
+        sys.exit(1)
+
+    # --if-needed は index/full のみ有効
+    if if_needed and mode not in ("index", "full"):
+        msg = "--if-needed は --mode index または --mode full でのみ使用できます"
+        if json_out:
+            _output_error(msg)
+        logger.error(msg)
         sys.exit(1)
 
     settings = get_settings()
@@ -1251,6 +1303,20 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
     controller = build_pipeline_controller(settings)
 
+    # --if-needed: 更新チェック（ロック取得前に判定）
+    if if_needed and not controller.db.needs_index_rebuild():
+        if json_out:
+            _output_result({
+                "mode": mode,
+                "skipped": True,
+                "reason": "前回の index/full rebuild 以降に更新がありません",
+            })
+        else:
+            logger.info(
+                "前回の index/full rebuild 以降に更新がありません（スキップ）"
+            )
+        return
+
     # rebuild ロック取得
     from .infrastructure.file_lock import LockAcquisitionError, rebuild_lock
 
@@ -1264,6 +1330,7 @@ def run_rebuild(args: argparse.Namespace) -> None:
         print(f"エラー: {msg}", file=sys.stderr)
         raise SystemExit(1)
 
+    has_error = False
     try:
         logger.info("再構築を開始します（モード: %s）", mode)
         if source_type:
@@ -1313,18 +1380,40 @@ def run_rebuild(args: argparse.Namespace) -> None:
                 "errors": summary.errors,
                 "elapsed": round(elapsed, 1),
             })
+            if summary.errors:
+                has_error = True
+                if if_needed:
+                    error_files = ", ".join(summary.errors)
+                    _show_error_dialog(
+                        f"rebuild --mode {mode} でエラーが発生しました。\n"
+                        f"エラーファイル: {error_files}"
+                    )
             return
 
         logger.info(
-            "再構築完了: %d 処理 / %d スキップ / %d エラー / %.1f 秒",
+            "再構築完了: %d 処理 / %d スキップ / %d エラー / %s",
             summary.processed,
             summary.skipped,
             len(summary.errors),
-            elapsed,
+            _format_elapsed(elapsed),
         )
         if summary.errors:
+            has_error = True
             for err_file in summary.errors:
                 logger.error("  エラーファイル: %s", err_file)
+    except Exception as e:
+        has_error = True
+        if if_needed:
+            _show_error_dialog(f"rebuild --mode {mode} でエラーが発生しました。\n{e}")
+        raise
+    else:
+        # 処理エラー（例外なしだがエラーファイルあり）
+        if has_error and if_needed:
+            error_files = ", ".join(summary.errors)
+            _show_error_dialog(
+                f"rebuild --mode {mode} でエラーが発生しました。\n"
+                f"エラーファイル: {error_files}"
+            )
     finally:
         lock.release()
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -194,6 +194,7 @@ class PipelineController:
                 from_commit_id=last_commit_id,
                 to_commit_id=head_commit,
                 processed_at=datetime.now(timezone.utc).isoformat(),
+                mode="incremental",
             )
 
         return summary
@@ -276,6 +277,7 @@ class PipelineController:
                 from_commit_id=NULL_COMMIT_HASH,
                 to_commit_id=to_commit,
                 processed_at=datetime.now(timezone.utc).isoformat(),
+                mode="full",
             )
 
         return PipelineSummary(
@@ -457,6 +459,19 @@ class PipelineController:
                 skipped += 1
             if progress_callback is not None:
                 progress_callback(processed + skipped, len(records), record.file_path)
+
+        # pipeline_history に記録（正常完了時のみ）
+        to_commit = ""
+        if self._git.has_commits():
+            to_commit = self._git.get_head_commit()
+
+        if not errors and to_commit:
+            self.db.add_pipeline_history(
+                from_commit_id=NULL_COMMIT_HASH,
+                to_commit_id=to_commit,
+                processed_at=datetime.now(timezone.utc).isoformat(),
+                mode="index",
+            )
 
         return PipelineSummary(
             mode=PipelineMode.INDEX_ONLY,

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS pipeline_history (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     from_commit_id TEXT NOT NULL,
     to_commit_id   TEXT NOT NULL,
-    processed_at   TEXT NOT NULL
+    processed_at   TEXT NOT NULL,
+    mode           TEXT NOT NULL DEFAULT 'incremental'
 );
 """
 
@@ -66,12 +67,26 @@ class MetadataDB:
     def initialize(self) -> None:
         """スキーマを初期化する."""
         self._connection.executescript(_SCHEMA_SQL)
+        self._migrate()
 
     def close(self) -> None:
         """接続を閉じる."""
         if self._conn is not None:
             self._conn.close()
             self._conn = None
+
+    def _migrate(self) -> None:
+        """既存テーブルのスキーマをマイグレーションする."""
+        # pipeline_history に mode 列を追加（既存レコードは incremental 扱い）
+        cursor = self._connection.execute("PRAGMA table_info(pipeline_history)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        if "mode" not in columns:
+            self._connection.execute(
+                "ALTER TABLE pipeline_history"
+                " ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'"
+            )
+            self._connection.commit()
+            logger.info("pipeline_history に mode 列を追加しました")
 
     def __enter__(self) -> MetadataDB:
         return self
@@ -254,14 +269,16 @@ class MetadataDB:
         from_commit_id: str,
         to_commit_id: str,
         processed_at: str,
+        mode: str = "incremental",
     ) -> None:
         """パイプライン実行履歴を追加する."""
         self._connection.execute(
             """\
-            INSERT INTO pipeline_history (from_commit_id, to_commit_id, processed_at)
-            VALUES (?, ?, ?)
+            INSERT INTO pipeline_history
+                (from_commit_id, to_commit_id, processed_at, mode)
+            VALUES (?, ?, ?, ?)
             """,
-            (from_commit_id, to_commit_id, processed_at),
+            (from_commit_id, to_commit_id, processed_at, mode),
         )
         self._connection.commit()
 
@@ -289,9 +306,40 @@ class MetadataDB:
                 from_commit_id=row["from_commit_id"],
                 to_commit_id=row["to_commit_id"],
                 processed_at=row["processed_at"],
+                mode=row["mode"],
             )
             for row in rows
         ]
+
+    def needs_index_rebuild(self) -> bool:
+        """前回の index/full rebuild 以降に更新があったかを判定する.
+
+        Returns:
+            True: rebuild が必要（更新あり or 履歴なし）
+            False: rebuild 不要（更新なし）
+        """
+        # 最後の index/full rebuild を取得
+        row = self._connection.execute(
+            "SELECT id FROM pipeline_history"
+            " WHERE mode IN ('index', 'full')"
+            " ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        if row is None:
+            # index/full rebuild の履歴なし → 必要
+            return True
+
+        last_id = row["id"]
+
+        # それ以降のレコードがあるか確認
+        newer = self._connection.execute(
+            "SELECT EXISTS("
+            "  SELECT 1 FROM pipeline_history WHERE id > ?"
+            ") as has_newer",
+            (last_id,),
+        ).fetchone()
+
+        return bool(newer["has_newer"])
 
     def checkpoint(self) -> None:
         """WAL をフラッシュする（バックアップ前に実行）."""

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -38,6 +38,7 @@ class PipelineHistoryRecord:
     from_commit_id: str
     to_commit_id: str
     processed_at: str
+    mode: str = "incremental"
 
 
 @dataclass

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -322,7 +322,7 @@ class TestConfigureAndRun:
         mod = import_module("rag.server")
         mock_settings = MagicMock()
         mock_settings.rag_transport = "http"
-        mock_settings.rag_http_host = "0.0.0.0"
+        mock_settings.rag_http_host = "127.0.0.1"
         mock_settings.rag_http_port = 9090
         mock_settings.rag_dns_rebinding_protection = True
 
@@ -333,7 +333,7 @@ class TestConfigureAndRun:
             _configure_and_run()
 
         mock_run.assert_called_once_with(transport="streamable-http")
-        assert mod.mcp.settings.host == "0.0.0.0"
+        assert mod.mcp.settings.host == "127.0.0.1"
         assert mod.mcp.settings.port == 9090
 
     def test_keyboard_interrupt_graceful_shutdown(self) -> None:

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from rag.cli import _format_elapsed
 from rag.pipeline.models import PipelineMode, PipelineSummary
 from rag.server import (
     CLISubprocessError,
@@ -677,3 +678,21 @@ async def test_rag_server_exposes_tools() -> None:
         "rag_list_recent",
     }
     assert tool_names == expected, f"Expected {expected}, got {tool_names}"
+
+
+# --- _format_elapsed テスト ---
+
+
+class TestFormatElapsed:
+    """所要時間の時分秒表記テスト."""
+
+    def test_seconds_only(self) -> None:
+        assert _format_elapsed(3.2) == "3.2 秒"
+        assert _format_elapsed(59.9) == "59.9 秒"
+
+    def test_minutes_and_seconds(self) -> None:
+        assert _format_elapsed(60.0) == "1 分 0.0 秒"
+        assert _format_elapsed(135.5) == "2 分 15.5 秒"
+
+    def test_hours_minutes_seconds(self) -> None:
+        assert _format_elapsed(3930.0) == "1 時間 5 分 30.0 秒"

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -329,6 +329,78 @@ class TestPipelineHistory:
         """checkpoint が例外なく実行できる."""
         db.checkpoint()
 
+    def test_add_pipeline_history_with_mode(self, db: MetadataDB) -> None:
+        """mode パラメータ付きで履歴を追加できる."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="abc",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="index",
+        )
+        history = db.get_pipeline_history()
+        assert len(history) == 1
+        assert history[0].mode == "index"
+
+    def test_add_pipeline_history_default_mode(self, db: MetadataDB) -> None:
+        """mode 未指定時は incremental がデフォルト."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="abc",
+            processed_at="2026-01-01T00:00:00Z",
+        )
+        history = db.get_pipeline_history()
+        assert history[0].mode == "incremental"
+
+    def test_needs_index_rebuild_empty_history(self, db: MetadataDB) -> None:
+        """履歴なしの場合 True を返す."""
+        assert db.needs_index_rebuild() is True
+
+    def test_needs_index_rebuild_after_index(self, db: MetadataDB) -> None:
+        """最後が index で以降レコードなしの場合 False を返す."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="index",
+        )
+        assert db.needs_index_rebuild() is False
+
+    def test_needs_index_rebuild_after_full(self, db: MetadataDB) -> None:
+        """最後が full で以降レコードなしの場合 False を返す."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="full",
+        )
+        assert db.needs_index_rebuild() is False
+
+    def test_needs_index_rebuild_incremental_after_index(self, db: MetadataDB) -> None:
+        """index 後に incremental がある場合 True を返す."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="index",
+        )
+        db.add_pipeline_history(
+            from_commit_id="c1",
+            to_commit_id="c2",
+            processed_at="2026-01-02T00:00:00Z",
+            mode="incremental",
+        )
+        assert db.needs_index_rebuild() is True
+
+    def test_needs_index_rebuild_only_incremental(self, db: MetadataDB) -> None:
+        """index/full がなく incremental のみの場合 True を返す."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="incremental",
+        )
+        assert db.needs_index_rebuild() is True
+
 
 class TestDeleteAllSources:
     """delete_all_sources のテスト."""


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] fix: バグ修正

## Summary

- `pipeline_history` テーブルに `mode` 列を追加し、rebuild モードを記録する
- `rebuild` CLI に `--if-needed` オプションを追加（前回 index/full rebuild 以降に更新がなければスキップ）
- rebuild 所要時間の表示を時分秒表記に改善
- `--if-needed` 実行時のエラーを Windows ダイアログで通知
- 仕様書 `docs/specs/infrastructure/scheduled-rebuild.md` を新規作成
- テスト `test_http_mode_calls_run_with_streamable_http` のバインドアドレスを修正 (#455)

## Test plan

- [x] ruff check 通過
- [x] mypy 通過
- [x] 全1496テスト PASS

## Related issues

Closes #445
Closes #455