### PR TITLE
feat(rag-knowledge): 全コマンド --output json 対応 + 進捗コールバック接続 (#479)

### DIFF
--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -305,6 +305,21 @@ CLI の JSON 出力は JSON Lines 形式:
 | `{"type": "result", ...}` | コマンド結果（コマンド固有のフィールドを含む） |
 | `{"type": "error", "error": true, "message": "..."}` | エラー報告（exit code 1） |
 
+全 CLI コマンドが `--output json` オプションに対応している（evaluate, init-test-db, get-document, migrate-journal, generate-api-key を除く。evaluate・init-test-db は評価専用、get-document はテキスト出力がそのまま結果となるため、これらは MCP 経由で使用しないか別の方式で結果を取得する）。
+
+#### 進捗コールバック
+
+複数件処理を行うコマンドは `--output json` モード時に `progress` メッセージを出力し、MCP 経由で進捗を通知する。
+
+| CLI コマンド | 進捗の粒度 |
+|------------|----------|
+| `rebuild` | パイプライン処理ファイル単位 |
+| `ingest-youtube-playlist` | 動画単位 |
+| `crawl-bluesky` | 投稿単位 |
+| `crawl-zenn` | 記事/スクラップ単位 |
+| `crawl-documents` | ファイル単位 |
+| `ingest-aozora-author` | 作品単位 |
+
 #### CLI stdin 入力プロトコル
 
 `rag_add_journal` と `rag_add_document` は MCP クライアントからコンテンツを文字列で受け取る。CLI コマンドはファイルパスを期待するため、`--stdin` オプションで stdin からコンテンツを読み取る方式を提供する。

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -400,7 +400,8 @@ def main() -> None:
     )
     _add_output_option(rebuild_parser)
     # stats サブコマンド
-    subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
+    stats_parser = subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
+    _add_output_option(stats_parser)
 
     # list-recent サブコマンド
     list_recent_parser = subparsers.add_parser(
@@ -425,6 +426,7 @@ def main() -> None:
         default=None,
         help="取得件数（1〜100、未指定時は設定値を使用）",
     )
+    _add_output_option(list_recent_parser)
 
     # search サブコマンド
     search_parser = subparsers.add_parser("search", help="ナレッジベースを検索")
@@ -452,6 +454,7 @@ def main() -> None:
         default=None,
         help="メタデータフィルタ（key=value 形式、例: 'repository=rag-knowledge'）",
     )
+    _add_output_option(search_parser)
 
     # delete サブコマンド
     delete_parser = subparsers.add_parser("delete", help="ソースをナレッジベースから論理削除")
@@ -515,6 +518,7 @@ def main() -> None:
         default=False,
         help="Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ",
     )
+    _add_output_option(siteingest_parser)
 
     # update-aozora-catalog: 青空文庫カタログ更新
     update_aozora_parser = subparsers.add_parser("update-aozora-catalog", help="青空文庫カタログを更新")
@@ -525,6 +529,7 @@ def main() -> None:
     search_aozora_parser.add_argument("--author", default=None, help="著者名（部分一致）")
     search_aozora_parser.add_argument("--title", default=None, help="作品タイトル（部分一致）")
     search_aozora_parser.add_argument("--limit", type=int, default=20, help="最大表示件数（デフォルト: 20）")
+    _add_output_option(search_aozora_parser)
 
     # ingest-aozora: 青空文庫作品取り込み
     ingest_aozora_parser = subparsers.add_parser("ingest-aozora", help="青空文庫の作品を取り込み")
@@ -1364,19 +1369,20 @@ def run_stats(args: argparse.Namespace) -> None:
     from .store.metadata_db import MetadataDB
     from .vector_store import VectorStore
 
+    json_out = _is_json_output(args)
     settings = get_settings()
 
-    parts: list[str] = ["RAG Knowledge 統計"]
+    # --- データ収集 ---
+    stats_data: dict[str, object] = {}
 
-    # --- source_store セクション ---
-    parts.append("")
-    parts.append("■ source_store")
+    # source_store
+    source_store_data: dict[str, object] = {}
     if not settings.source_store_dir:
-        parts.append("  未設定")
+        source_store_data["status"] = "unconfigured"
     else:
         source_store_dir = Path(settings.source_store_dir)
         if not source_store_dir.exists():
-            parts.append("  ディレクトリが存在しません")
+            source_store_data["status"] = "not_found"
         else:
             total_files = 0
             total_size = 0
