### PR TITLE
docs(qa-skill): F グループ HTTP サーバー手順明示・テストケース不備修正 (#465, #466)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -168,6 +168,7 @@ NG を検出した場合、Issue 起票を提案する。
 - `.qa/pdf_add_test.pdf` — PDF 取り込みテスト用
 - `.qa/journal_add_test.md` — add-journal テスト用
 - `.qa/journal_upload_test.md` — Upload journal テスト用
+- `.qa/upload_doc_test.md` — Upload document テスト用
 - `.qa/journals/` — migrate-journal テスト用（ジャーナル 10 件）
 
 | グループ | リソース | 値 |
@@ -187,7 +188,7 @@ NG を検出した場合、Issue 起票を提案する。
 | E) Aozora | 著者検索キーワード | `太宰`（「太宰 治」にマッチ） |
 | E) Aozora | person_id | `000035`（太宰治） |
 | E) Aozora | book_id | `001567`（走れメロス） |
-| F) Upload | document | リポジトリの `README.md` |
+| F) Upload | document | `.qa/upload_doc_test.md`（Upload 専用テストファイル） |
 | F) Upload | journal | `.qa/journal_upload_test.md`（`title: "QA スキルの仕様書・スキル定義作成"` `repository: rag-knowledge`） |
 | G) Eval | フィクスチャ | メモリ `reference_eval_fixtures.md` を参照 |
 | G) Eval | init-test-db パラメータ | `--chunk-size 200 --chunk-overlap 30 --bm25-k1 1.5 --bm25-b 0.75` |
@@ -256,25 +257,80 @@ MCP 対応: `rag_add_youtube` / `rag_crawl_youtube`
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `update-aozora-catalog` | カタログ CSV が source_store に配置される | `none` |
-| 2 | `search-aozora --author 太宰` | 結果に `001567`（走れメロス）が含まれる | `none` |
+| 2 | `search-aozora --author 太宰 --limit 300` | 結果に `001567`（走れメロス）が含まれる | `none` |
 | 3 | `ingest-aozora 001567` | 作品 1 件取り込み成功 | `ingest` |
 
 MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
 ### F) Upload（HTTP モード固定）
 
-HTTP モードで MCP サーバーを起動して実行:
+#### グループ準備
+
+1. `.env` の `RAG_TRANSPORT` を `http` に変更する
+2. API キーが keyring に登録済みか確認する:
+
+   ```bash
+   uv run python -c "
+   from rag.config import UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME
+   import keyring
+   key = keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME)
+   print('OK: API key found' if key else 'NG: API key not found')
+   "
+   ```
+
+   未登録の場合は `uv run python -m rag.cli generate-api-key --save` で生成・保存する
+
+3. API キーをテンポラリファイルに書き出す（curl コマンドで使用）:
+
+   ```bash
+   uv run python -c "
+   from rag.config import UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME
+   import keyring
+   print(keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME))
+   " > /tmp/qa_api_key.txt
+   ```
+
+4. HTTP サーバーを起動する:
+
+   ```bash
+   uv run python -m rag.server &
+   ```
+
+5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
+
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/
+   ```
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
 
+全リクエストに API キーヘッダー（`-H "X-API-Key: $(cat /tmp/qa_api_key.txt)"`）を付与する。
+
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
-| 3 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
-| 4 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
-| 6 | ステップ 1 のコマンドを `&` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+| 1 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 6 | 下記の並行リクエストコマンドを実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+
+F-6 並行リクエストコマンド（API キーをファイル経由で共有し、バックグラウンドプロセスへの変数伝搬問題を回避する）:
+
+```bash
+(curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
+  > /tmp/upload_bg.txt 2>&1 &) \
+&& curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
+&& sleep 5 && cat /tmp/upload_bg.txt
+```
+
+#### グループ片付け
+
+1. HTTP サーバーを停止する
+2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
+3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 
 ### G) Eval（CLI 固定）
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -257,7 +257,7 @@ MCP 対応: `rag_add_youtube` / `rag_crawl_youtube`
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `update-aozora-catalog` | カタログ CSV が source_store に配置される | `none` |
-| 2 | `search-aozora --author 太宰 --limit 300` | 結果に `001567`（走れメロス）が含まれる | `none` |
+| 2 | `search-aozora --author 太宰 --limit 100` | 結果に `001567`（走れメロス）が含まれる | `none` |
 | 3 | `ingest-aozora 001567` | 作品 1 件取り込み成功 | `ingest` |
 
 MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
@@ -266,7 +266,12 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
 #### グループ準備
 
-1. `.env` の `RAG_TRANSPORT` を `http` に変更する
+1. `.env` の `RAG_TRANSPORT` の現在の値を退避し、`http` に変更する:
+
+   ```bash
+   grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
+   ```
+
 2. API キーが keyring に登録済みか確認する:
 
    ```bash
