### PR TITLE
fix(pipeline-controller): source_store の .gitignore にロックファイルを追加 (#458)

### DIFF
--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -13,16 +13,19 @@ import os
 import subprocess
 from pathlib import Path
 
+from rag.infrastructure.file_lock import INGEST_LOCK_FILENAME, REBUILD_LOCK_FILENAME
+
 logger = logging.getLogger(__name__)
 
-# metadata.db 関連ファイルの .gitignore 内容
-_GITIGNORE_CONTENT = """\
-metadata.db
-metadata.db-wal
-metadata.db-shm
-.rebuild.lock
-.ingest.lock
-"""
+# source_store の .gitignore に含めるエントリ
+_GITIGNORE_ENTRIES: list[str] = [
+    "metadata.db",
+    "metadata.db-wal",
+    "metadata.db-shm",
+    REBUILD_LOCK_FILENAME,
+    INGEST_LOCK_FILENAME,
+]
+_GITIGNORE_CONTENT = "\n".join(_GITIGNORE_ENTRIES) + "\n"
 
 
 class GitOperations:
@@ -191,9 +194,12 @@ class GitOperations:
             gitignore.write_text(_GITIGNORE_CONTENT, encoding="utf-8")
             return
         content = gitignore.read_text(encoding="utf-8")
+        existing_entries = {
+            line.strip() for line in content.splitlines() if line.strip()
+        }
         required_entries = [
-            line for line in _GITIGNORE_CONTENT.strip().splitlines()
-            if line and line not in content
+            entry for entry in _GITIGNORE_ENTRIES
+            if entry not in existing_entries
         ]
         if required_entries:
             if not content.endswith("\n"):

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -20,6 +20,8 @@ _GITIGNORE_CONTENT = """\
 metadata.db
 metadata.db-wal
 metadata.db-shm
+.rebuild.lock
+.ingest.lock
 """
 
 
@@ -183,16 +185,20 @@ class GitOperations:
         return entries
 
     def _ensure_gitignore(self) -> None:
-        """metadata.db を .gitignore に含めることを保証する."""
+        """必要なエントリを .gitignore に含めることを保証する."""
         gitignore = self._repo_dir / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text(_GITIGNORE_CONTENT, encoding="utf-8")
             return
         content = gitignore.read_text(encoding="utf-8")
-        if "metadata.db" not in content:
+        required_entries = [
+            line for line in _GITIGNORE_CONTENT.strip().splitlines()
+            if line and line not in content
+        ]
+        if required_entries:
             if not content.endswith("\n"):
                 content += "\n"
-            content += _GITIGNORE_CONTENT
+            content += "\n".join(required_entries) + "\n"
             gitignore.write_text(content, encoding="utf-8")
 
     def _run(self, cmd: list[str]) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- source_store の `.gitignore` に `.rebuild.lock` と `.ingest.lock` を追加
- `_ensure_gitignore` を改善し、既存の `.gitignore` にも不足エントリを追記するように変更
- これにより `rebuild --mode index --if-needed` がロックファイルを未追跡変更として検出して失敗する問題を修正

## Test plan

- [x] ruff check 通過
- [x] mypy 通過
- [x] pipeline_controller テスト 40件 PASS
- [x] クリーン環境での動作確認: add-document → rebuild --mode index --if-needed がエラーなく実行

## Related issues

Closes #458