@@ -1405,26 +1411,23 @@ def run_stats(args: argparse.Namespace) -> None:
                 by_type[st]["files"] += 1
                 by_type[st]["size"] += size
 
-            parts.append(f"  総ファイル数: {total_files:,}")
-            parts.append(f"  総サイズ: {_format_cli_size(total_size)}")
+            source_store_data["total_files"] = total_files
+            source_store_data["total_size"] = total_size
             if by_type:
-                parts.append("  媒体別:")
-                for st_key in sorted(by_type.keys()):
-                    info = by_type[st_key]
-                    parts.append(
-                        f"    {st_key}: {info['files']} files"
-                        f" ({_format_cli_size(info['size'])})"
-                    )
+                source_store_data["by_type"] = {
+                    k: {"files": v["files"], "size": v["size"]}
+                    for k, v in sorted(by_type.items())
+                }
+    stats_data["source_store"] = source_store_data
 
-    # --- converted_store セクション ---
-    parts.append("")
-    parts.append("■ converted_store")
+    # converted_store
+    converted_store_data: dict[str, object] = {}
     if not settings.converted_store_dir:
-        parts.append("  未設定")
+        converted_store_data["status"] = "unconfigured"
     else:
         cs_dir = Path(settings.converted_store_dir)
         if not cs_dir.exists():
-            parts.append("  ディレクトリが存在しません")
+            converted_store_data["status"] = "not_found"
         else:
             cs_files = 0
             cs_size = 0
@@ -1432,12 +1435,12 @@ def run_stats(args: argparse.Namespace) -> None:
                 if file.is_file():
                     cs_files += 1
                     cs_size += file.stat().st_size
-            parts.append(f"  総ファイル数: {cs_files:,}")
-            parts.append(f"  総サイズ: {_format_cli_size(cs_size)}")
+            converted_store_data["total_files"] = cs_files
+            converted_store_data["total_size"] = cs_size
+    stats_data["converted_store"] = converted_store_data
 
-    # --- インデックスセクション ---
-    parts.append("")
-    parts.append("■ インデックス")
+    # インデックス
+    index_data: dict[str, object] = {}
     try:
         embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
         with contextlib.redirect_stdout(io.StringIO()):
@@ -1450,25 +1453,23 @@ def run_stats(args: argparse.Namespace) -> None:
                 hnsw_construction_ef=settings.hnsw_construction_ef,
                 hnsw_search_ef=settings.hnsw_search_ef,
             )
-        index_stats = vector_store.get_stats()
-        total_chunks = int(str(index_stats.get("total_chunks", 0)))
-        source_count = int(str(index_stats.get("source_count", 0)))
-        parts.append(f"  総チャンク数: {total_chunks:,}")
-        parts.append(f"  ソース数: {source_count:,}")
+        raw_stats = vector_store.get_stats()
+        index_data["total_chunks"] = int(str(raw_stats.get("total_chunks", 0)))
+        index_data["source_count"] = int(str(raw_stats.get("source_count", 0)))
     except Exception:
         logger.exception("インデックス統計の取得に失敗")
-        parts.append("  エラー: 統計の取得に失敗しました")
+        index_data["error"] = "統計の取得に失敗しました"
+    stats_data["index"] = index_data
 
-    # --- パイプラインセクション ---
-    parts.append("")
-    parts.append("■ パイプライン")
+    # パイプライン
+    pipeline_data: dict[str, object] = {}
     if not settings.source_store_dir:
-        parts.append("  未設定")
+        pipeline_data["status"] = "unconfigured"
     else:
         from .store.models import NULL_COMMIT_HASH
         db_path = Path(settings.source_store_dir) / "metadata.db"
         if not db_path.exists():
-            parts.append("  未初期化")
+            pipeline_data["status"] = "uninitialized"
         else:
             db = MetadataDB(db_path)
             try:
@@ -1476,17 +1477,77 @@ def run_stats(args: argparse.Namespace) -> None:
                 history = db.get_pipeline_history()
                 last_commit_id = db.get_last_commit_id()
                 deleted_count = db.source_count(status="deleted")
-                last_at = history[-1].processed_at if history else "（未実行）"
-                parts.append(f"  最終処理: {last_at}")
-                parts.append(f"  実行回数: {len(history)}")
+                pipeline_data["last_processed_at"] = (
+                    history[-1].processed_at if history else None
+                )
+                pipeline_data["run_count"] = len(history)
                 commit_str = str(last_commit_id)
