### PR TITLE
fix(upload-auth): RAG_DNS_REBINDING_PROTECTION=false 時に 0.0.0.0 バインドを許可 (#464)

### DIFF
--- a/docs/specs/infrastructure/upload-auth.md
+++ b/docs/specs/infrastructure/upload-auth.md
@@ -44,7 +44,7 @@ API キーが平文で通信経路に流れることを防止する目的で、�
 | 上記以外（パブリックアドレス） | 起動拒否 | 許可 |
 
 - **`0.0.0.0` の扱い**: 全インターフェースでバインドするため、意図しない外部公開のリスクがある。
-  デフォルト（`RAG_DNS_REBINDING_PROTECTION=true`）では起動を拒否する。
+  推奨設定値（`RAG_DNS_REBINDING_PROTECTION=true`）では起動を拒否する。
   `RAG_DNS_REBINDING_PROTECTION=false` を明示的に設定した場合は、
   利用者がリスクを理解した上での運用とみなし、`0.0.0.0` バインドを許可する。
   この場合、バインドアドレス検証の許可に加え、FastMCP の DNS rebinding protection も無効化する。
@@ -125,7 +125,7 @@ HTTP モードでのサーバー起動時に、バインドアドレスの安全
 
 本仕様で新たに追加する設定項目はない。
 API キーは keyring で管理し、バインドアドレスは既存の `rag_http_host`（`.env` では `RAG_HTTP_HOST`）を使用する。
-バインドアドレス検証では `rag_dns_rebinding_protection`（`.env` では `RAG_DNS_REBINDING_PROTECTION`、デフォルト: `true`）も参照する。
+バインドアドレス検証では `rag_dns_rebinding_protection`（`.env` では `RAG_DNS_REBINDING_PROTECTION`、推奨値: `true`）も参照する。
 設定項目自体は rag-knowledge.md で定義済み。
 
 ## コンポーネント構成

--- a/docs/specs/infrastructure/upload-auth.md
+++ b/docs/specs/infrastructure/upload-auth.md
@@ -39,10 +39,16 @@ API キーが平文で通信経路に流れることを防止する目的で、�
 |---|---|---|
 | `127.0.0.1` / `localhost` | 許可 | 許可 |
 | プライベートアドレス（`ipaddress.is_private` 判定: RFC 1918、リンクローカル、CGNAT 等） | 許可 | 許可 |
-| `0.0.0.0` | 起動拒否 | 起動拒否 |
+| `0.0.0.0`（`RAG_DNS_REBINDING_PROTECTION=true`） | 起動拒否 | 起動拒否 |
+| `0.0.0.0`（`RAG_DNS_REBINDING_PROTECTION=false`） | 許可 | 許可 |
 | 上記以外（パブリックアドレス） | 起動拒否 | 許可 |
 
-- **`0.0.0.0` の拒否理由**: 全インターフェースでバインドするため、意図しない外部公開のリスクがある。LAN 内の他マシンからアクセスする場合は、具体的なプライベート IP アドレスを指定する
+- **`0.0.0.0` の扱い**: 全インターフェースでバインドするため、意図しない外部公開のリスクがある。
+  デフォルト（`RAG_DNS_REBINDING_PROTECTION=true`）では起動を拒否する。
+  `RAG_DNS_REBINDING_PROTECTION=false` を明示的に設定した場合は、
+  利用者がリスクを理解した上での運用とみなし、`0.0.0.0` バインドを許可する。
+  この場合、バインドアドレス検証の許可に加え、FastMCP の DNS rebinding protection も無効化する。
+  LAN 内の他マシンからアクセスする場合は、具体的なプライベート IP アドレスの指定を推奨する
 - **HTTPS 未実装の現状**: HTTPS（TLS）対応は #449 で実装予定。現時点ではパブリックアドレスでの運用は不可
 - **stdio モードへの影響なし**: バインドアドレス検証は HTTP モードでのみ実行する
 
@@ -110,14 +116,17 @@ HTTP モードでのサーバー起動時に、バインドアドレスの安全
 検証フロー:
 
 1. `rag_http_host` の値を取得する
-2. `0.0.0.0` の場合: エラーメッセージを出力して起動を拒否する
+2. `0.0.0.0` の場合: `rag_dns_rebinding_protection` が `true` なら起動を拒否する。`false` なら許可する
 3. `127.0.0.1` または `localhost` の場合: 許可する
 4. プライベートアドレス（`ipaddress.is_private` 判定）の場合: 許可する
 5. 上記以外（パブリックアドレス）の場合: HTTPS が設定されていなければ起動を拒否する
 
 ### 設定項目
 
-本仕様で新たに追加する設定項目はない。API キーは keyring で管理し、バインドアドレスは既存の `rag_http_host`（`.env` では `RAG_HTTP_HOST`）を使用する。
+本仕様で新たに追加する設定項目はない。
+API キーは keyring で管理し、バインドアドレスは既存の `rag_http_host`（`.env` では `RAG_HTTP_HOST`）を使用する。
+バインドアドレス検証では `rag_dns_rebinding_protection`（`.env` では `RAG_DNS_REBINDING_PROTECTION`、デフォルト: `true`）も参照する。
+設定項目自体は rag-knowledge.md で定義済み。
 
 ## コンポーネント構成
 
@@ -181,7 +190,8 @@ flowchart TB
 
 | ケース | 振る舞い |
 |--------|---------|
-| `rag_http_host=0.0.0.0` | 起動拒否。エラーメッセージに具体的なプライベート IP の指定を案内する |
+| `rag_http_host=0.0.0.0`、`rag_dns_rebinding_protection=true` | 起動拒否。エラーメッセージに具体的なプライベート IP の指定、または `RAG_DNS_REBINDING_PROTECTION=false` の設定を案内する |
+| `rag_http_host=0.0.0.0`、`rag_dns_rebinding_protection=false` | 許可 |
 | `rag_http_host` がパブリックアドレスで HTTPS 未設定 | 起動拒否。エラーメッセージに HTTPS の必要性を案内する |
 | `rag_http_host` がパブリックアドレスで HTTPS 設定済み | 許可（#449 実装後に有効） |
 | stdio モードでのバインドアドレス検証 | 検証しない（HTTP モードでのみ実行） |

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -2058,7 +2058,9 @@ async def upload_journal(request: Request) -> Response:
         return _upload_error(500, "インジェスト処理中にエラーが発生しました")
 
 
-def _validate_bind_address(host: str) -> str | None:
+def _validate_bind_address(
+    host: str, *, dns_rebinding_protection: bool
+) -> str | None:
     """HTTP モードのバインドアドレスを検証する.
 
     仕様: docs/specs/infrastructure/upload-auth.md
@@ -2069,11 +2071,14 @@ def _validate_bind_address(host: str) -> str | None:
     import ipaddress
 
     if host == "0.0.0.0":
-        return (
-            "Binding to 0.0.0.0 is not allowed. "
-            "Use a specific private IP address (e.g., 192.168.x.x) "
-            "for LAN access, or 127.0.0.1 for local access."
-        )
+        if dns_rebinding_protection:
+            return (
+                "Binding to 0.0.0.0 is not allowed. "
+                "Use a specific private IP address (e.g., 192.168.x.x) "
+                "for LAN access, or 127.0.0.1 for local access. "
+                "Or set RAG_DNS_REBINDING_PROTECTION=false to allow 0.0.0.0."
+            )
+        return None
 
     if host in ("127.0.0.1", "localhost"):
         return None
@@ -2137,7 +2142,10 @@ def _configure_and_run() -> None:
 
     # HTTP モードの事前検証（外部依存の起動前に設定の妥当性を確認する）
     if transport == "http":
-        bind_error = _validate_bind_address(settings.rag_http_host)
+        bind_error = _validate_bind_address(
+            settings.rag_http_host,
+            dns_rebinding_protection=settings.rag_dns_rebinding_protection,
+        )
         if bind_error is not None:
             logger.error(bind_error)
             raise SystemExit(1)

--- a/tests/test_upload_auth.py
+++ b/tests/test_upload_auth.py
@@ -4,7 +4,7 @@
 
 テスト方針:
 - API キー検証（ヘッダー未指定、値不正、一致、keyring エラー）
-- バインドアドレス検証（0.0.0.0 拒否、localhost 許可、プライベート許可、パブリック拒否）
+- バインドアドレス検証（0.0.0.0 拒否/許可、localhost 許可、プライベート許可、パブリック拒否）
 - API キー未登録時の起動拒否
 - generate-api-key CLI サブコマンド（表示のみ、--save、--force、既存キーの上書き確認）
 """
@@ -157,41 +157,59 @@ class TestCheckApiKey:
 class TestValidateBindAddress:
     """_validate_bind_address のテスト."""
 
-    def test_0000_is_rejected(self) -> None:
-        """0.0.0.0 は拒否される."""
-        result = _validate_bind_address("0.0.0.0")
+    def test_0000_is_rejected_with_protection(self) -> None:
+        """0.0.0.0 は dns_rebinding_protection=True で拒否される."""
+        result = _validate_bind_address("0.0.0.0", dns_rebinding_protection=True)
         assert result is not None
         assert "0.0.0.0" in result
+        assert "RAG_DNS_REBINDING_PROTECTION=false" in result
+
+    def test_0000_is_allowed_without_protection(self) -> None:
+        """0.0.0.0 は dns_rebinding_protection=False で許可される."""
+        assert (
+            _validate_bind_address("0.0.0.0", dns_rebinding_protection=False) is None
+        )
 
     def test_localhost_is_allowed(self) -> None:
         """localhost は許可される."""
-        assert _validate_bind_address("localhost") is None
+        assert (
+            _validate_bind_address("localhost", dns_rebinding_protection=True) is None
+        )
 
     def test_127001_is_allowed(self) -> None:
         """127.0.0.1 は許可される."""
-        assert _validate_bind_address("127.0.0.1") is None
+        assert (
+            _validate_bind_address("127.0.0.1", dns_rebinding_protection=True) is None
+        )
 
     def test_private_rfc1918_10_is_allowed(self) -> None:
         """10.x.x.x プライベートアドレスは許可される."""
-        assert _validate_bind_address("10.0.0.1") is None
+        assert (
+            _validate_bind_address("10.0.0.1", dns_rebinding_protection=True) is None
+        )
 
     def test_private_rfc1918_172_is_allowed(self) -> None:
         """172.16.x.x プライベートアドレスは許可される."""
-        assert _validate_bind_address("172.16.0.1") is None
+        assert (
+            _validate_bind_address("172.16.0.1", dns_rebinding_protection=True) is None
+        )
 
     def test_private_rfc1918_192_is_allowed(self) -> None:
         """192.168.x.x プライベートアドレスは許可される."""
-        assert _validate_bind_address("192.168.1.100") is None
+        assert (
+            _validate_bind_address("192.168.1.100", dns_rebinding_protection=True)
+            is None
+        )
 
     def test_public_address_is_rejected_without_https(self) -> None:
         """パブリックアドレスは HTTPS なしで拒否される."""
-        result = _validate_bind_address("8.8.8.8")
+        result = _validate_bind_address("8.8.8.8", dns_rebinding_protection=True)
         assert result is not None
         assert "HTTPS" in result
 
     def test_hostname_is_rejected_without_https(self) -> None:
         """ホスト名（IP でない文字列）は HTTPS なしで拒否される."""
-        result = _validate_bind_address("myhost.local")
+        result = _validate_bind_address("myhost.local", dns_rebinding_protection=True)
         assert result is not None
         assert "HTTPS" in result
 


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [x] fix: バグ修正 ★
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- `_validate_bind_address` に `dns_rebinding_protection` パラメータを追加し、`RAG_DNS_REBINDING_PROTECTION=false` 時に `0.0.0.0` バインドを許可するよう修正
- upload-auth 仕様書のバインドアドレス制約テーブル・検証フロー・エッジケースに `RAG_DNS_REBINDING_PROTECTION` による条件分岐を追記
- テストに `dns_rebinding_protection=False` のケースを追加し、既存テストのシグネチャを更新

## Test plan

- [x] `TestValidateBindAddress` 全 9 テスト PASSED
- [x] `test_upload_auth.py` 全 25 テスト PASSED
- [x] ruff / mypy クリア
- [x] `RAG_DNS_REBINDING_PROTECTION=true` + `0.0.0.0` → 起動拒否を確認
- [x] `RAG_DNS_REBINDING_PROTECTION=false` + `0.0.0.0` → 起動成功を確認

## Related issues

Closes #464