@@ -291,16 +296,17 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
    chmod 600 /tmp/qa_api_key.txt
    ```
 
-4. HTTP サーバーを起動する:
+4. HTTP サーバーを起動し、PID を記録する:
 
    ```bash
    uv run python -m rag.server &
+   echo $! > /tmp/qa_rag_server.pid
    ```
 
 5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
 
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/upload/document
    ```
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
@@ -331,9 +337,9 @@ cat /tmp/upload_bg.txt
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する: `pkill -f "python -m rag.server" 2>/dev/null || true`
-2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
-3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
+1. HTTP サーバーを停止する（起動時に記録した PID を使用）: `if [ -f /tmp/qa_rag_server.pid ]; then kill "$(cat /tmp/qa_rag_server.pid)" 2>/dev/null || true; rm -f /tmp/qa_rag_server.pid; fi`
+2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する（ステップ 1 で退避した値を使用）
+3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
 
 ### G) Eval（CLI 固定）
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -288,6 +288,7 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
    import keyring
    print(keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME))
    " > /tmp/qa_api_key.txt
+   chmod 600 /tmp/qa_api_key.txt
    ```
 
 4. HTTP サーバーを起動する:
@@ -308,27 +309,29 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
-| 3 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
-| 4 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 1 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
 | 6 | 下記の並行リクエストコマンドを実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
 
 F-6 並行リクエストコマンド（API キーをファイル経由で共有し、バックグラウンドプロセスへの変数伝搬問題を回避する）:
 
 ```bash
-(curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:<RAG_HTTP_PORT>/upload/document \
   -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
-  > /tmp/upload_bg.txt 2>&1 &) \
-&& curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
-  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
-&& sleep 5 && cat /tmp/upload_bg.txt
+  > /tmp/upload_bg.txt 2>&1 &
+bg_pid=$!
+curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:<RAG_HTTP_PORT>/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"
+wait "$bg_pid"
+cat /tmp/upload_bg.txt
 ```
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する
+1. HTTP サーバーを停止する: `pkill -f "python -m rag.server" 2>/dev/null || true`
 2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
 3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -270,6 +270,7 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
    ```bash
    grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
+   sed -i 's/^RAG_TRANSPORT=.*/RAG_TRANSPORT=http/' .env
    ```
 
 2. API キーが keyring に登録済みか確認する:
@@ -303,11 +304,13 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
    echo $! > /tmp/qa_rag_server.pid
    ```
 
-5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
+5. サーバーの起動を待機する（起動に数秒かかる場合がある）:
 
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/upload/document
+   sleep 5
    ```
+
+   起動確認は F-1（最初のリクエスト）で HTTP 200 が返ることをもって行う。
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
 
@@ -338,7 +341,7 @@ cat /tmp/upload_bg.txt
 #### グループ片付け
 
 1. HTTP サーバーを停止する（起動時に記録した PID を使用）: `if [ -f /tmp/qa_rag_server.pid ]; then kill "$(cat /tmp/qa_rag_server.pid)" 2>/dev/null || true; rm -f /tmp/qa_rag_server.pid; fi`
-2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する（ステップ 1 で退避した値を使用）
+2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する: `if [ -f /tmp/qa_original_transport.txt ]; then sed -i "s/^RAG_TRANSPORT=.*/RAG_TRANSPORT=$(cat /tmp/qa_original_transport.txt)/" .env; fi`
 3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
 
 ### G) Eval（CLI 固定）

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -299,6 +299,7 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
    ```bash
    grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
+   sed -i 's/^RAG_TRANSPORT=.*/RAG_TRANSPORT=http/' .env
    ```
 
 2. API キーが keyring に登録済みか確認する:
@@ -332,11 +333,13 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
    echo $! > /tmp/qa_rag_server.pid
    ```
 