-                if commit_str == NULL_COMMIT_HASH:
-                    parts.append("  last_commit_id: （未実行）")
-                else:
-                    parts.append(f"  last_commit_id: {commit_str[:7]}")
-                parts.append(f"  論理削除: {deleted_count} 件")
+                pipeline_data["last_commit_id"] = (
+                    None if commit_str == NULL_COMMIT_HASH else commit_str[:7]
+                )
+                pipeline_data["deleted_count"] = deleted_count
             finally:
                 db.close()
+    stats_data["pipeline"] = pipeline_data
+
+    # --- 出力 ---
+    if json_out:
+        _output_result(stats_data)
+        return
+
+    # text 出力
+    parts: list[str] = ["RAG Knowledge 統計"]
+
+    parts.append("")
+    parts.append("■ source_store")
+    if source_store_data.get("status") == "unconfigured":
+        parts.append("  未設定")
+    elif source_store_data.get("status") == "not_found":
+        parts.append("  ディレクトリが存在しません")
+    else:
+        parts.append(f"  総ファイル数: {source_store_data.get('total_files', 0):,}")
+        parts.append(f"  総サイズ: {_format_cli_size(int(str(source_store_data.get('total_size', 0))))}")
+        by_type_data = source_store_data.get("by_type")
+        if by_type_data and isinstance(by_type_data, dict):
+            parts.append("  媒体別:")
+            for st_key in sorted(by_type_data.keys()):
+                info = by_type_data[st_key]
+                parts.append(
+                    f"    {st_key}: {info['files']} files"
+                    f" ({_format_cli_size(info['size'])})"
+                )
+
+    parts.append("")
+    parts.append("■ converted_store")
+    if converted_store_data.get("status") == "unconfigured":
+        parts.append("  未設定")
+    elif converted_store_data.get("status") == "not_found":
+        parts.append("  ディレクトリが存在しません")
+    else:
+        parts.append(f"  総ファイル数: {converted_store_data.get('total_files', 0):,}")
+        parts.append(f"  総サイズ: {_format_cli_size(int(str(converted_store_data.get('total_size', 0))))}")
+
+    parts.append("")
+    parts.append("■ インデックス")
+    if "error" in index_data:
+        parts.append(f"  エラー: {index_data['error']}")
+    else:
+        parts.append(f"  総チャンク数: {index_data.get('total_chunks', 0):,}")
+        parts.append(f"  ソース数: {index_data.get('source_count', 0):,}")
+
+    parts.append("")
+    parts.append("■ パイプライン")
+    if pipeline_data.get("status") == "unconfigured":
+        parts.append("  未設定")
+    elif pipeline_data.get("status") == "uninitialized":
+        parts.append("  未初期化")
+    else:
+        last_at = pipeline_data.get("last_processed_at") or "（未実行）"
+        parts.append(f"  最終処理: {last_at}")
+        parts.append(f"  実行回数: {pipeline_data.get('run_count', 0)}")
+        lci = pipeline_data.get("last_commit_id")
+        parts.append(f"  last_commit_id: {lci if lci else '（未実行）'}")
+        parts.append(f"  論理削除: {pipeline_data.get('deleted_count', 0)} 件")
 
     print("\n".join(parts))
 
