### PR TITLE
docs(local): crawl_documents の配置パス仕様を実装に合わせて修正 (#393)

### DIFF
--- a/docs/specs/ingesters/local.md
+++ b/docs/specs/ingesters/local.md
@@ -69,7 +69,7 @@ Local インジェスターは、ローカルファイルシステム上のテ�
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
 | `rag_add_document` | `content`、`filename`、`encoding`（任意）、`upload_mode`（任意） | ファイルコンテンツを受け取り、source_store の `local/` に配置する。`upload_mode=fail`（デフォルト）では当日の配置先に同名ファイルが存在する場合エラーを返す。`upload_mode=replace` では上書きする |
-| `rag_crawl_documents` | `dir_path`、`pattern`（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括で source_store の `local/.upload/{date}/` 配下にコピーする。同日・同パスの再取り込み時は上書きする |
+| `rag_crawl_documents` | `dir_path`、`pattern`（任意）、`upload_mode`（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括で source_store の `local/.upload/{date}/` 配下にコピーする。`upload_mode=fail`（デフォルト）では同一配置先が既に存在するファイルは warning を出してスキップ（`skipped` に加算）し、`upload_mode=replace` の場合のみ同日・同パスの再取り込み時に上書きする |
 
 #### rag_add_document パラメータ
 
@@ -88,6 +88,7 @@ Local インジェスターは、ローカルファイルシステム上のテ�
 |-----------|-----|------|------|
 | `dir_path` | 文字列 | はい | 取り込み対象ディレクトリのパス（絶対パスまたは相対パス） |
 | `pattern` | 文字列 | いいえ | glob パターン。デフォルト: `**/*`（再帰的に全対応ファイルを検索） |
+| `upload_mode` | 文字列 | いいえ | 同一配置先が存在する場合の動作。`fail`（デフォルト）: スキップして warning ログ出力、`replace`: 上書き |
 
 パターンのバリデーション: `pattern` に `..` が含まれる場合、または絶対パス（`Path(pattern).is_absolute()` で判定。`/` 始まりおよび Windows ドライブレター形式の両方を検出）の場合はバリデーションエラーとして拒否する。加えて、glob マッチ結果の各ファイルを `Path.resolve()` で正規化した後、`dir_path` の配下であることを検証し、配下でないファイルは除外する。
 
@@ -132,7 +133,7 @@ source_store 内の相対パスを source_id として使用する。
 - `/home/user/project-docs/design/arch.md` → `source_store/local/.upload/YYYY/MM/DD/project-docs/design/arch.md`
 - source_id: `local/.upload/YYYY/MM/DD/project-docs/readme.md`、`local/.upload/YYYY/MM/DD/project-docs/design/arch.md`
 
-`.upload/{date}/` プレフィックスにより、手動配置ファイルや異なるディレクトリからの取り込みとのパス衝突を回避する。同一ディレクトリの再取り込み時は、同日であれば上書き、異日であれば別 source_id となる。
+`.upload/{date}/` プレフィックスにより、手動配置ファイルとのパス衝突を回避しつつ、日付が異なる取り込みは別 source_id となる。同一ディレクトリの再取り込み時は、同日であれば上書き、異日であれば別 source_id となる。また、同一日付かつ同じ末尾コンポーネント名（`dir_basename`）を持つ異なるディレクトリを取り込んだ場合は、配置先パスが衝突し、後から取り込んだ内容で上書きされる可能性がある。
 
 #### 手動配置との共存
 

--- a/docs/specs/ingesters/local.md
+++ b/docs/specs/ingesters/local.md
@@ -69,7 +69,7 @@ Local インジェスターは、ローカルファイルシステム上のテ�
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
 | `rag_add_document` | `content`、`filename`、`encoding`（任意）、`upload_mode`（任意） | ファイルコンテンツを受け取り、source_store の `local/` に配置する。`upload_mode=fail`（デフォルト）では当日の配置先に同名ファイルが存在する場合エラーを返す。`upload_mode=replace` では上書きする |
-| `rag_crawl_documents` | `dir_path`、`pattern`（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括で source_store の `local/` にコピーする。同一パスの再取り込み時は上書きする |
+| `rag_crawl_documents` | `dir_path`、`pattern`（任意） | 指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、一括で source_store の `local/.upload/{date}/` 配下にコピーする。同日・同パスの再取り込み時は上書きする |
 
 #### rag_add_document パラメータ
 
@@ -108,7 +108,7 @@ Local インジェスターは、ローカルファイルシステム上のテ�
 
 source_store 内の相対パスを source_id として使用する。
 
-- 例: `local/resume.pdf`、`local/project-docs/readme.md`
+- 例: `local/.upload/2026/03/29/resume.pdf`、`local/.upload/2026/03/29/project-docs/readme.md`
 - source_id は配置先のパスから自動的に決定される
 
 ### ファイル配置規則
@@ -125,16 +125,18 @@ source_store 内の相対パスを source_id として使用する。
 
 #### ディレクトリ一括（`rag_crawl_documents`）
 
-`dir_path` の末尾コンポーネント名をサブディレクトリとし、ディレクトリ内の相対パス構造を保持して `local/{dir_basename}/{relative_path}` に配置する。
+`rag_add_document` と同じ `.upload/{date}/` 名前空間を使用し、`dir_path` の末尾コンポーネント名をサブディレクトリとして、ディレクトリ内の相対パス構造を保持して `local/.upload/YYYY/MM/DD/{dir_basename}/{relative_path}` に配置する。
 
 - 入力: `dir_path=/home/user/project-docs/`、`pattern=**/*.md`
-- `/home/user/project-docs/readme.md` → `source_store/local/project-docs/readme.md`
-- `/home/user/project-docs/design/arch.md` → `source_store/local/project-docs/design/arch.md`
-- source_id: `local/project-docs/readme.md`、`local/project-docs/design/arch.md`
+- `/home/user/project-docs/readme.md` → `source_store/local/.upload/YYYY/MM/DD/project-docs/readme.md`
+- `/home/user/project-docs/design/arch.md` → `source_store/local/.upload/YYYY/MM/DD/project-docs/design/arch.md`
+- source_id: `local/.upload/YYYY/MM/DD/project-docs/readme.md`、`local/.upload/YYYY/MM/DD/project-docs/design/arch.md`
+
+`.upload/{date}/` プレフィックスにより、手動配置ファイルや異なるディレクトリからの取り込みとのパス衝突を回避する。同一ディレクトリの再取り込み時は、同日であれば上書き、異日であれば別 source_id となる。
 
 #### 手動配置との共存
 
-ユーザーが `source_store/local/` 配下に手動でファイルやフォルダを配置することも可能。手動配置ファイルはパイプライン制御の差分更新で自動的に検出・処理される。MCP ツール経由の配置と手動配置は同じディレクトリ構造を共有する。
+ユーザーが `source_store/local/` 配下に手動でファイルやフォルダを配置することも可能。手動配置ファイルはパイプライン制御の差分更新で自動的に検出・処理される。MCP ツール経由の配置（`local/.upload/` 配下）と手動配置（`local/` 直下の任意パス）は名前空間が分離されているため、パス衝突は発生しない。
 
 ### 重複検出
 
@@ -234,7 +236,7 @@ flowchart TD
     SORT["パスの辞書順でソート"]
     CHECK_LIMIT{"ファイル数上限（100件）超過?"}
     CLAMP["先頭100件にクランプ + 警告ログ"]
-    LOOP["各ファイルを順次 source_store/local/ にコピー"]
+    LOOP["各ファイルを順次 source_store/local/.upload/YYYY/MM/DD/ にコピー"]
     NOTIFY["パイプライン制御に完了通知"]
     RESULT["結果サマリーを返却"]
 
@@ -287,7 +289,7 @@ flowchart TD
 7. 対応拡張子でフィルタする
 8. パスの辞書順でソートする
 9. ファイル数がハードリミット（100 件）を超える場合、先頭 100 件にクランプし警告ログを出力する
-10. 各ファイルを `source_store/local/{dir_basename}/{relative_path}` にコピーする
+10. 各ファイルを `source_store/local/.upload/YYYY/MM/DD/{dir_basename}/{relative_path}` にコピーする
 11. 個別ファイルのコピーエラーは該当ファイルをスキップし、他のファイルの処理を続行する
 12. 全ファイルのコピー完了後、パイプライン制御に取り込み完了を通知する
 13. 結果サマリーを返す（処理ファイル数、スキップ数、エラー数）


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- `crawl_documents` の配置パス仕様を実装に合わせて `local/.upload/YYYY/MM/DD/{dir_basename}/{relative_path}` に修正
- source_id の例、処理フロー図、手動配置との共存セクションを更新
- `.upload/{date}/` プレフィックスによるパス衝突回避の設計意図を明記

## Test plan

- [x] ドキュメントレビュー通過
- [x] markdownlint・mermaid-lint 通過

## Related issues

Closes #393