-5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
+5. サーバーの起動を待機する（起動に数秒かかる場合がある）:
 
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/upload/document
+   sleep 5
    ```
+
+   起動確認は F-1（最初のリクエスト）で HTTP 200 が返ることをもって行う。
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
 
@@ -367,7 +370,7 @@ cat /tmp/upload_bg.txt
 #### グループ片付け
 
 1. HTTP サーバーを停止する（起動時に記録した PID を使用）: `if [ -f /tmp/qa_rag_server.pid ]; then kill "$(cat /tmp/qa_rag_server.pid)" 2>/dev/null || true; rm -f /tmp/qa_rag_server.pid; fi`
-2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する（ステップ 1 で退避した値を使用）
+2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する: `if [ -f /tmp/qa_original_transport.txt ]; then sed -i "s/^RAG_TRANSPORT=.*/RAG_TRANSPORT=$(cat /tmp/qa_original_transport.txt)/" .env; fi`
 3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
 
 ### G) Eval

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -317,6 +317,7 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
    import keyring
    print(keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME))
    " > /tmp/qa_api_key.txt
+   chmod 600 /tmp/qa_api_key.txt
    ```
 
 4. HTTP サーバーを起動する:
@@ -337,27 +338,29 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
-| 3 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
-| 4 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 1 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:<RAG_HTTP_PORT>/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
 | 6 | 下記の並行リクエストコマンドを実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
 
 F-6 並行リクエストコマンド（API キーをファイル経由で共有し、バックグラウンドプロセスへの変数伝搬問題を回避する）:
 
 ```bash
-(curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:<RAG_HTTP_PORT>/upload/document \
   -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
-  > /tmp/upload_bg.txt 2>&1 &) \
-&& curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
-  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
-&& sleep 5 && cat /tmp/upload_bg.txt
+  > /tmp/upload_bg.txt 2>&1 &
+bg_pid=$!
+curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:<RAG_HTTP_PORT>/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"
+wait "$bg_pid"
+cat /tmp/upload_bg.txt
 ```
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する
+1. HTTP サーバーを停止する: `pkill -f "python -m rag.server" 2>/dev/null || true`
 2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
 3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -282,7 +282,7 @@ CLI / MCP 対応: `rag_add_youtube` / `rag_crawl_youtube`
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `update-aozora-catalog` | カタログ CSV が source_store に配置される | `none` |
-| 2 | `search-aozora --author 太宰` | 結果に `001567`（走れメロス）が含まれる | `none` |
+| 2 | `search-aozora --author 太宰 --limit 300` | 結果に `001567`（走れメロス）が含まれる | `none` |
 | 3 | `ingest-aozora 001567` | 作品 1 件取り込み成功 | `ingest` |
 
 CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
@@ -293,18 +293,73 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
 目的: HTTP Upload API の動作確認。HTTP モードでの MCP サーバー起動が必要。
 