@@ -1500,11 +1561,50 @@ def run_list_recent(args: argparse.Namespace) -> None:
         args: コマンドライン引数
     """
     from .config import get_settings
-    from .rag_knowledge import list_recent_sources
 
+    json_out = _is_json_output(args)
     settings = get_settings()
     limit: int = args.limit if args.limit is not None else settings.rag_list_recent_limit
-    print(list_recent_sources(settings.source_store_dir, args.source_type, limit))
+
+    if json_out:
+        from .store.metadata_db import MetadataDB
+        from .store.models import SourceType
+        from typing import cast
+
+        db_path = Path(settings.source_store_dir) / "metadata.db"
+        if not db_path.exists():
+            _output_result({
+                "source_type": args.source_type,
+                "sources": [],
+                "count": 0,
+                "total": 0,
+            })
+            return
+        db = MetadataDB(db_path)
+        try:
+            db.initialize()
+            st = cast(SourceType, args.source_type)
+            sources = db.list_sources(source_type=st, limit=limit)
+            total = db.count_sources_by_type(source_type=st)
+        finally:
+            db.close()
+        _output_result({
+            "source_type": args.source_type,
+            "sources": [
+                {
+                    "source_id": s.source_id,
+                    "title": s.title,
+                    "collected_at": s.collected_at,
+                    "file_size": s.file_size,
+                }
+                for s in sources
+            ],
+            "count": len(sources),
+            "total": total,
+        })
+    else:
+        from .rag_knowledge import list_recent_sources
+        print(list_recent_sources(settings.source_store_dir, args.source_type, limit))
 
 
 def run_search(args: argparse.Namespace) -> None:
@@ -1525,6 +1625,7 @@ def run_search(args: argparse.Namespace) -> None:
     from .rag_knowledge import RAGKnowledgeService
     from .vector_store import VectorStore
 
+    json_out = _is_json_output(args)
     settings = get_settings()
     embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
 
@@ -1565,8 +1666,10 @@ def run_search(args: argparse.Namespace) -> None:
         try:
             parsed_filters = parse_filters(args.filters)
         except ValueError as e:
-            print(f"エラー: {e}")
-            return
+            if json_out:
+                _output_error(str(e))
+            logger.error("エラー: %s", e)
+            sys.exit(1)
 
     raw = _asyncio.run(
         service.retrieve_raw_results(
@@ -1575,9 +1678,15 @@ def run_search(args: argparse.Namespace) -> None:
         )
     )
 
-    from .rag_knowledge import format_raw_search_results
-
-    print(format_raw_search_results(raw))
+    if json_out:
+        _output_result({
+            "query": args.query,
+            "vector_results": [r.to_dict() for r in raw.vector_results],
+            "bm25_results": [r.to_dict() for r in raw.bm25_results],
+        })
+    else:
+        from .rag_knowledge import format_raw_search_results
+        print(format_raw_search_results(raw))
 
 
 def run_delete(args: argparse.Namespace) -> None:
@@ -1969,10 +2078,13 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
         max_duration=settings.rag_youtube_max_duration,
     )
 
+    progress_cb = _output_progress if json_out else None
+
     try:
         ingest_result = await youtube_ingester.crawl_playlist(
             args.playlist_url,
             max_videos=max_videos,
+            progress_callback=progress_cb,
         )
     except (ValueError, TypeError) as e:
         if json_out:
@@ -2027,6 +2139,8 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
         include_reposts=include_reposts,
     )
 
+    progress_cb = _output_progress if json_out else None
+
     try:
         async with ConstrainedClient(
             request_timeout=settings.rag_bluesky_request_timeout,
@@ -2037,6 +2151,7 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
                 max_posts=max_posts,
                 include_reposts=include_reposts,
                 client=client,
+                progress_callback=progress_cb,
             )
 
             # 投稿内 URL の自動取り込み
@@ -2094,6 +2209,8 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
         max_articles=max_articles,
     )
 
+    progress_cb = _output_progress if json_out else None
+
     try:
         async with ConstrainedClient(
             request_timeout=settings.rag_zenn_request_timeout,
@@ -2105,6 +2222,7 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 content_type=args.content_type,
                 force=args.force,
                 client=client,
+                progress_callback=progress_cb,
             )
     except (ValueError, TypeError) as e:
         if json_out:
@@ -2279,8 +2397,11 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
         allowed_dirs=None,
     )
 
+    progress_cb = _output_progress if json_out else None
+
     ingest_result = local_ingester.crawl_documents(
         args.dir_path, args.pattern, upload_mode=args.upload_mode,
+        progress_callback=progress_cb,
     )
 
     if ingest_result.placed == 0 and ingest_result.errors == 0:
@@ -2308,6 +2429,8 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     from .scrapy.runner import ScrapyRunner
     from .utils.url import check_ssrf, validate_url
 
+    json_out = _is_json_output(args)
+
     urls: list[str] = args.url  # nargs='+' なのでリスト
     multi_url_mode = len(urls) >= 2
 
@@ -2319,6 +2442,8 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             check_ssrf(validated)
             validated_urls.append(validated)
         except ValueError as e:
+            if json_out:
+                _output_error(str(e))
             logger.error("エラー: %s", e)
             sys.exit(1)
 
@@ -2327,6 +2452,8 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
         try:
             re.compile(args.url_pattern)
         except re.error as e:
+            if json_out:
+                _output_error(f"無効な正規表現パターン: {e}")
             logger.error("無効な正規表現パターン: %s", e)
             sys.exit(1)
 
@@ -2390,10 +2517,21 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
 
     if not crawl_result.jsonl_path.exists():
         elapsed = time_mod.monotonic() - start_time
-        print(
-            f"クロールが完了しましたが、メタデータが出力されませんでした。"
-            f" exit_code={crawl_result.exit_code}, 所要時間={elapsed:.1f}秒",
-        )
+        if json_out:
+            _output_result({
+                "placed": 0,
+                "overwritten": 0,
+                "skipped": 0,
+                "errors": 0,
+                "elapsed": round(elapsed, 1),
+                "scrapy_exit_code": crawl_result.exit_code,
+                "no_output": True,
+            })
+        else:
+            print(
+                f"クロールが完了しましたが、メタデータが出力されませんでした。"
+                f" exit_code={crawl_result.exit_code}, 所要時間={elapsed:.1f}秒",
+            )
         return
 
     # Bridge: JSONL + HTML → source_store
@@ -2418,22 +2556,30 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     # 操作全体の所要時間（クロール + Bridge + パイプライン）
     elapsed = time_mod.monotonic() - start_time
 
-    # 結果表示
-    print(
-        f"サイト取り込み完了: {bridge_result.ingest.placed}件新規配置"
-        f", {bridge_result.ingest.overwritten}件上書き"
-        f", {bridge_result.ingest.skipped}件スキップ"
-        f", {bridge_result.ingest.errors}件エラー"
-    )
-    print(f"所要時間: {elapsed:.1f}秒")
-    if args.download_only:
-        print("パイプライン処理: スキップ（download_only）")
-    elif pipeline_summary is not None:
-        print(f"パイプライン: {pipeline_summary.processed}件処理")
-        if pipeline_summary.errors:
-            print(f"パイプラインエラー: {len(pipeline_summary.errors)}件")
-    if not crawl_result.success:
-        print(f"Scrapy exit_code={crawl_result.exit_code}（部分的な結果）")
+    if json_out:
+        data: dict[str, object] = _ingest_result_to_dict(bridge_result.ingest, pipeline_summary)
+        data["elapsed"] = round(elapsed, 1)
+        data["download_only"] = args.download_only
+        if not crawl_result.success:
+            data["scrapy_exit_code"] = crawl_result.exit_code
+        _output_result(data)
+    else:
+        # text 出力
+        print(
+            f"サイト取り込み完了: {bridge_result.ingest.placed}件新規配置"
+            f", {bridge_result.ingest.overwritten}件上書き"
+            f", {bridge_result.ingest.skipped}件スキップ"
+            f", {bridge_result.ingest.errors}件エラー"
+        )
+        print(f"所要時間: {elapsed:.1f}秒")
+        if args.download_only:
+            print("パイプライン処理: スキップ（download_only）")
+        elif pipeline_summary is not None:
+            print(f"パイプライン: {pipeline_summary.processed}件処理")
+            if pipeline_summary.errors:
+                print(f"パイプラインエラー: {len(pipeline_summary.errors)}件")
+        if not crawl_result.success:
+            print(f"Scrapy exit_code={crawl_result.exit_code}（部分的な結果）")
 
 
 async def run_update_aozora_catalog(args: argparse.Namespace) -> None:
@@ -2476,6 +2622,8 @@ def run_search_aozora(args: argparse.Namespace) -> None:
     """青空文庫カタログ検索."""
     from .pipeline.ingesters.aozora import AozoraIngester
 
+    json_out = _is_json_output(args)
+
     controller, settings = _build_cli_pipeline_controller()
 
     aozora_ingester = AozoraIngester(
@@ -2490,8 +2638,26 @@ def run_search_aozora(args: argparse.Namespace) -> None:
             limit=args.limit,
         )
     except (ValueError, TypeError) as e:
+        if json_out:
+            _output_error(str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
+
+    if json_out:
+        _output_result({
+            "results": [
+                {
+                    "book_id": r["book_id"],
+                    "title": r["title"],
+                    "person_id": r["person_id"],
+                    "author": r["author"],
+                    "copyright": r["copyright"],
+                }
+                for r in results
+            ],
+            "count": len(results),
+        })
+        return
 
     if not results:
         print("検索結果: 0件")
@@ -2555,6 +2721,8 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
         max_works=max_works,
     )
 
+    progress_cb = _output_progress if json_out else None
+
     try:
         async with ConstrainedClient(
             request_timeout=settings.rag_aozora_request_timeout,
@@ -2564,6 +2732,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
                 args.person_id,
                 max_works=max_works,
                 client=client,
+                progress_callback=progress_cb,
             )
     except (ValueError, TypeError) as e:
         if json_out:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1571,6 +1571,14 @@ def run_list_recent(args: argparse.Namespace) -> None:
         from .store.models import SourceType
         from typing import cast
 
+        if not settings.source_store_dir:
+            _output_result({
+                "source_type": args.source_type,
+                "sources": [],
+                "count": 0,
+                "total": 0,
+            })
+            return
         db_path = Path(settings.source_store_dir) / "metadata.db"
         if not db_path.exists():
             _output_result({
@@ -1667,9 +1675,10 @@ def run_search(args: argparse.Namespace) -> None:
             parsed_filters = parse_filters(args.filters)
         except ValueError as e:
             if json_out:
-                _output_error(str(e))
-            logger.error("エラー: %s", e)
-            sys.exit(1)
+                _output_error(str(e))  # sys.exit(1) で終了
+            else:
+                logger.error("エラー: %s", e)
+                sys.exit(1)
 
     raw = _asyncio.run(
         service.retrieve_raw_results(

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import subprocess
-from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -37,10 +36,9 @@ from rag.store.models import (
 from rag.store.resolve import resolve_source_id, resolve_title
 from rag.store.source_store import SourceStore
 
-logger = logging.getLogger(__name__)
+from rag.pipeline.ingesters._common import ProgressCallback
 
-# 進捗コールバック型: (processed, total, current_file) -> None
-ProgressCallback = Callable[[int, int, str], None]
+logger = logging.getLogger(__name__)
 
 # .meta を持たない媒体
 _NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})

--- a/src/rag/pipeline/ingesters/_common.py
+++ b/src/rag/pipeline/ingesters/_common.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+
+ProgressCallback = Callable[[int, int, str], None]
 
 
 @dataclass

--- a/src/rag/pipeline/ingesters/aozora.py
+++ b/src/rag/pipeline/ingesters/aozora.py
@@ -15,7 +15,7 @@ import zipfile
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
-from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
 
 if TYPE_CHECKING:
 
@@ -275,6 +275,7 @@ class AozoraIngester:
         *,
         max_works: int | None = None,
         client: Any | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> IngestResult:
         """指定著者の著作権フリー作品を一括取り込みする.
 
