### PR TITLE
feat(rag-knowledge): CLI --output json モードの stdout 保護機構導入 (#478)

### DIFF
--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -272,19 +272,30 @@ MCP サーバーは CLI コマンドを呼び出す薄いアダプター層と�
 | `/upload/document` | `add-document` | 一時ファイル経由 |
 | `/upload/journal` | `add-journal` | 一時ファイル経由 |
 
+#### stdout 保護機構
+
+`--output json` モード時、CLI は fd レベルで stdout を保護する。サードパーティライブラリ（yt-dlp、BM25s 等）が stdout に直接書き込むと JSON Lines 通信が破壊されるため、以下の方式で隔離する:
+
+1. 元の stdout fd を複製して JSON 専用チャネルとして保存
+2. fd 1 を stderr にリダイレクト（Python レベル・OS レベルの両方）
+3. JSON 出力ヘルパーは保存した fd に書き込む
+
+これにより `print()` や C 拡張の stdout 書き込みは全て stderr に流れ、JSON 通信チャネルは汚染されない。
+
 #### CLI サブプロセス実行方式
 
 MCP サーバーは `_run_cli_subprocess` で CLI コマンドを実行する:
 
 1. コマンド構築: `python -m rag.cli <command> --output json [args...]`
 2. `asyncio.create_subprocess_exec` でサブプロセスを起動
-3. stdout を行単位で非同期に読み取り、各行を JSON パース:
-   - `type: "progress"` → `ctx.info()` でログ通知 + `ctx.report_progress()` で数値通知
-   - `type: "result"` → 結果として返却
-   - `type: "error"` → エラーとして処理
-4. stderr はプロセス終了後に読み取る
-5. SEGFAULT 検出: exit code が SEGFAULT シグナル（Unix: -11/139、Windows: -1073741819/3221225477）の場合、エラーメッセージを返却
-6. サブプロセス完了後、RAGKnowledgeService と PipelineController のキャッシュをリセットする（サブプロセスが ChromaDB・source_store を更新するため、インプロセスのキャッシュが古くなる）
+3. stdout と stderr を `asyncio.gather` で並行に読み取る（パイプバッファのデッドロック防止）:
+   - stdout: 行単位で非同期に読み取り、各行を JSON パース:
+     - `type: "progress"` → `ctx.info()` でログ通知 + `ctx.report_progress()` で数値通知
+     - `type: "result"` → 結果として返却
+     - `type: "error"` → エラーとして処理
+   - stderr: 全量を読み取り、エラー時の診断に使用
+4. SEGFAULT 検出: exit code が SEGFAULT シグナル（Unix: -11/139、Windows: -1073741819/3221225477）の場合、エラーメッセージを返却
+5. サブプロセス完了後、RAGKnowledgeService と PipelineController のキャッシュをリセットする（サブプロセスが ChromaDB・source_store を更新するため、インプロセスのキャッシュが古くなる）
 
 CLI の JSON 出力は JSON Lines 形式:
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import io
 import json
 import logging
 import math
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -66,14 +68,55 @@ class RegressionInfo(TypedDict):
 logger = logging.getLogger(__name__)
 
 
+# --- stdout 保護機構 ---
+# --output json モード時に stdout を JSON 専用チャネルとして保護する。
+# OS レベルで fd 1 を stderr にリダイレクトし、サードパーティライブラリの
+# stdout 出力（yt-dlp 等）が JSON 通信を汚染しないようにする。
+# JSON 出力は保存した元の fd に直接書き込む。
+
+_json_output_stream: io.TextIOWrapper | None = None
+
+
+def _install_stdout_guard() -> None:
+    """stdout を JSON 専用に保護する.
+
+    1. fd 1 を複製して保存（JSON 出力先）
+    2. fd 1 を stderr（fd 2）にリダイレクト
+    3. sys.stdout を stderr に差し替え
+
+    これにより print() や C 拡張の stdout 書き込みは全て stderr に流れ、
+    _output_json のみが元の stdout に JSON を書き込む。
+    """
+    global _json_output_stream  # noqa: PLW0603
+
+    saved_fd = os.dup(sys.stdout.fileno())
+    _json_output_stream = io.TextIOWrapper(
+        io.FileIO(saved_fd, mode="w", closefd=True),
+        encoding="utf-8",
+        line_buffering=True,
+    )
+
+    os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+    sys.stdout = sys.stderr
+
+
 # --- JSON 出力ヘルパー ---
 # worker.py の JSON Lines プロトコルと互換のフォーマットで出力する。
 # 仕様: docs/specs/rag-knowledge.md (MCP 薄層アダプターパターン)
 
 
 def _output_json(data: dict[str, object]) -> None:
-    """JSON Lines 形式で 1 行出力する."""
-    print(json.dumps(data, ensure_ascii=False), flush=True)
+    """JSON Lines 形式で 1 行出力する.
+
+    stdout 保護機構が有効な場合は保存した元の fd に書き込む。
+    無効な場合（text モード）は通常の print を使用する。
+    """
+    line = json.dumps(data, ensure_ascii=False)
+    if _json_output_stream is not None:
+        _json_output_stream.write(line + "\n")
+        _json_output_stream.flush()
+    else:
+        print(line, flush=True)
 
 
 def _output_progress(processed: int, total: int, current: str) -> None:
@@ -519,6 +562,10 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    # --output json モード時は stdout を保護する
+    if _is_json_output(args):
+        _install_stdout_guard()
 
     # コマンドディスパッチ（sync / async 統一）
     _ASYNC_COMMANDS: dict[str, object] = {

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -86,8 +86,12 @@ def _install_stdout_guard() -> None:
 
     これにより print() や C 拡張の stdout 書き込みは全て stderr に流れ、
     _output_json のみが元の stdout に JSON を書き込む。
+    冪等: 既にインストール済みの場合は何もしない。
     """
     global _json_output_stream  # noqa: PLW0603
+
+    if _json_output_stream is not None:
+        return
 
     saved_fd = os.dup(sys.stdout.fileno())
     _json_output_stream = io.TextIOWrapper(

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1228,8 +1228,9 @@ async def _run_cli_subprocess(
             process.stdin.close()
             await process.stdin.wait_closed()
 
-    result_line = ""
-    try:
+    async def _read_stdout() -> str:
+        """stdout を行単位で読み、progress 通知を処理し、最終 result/error 行を返す."""
+        _result_line = ""
         assert process.stdout is not None  # noqa: S101
         while True:
             raw = await process.stdout.readline()
@@ -1254,10 +1255,24 @@ async def _run_cli_subprocess(
                         continue
                     # result/error のみ最終結果として保持
                     if msg_type in {"result", "error"}:
-                        result_line = line
+                        _result_line = line
             except json.JSONDecodeError:
                 # 非 JSON 行（ログ等）は result_line を上書きしない
                 pass
+        return _result_line
+
+    async def _drain_stderr() -> bytes:
+        """stderr を並行に drain する（パイプバッファ溢れ防止）."""
+        if process.stderr is None:
+            return b""
+        return await process.stderr.read()
+
+    # stdout と stderr を並行に読み取る（パイプバッファのデッドロック防止）
+    try:
+        result_line, stderr_bytes = await asyncio.gather(
+            _read_stdout(),
+            _drain_stderr(),
+        )
     except asyncio.CancelledError:
         if process.returncode is None:
             with contextlib.suppress(ProcessLookupError):
@@ -1266,8 +1281,6 @@ async def _run_cli_subprocess(
                 await process.wait()
         raise
 
-    # stderr 読み取り + wait
-    stderr_bytes = await process.stderr.read() if process.stderr else b""
     await process.wait()
 
     assert process.returncode is not None  # noqa: S101


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- CLI の `--output json` モード時に OS レベル（fd 操作）で stdout を保護する機構を導入。サードパーティライブラリ（yt-dlp 等）の stdout 出力が JSON 通信を汚染しないよう隔離
- `_run_cli_subprocess` の stderr 読み取りを stdout と並行実行するようリファクタリング（パイプバッファデッドロック防止）
- 仕様書に stdout 保護機構の設計意図と CLI サブプロセス実行方式の更新を追記

## Test plan

- [x] pytest 72件パス（test_rag_cli.py 22件 + test_rag_mcp_server.py 50件）
- [x] ruff check クリーン
- [x] mypy 型チェッククリーン
- [ ] MCP 経由の YouTube プレイリスト取り込みで yt-dlp stdout 汚染が発生しないこと（QA で検証）

## Related issues

Closes #478