-前提: MCP サーバーを HTTP モードで起動する（`.env` で `RAG_TRANSPORT=http` を設定）。
+#### グループ準備
+
+1. `.env` の `RAG_TRANSPORT` を `http` に変更する
+2. API キーが keyring に登録済みか確認する:
+
+   ```bash
+   uv run python -c "
+   from rag.config import UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME
+   import keyring
+   key = keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME)
+   print('OK: API key found' if key else 'NG: API key not found')
+   "
+   ```
+
+   未登録の場合は `uv run python -m rag.cli generate-api-key --save` で生成・保存する
+
+3. API キーをテンポラリファイルに書き出す（curl コマンドで使用）:
+
+   ```bash
+   uv run python -c "
+   from rag.config import UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME
+   import keyring
+   print(keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME))
+   " > /tmp/qa_api_key.txt
+   ```
+
+4. HTTP サーバーを起動する:
+
+   ```bash
+   uv run python -m rag.server &
+   ```
+
+5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
+
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/
+   ```
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
 
+全リクエストに API キーヘッダー（`-H "X-API-Key: $(cat /tmp/qa_api_key.txt)"`）を付与する。
+
 | # | コマンド（curl） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 2 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
-| 3 | `curl -X POST http://localhost:8081/upload/document -F "file=@README.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
-| 4 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
-| 5 | `curl -X POST http://localhost:8081/upload/journal -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
-| 6 | ステップ 1 のコマンドを `&` でバックグラウンド送信 + 同一コマンドをフォアグラウンドで実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+| 1 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 2 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md"` | HTTP 409（重複検出エラー、`upload_mode` デフォルト `fail`） | `none` |
+| 3 | `curl -X POST http://localhost:8081/upload/document -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace"` | HTTP 200 | `none` |
+| 4 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "title=QA スキルの仕様書・スキル定義作成" -F "repository=rag-knowledge"` | HTTP 200、`status: ok` と `source_id` が返る | `ingest` |
+| 5 | `curl -X POST http://localhost:8081/upload/journal -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/journal_upload_test.md" -F "repository=rag-knowledge"` | HTTP 400（必須フィールド `title` 欠落） | `none` |
+| 6 | 下記の並行リクエストコマンドを実行 | いずれか一方が HTTP 409 Conflict（ロック競合） | `none` |
+
+F-6 並行リクエストコマンド（API キーをファイル経由で共有し、バックグラウンドプロセスへの変数伝搬問題を回避する）:
+
+```bash
+(curl -s -w "\nBG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
+  > /tmp/upload_bg.txt 2>&1 &) \
+&& curl -s -w "\nFG: %{http_code}\n" -X POST http://localhost:8081/upload/document \
+  -H "X-API-Key: $(cat /tmp/qa_api_key.txt)" -F "file=@.qa/upload_doc_test.md" -F "upload_mode=replace" \
+&& sleep 5 && cat /tmp/upload_bg.txt
+```
+
+#### グループ片付け
+
+1. HTTP サーバーを停止する
+2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
+3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 
 ### G) Eval
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -282,7 +282,7 @@ CLI / MCP 対応: `rag_add_youtube` / `rag_crawl_youtube`
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `update-aozora-catalog` | カタログ CSV が source_store に配置される | `none` |
-| 2 | `search-aozora --author 太宰 --limit 300` | 結果に `001567`（走れメロス）が含まれる | `none` |
+| 2 | `search-aozora --author 太宰 --limit 100` | 結果に `001567`（走れメロス）が含まれる | `none` |
 | 3 | `ingest-aozora 001567` | 作品 1 件取り込み成功 | `ingest` |
 
 CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
@@ -295,7 +295,12 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
 #### グループ準備
 
-1. `.env` の `RAG_TRANSPORT` を `http` に変更する
+1. `.env` の `RAG_TRANSPORT` の現在の値を退避し、`http` に変更する:
+
+   ```bash
+   grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
+   ```
+
 2. API キーが keyring に登録済みか確認する:
 
    ```bash
@@ -320,16 +325,17 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
    chmod 600 /tmp/qa_api_key.txt
    ```
 
-4. HTTP サーバーを起動する:
+4. HTTP サーバーを起動し、PID を記録する:
 
    ```bash
    uv run python -m rag.server &
+   echo $! > /tmp/qa_rag_server.pid
    ```
 
 5. ヘルスチェックで起動を確認する（起動に数秒かかる場合がある）:
 
    ```bash
-   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:<RAG_HTTP_PORT>/upload/document
    ```
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
@@ -360,9 +366,9 @@ cat /tmp/upload_bg.txt
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する: `pkill -f "python -m rag.server" 2>/dev/null || true`
-2. `.env` の `RAG_TRANSPORT` を元の値（`stdio`）に復元する
-3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
+1. HTTP サーバーを停止する（起動時に記録した PID を使用）: `if [ -f /tmp/qa_rag_server.pid ]; then kill "$(cat /tmp/qa_rag_server.pid)" 2>/dev/null || true; rm -f /tmp/qa_rag_server.pid; fi`
+2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する（ステップ 1 で退避した値を使用）
+3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
 
 ### G) Eval
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- F グループ（Upload HTTP API）にグループ準備・片付け手順を追加（.env 変更、API キー確認・書き出し、HTTP サーバー起動・停止）
- F-1〜F-6 の curl コマンドに API キーヘッダーを追加
- F-1〜F-3 のテストファイルを `README.md` から `.qa/upload_doc_test.md` に変更（A グループとのデータ重複解消）
- F-6 の並行リクエストコマンドをファイル経由の API キー共有方式に安定化
- E-2 に `--limit 300` を追加（デフォルト取得件数では走れメロスが結果に含まれない問題を修正）
- 検証リソーステーブル全体でグループ間のテストデータ重複がないことを確認済み

## Test plan

- [x] markdownlint: 0 errors
- [x] ドキュメントレビュー: 指摘なし

## Related issues

Closes #465
Closes #466