@@ -282,6 +283,7 @@ class AozoraIngester:
             person_id: 著者の人物 ID
             max_works: 最大取り込み数
             client: ConstrainedClient インスタンス
+            progress_callback: 進捗コールバック (processed, total, current)
 
         Returns:
             配置結果
@@ -322,7 +324,8 @@ class AozoraIngester:
         result = IngestResult()
         consecutive_failures = 0
 
-        for record in targets:
+        for work_idx, record in enumerate(targets):
+            book_id = record.get(COL_BOOK_ID, "?")
             try:
                 placed = await self._ingest_work(record, client, result)
                 if placed:
@@ -331,7 +334,6 @@ class AozoraIngester:
                     # スキップ（重複）の場合はリセット
                     consecutive_failures = 0
             except Exception:
-                book_id = record.get(COL_BOOK_ID, "?")
                 logger.exception("作品の取得・配置に失敗しました: %s", book_id)
                 result.errors += 1
                 result.error_details.append(f"book_id={book_id}")
@@ -343,6 +345,9 @@ class AozoraIngester:
                         "操作を中断します"
                     )
                     break
+
+            if progress_callback is not None:
+                progress_callback(work_idx + 1, len(targets), f"book_id={book_id}")
 
         return result
 

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -15,7 +15,7 @@ import re
 import sys
 from datetime import datetime
 
-from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -200,6 +200,7 @@ class BlueskyIngester:
         max_posts: int | None = None,
         include_reposts: bool | None = None,
         client: ConstrainedClient | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> tuple[IngestResult, list[dict[str, Any]]]:
         """BlueSky 投稿を取得し source_store に配置する.
 
@@ -208,6 +209,7 @@ class BlueskyIngester:
             max_posts: 取得する最大投稿数（None の場合はインスタンス設定を使用）
             include_reposts: リポストを含めるか（None の場合はインスタンス設定を使用）
             client: ConstrainedClient インスタンス
+            progress_callback: 進捗コールバック (processed, total, current)
 
         Returns:
             (配置結果, 配置済みフィードアイテムのリスト)
@@ -377,6 +379,9 @@ class BlueskyIngester:
                     logger.exception("投稿の配置に失敗しました: %s", rel_path)
                     result.errors += 1
                     result.error_details.append(rel_path)
+
+                if progress_callback is not None:
+                    progress_callback(total_processed, effective_max, bsky_url)
 
             # 次ページの確認
             cursor = data.get("cursor")

--- a/src/rag/pipeline/ingesters/local.py
+++ b/src/rag/pipeline/ingesters/local.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from rag.pipeline.ingesters._common import IngestResult
+from rag.pipeline.ingesters._common import IngestResult, ProgressCallback
 
 if TYPE_CHECKING:
     from rag.store.source_store import SourceStore
@@ -84,6 +84,7 @@ class LocalIngester:
         pattern: str = "**/*",
         *,
         upload_mode: UploadMode = "fail",
+        progress_callback: ProgressCallback | None = None,
     ) -> IngestResult:
         """ディレクトリ内のドキュメントファイルを一括配置する.
 
@@ -92,6 +93,7 @@ class LocalIngester:
             pattern: glob パターン
             upload_mode: 同名ファイル存在時の動作
                 ``fail`` — スキップ（個別ファイル）、``replace`` — 上書き
+            progress_callback: 進捗コールバック (processed, total, current)
         """
         result = IngestResult()
         try:
@@ -105,7 +107,7 @@ class LocalIngester:
         resolved_dir = Path(dir_path.strip()).resolve()
         dir_basename = resolved_dir.name
         date_prefix = self._upload_date_prefix()
-        for fp in files:
+        for file_idx, fp in enumerate(files):
             try:
                 if fp.stat().st_size == 0:
                     logger.warning("Skipping empty file (0 bytes): %s", fp)
@@ -131,6 +133,9 @@ class LocalIngester:
                 logger.exception("Failed to copy file: %s", fp)
                 result.errors += 1
                 result.error_details.append(str(fp))
+
+            if progress_callback is not None:
+                progress_callback(file_idx + 1, len(files), str(fp))
         return result
 
     @staticmethod

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
-from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
 
 if TYPE_CHECKING:
     from rag.store.source_store import SourceStore
@@ -279,12 +279,14 @@ class YoutubeIngester:
         playlist_url: str,
         *,
         max_videos: int | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> IngestResult:
         """プレイリスト内の動画を一括取り込みする.
 
         Args:
             playlist_url: YouTube プレイリスト URL
             max_videos: 取得する最大動画数（None の場合はインスタンス設定を使用）
+            progress_callback: 進捗コールバック (processed, total, current)
 
         Returns:
             配置結果
@@ -357,6 +359,9 @@ class YoutubeIngester:
                     CIRCUIT_BREAKER_THRESHOLD,
                 )
                 break
+
+            if progress_callback is not None:
+                progress_callback(i + 1, len(entries_to_process), video_url)
 
             # リクエスト間隔待機（次の動画がある場合のみ）
             if i < len(entries_to_process) - 1:

--- a/src/rag/pipeline/ingesters/zenn.py
+++ b/src/rag/pipeline/ingesters/zenn.py
@@ -12,7 +12,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from rag.pipeline.ingesters._common import IngestResult, now_iso
+from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
 
 if TYPE_CHECKING:
 
@@ -54,6 +54,7 @@ class ZennIngester:
         content_type: str = "all",
         force: bool = False,
         client: Any | None = None,
+        progress_callback: ProgressCallback | None = None,
     ) -> IngestResult:
         """Zenn コンテンツを取得し source_store に配置する.
 
@@ -63,6 +64,7 @@ class ZennIngester:
             content_type: 取得対象（``articles``, ``scraps``, ``all``）
             force: 既存ファイルを上書きするか（デフォルト: False＝スキップモード）
             client: ConstrainedClient インスタンス
+            progress_callback: 進捗コールバック (processed, total, current)
 
         Returns:
             配置結果
@@ -86,13 +88,32 @@ class ZennIngester:
             raise ValueError("client (ConstrainedClient) が必要です")
 
         # content_type に応じて処理
-        if content_type in ("articles", "all"):
-            await self._crawl_articles(
-                username, effective_max, client, result, force=force
+        # content_type="all" 時は articles → scraps の順に処理するため、
+        # 進捗の total がリセットされないようオフセットで合計管理する
+        progress_offset = [0]
+
+        def _offset_progress(processed: int, total: int, current: str) -> None:
+            assert progress_callback is not None  # noqa: S101
+            progress_callback(
+                progress_offset[0] + processed,
+                progress_offset[0] + total,
+                current,
             )
+
+        effective_cb = _offset_progress if progress_callback is not None else None
+
+        if content_type in ("articles", "all"):
+            items_before = result.placed + result.skipped + result.errors
+            await self._crawl_articles(
+                username, effective_max, client, result, force=force,
+                progress_callback=effective_cb,
+            )
+            progress_offset[0] = (result.placed + result.skipped + result.errors) - items_before
+
         if content_type in ("scraps", "all"):
             await self._crawl_scraps(
-                username, effective_max, client, result, force=force
+                username, effective_max, client, result, force=force,
+                progress_callback=effective_cb,
             )
 
         return result
@@ -105,6 +126,7 @@ class ZennIngester:
         result: IngestResult,
         *,
         force: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> None:
         """記事を取得して配置する."""
         # 一覧走査
@@ -112,7 +134,7 @@ class ZennIngester:
             username, "articles", max_articles, client
         )
 
-        for slug in slugs:
+        for i, slug in enumerate(slugs):
             try:
                 # スキップ判定: 既存ファイルがあり force でなければスキップ
                 rel_path = f"zenn/{username}/articles/{slug}.json"
@@ -172,6 +194,9 @@ class ZennIngester:
                 result.errors += 1
                 result.error_details.append(f"articles/{slug}")
 
+            if progress_callback is not None:
+                progress_callback(i + 1, len(slugs), f"articles/{slug}")
+
     async def _crawl_scraps(
         self,
         username: str,
@@ -180,6 +205,7 @@ class ZennIngester:
         result: IngestResult,
         *,
         force: bool = False,
+        progress_callback: ProgressCallback | None = None,
     ) -> None:
         """スクラップを取得して配置する."""
         # 一覧走査
@@ -187,7 +213,7 @@ class ZennIngester:
             username, "scraps", max_articles, client
         )
 
-        for slug in slugs:
+        for i, slug in enumerate(slugs):
             try:
                 # スキップ判定: 既存ファイルがあり force でなければスキップ
                 rel_path = f"zenn/{username}/scraps/{slug}.json"
@@ -239,6 +265,9 @@ class ZennIngester:
                 logger.exception("スクラップの取得・配置に失敗しました: %s", slug)
                 result.errors += 1
                 result.error_details.append(f"scraps/{slug}")
+
+            if progress_callback is not None:
+                progress_callback(i + 1, len(slugs), f"scraps/{slug}")
 
     async def _discover_slugs(
         self,

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -115,6 +115,20 @@ class VectorSearchItem:
     collected_at: str = ""
     section_path: str = ""
 
+    def to_dict(self) -> dict[str, object]:
+        """JSON 出力用 dict に変換する."""
+        return {
+            "text": self.text,
+            "source_url": self.source_url,
+            "distance": self.distance,
+            "chunk_index": self.chunk_index,
+            "title": self.title,
+            "source_type": self.source_type,
+            "total_chunks": self.total_chunks,
+            "collected_at": self.collected_at,
+            "section_path": self.section_path,
+        }
+
 
 @dataclass
 class BM25SearchItem:
@@ -144,6 +158,21 @@ class BM25SearchItem:
     total_chunks: int = 0
     collected_at: str = ""
     section_path: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """JSON 出力用 dict に変換する."""
+        return {
+            "text": self.text,
+            "source_url": self.source_url,
+            "score": self.score,
+            "doc_id": self.doc_id,
+            "chunk_index": self.chunk_index,
+            "title": self.title,
+            "source_type": self.source_type,
+            "total_chunks": self.total_chunks,
+            "collected_at": self.collected_at,
+            "section_path": self.section_path,
+        }
 
 
 @dataclass


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- stats, list-recent, search, search-aozora, site-ingest に `--output json` オプションを追加
- crawl-zenn, crawl-bluesky, ingest-youtube-playlist, crawl-documents, ingest-aozora-author に `_output_progress` 進捗コールバックを接続
- `ProgressCallback` 型をインジェスター共通モジュール (`_common.py`) に定義し、全インジェスターから参照
- `VectorSearchItem` / `BM25SearchItem` に `to_dict()` メソッドを追加
- Zenn `content_type=all` 時の進捗リセット問題をオフセット管理で解決
- 仕様書に進捗コールバック対応コマンド一覧を追記

## Test plan

- [x] ruff check: クリーン
- [x] mypy: クリーン
- [x] pytest: 1331 passed
- [x] コードレビュー: 指摘対応済み
- [x] ドキュメントレビュー: 指摘対応済み

## Related issues

Closes #479