### PR TITLE
feat(rag-knowledge): MCP 全ツールを CLI サブプロセス委譲に統一 (#480)

### DIFF
--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -95,6 +95,15 @@ MCP サーバーとして独立動作し、18 個のツールを提供する。
 | HNSW search_ef（検索時探索幅） | 設定値 | 許容範囲 10〜2000、デフォルト 300 | 範囲内で変更可 |
 | 生 HTTP クライアント利用禁止 | CI チェック | `src/` 全体を grep で走査（httpx / aiohttp / requests / urllib.request）。`# safety:allowed` 行を除外。ConstrainedClient は py-common-lib パッケージで提供（`src/` 外のため検出対象外） | 許可例外の追加は `# safety:allowed` コメントで可 |
 
+### MCP 薄層アダプターパターン
+
+MCP サーバーの全ツールは CLI サブプロセスに委譲する（薄層アダプターパターン）。MCP ツール側にビジネスロジックを持たず、パラメータの組み立て・バリデーション・結果の整形のみを行う。
+
+- CLI が `--output json` で構造化 JSON を返し、MCP ツールはその結果をテキスト応答に整形する
+- 書き込み系ツール: C 拡張（BM25s 等）の SEGFAULT からサーバープロセスを隔離する
+- 読み取り系ツール（検索・統計・一覧）: SEGFAULT リスクは低いが、一貫性のため同一パターンに統一する。サブプロセス起動のオーバーヘッドは許容する
+- ロジックの重複を排除し、CLI と MCP で同一のコードパスを通す
+
 ## インターフェース
 
 ### MCP ツール
@@ -157,8 +166,7 @@ flowchart TB
     CLIENT["MCP クライアント"]
 
     subgraph MCP["MCP サーバー（薄層アダプター）"]
-        SEARCH["検索ツール（インプロセス）"]
-        WRITE["書き込みツール（CLI subprocess）"]
+        TOOLS["全ツール（CLI subprocess 委譲）"]
         CSM["ChromaDB Server Manager"]
     end
 
@@ -200,9 +208,7 @@ flowchart TB
     WEB["対象 Web サイト / API"]
 
     CLIENT -->|stdio / http| MCP
-    SEARCH -->|HttpClient| CHROMA_SRV
-    SEARCH --> BM25
-    WRITE -->|subprocess| CLI_CMD
+    TOOLS -->|subprocess| CLI_CMD
     CSM -->|起動管理| CHROMA_SRV
     CLI_CMD --> PC
     PC --> Stage1
@@ -240,23 +246,19 @@ ChromaDB は `uv run chroma run` によるサーバーモードで動作し、MC
 | `CHROMADB_SERVER_PORT` | ChromaDB サーバーのポート | `8000`（ChromaDB デフォルト） |
 | `CHROMADB_AUTO_START` | MCP サーバー起動時に ChromaDB サーバーを自動起動するか | `true` |
 
-### MCP 薄層アダプターパターン
+### MCP 薄層アダプター実装方式
 
-MCP サーバーは CLI コマンドを呼び出す薄いアダプター層として動作する。書き込み系ツールは CLI サブプロセスとして実行し、C 拡張（BM25s 等）の SEGFAULT からサーバープロセスを隔離する。検索系ツールはパフォーマンスのためインプロセス実行を維持する。
-
-#### ツール分類
-
-| ツール分類 | 実行方式 | 対象 |
-|-----------|---------|------|
-| 検索系 | インプロセス（RAGKnowledgeService 直接呼び出し） | `rag_search`, `rag_get_document`, `rag_stats`, `rag_search_aozora`, `rag_list_recent` |
-| 書き込み系 | CLI サブプロセス（`--output json` で結果をパース） | `rag_crawl_zenn`, `rag_crawl_bluesky`, `rag_add_youtube`, `rag_crawl_youtube`, `rag_add_document`, `rag_crawl_documents`, `rag_add_journal`, `rag_add_aozora`, `rag_crawl_aozora`, `rag_update_aozora_catalog`, `rag_delete`, `rag_rebuild` |
-| Upload HTTP API | CLI サブプロセス（書き込み系と同一方式） | `/upload/document`, `/upload/journal` |
-| 特殊 | Scrapy サブプロセス + Bridge（現行維持） | `rag_site_ingest` |
+MCP サーバーの全ツールは CLI サブプロセスに委譲する。設計方針は「MCP 薄層アダプターパターン」セクション（制約内）を参照。
 
 #### MCP ツール → CLI コマンドマッピング
 
 | MCP ツール / エンドポイント | CLI コマンド | 備考 |
 |---------------------------|------------|------|
+| `rag_search` | `search` | |
+| `rag_get_document` | `get-document` | |
+| `rag_stats` | `stats` | |
+| `rag_list_recent` | `list-recent` | |
+| `rag_search_aozora` | `search-aozora` | |
 | `rag_crawl_zenn` | `crawl-zenn` | |
 | `rag_crawl_bluesky` | `crawl-bluesky` | |
 | `rag_add_youtube` | `ingest-youtube` | |
@@ -264,6 +266,7 @@ MCP サーバーは CLI コマンドを呼び出す薄いアダプター層と�
 | `rag_add_document` | `add-document` | stdin 入力（後述） |
 | `rag_crawl_documents` | `crawl-documents` | |
 | `rag_add_journal` | `add-journal` | stdin 入力（後述） |
+| `rag_site_ingest` | `site-ingest` | |
 | `rag_add_aozora` | `ingest-aozora` | |
 | `rag_crawl_aozora` | `ingest-aozora-author` | |
 | `rag_update_aozora_catalog` | `update-aozora-catalog` | |
@@ -295,7 +298,6 @@ MCP サーバーは `_run_cli_subprocess` で CLI コマンドを実行する:
      - `type: "error"` → エラーとして処理
    - stderr: 全量を読み取り、エラー時の診断に使用
 4. SEGFAULT 検出: exit code が SEGFAULT シグナル（Unix: -11/139、Windows: -1073741819/3221225477）の場合、エラーメッセージを返却
-5. サブプロセス完了後、RAGKnowledgeService と PipelineController のキャッシュをリセットする（サブプロセスが ChromaDB・source_store を更新するため、インプロセスのキャッシュが古くなる）
 
 CLI の JSON 出力は JSON Lines 形式:
 
@@ -305,7 +307,7 @@ CLI の JSON 出力は JSON Lines 形式:
 | `{"type": "result", ...}` | コマンド結果（コマンド固有のフィールドを含む） |
 | `{"type": "error", "error": true, "message": "..."}` | エラー報告（exit code 1） |
 
-全 CLI コマンドが `--output json` オプションに対応している（evaluate, init-test-db, get-document, migrate-journal, generate-api-key を除く。evaluate・init-test-db は評価専用、get-document はテキスト出力がそのまま結果となるため、これらは MCP 経由で使用しないか別の方式で結果を取得する）。
+全 CLI コマンドが `--output json` オプションに対応している（evaluate, init-test-db, migrate-journal, generate-api-key を除く。これらは評価専用・マイグレーション専用であり、MCP 経由では使用しない）。
 
 #### 進捗コールバック
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1127,8 +1127,9 @@ def run_get_document(args: argparse.Namespace) -> None:
     if result.error:
         if json_out:
             _output_error(result.error)
-        print(f"エラー: {result.error}", file=sys.stderr)
-        sys.exit(1)
+        else:
+            print(f"エラー: {result.error}", file=sys.stderr)
+            sys.exit(1)
 
     if json_out:
         _output_result({

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -365,10 +365,11 @@ def main() -> None:
         help="取得形式（text: 変換済みテキスト、original: オリジナル、デフォルト: text）",
     )
     doc_parser.add_argument(
-        "--output",
+        "--output-file",
         default=None,
         help="出力先ファイルパス（未指定時は標準出力）",
     )
+    _add_output_option(doc_parser)
 
     # rebuild サブコマンド
     rebuild_parser = subparsers.add_parser(
@@ -1113,6 +1114,7 @@ def run_get_document(args: argparse.Namespace) -> None:
     from .config import get_settings
     from .rag_knowledge import format_document_response, get_document
 
+    json_out = _is_json_output(args)
     settings = get_settings()
 
     result = get_document(
@@ -1123,16 +1125,31 @@ def run_get_document(args: argparse.Namespace) -> None:
     )
 
     if result.error:
+        if json_out:
+            _output_error(result.error)
         print(f"エラー: {result.error}", file=sys.stderr)
         sys.exit(1)
 
+    if json_out:
+        _output_result({
+            "source_id": result.source_id,
+            "title": result.title,
+            "source_type": result.source_type,
+            "format": result.format,
+            "content": result.content,
+            "is_binary": result.is_binary,
+            "collected_at": result.collected_at,
+            "extra": result.extra,
+        })
+        return
+
     response = format_document_response(result)
 
-    if args.output:
-        output_path = Path(args.output)
+    if args.output_file:
+        output_path = Path(args.output_file)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(response, encoding="utf-8")
-        print(f"出力しました: {args.output}")
+        print(f"出力しました: {args.output_file}")
     else:
         print(response)
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -40,37 +40,20 @@ from typing import Any
 # ChromaDB テレメトリを無効化（import 前に設定する必要がある）
 os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
 
-# RAG モジュールをモジュールレベルで import する。
-# 重要: asyncio.to_thread のワーカースレッド内で import すると、
-# anyio イベントループの import lock とデッドロックするため、
-# サーバー起動時（メインスレッド）に全て import しておく。
 # bm25s が "resource module not available on Windows" を stdout に print する
 # 問題への対策として、import 時に stdout を抑制する。
 from .config import ensure_utf8_streams
-from .filter_parser import parse_filters
-from .rag_knowledge import format_file_size, format_raw_search_results
+from .rag_knowledge import format_file_size
 
 with contextlib.redirect_stdout(io.StringIO()):
-    from .bm25_index import BM25Index
     from .config import UPLOAD_API_KEY_NAME, UPLOAD_API_KEY_SERVICE, get_settings
-    from .embedding.factory import get_embedding_provider
-    from .rag_knowledge import (
-        RAGKnowledgeService,
-        format_document_response,
-        get_document,
-    )
-    from .vector_store import VectorStore
 
     # パイプライン関連
-    from .pipeline.controller import PipelineController
     from .pipeline.ingesters._common import IngestResult
     from .upload import sanitize_filename as sanitize_upload_filename
-    from .pipeline.ingesters.aozora import AozoraIngester as PipelineAozoraIngester
     from .pipeline.ingesters.local import _UPLOAD_DIR as _LOCAL_UPLOAD_DIR
 
-    from .pipeline.models import PipelineMode, PipelineSummary, detect_source_type
-    from .store.metadata_db import MetadataDB
-    from .store.models import NULL_COMMIT_HASH
+    from .pipeline.models import PipelineMode, PipelineSummary
 from .safe_browsing import (
     SafeBrowsingClient,
     SafeBrowsingConfigError,
@@ -92,121 +75,6 @@ ensure_utf8_streams()
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("rag")
-
-# --- 遅延初期化: RAGKnowledgeService（検索用） ---
-
-_rag_service: RAGKnowledgeService | None = None
-_init_lock = asyncio.Lock()
-
-
-def _reset_rag_service() -> None:
-    """グローバルな RAGKnowledgeService をリセットする.
-
-    CLI サブプロセスが BM25 インデックスをディスク上で更新した後、
-    MCP プロセス内のインメモリ BM25 キャッシュが陳腐化するためリセットが必要。
-    ChromaDB は HttpClient 経由のためクライアント側キャッシュの問題はない。
-    """
-    global _rag_service
-    if _rag_service is not None:
-        try:
-            _rag_service.close()
-        except Exception:
-            logger.warning("Failed to close RAG service", exc_info=True)
-    _rag_service = None
-
-
-async def _get_rag_service() -> RAGKnowledgeService:
-    """RAGKnowledgeService を遅延初期化して返す."""
-    global _rag_service
-    if _rag_service is not None:
-        return _rag_service
-
-    async with _init_lock:
-        if _rag_service is not None:
-            return _rag_service
-
-        _rag_service = await asyncio.to_thread(_build_rag_service)
-        logger.info("RAG service initialized")
-        return _rag_service
-
-
-def _build_rag_service() -> RAGKnowledgeService:
-    """RAGKnowledgeService を構築する（ワーカースレッド用、import なし）."""
-    settings = get_settings()
-
-    embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
-
-    with contextlib.redirect_stdout(io.StringIO()):
-        # HttpClient で ChromaDB サーバーに接続。
-        # ChromaDB サーバーの起動確保は _configure_and_run() の
-        # ChromaDBServerManager.ensure_server_running() で実施済み。
-        vector_store = VectorStore.create_http(
-            embedding_provider=embedding_provider,
-            host=settings.chromadb_server_host,
-            port=settings.chromadb_server_port,
-            collection_name=settings.chromadb_collection_name,
-            hnsw_m=settings.hnsw_m,
-            hnsw_construction_ef=settings.hnsw_construction_ef,
-            hnsw_search_ef=settings.hnsw_search_ef,
-        )
-        bm25_index = BM25Index(
-            k1=settings.rag_bm25_k1,
-            b=settings.rag_bm25_b,
-            persist_dir=settings.bm25_persist_dir,
-        )
-
-    return RAGKnowledgeService(
-        vector_store=vector_store,
-        chunk_size=settings.rag_chunk_size,
-        chunk_overlap=settings.rag_chunk_overlap,
-        similarity_threshold=settings.rag_similarity_threshold,
-        bm25_index=bm25_index,
-        hybrid_search_enabled=settings.rag_hybrid_search_enabled,
-        vector_weight=settings.rag_vector_weight,
-        min_combined_score=settings.rag_min_combined_score,
-        debug_log_enabled=settings.rag_debug_log_enabled,
-    )
-
-
-# --- 遅延初期化: PipelineController（取り込み・再構築用） ---
-
-_pipeline_controller: PipelineController | None = None
-_pipeline_lock = asyncio.Lock()
-
-
-def _reset_pipeline_controller() -> None:
-    """グローバルな PipelineController をリセットする.
-
-    既存インスタンスが保持する SQLite 接続等を解放してから破棄する。
-    """
-    global _pipeline_controller
-    if _pipeline_controller is not None:
-        with contextlib.suppress(Exception):
-            _pipeline_controller.source_store.close()
-    _pipeline_controller = None
-
-
-async def _get_pipeline_controller() -> PipelineController:
-    """PipelineController を遅延初期化して返す."""
-    global _pipeline_controller
-    if _pipeline_controller is not None:
-        return _pipeline_controller
-
-    async with _pipeline_lock:
-        if _pipeline_controller is not None:
-            return _pipeline_controller
-
-        _pipeline_controller = await asyncio.to_thread(_build_pipeline_controller)
-        logger.info("Pipeline controller initialized")
-        return _pipeline_controller
-
-
-def _build_pipeline_controller() -> PipelineController:
-    """パイプライン制御コントローラを構築する（ワーカースレッド用）."""
-    from .pipeline.factory import build_pipeline_controller
-
-    return build_pipeline_controller()
-
 
 _safe_browsing_client_cache: SafeBrowsingClient | None = None
 _safe_browsing_client_initialized = False
@@ -310,24 +178,19 @@ async def rag_search(
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
         return f"無効な source_type: {source_type!r}（有効値: {valid}）"
 
-    # filters パラメータのパース
-    parsed_filters: dict[str, str] | None = None
+    args: list[str] = [query]
+    if n_results is not None:
+        args.extend(["--n-results", str(n_results)])
+    if source_type is not None:
+        args.extend(["--source-type", source_type])
     if filters is not None:
-        try:
-            parsed_filters = parse_filters(filters)
-        except ValueError as e:
-            return f"エラー: {e}"
+        args.extend(["--filters", filters])
 
-    service = await _get_rag_service()
-    if n_results is None:
-        n_results = get_settings().rag_retrieval_count
-
-    raw = await service.retrieve_raw_results(
-        query, n_results=n_results, source_type=source_type,
-        filters=parsed_filters,
-    )
-
-    return format_raw_search_results(raw)
+    try:
+        result = await _run_cli_subprocess("search", args)
+        return _format_cli_search_result(result)
+    except CLISubprocessError as e:
+        return f"エラー: 検索に失敗しました ({e})"
 
 
 _VALID_DOCUMENT_FORMATS: frozenset[str] = frozenset({"text", "original"})
@@ -357,28 +220,15 @@ async def rag_get_document(
         valid = ", ".join(sorted(_VALID_DOCUMENT_FORMATS))
         return f"無効な format: {format!r}（有効値: {valid}）"
 
-    settings = get_settings()
-    result = await asyncio.to_thread(
-        get_document,
-        source_id=source_id,
-        format=format,
-        source_store_dir=settings.source_store_dir,
-        converted_store_dir=settings.converted_store_dir,
-    )
+    args: list[str] = [source_id]
+    if format != "text":
+        args.extend(["--format", format])
 
-    response = format_document_response(result)
-
-    # MCP 経由の場合、rag_max_response_chars でトランケーション（通知文込みで上限内に収める）
-    max_chars = settings.rag_max_response_chars
-    if max_chars is not None and not result.error and len(response) > max_chars:
-        truncation_notice = (
-            "\n\n…（レスポンスが上限の{:,}文字を超えたためトランケートされました。"
-            "CLI の --output オプションで全文取得できます）"
-        ).format(max_chars)
-        truncate_at = max(0, max_chars - len(truncation_notice))
-        response = response[:truncate_at] + truncation_notice
-
-    return response
+    try:
+        result = await _run_cli_subprocess("get-document", args)
+        return _format_cli_document_result(result)
+    except CLISubprocessError as e:
+        return f"エラー: ドキュメント取得に失敗しました ({e})"
 
 
 _VALID_ZENN_CONTENT_TYPES: frozenset[str] = frozenset({"articles", "scraps", "all"})
@@ -838,37 +688,19 @@ async def rag_search_aozora(
     Returns:
         検索結果リスト（作品 ID、タイトル、著者名、著作権フラグ）
     """
-    controller = await _get_pipeline_controller()
-    settings = get_settings()
-    aozora_ingester = PipelineAozoraIngester(
-        controller.source_store,
-        max_works=settings.rag_aozora_max_works,
-    )
+    args: list[str] = []
+    if author is not None:
+        args.extend(["--author", author])
+    if title is not None:
+        args.extend(["--title", title])
+    if limit != 20:
+        args.extend(["--limit", str(limit)])
 
     try:
-        results = aozora_ingester.search(
-            author=author,
-            title=title,
-            limit=limit,
-        )
-    except (ValueError, TypeError) as e:
-        return f"エラー: {e}"
-
-    if not results:
-        parts = []
-        if author:
-            parts.append(f"著者: {author}")
-        if title:
-            parts.append(f"タイトル: {title}")
-        return f"検索結果: 0件（{', '.join(parts)}）"
-
-    lines = [f"検索結果: {len(results)}件", ""]
-    for r in results:
-        lines.append(
-            f"- [{r['book_id']}] {r['title']} / {r['author']} "
-            f"({r['copyright']})"
-        )
-    return "\n".join(lines)
+        result = await _run_cli_subprocess("search-aozora", args)
+        return _format_cli_search_aozora_result(result)
+    except CLISubprocessError as e:
+        return f"エラー: 青空文庫カタログ検索に失敗しました ({e})"
 
 
 @mcp.tool()
@@ -982,9 +814,6 @@ _VALID_PIPELINE_SOURCE_TYPES: frozenset[str] = frozenset({
 })
 
 
-_format_size = format_file_size
-
-
 def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
     """PipelineSummary をテキストに変換する."""
     mode_names = {
@@ -1016,93 +845,6 @@ def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
 # Windows: 0xC0000005 は signed (-1073741819) / unsigned (3221225477) 両方で返りうる
 # Unix: SIGSEGV=11, shell: 128+11=139
 _SEGFAULT_EXIT_CODES: frozenset[int] = frozenset({-1073741819, 3221225477, -11, 139})
-
-
-def _collect_source_store_stats(
-    source_store_dir: Path,
-) -> dict[str, Any]:
-    """source_store のファイル統計を収集する."""
-    if not source_store_dir.exists():
-        return {"total_files": 0, "total_size": 0, "by_type": {}}
-
-    total_files = 0
-    total_size = 0
-    by_type: dict[str, dict[str, int]] = {}
-
-    for file in source_store_dir.rglob("*"):
-        if not file.is_file():
-            continue
-
-        rel = file.relative_to(source_store_dir)
-        rel_posix = rel.as_posix()
-
-        # 除外: .git (ディレクトリ/ファイル), .meta, metadata.db*, .gitignore
-        if (
-            rel_posix == ".git"
-            or rel_posix.startswith(".git/")
-            or rel_posix == ".gitignore"
-        ):
-            continue
-        name = file.name
-        if name.endswith(".meta") or name.startswith("metadata.db"):
-            continue
-
-        size = file.stat().st_size
-        total_files += 1
-        total_size += size
-
-        st = detect_source_type(rel_posix)
-        if st not in by_type:
-            by_type[st] = {"files": 0, "size": 0}
-        by_type[st]["files"] += 1
-        by_type[st]["size"] += size
-
-    return {"total_files": total_files, "total_size": total_size, "by_type": by_type}
-
-
-def _collect_converted_store_stats(
-    converted_store_dir: Path,
-) -> dict[str, Any]:
-    """converted_store のファイル統計を収集する."""
-    if not converted_store_dir.exists():
-        return {"total_files": 0, "total_size": 0}
-
-    total_files = 0
-    total_size = 0
-
-    for file in converted_store_dir.rglob("*"):
-        if not file.is_file():
-            continue
-        total_files += 1
-        total_size += file.stat().st_size
-
-    return {"total_files": total_files, "total_size": total_size}
-
-
-def _collect_pipeline_stats(
-    source_store_dir: Path,
-) -> dict[str, Any] | None:
-    """metadata.db からパイプライン統計を収集する."""
-    db_path = source_store_dir / "metadata.db"
-    if not db_path.exists():
-        return None
-
-    db = MetadataDB(db_path)
-    try:
-        db.initialize()
-        history = db.get_pipeline_history()
-        last_commit_id = db.get_last_commit_id()
-        deleted_count = db.source_count(status="deleted")
-        last_processed_at = history[-1].processed_at if history else None
-
-        return {
-            "last_processed_at": last_processed_at,
-            "execution_count": len(history),
-            "last_commit_id": last_commit_id,
-            "deleted_count": deleted_count,
-        }
-    finally:
-        db.close()
 
 
 @mcp.tool()
@@ -1290,10 +1032,6 @@ async def _run_cli_subprocess(
     stderr_lines = stderr_text.rstrip().splitlines()
     stderr_tail = "\n".join(stderr_lines[-10:])
 
-    # キャッシュリセット（サブプロセスが DB を更新するため）
-    _reset_pipeline_controller()
-    _reset_rag_service()
-
     # SEGFAULT 検出
     if exit_code in _SEGFAULT_EXIT_CODES:
         raise CLISubprocessError(
@@ -1372,6 +1110,194 @@ def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
         return None
 
 
+def _format_chunk_position(chunk_index: int, total_chunks: int) -> str:
+    """チャンク位置を表示用文字列にフォーマットする."""
+    pos = chunk_index + 1
+    if total_chunks > 0:
+        return f"{pos}/{total_chunks}"
+    return f"{pos}/?"
+
+
+def _format_cli_search_result(result: dict[str, Any]) -> str:
+    """CLI search の JSON 結果を MCP レスポンス文字列に変換する."""
+    vector_results = result.get("vector_results", [])
+    bm25_results = result.get("bm25_results", [])
+
+    if not vector_results and not bm25_results:
+        return "該当する情報が見つかりませんでした"
+
+    sections: list[tuple[str, list[dict[str, Any]], str]] = []
+    if vector_results:
+        sections.append(("## ベクトル検索結果 (意味的類似度)\n", vector_results, "distance"))
+    if bm25_results:
+        sections.append(("## BM25 検索結果 (キーワード一致)\n", bm25_results, "score"))
+
+    parts: list[str] = []
+    for header, items, score_key in sections:
+        parts.append(header)
+        for i, item in enumerate(items, start=1):
+            score_val = item.get(score_key, 0.0)
+            parts.append(f"### Result {i} [{score_key}={score_val:.3f}]")
+
+            chunk_pos = _format_chunk_position(
+                item.get("chunk_index", 0), item.get("total_chunks", 0),
+            )
+            parts.append(f"Source: {item.get('source_url', '')}")
+            parts.append(f"Title: {item.get('title', '')}")
+            parts.append(f"Chunk: {chunk_pos}")
+            parts.append(f"Type: {item.get('source_type', '')}")
+            section_path = item.get("section_path", "")
+            if section_path:
+                parts.append(f"Section: {section_path}")
+            collected_at = item.get("collected_at", "")
+            if collected_at:
+                parts.append(f"Collected: {collected_at}")
+            parts.append("")
+            parts.append(item.get("text", ""))
+            parts.append("")
+
+    return "\n".join(parts).rstrip()
+
+
+def _format_cli_document_result(result: dict[str, Any]) -> str:
+    """CLI get-document の JSON 結果を MCP レスポンス文字列に変換する."""
+    parts: list[str] = []
+    parts.append(f"Source: {result.get('source_id', '')}")
+    if result.get("title"):
+        parts.append(f"Title: {result['title']}")
+    if result.get("source_type"):
+        parts.append(f"Type: {result['source_type']}")
+    if result.get("collected_at"):
+        parts.append(f"Collected: {result['collected_at']}")
+    fmt = result.get("format", "text")
+    parts.append(f"Format: {fmt}")
+    parts.append("")
+    content = result.get("content", "")
+    parts.append(content)
+
+    response = "\n".join(parts)
+
+    # MCP 経由の場合、rag_max_response_chars でトランケーション
+    settings = get_settings()
+    max_chars = settings.rag_max_response_chars
+    if max_chars is not None and len(response) > max_chars:
+        truncation_notice = (
+            "\n\n…（レスポンスが上限の{:,}文字を超えたためトランケートされました。"
+            "CLI の --output オプションで全文取得できます）"
+        ).format(max_chars)
+        truncate_at = max(0, max_chars - len(truncation_notice))
+        response = response[:truncate_at] + truncation_notice
+
+    return response
+
+
+def _format_cli_search_aozora_result(result: dict[str, Any]) -> str:
+    """CLI search-aozora の JSON 結果を MCP レスポンス文字列に変換する."""
+    results = result.get("results", [])
+    count = result.get("count", len(results))
+
+    if not results:
+        return f"検索結果: {count}件"
+
+    lines = [f"検索結果: {count}件", ""]
+    for r in results:
+        lines.append(
+            f"- [{r.get('book_id', '')}] {r.get('title', '')} / {r.get('author', '')} "
+            f"({r.get('copyright', '')})"
+        )
+    return "\n".join(lines)
+
+
+def _format_cli_list_recent_result(result: dict[str, Any]) -> str:
+    """CLI list-recent の JSON 結果を MCP レスポンス文字列に変換する."""
+    sources = result.get("sources", [])
+    source_type = result.get("source_type", "")
+    count = result.get("count", len(sources))
+    total = result.get("total", count)
+
+    if not sources:
+        return f"{source_type}: 0 件"
+
+    lines = [f"{source_type}: {count} 件（全 {total} 件中）", ""]
+    for s in sources:
+        title = s.get("title", "(無題)")
+        source_id = s.get("source_id", "")
+        collected_at = s.get("collected_at", "")
+        file_size = s.get("file_size", 0)
+        size_str = format_file_size(file_size) if file_size else ""
+        line = f"- {title}"
+        if collected_at:
+            line += f"  [{collected_at}]"
+        if size_str:
+            line += f"  ({size_str})"
+        lines.append(line)
+        lines.append(f"  {source_id}")
+
+    return "\n".join(lines)
+
+
+def _format_cli_stats_result(result: dict[str, Any]) -> str:
+    """CLI stats の JSON 結果を MCP レスポンス文字列に変換する."""
+    parts: list[str] = ["📊 RAG Knowledge 統計"]
+
+    # source_store
+    ss = result.get("source_store", {})
+    parts.append("")
+    parts.append("■ source_store")
+    if ss.get("status") in {"unconfigured", "not_found"}:
+        parts.append("  未設定" if ss.get("status") == "unconfigured" else "  ディレクトリが存在しません")
+    else:
+        parts.append(f"  総ファイル数: {ss.get('total_files', 0):,}")
+        parts.append(f"  総サイズ: {format_file_size(int(str(ss.get('total_size', 0))))}")
+        by_type = ss.get("by_type")
+        if by_type and isinstance(by_type, dict):
+            parts.append("  媒体別:")
+            for st_key in sorted(by_type.keys()):
+                info = by_type[st_key]
+                parts.append(
+                    f"    {st_key}: {info['files']} files"
+                    f" ({format_file_size(info['size'])})"
+                )
+
+    # converted_store
+    cs = result.get("converted_store", {})
+    parts.append("")
+    parts.append("■ converted_store")
+    if cs.get("status") in {"unconfigured", "not_found"}:
+        parts.append("  未設定" if cs.get("status") == "unconfigured" else "  ディレクトリが存在しません")
+    else:
+        parts.append(f"  総ファイル数: {cs.get('total_files', 0):,}")
+        parts.append(f"  総サイズ: {format_file_size(int(str(cs.get('total_size', 0))))}")
+
+    # インデックス
+    idx = result.get("index", {})
+    parts.append("")
+    parts.append("■ インデックス")
+    if "error" in idx:
+        parts.append(f"  エラー: {idx['error']}")
+    else:
+        parts.append(f"  総チャンク数: {idx.get('total_chunks', 0):,}")
+        parts.append(f"  ソース数: {idx.get('source_count', 0):,}")
+
+    # パイプライン
+    pl = result.get("pipeline", {})
+    parts.append("")
+    parts.append("■ パイプライン")
+    if pl.get("status") == "unconfigured":
+        parts.append("  未設定")
+    elif pl.get("status") == "uninitialized":
+        parts.append("  未初期化")
+    else:
+        last_at = pl.get("last_processed_at") or "（未実行）"
+        parts.append(f"  最終処理: {last_at}")
+        parts.append(f"  実行回数: {pl.get('run_count', 0)}")
+        lci = pl.get("last_commit_id")
+        parts.append(f"  last_commit_id: {lci if lci else '（未実行）'}")
+        parts.append(f"  論理削除: {pl.get('deleted_count', 0)} 件")
+
+    return "\n".join(parts)
+
+
 @mcp.tool()
 async def rag_list_recent(
     source_type: str,
@@ -1394,20 +1320,18 @@ async def rag_list_recent(
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
         return f"無効な source_type: {source_type!r}（有効値: {valid}）"
 
-    settings = get_settings()
-    if limit is None:
-        limit = settings.rag_list_recent_limit
-    if limit < 1 or limit > 100:
+    if limit is not None and (limit < 1 or limit > 100):
         return "エラー: limit は 1〜100 の範囲で指定してください"
 
-    from .rag_knowledge import list_recent_sources
+    args: list[str] = [source_type]
+    if limit is not None:
+        args.extend(["--limit", str(limit)])
 
-    return await asyncio.to_thread(
-        list_recent_sources,
-        settings.source_store_dir,
-        source_type,
-        limit,
-    )
+    try:
+        result = await _run_cli_subprocess("list-recent", args)
+        return _format_cli_list_recent_result(result)
+    except CLISubprocessError as e:
+        return f"エラー: ソース一覧の取得に失敗しました ({e})"
 
 
 @mcp.tool()
@@ -1423,129 +1347,11 @@ async def rag_stats() -> str:
     Returns:
         統計情報のテキスト
     """
-    settings = get_settings()
-
-    parts: list[str] = ["📊 RAG Knowledge 統計"]
-
-    # --- source_store セクション ---
-    parts.append("")
-    parts.append("■ source_store")
-    if not settings.source_store_dir:
-        parts.append("  未設定")
-    else:
-        try:
-            ss_stats = await asyncio.to_thread(
-                _collect_source_store_stats, Path(settings.source_store_dir),
-            )
-            parts.append(f"  総ファイル数: {ss_stats['total_files']:,}")
-            parts.append(f"  総サイズ: {_format_size(ss_stats['total_size'])}")
-            by_type = ss_stats.get("by_type", {})
-            if by_type:
-                parts.append("  媒体別:")
-                for st in sorted(by_type.keys()):
-                    info = by_type[st]
-                    parts.append(
-                        f"    {st}: {info['files']} files"
-                        f" ({_format_size(info['size'])})"
-                    )
-        except Exception:
-            logger.exception("source_store 統計の取得に失敗")
-            parts.append("  エラー: 統計の取得に失敗しました")
-
-    # --- converted_store セクション ---
-    parts.append("")
-    parts.append("■ converted_store")
-    if not settings.converted_store_dir:
-        parts.append("  未設定")
-    else:
-        try:
-            cs_stats = await asyncio.to_thread(
-                _collect_converted_store_stats,
-                Path(settings.converted_store_dir),
-            )
-            parts.append(f"  総ファイル数: {cs_stats['total_files']:,}")
-            parts.append(f"  総サイズ: {_format_size(cs_stats['total_size'])}")
-        except Exception:
-            logger.exception("converted_store 統計の取得に失敗")
-            parts.append("  エラー: 統計の取得に失敗しました")
-
-    # --- インデックスセクション ---
-    parts.append("")
-    parts.append("■ インデックス")
     try:
-        service = await _get_rag_service()
-        index_stats = await service.get_stats()
-        total_chunks = index_stats.get("total_chunks", 0)
-        source_count = index_stats.get("source_count", 0)
-        sources = index_stats.get("sources", [])
-
-        parts.append(f"  総チャンク数: {total_chunks:,}")
-        parts.append(f"  ソース数: {source_count:,}")
-
-        if sources and isinstance(sources, list):
-            max_sources = settings.rag_stats_max_sources
-            parts.append("  ドメイン別:")
-
-            displayed = 0
-            truncated = False
-            for group in sources:
-                if displayed >= max_sources:
-                    truncated = True
-                    break
-                if not isinstance(group, dict):
-                    continue
-                domain = group.get("domain", "unknown")
-                pages = group.get("pages", [])
-                if not isinstance(pages, list):
-                    continue
-
-                page_count = len(pages)
-                domain_chunks = sum(
-                    int(p.get("chunks", 0))
-                    for p in pages
-                    if isinstance(p, dict)
-                )
-                parts.append(
-                    f"    {domain}: {page_count} pages"
-                    f" ({domain_chunks:,} chunks)"
-                )
-                displayed += 1
-
-            if truncated:
-                parts.append(
-                    f"  (以下省略、{max_sources}件まで表示)"
-                )
-    except Exception:
-        logger.exception("インデックス統計の取得に失敗")
-        parts.append("  エラー: 統計の取得に失敗しました")
-
-    # --- パイプラインセクション ---
-    parts.append("")
-    parts.append("■ パイプライン")
-    if not settings.source_store_dir:
-        parts.append("  未設定")
-    else:
-        try:
-            pl_stats = await asyncio.to_thread(
-                _collect_pipeline_stats, Path(settings.source_store_dir),
-            )
-            if pl_stats is None:
-                parts.append("  未初期化")
-            else:
-                last_at = pl_stats["last_processed_at"] or "（未実行）"
-                parts.append(f"  最終処理: {last_at}")
-                parts.append(f"  実行回数: {pl_stats['execution_count']}")
-                commit_id = str(pl_stats["last_commit_id"])
-                if commit_id == NULL_COMMIT_HASH:
-                    parts.append("  last_commit_id: （未実行）")
-                else:
-                    parts.append(f"  last_commit_id: {commit_id[:7]}")
-                parts.append(f"  論理削除: {pl_stats['deleted_count']} 件")
-        except Exception:
-            logger.exception("パイプライン統計の取得に失敗")
-            parts.append("  エラー: 統計の取得に失敗しました")
-
-    return "\n".join(parts)
+        result = await _run_cli_subprocess("stats")
+        return _format_cli_stats_result(result)
+    except CLISubprocessError as e:
+        return f"エラー: 統計情報の取得に失敗しました ({e})"
 
 
 # --- Upload HTTP API ---

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -178,7 +178,7 @@ async def rag_search(
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
         return f"無効な source_type: {source_type!r}（有効値: {valid}）"
 
-    args: list[str] = [query]
+    args: list[str] = ["--query", query]
     if n_results is not None:
         args.extend(["--n-results", str(n_results)])
     if source_type is not None:
@@ -1183,7 +1183,7 @@ def _format_cli_document_result(result: dict[str, Any]) -> str:
     if max_chars is not None and len(response) > max_chars:
         truncation_notice = (
             "\n\n…（レスポンスが上限の{:,}文字を超えたためトランケートされました。"
-            "CLI の --output オプションで全文取得できます）"
+            "CLI の get-document コマンド（--output-file オプション）で全文を取得できます）"
         ).format(max_chars)
         truncate_at = max(0, max_chars - len(truncation_notice))
         response = response[:truncate_at] + truncation_notice
@@ -1323,7 +1323,7 @@ async def rag_list_recent(
     if limit is not None and (limit < 1 or limit > 100):
         return "エラー: limit は 1〜100 の範囲で指定してください"
 
-    args: list[str] = [source_type]
+    args: list[str] = ["--source-type", source_type]
     if limit is not None:
         args.extend(["--limit", str(limit)])
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1248,7 +1248,7 @@ def _format_cli_stats_result(result: dict[str, Any]) -> str:
         parts.append("  未設定" if ss.get("status") == "unconfigured" else "  ディレクトリが存在しません")
     else:
         parts.append(f"  総ファイル数: {ss.get('total_files', 0):,}")
-        parts.append(f"  総サイズ: {format_file_size(int(str(ss.get('total_size', 0))))}")
+        parts.append(f"  総サイズ: {format_file_size(int(ss.get('total_size', 0)))}")
         by_type = ss.get("by_type")
         if by_type and isinstance(by_type, dict):
             parts.append("  媒体別:")
@@ -1267,7 +1267,7 @@ def _format_cli_stats_result(result: dict[str, Any]) -> str:
         parts.append("  未設定" if cs.get("status") == "unconfigured" else "  ディレクトリが存在しません")
     else:
         parts.append(f"  総ファイル数: {cs.get('total_files', 0):,}")
-        parts.append(f"  総サイズ: {format_file_size(int(str(cs.get('total_size', 0))))}")
+        parts.append(f"  総サイズ: {format_file_size(int(cs.get('total_size', 0)))}")
 
     # インデックス
     idx = result.get("index", {})

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -18,19 +18,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rag.rag_knowledge import (
-    BM25SearchItem,
-    RawSearchResults,
-    VectorSearchItem,
-)
-from rag.server import _configure_and_run, _reset_pipeline_controller, _reset_rag_service, _reset_safe_browsing_client
+from rag.server import _configure_and_run, _reset_safe_browsing_client
 
 
 @pytest.fixture(autouse=True)
 def _reset_rag_global_state() -> None:
     """各テスト前にRAGサービスのグローバル状態をリセットする."""
-    _reset_rag_service()
-    _reset_pipeline_controller()
     _reset_safe_browsing_client()
 
 
@@ -68,82 +61,44 @@ async def test_rag_server_tool_count() -> None:
 
 
 class TestRagSearchOutput:
-    """rag_search ツールのチャンク単位出力フォーマットテスト（#251）."""
+    """rag_search ツールのチャンク単位出力フォーマットテスト（CLI 委譲版）."""
 
-    @pytest.fixture(autouse=True)
-    def _patch_rag_service(self) -> None:
-        """rag_search のテスト用に RAGKnowledgeService をモックする."""
-        self.mock_service = AsyncMock()
-        self.mock_settings = MagicMock()
-        self.mock_settings.rag_retrieval_count = 3
+    def _make_cli_result(
+        self,
+        vector_results: list[dict[str, object]] | None = None,
+        bm25_results: list[dict[str, object]] | None = None,
+    ) -> dict[str, object]:
+        return {
+            "query": "テスト",
+            "vector_results": vector_results or [],
+            "bm25_results": bm25_results or [],
+        }
 
     async def test_output_contains_vector_and_bm25_sections(self) -> None:
         """出力にベクトル検索結果とBM25検索結果のセクションが含まれること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="ベクトルの結果テキスト",
-                        source_url="https://example.com/vec1",
-                        distance=0.234,
-                        chunk_index=2,
-                        title="ガイドページ",
-                        source_type="web",
-                        total_chunks=15,
-                    ),
-                ],
-                bm25_results=[
-                    BM25SearchItem(
-                        text="BM25の結果テキスト",
-                        source_url="https://example.com/bm25_1",
-                        score=4.521,
-                        doc_id="doc1",
-                        chunk_index=4,
-                        title="サンプル記事",
-                        source_type="zenn",
-                        total_chunks=20,
-                    ),
-                ],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[{"text": "ベクトルの結果テキスト", "source_url": "https://example.com/vec1", "distance": 0.234, "chunk_index": 2, "title": "ガイドページ", "source_type": "web", "total_chunks": 15, "collected_at": "", "section_path": ""}],
+            bm25_results=[{"text": "BM25の結果テキスト", "source_url": "https://example.com/bm25_1", "score": 4.521, "doc_id": "doc1", "chunk_index": 4, "title": "サンプル記事", "source_type": "zenn", "total_chunks": 20, "collected_at": "", "section_path": ""}],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テストクエリ")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テストクエリ")
 
         assert "## ベクトル検索結果 (意味的類似度)" in result
         assert "## BM25 検索結果 (キーワード一致)" in result
 
     async def test_output_contains_chunk_metadata(self) -> None:
         """各結果にSource/Title/Chunk/Typeメタデータが含まれること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="チャンクテキスト",
-                        source_url="https://example.com/docs/guide",
-                        distance=0.234,
-                        chunk_index=2,
-                        title="ガイドページ",
-                        source_type="web",
-                        total_chunks=15,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[{"text": "チャンクテキスト", "source_url": "https://example.com/docs/guide", "distance": 0.234, "chunk_index": 2, "title": "ガイドページ", "source_type": "web", "total_chunks": 15, "collected_at": "", "section_path": ""}],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テスト")
 
         assert "Source: https://example.com/docs/guide" in result
         assert "Title: ガイドページ" in result
@@ -153,148 +108,69 @@ class TestRagSearchOutput:
 
     async def test_chunk_position_with_unknown_total(self) -> None:
         """total_chunks=0（レガシーデータ）のとき Chunk: N/? と表示されること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=4,
-                        total_chunks=0,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[{"text": "テキスト", "source_url": "https://example.com/page1", "distance": 0.1, "chunk_index": 4, "total_chunks": 0, "title": "", "source_type": "", "collected_at": "", "section_path": ""}],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テスト")
 
         assert "Chunk: 5/?" in result
 
     async def test_output_contains_raw_scores(self) -> None:
         """出力に生スコアが含まれること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/v",
-                        distance=0.567,
-                        chunk_index=0,
-                    ),
-                ],
-                bm25_results=[
-                    BM25SearchItem(
-                        text="テキスト",
-                        source_url="https://example.com/b",
-                        score=3.456,
-                        doc_id="d1",
-                    ),
-                ],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[{"text": "テキスト", "source_url": "https://example.com/v", "distance": 0.567, "chunk_index": 0, "total_chunks": 0, "title": "", "source_type": "", "collected_at": "", "section_path": ""}],
+            bm25_results=[{"text": "テキスト", "source_url": "https://example.com/b", "score": 3.456, "doc_id": "d1", "chunk_index": 0, "total_chunks": 0, "title": "", "source_type": "", "collected_at": "", "section_path": ""}],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テスト")
 
         assert "[distance=0.567]" in result
         assert "[score=3.456]" in result
 
     async def test_empty_results_returns_not_found_message(self) -> None:
         """0件時に「該当する情報が見つかりませんでした」が返ること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[],
-                bm25_results=[],
-            )
-        )
+        cli_result = self._make_cli_result()
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("存在しないクエリ")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("存在しないクエリ")
 
         assert result == "該当する情報が見つかりませんでした"
 
     async def test_chunk_text_returned_directly(self) -> None:
         """チャンクテキストがそのまま返却されること（ページ全文ではない）."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="これはチャンクテキストです",
-                        source_url="https://example.com/page1",
-                        distance=0.1,
-                        chunk_index=0,
-                        title="ページ1",
-                        source_type="web",
-                        total_chunks=5,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[{"text": "これはチャンクテキストです", "source_url": "https://example.com/page1", "distance": 0.1, "chunk_index": 0, "title": "ページ1", "source_type": "web", "total_chunks": 5, "collected_at": "", "section_path": ""}],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テスト")
 
         assert "これはチャンクテキストです" in result
 
     async def test_same_source_different_chunks_shown_individually(self) -> None:
         """同一ソースの異なるチャンクが個別に表示されること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_search
 
-        self.mock_service.retrieve_raw_results = AsyncMock(
-            return_value=RawSearchResults(
-                vector_results=[
-                    VectorSearchItem(
-                        text="チャンク1のテキスト",
-                        source_url="https://example.com/page",
-                        distance=0.1,
-                        chunk_index=0,
-                        title="ページ",
-                        source_type="web",
-                        total_chunks=3,
-                    ),
-                    VectorSearchItem(
-                        text="チャンク2のテキスト",
-                        source_url="https://example.com/page",
-                        distance=0.2,
-                        chunk_index=2,
-                        title="ページ",
-                        source_type="web",
-                        total_chunks=3,
-                    ),
-                ],
-                bm25_results=[],
-            )
+        cli_result = self._make_cli_result(
+            vector_results=[
+                {"text": "チャンク1のテキスト", "source_url": "https://example.com/page", "distance": 0.1, "chunk_index": 0, "title": "ページ", "source_type": "web", "total_chunks": 3, "collected_at": "", "section_path": ""},
+                {"text": "チャンク2のテキスト", "source_url": "https://example.com/page", "distance": 0.2, "chunk_index": 2, "title": "ページ", "source_type": "web", "total_chunks": 3, "collected_at": "", "section_path": ""},
+            ],
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_search("テスト")
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_search("テスト")
 
         assert "チャンク1のテキスト" in result
         assert "チャンク2のテキスト" in result
@@ -394,34 +270,31 @@ class TestConfigureAndRun:
 
 
 class TestRagGetDocumentTool:
-    """rag_get_document ツールのテスト（#251）."""
-
-    @pytest.fixture(autouse=True)
-    def _patch_settings(self) -> None:
-        """テスト用の設定をモックする."""
-        self.mock_settings = MagicMock()
-        self.mock_settings.source_store_dir = "/tmp/source_store"
-        self.mock_settings.converted_store_dir = "/tmp/converted_store"
-        self.mock_settings.rag_max_response_chars = None
+    """rag_get_document ツールのテスト（CLI 委譲版）."""
 
     async def test_format_text_returns_document(self) -> None:
         """format=text でドキュメントが返ること."""
-        from rag.rag_knowledge import DocumentResult
+        from rag.server import rag_get_document
 
-        mod = import_module("rag.server")
-        mock_result = DocumentResult(
-            source_id="https://example.com/docs/guide",
-            title="ガイドページ",
-            source_type="web",
-            format="text",
-            content="これはドキュメント全文です。",
-        )
+        cli_result: dict[str, object] = {
+            "source_id": "https://example.com/docs/guide",
+            "title": "ガイドページ",
+            "source_type": "web",
+            "format": "text",
+            "content": "これはドキュメント全文です。",
+            "is_binary": False,
+            "collected_at": "",
+            "extra": {},
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.rag_max_response_chars = None
 
         with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
+            patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result),
+            patch("rag.server.get_settings", return_value=mock_settings),
         ):
-            result = await mod.rag_get_document("https://example.com/docs/guide")
+            result = await rag_get_document("https://example.com/docs/guide")
 
         assert "Source: https://example.com/docs/guide" in result
         assert "Title: ガイドページ" in result
@@ -431,276 +304,163 @@ class TestRagGetDocumentTool:
 
     async def test_format_original_returns_document(self) -> None:
         """format=original でドキュメントが返ること."""
-        from rag.rag_knowledge import DocumentResult
+        from rag.server import rag_get_document
 
-        mod = import_module("rag.server")
-        mock_result = DocumentResult(
-            source_id="https://example.com/page.html",
-            title="HTMLページ",
-            source_type="web",
-            format="original",
-            content="<html>...</html>",
-        )
+        cli_result: dict[str, object] = {
+            "source_id": "https://example.com/page.html",
+            "title": "HTMLページ",
+            "source_type": "web",
+            "format": "original",
+            "content": "<html>...</html>",
+            "is_binary": False,
+            "collected_at": "",
+            "extra": {},
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.rag_max_response_chars = None
 
         with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
+            patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result),
+            patch("rag.server.get_settings", return_value=mock_settings),
         ):
-            result = await mod.rag_get_document(
-                "https://example.com/page.html", format="original"
-            )
+            result = await rag_get_document("https://example.com/page.html", format="original")
 
         assert "Format: original" in result
         assert "<html>...</html>" in result
 
-    async def test_missing_source_returns_error(self) -> None:
-        """存在しない source_id でエラーが返ること."""
-        from rag.rag_knowledge import DocumentResult
+    async def test_cli_error_returns_error(self) -> None:
+        """CLI サブプロセスエラー時にエラーメッセージを返すこと."""
+        from rag.server import CLISubprocessError, rag_get_document
 
-        mod = import_module("rag.server")
-        mock_result = DocumentResult(
-            source_id="nonexistent",
-            title="",
-            source_type="",
-            format="text",
-            content="",
-            error="ソースが見つかりません: nonexistent",
-        )
-
-        with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
+        with patch(
+            "rag.server._run_cli_subprocess",
+            new_callable=AsyncMock,
+            side_effect=CLISubprocessError("ソースが見つかりません"),
         ):
-            result = await mod.rag_get_document("nonexistent")
+            result = await rag_get_document("nonexistent")
 
-        assert "エラー:" in result
-        assert "ソースが見つかりません" in result
+        assert "エラー" in result
 
     async def test_truncation_with_max_response_chars(self) -> None:
         """rag_max_response_chars でトランケーションされ、通知文込みで上限内に収まること."""
-        from rag.rag_knowledge import DocumentResult
+        from rag.server import rag_get_document
 
-        mod = import_module("rag.server")
         max_chars = 200
-        self.mock_settings.rag_max_response_chars = max_chars
-
         long_content = "あ" * 1000
-        mock_result = DocumentResult(
-            source_id="https://example.com/long",
-            title="Long Page",
-            source_type="web",
-            format="text",
-            content=long_content,
-        )
+        cli_result: dict[str, object] = {
+            "source_id": "https://example.com/long",
+            "title": "Long Page",
+            "source_type": "web",
+            "format": "text",
+            "content": long_content,
+            "is_binary": False,
+            "collected_at": "",
+            "extra": {},
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.rag_max_response_chars = max_chars
 
         with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
+            patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result),
+            patch("rag.server.get_settings", return_value=mock_settings),
         ):
-            result = await mod.rag_get_document("https://example.com/long")
+            result = await rag_get_document("https://example.com/long")
 
         assert "トランケートされました" in result
         assert "--output" in result
-        # 通知文込みで上限以内に収まること
         assert len(result) <= max_chars
 
     async def test_no_truncation_when_limit_is_none(self) -> None:
         """rag_max_response_chars=None のときトランケーションされないこと."""
-        from rag.rag_knowledge import DocumentResult
-
-        mod = import_module("rag.server")
-        self.mock_settings.rag_max_response_chars = None
+        from rag.server import rag_get_document
 
         long_content = "あ" * 1000
-        mock_result = DocumentResult(
-            source_id="https://example.com/long",
-            title="Long Page",
-            source_type="web",
-            format="text",
-            content=long_content,
-        )
+        cli_result: dict[str, object] = {
+            "source_id": "https://example.com/long",
+            "title": "Long Page",
+            "source_type": "web",
+            "format": "text",
+            "content": long_content,
+            "is_binary": False,
+            "collected_at": "",
+            "extra": {},
+        }
+
+        mock_settings = MagicMock()
+        mock_settings.rag_max_response_chars = None
 
         with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
+            patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result),
+            patch("rag.server.get_settings", return_value=mock_settings),
         ):
-            result = await mod.rag_get_document("https://example.com/long")
+            result = await rag_get_document("https://example.com/long")
 
         assert "トランケートされました" not in result
         assert long_content in result
 
-    async def test_binary_file_returns_info(self) -> None:
-        """format=original でバイナリファイルの場合、MIME情報が返ること."""
-        from rag.rag_knowledge import DocumentResult
-
-        mod = import_module("rag.server")
-        mock_result = DocumentResult(
-            source_id="https://example.com/doc.pdf",
-            title="PDF Doc",
-            source_type="web",
-            format="original",
-            content="バイナリファイルです（MIME: application/pdf, サイズ: 1,234 bytes）。\nテキスト形式で取得するには format=text を指定してください。",
-            is_binary=True,
-        )
-
-        with (
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-            patch.object(mod, "get_document", return_value=mock_result),
-        ):
-            result = await mod.rag_get_document(
-                "https://example.com/doc.pdf", format="original"
-            )
-
-        assert "application/pdf" in result
-        assert "format=text" in result
-
     async def test_invalid_format_returns_error(self) -> None:
         """無効な format 値でエラーが返ること."""
-        mod = import_module("rag.server")
+        from rag.server import rag_get_document
 
-        result = await mod.rag_get_document("source", format="invalid")
+        result = await rag_get_document("source", format="invalid")
 
         assert "無効な format" in result
 
 
 class TestRagStatsOutput:
-    """rag_stats ツールの出力フォーマットテスト（Issue #25）."""
+    """rag_stats ツールの出力フォーマットテスト（CLI 委譲版）."""
 
-    @pytest.fixture(autouse=True)
-    def _patch_rag_service(self) -> None:
-        """rag_stats のテスト用に RAGKnowledgeService をモックする."""
-        self.mock_service = AsyncMock()
-        self.mock_settings = MagicMock()
-        self.mock_settings.rag_stats_max_sources = 100
-        self.mock_settings.source_store_dir = ""
-        self.mock_settings.converted_store_dir = ""
+    def _make_cli_result(self, **overrides: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "source_store": {"total_files": 0, "total_size": 0},
+            "converted_store": {"total_files": 0, "total_size": 0},
+            "index": {"total_chunks": 0, "source_count": 0},
+            "pipeline": {"status": "unconfigured"},
+        }
+        base.update(overrides)
+        return base
 
-    async def test_stats_contains_domain_summary(self) -> None:
-        """インデックスセクションにドメイン別サマリが含まれること."""
-        mod = import_module("rag.server")
+    async def test_stats_contains_index_data(self) -> None:
+        """インデックスセクションの統計が表示されること."""
+        from rag.server import rag_stats
 
-        self.mock_service.get_stats = AsyncMock(
-            return_value={
-                "total_chunks": 150,
-                "source_count": 3,
-                "sources": [
-                    {
-                        "domain": "example.com",
-                        "pages": [
-                            {
-                                "url": "https://example.com/page1",
-                                "title": "Page1",
-                                "chunks": 5,
-                            },
-                            {
-                                "url": "https://example.com/page2",
-                                "title": "Page2",
-                                "chunks": 3,
-                            },
-                        ],
-                    },
-                    {
-                        "domain": "other.com",
-                        "pages": [
-                            {
-                                "url": "https://other.com/doc",
-                                "title": "Doc",
-                                "chunks": 10,
-                            },
-                        ],
-                    },
-                ],
-            }
+        cli_result = self._make_cli_result(
+            index={"total_chunks": 150, "source_count": 3},
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_stats()
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_stats()
 
         assert "📊 RAG Knowledge 統計" in result
         assert "総チャンク数: 150" in result
         assert "ソース数: 3" in result
-        assert "example.com: 2 pages (8 chunks)" in result
-        assert "other.com: 1 pages (10 chunks)" in result
 
     async def test_stats_empty_sources(self) -> None:
-        """ソースが空の場合はドメイン別が含まれないこと."""
-        mod = import_module("rag.server")
+        """ソースが空の場合."""
+        from rag.server import rag_stats
 
-        self.mock_service.get_stats = AsyncMock(
-            return_value={
-                "total_chunks": 0,
-                "source_count": 0,
-                "sources": [],
-            }
+        cli_result = self._make_cli_result(
+            index={"total_chunks": 0, "source_count": 0},
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_stats()
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_stats()
 
         assert "📊 RAG Knowledge 統計" in result
         assert "総チャンク数: 0" in result
-        assert "ドメイン別:" not in result
-
-    async def test_stats_domain_truncation_when_exceeds_limit(self) -> None:
-        """ドメイン表示上限を超える場合に省略メッセージが出ること."""
-        mod = import_module("rag.server")
-
-        # 3ドメイン分のデータを用意し、上限を2に設定
-        self.mock_settings.rag_stats_max_sources = 2
-        self.mock_service.get_stats = AsyncMock(
-            return_value={
-                "total_chunks": 30,
-                "source_count": 3,
-                "sources": [
-                    {
-                        "domain": f"domain{i}.com",
-                        "pages": [
-                            {
-                                "url": f"https://domain{i}.com/p",
-                                "title": "P",
-                                "chunks": 10,
-                            },
-                        ],
-                    }
-                    for i in range(3)
-                ],
-            }
-        )
-
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_stats()
-
-        assert "domain0.com" in result
-        assert "domain1.com" in result
-        assert "domain2.com" not in result
-        assert "以下省略" in result
 
     async def test_stats_four_sections(self) -> None:
         """4セクション構成の出力フォーマット."""
-        mod = import_module("rag.server")
+        from rag.server import rag_stats
 
-        self.mock_service.get_stats = AsyncMock(
-            return_value={
-                "total_chunks": 5,
-                "source_count": 1,
-                "sources": [],
-            }
+        cli_result = self._make_cli_result(
+            index={"total_chunks": 5, "source_count": 1},
         )
 
-        with (
-            patch.object(mod, "_get_rag_service", return_value=self.mock_service),
-            patch.object(mod, "get_settings", return_value=self.mock_settings),
-        ):
-            result = await mod.rag_stats()
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+            result = await rag_stats()
 
         assert "■ source_store" in result
         assert "■ converted_store" in result

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -83,9 +83,10 @@ class TestRagSearchOutput:
             bm25_results=[{"text": "BM25の結果テキスト", "source_url": "https://example.com/bm25_1", "score": 4.521, "doc_id": "doc1", "chunk_index": 4, "title": "サンプル記事", "source_type": "zenn", "total_chunks": 20, "collected_at": "", "section_path": ""}],
         )
 
-        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=cli_result) as mock_subprocess:
             result = await rag_search("テストクエリ")
 
+        mock_subprocess.assert_called_once_with("search", ["--query", "テストクエリ"])
         assert "## ベクトル検索結果 (意味的類似度)" in result
         assert "## BM25 検索結果 (キーワード一致)" in result
 

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -8,53 +8,41 @@ rag_rebuild MCP ツール・CLI、rag_stats 拡張の振る舞いを検証する
 from __future__ import annotations
 
 from importlib import import_module
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from rag.cli import _format_elapsed
 from rag.pipeline.models import PipelineMode, PipelineSummary
+from rag.rag_knowledge import format_file_size
 from rag.server import (
     CLISubprocessError,
-    _collect_converted_store_stats,
-    _collect_pipeline_stats,
-    _collect_source_store_stats,
     _format_rebuild_summary,
-    _format_size,
-    _reset_rag_service,
 )
-from rag.store.metadata_db import MetadataDB
 
 
-@pytest.fixture(autouse=True)
-def _reset_rag_global_state() -> None:
-    """各テスト前にRAGサービスのグローバル状態をリセットする."""
-    _reset_rag_service()
-
-
-# --- _format_size テスト ---
+# --- format_file_size テスト ---
 
 
 class TestFormatSize:
     """サイズ表示の自動単位変換テスト."""
 
     def test_bytes(self) -> None:
-        assert _format_size(0) == "0 B"
-        assert _format_size(512) == "512 B"
-        assert _format_size(1023) == "1023 B"
+        assert format_file_size(0) == "0 B"
+        assert format_file_size(512) == "512 B"
+        assert format_file_size(1023) == "1023 B"
 
     def test_kilobytes(self) -> None:
-        assert _format_size(1024) == "1.0 KB"
-        assert _format_size(1536) == "1.5 KB"
+        assert format_file_size(1024) == "1.0 KB"
+        assert format_file_size(1536) == "1.5 KB"
 
     def test_megabytes(self) -> None:
-        assert _format_size(1024 * 1024) == "1.0 MB"
-        assert _format_size(int(45.6 * 1024 * 1024)) == "45.6 MB"
+        assert format_file_size(1024 * 1024) == "1.0 MB"
+        assert format_file_size(int(45.6 * 1024 * 1024)) == "45.6 MB"
 
     def test_gigabytes(self) -> None:
-        assert _format_size(1024 * 1024 * 1024) == "1.0 GB"
-        assert _format_size(int(2.5 * 1024 * 1024 * 1024)) == "2.5 GB"
+        assert format_file_size(1024 * 1024 * 1024) == "1.0 GB"
+        assert format_file_size(int(2.5 * 1024 * 1024 * 1024)) == "2.5 GB"
 
 
 # --- _format_rebuild_summary テスト ---
@@ -104,133 +92,6 @@ class TestFormatRebuildSummary:
             )
             result = _format_rebuild_summary(summary, 0.0)
             assert label in result
-
-
-# --- _collect_source_store_stats テスト ---
-
-
-class TestCollectSourceStoreStats:
-    """source_store 統計収集のテスト."""
-
-    def test_nonexistent_dir(self, tmp_path: Path) -> None:
-        stats = _collect_source_store_stats(tmp_path / "nonexistent")
-        assert stats["total_files"] == 0
-        assert stats["total_size"] == 0
-        assert stats["by_type"] == {}
-
-    def test_empty_dir(self, tmp_path: Path) -> None:
-        stats = _collect_source_store_stats(tmp_path)
-        assert stats["total_files"] == 0
-
-    def test_counts_data_files_by_type(self, tmp_path: Path) -> None:
-        # web ファイル
-        web_dir = tmp_path / "web"
-        web_dir.mkdir()
-        (web_dir / "page1.html").write_text("hello", encoding="utf-8")
-        (web_dir / "page2.html").write_text("world!", encoding="utf-8")
-
-        # bluesky ファイル
-        bs_dir = tmp_path / "bluesky"
-        bs_dir.mkdir()
-        (bs_dir / "post1.json").write_text("{}", encoding="utf-8")
-
-        # local ファイル（ルート直下）
-        (tmp_path / "doc.md").write_text("# Title", encoding="utf-8")
-
-        stats = _collect_source_store_stats(tmp_path)
-        assert stats["total_files"] == 4
-        assert stats["by_type"]["web"]["files"] == 2
-        assert stats["by_type"]["bluesky"]["files"] == 1
-        assert stats["by_type"]["local"]["files"] == 1
-
-    def test_excludes_meta_and_db_files(self, tmp_path: Path) -> None:
-        web_dir = tmp_path / "web"
-        web_dir.mkdir()
-        (web_dir / "page.html").write_text("data", encoding="utf-8")
-        (web_dir / "page.html.meta").write_text("meta", encoding="utf-8")
-        (tmp_path / "metadata.db").write_bytes(b"\x00" * 100)
-        (tmp_path / "metadata.db-wal").write_bytes(b"\x00")
-        (tmp_path / ".gitignore").write_text("*.pyc", encoding="utf-8")
-
-        stats = _collect_source_store_stats(tmp_path)
-        assert stats["total_files"] == 1  # page.html のみ
-
-
-# --- _collect_converted_store_stats テスト ---
-
-
-class TestCollectConvertedStoreStats:
-    """converted_store 統計収集のテスト."""
-
-    def test_nonexistent_dir(self, tmp_path: Path) -> None:
-        stats = _collect_converted_store_stats(tmp_path / "nonexistent")
-        assert stats["total_files"] == 0
-        assert stats["total_size"] == 0
-
-    def test_counts_all_files(self, tmp_path: Path) -> None:
-        (tmp_path / "a.md").write_text("content a", encoding="utf-8")
-        sub = tmp_path / "web"
-        sub.mkdir()
-        (sub / "b.md").write_text("content b", encoding="utf-8")
-
-        stats = _collect_converted_store_stats(tmp_path)
-        assert stats["total_files"] == 2
-        assert stats["total_size"] > 0
-
-
-# --- _collect_pipeline_stats テスト ---
-
-
-class TestCollectPipelineStats:
-    """metadata.db からのパイプライン統計収集テスト."""
-
-    def test_no_db(self, tmp_path: Path) -> None:
-        result = _collect_pipeline_stats(tmp_path)
-        assert result is None
-
-    def test_empty_history(self, tmp_path: Path) -> None:
-        db = MetadataDB(tmp_path / "metadata.db")
-        db.initialize()
-        db.close()
-
-        result = _collect_pipeline_stats(tmp_path)
-        assert result is not None
-        assert result["last_processed_at"] is None
-        assert result["execution_count"] == 0
-        assert result["deleted_count"] == 0
-
-    def test_with_history(self, tmp_path: Path) -> None:
-        db = MetadataDB(tmp_path / "metadata.db")
-        db.initialize()
-        db.add_pipeline_history(
-            from_commit_id="aaa",
-            to_commit_id="bbb",
-            processed_at="2026-03-19T10:00:00+09:00",
-        )
-        db.add_pipeline_history(
-            from_commit_id="bbb",
-            to_commit_id="ccc",
-            processed_at="2026-03-19T11:00:00+09:00",
-        )
-        db.register_source(
-            source_id="src1",
-            source_type="web",
-            file_path="web/test.html",
-            title="Test",
-            content_hash="abc",
-            file_size=100,
-            collected_at="2026-01-01",
-            updated_at="2026-01-01",
-        )
-        db.set_status("src1", "deleted")
-        db.close()
-
-        result = _collect_pipeline_stats(tmp_path)
-        assert result is not None
-        assert result["last_processed_at"] == "2026-03-19T11:00:00+09:00"
-        assert result["execution_count"] == 2
-        assert result["last_commit_id"] == "ccc"
-        assert result["deleted_count"] == 1
 
 
 # --- rag_rebuild MCP ツールテスト ---
@@ -362,28 +223,21 @@ class TestRagRebuild:
 
 
 class TestRagStats:
-    """rag_stats MCP ツール（拡張版）のテスト."""
+    """rag_stats MCP ツール（CLI 委譲版）のテスト."""
 
     @pytest.mark.asyncio
     async def test_stats_output_format(self) -> None:
         """4セクション構成の出力フォーマット."""
         from rag.server import rag_stats
 
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = ""
-        mock_settings.converted_store_dir = ""
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 100,
-            "source_count": 10,
-            "sources": [],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {"total_files": 5, "total_size": 1024},
+            "converted_store": {"total_files": 3, "total_size": 512},
+            "index": {"total_chunks": 100, "source_count": 10},
+            "pipeline": {"last_processed_at": None, "run_count": 0, "last_commit_id": None, "deleted_count": 0},
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
         assert "📊 RAG Knowledge 統計" in result
@@ -397,24 +251,16 @@ class TestRagStats:
         """source_store 未設定時は「未設定」表示."""
         from rag.server import rag_stats
 
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = ""
-        mock_settings.converted_store_dir = ""
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 0,
-            "source_count": 0,
-            "sources": [],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {"status": "unconfigured"},
+            "converted_store": {"status": "unconfigured"},
+            "index": {"total_chunks": 0, "source_count": 0},
+            "pipeline": {"status": "unconfigured"},
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
-        # source_store セクション直後に「未設定」が表示される
         lines = result.split("\n")
         ss_idx = next(
             i for i, line in enumerate(lines) if "■ source_store" in line
@@ -422,35 +268,22 @@ class TestRagStats:
         assert "未設定" in lines[ss_idx + 1]
 
     @pytest.mark.asyncio
-    async def test_stats_with_source_store_data(
-        self, tmp_path: Path,
-    ) -> None:
+    async def test_stats_with_source_store_data(self) -> None:
         """source_store に実データがある場合の統計表示."""
         from rag.server import rag_stats
 
-        # テストデータ作成
-        ss_dir = tmp_path / "source"
-        web_dir = ss_dir / "web"
-        web_dir.mkdir(parents=True)
-        (web_dir / "page.html").write_text(
-            "<html>test</html>", encoding="utf-8",
-        )
-
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = str(ss_dir)
-        mock_settings.converted_store_dir = ""
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 0,
-            "source_count": 0,
-            "sources": [],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {
+                "total_files": 1,
+                "total_size": 100,
+                "by_type": {"web": {"files": 1, "size": 100}},
+            },
+            "converted_store": {"total_files": 0, "total_size": 0},
+            "index": {"total_chunks": 0, "source_count": 0},
+            "pipeline": {"status": "uninitialized"},
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
         assert "総ファイル数: 1" in result
@@ -461,78 +294,37 @@ class TestRagStats:
         """インデックスセクションの統計表示."""
         from rag.server import rag_stats
 
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = ""
-        mock_settings.converted_store_dir = ""
-        mock_settings.rag_stats_max_sources = 50
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 1234,
-            "source_count": 120,
-            "sources": [
-                {
-                    "domain": "example.com",
-                    "pages": [
-                        {
-                            "url": "https://example.com/a",
-                            "title": "Page A",
-                            "chunks": 50,
-                        },
-                        {
-                            "url": "https://example.com/b",
-                            "title": "Page B",
-                            "chunks": 30,
-                        },
-                    ],
-                },
-            ],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {"status": "unconfigured"},
+            "converted_store": {"status": "unconfigured"},
+            "index": {"total_chunks": 1234, "source_count": 120},
+            "pipeline": {"status": "unconfigured"},
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
         assert "総チャンク数: 1,234" in result
         assert "ソース数: 120" in result
-        assert "example.com: 2 pages (80 chunks)" in result
 
     @pytest.mark.asyncio
-    async def test_stats_pipeline_section(
-        self, tmp_path: Path,
-    ) -> None:
+    async def test_stats_pipeline_section(self) -> None:
         """パイプラインセクションの統計表示."""
         from rag.server import rag_stats
 
-        # metadata.db を作成
-        ss_dir = tmp_path / "source"
-        ss_dir.mkdir()
-        db = MetadataDB(ss_dir / "metadata.db")
-        db.initialize()
-        db.add_pipeline_history(
-            from_commit_id="aaa",
-            to_commit_id="bbbcccc",
-            processed_at="2026-03-19T10:30:00+09:00",
-        )
-        db.close()
-
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = str(ss_dir)
-        mock_settings.converted_store_dir = ""
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 0,
-            "source_count": 0,
-            "sources": [],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {"total_files": 0, "total_size": 0},
+            "converted_store": {"total_files": 0, "total_size": 0},
+            "index": {"total_chunks": 0, "source_count": 0},
+            "pipeline": {
+                "last_processed_at": "2026-03-19T10:30:00+09:00",
+                "run_count": 1,
+                "last_commit_id": "bbbcccc",
+                "deleted_count": 0,
+            },
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
         assert "最終処理: 2026-03-19T10:30:00+09:00" in result
@@ -541,31 +333,18 @@ class TestRagStats:
         assert "論理削除: 0 件" in result
 
     @pytest.mark.asyncio
-    async def test_stats_pipeline_uninitialized(
-        self, tmp_path: Path,
-    ) -> None:
+    async def test_stats_pipeline_uninitialized(self) -> None:
         """metadata.db が存在しない場合「未初期化」表示."""
         from rag.server import rag_stats
 
-        ss_dir = tmp_path / "source"
-        ss_dir.mkdir()
-        # metadata.db は作成しない
-
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = str(ss_dir)
-        mock_settings.converted_store_dir = ""
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 0,
-            "source_count": 0,
-            "sources": [],
+        mock_cli_result: dict[str, object] = {
+            "source_store": {"total_files": 0, "total_size": 0},
+            "converted_store": {"total_files": 0, "total_size": 0},
+            "index": {"total_chunks": 0, "source_count": 0},
+            "pipeline": {"status": "uninitialized"},
         }
 
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
+        with patch("rag.server._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result):
             result = await rag_stats()
 
         lines = result.split("\n")
@@ -575,83 +354,18 @@ class TestRagStats:
         assert "未初期化" in lines[pl_idx + 1]
 
     @pytest.mark.asyncio
-    async def test_stats_domain_limit(self) -> None:
-        """ドメイン別一覧の表示上限テスト."""
+    async def test_stats_cli_error(self) -> None:
+        """CLI サブプロセスエラー時にエラーメッセージを返すこと."""
         from rag.server import rag_stats
 
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = ""
-        mock_settings.converted_store_dir = ""
-        mock_settings.rag_stats_max_sources = 2
-
-        # 3ドメイン分のデータを用意
-        sources = [
-            {
-                "domain": f"domain{i}.com",
-                "pages": [{"url": f"https://domain{i}.com/p", "title": "P", "chunks": 10}],
-            }
-            for i in range(3)
-        ]
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 30,
-            "source_count": 3,
-            "sources": sources,
-        }
-
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
+        with patch(
+            "rag.server._run_cli_subprocess",
+            new_callable=AsyncMock,
+            side_effect=CLISubprocessError("subprocess failed"),
         ):
             result = await rag_stats()
 
-        assert "domain0.com" in result
-        assert "domain1.com" in result
-        assert "domain2.com" not in result
-        assert "以下省略" in result
-
-    @pytest.mark.asyncio
-    async def test_stats_domain_no_truncation_at_exact_limit(self) -> None:
-        """ドメイン数がちょうど上限と等しい場合に省略メッセージが出ないこと."""
-        from rag.server import rag_stats
-
-        mock_settings = MagicMock()
-        mock_settings.source_store_dir = ""
-        mock_settings.converted_store_dir = ""
-        mock_settings.rag_stats_max_sources = 2
-
-        # ちょうど2ドメイン（上限と同数）
-        sources = [
-            {
-                "domain": f"domain{i}.com",
-                "pages": [
-                    {
-                        "url": f"https://domain{i}.com/p",
-                        "title": "P",
-                        "chunks": 10,
-                    },
-                ],
-            }
-            for i in range(2)
-        ]
-
-        mock_service = AsyncMock()
-        mock_service.get_stats.return_value = {
-            "total_chunks": 20,
-            "source_count": 2,
-            "sources": sources,
-        }
-
-        with (
-            patch("rag.server.get_settings", return_value=mock_settings),
-            patch("rag.server._get_rag_service", return_value=mock_service),
-        ):
-            result = await rag_stats()
-
-        assert "domain0.com" in result
-        assert "domain1.com" in result
-        assert "以下省略" not in result
+        assert "エラー" in result
 
 
 # --- ツール数テスト ---

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -23,14 +23,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rag.server import _reset_pipeline_controller, _reset_rag_service, _reset_safe_browsing_client
+from rag.server import _reset_safe_browsing_client
 
 
 @pytest.fixture(autouse=True)
 def _reset_global_state() -> None:
     """各テスト前にグローバル状態をリセットする."""
-    _reset_rag_service()
-    _reset_pipeline_controller()
     _reset_safe_browsing_client()
 
 

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -19,8 +19,6 @@ import pytest
 from rag.server import (
     CLISubprocessError,
     _decode_form_value,
-    _reset_pipeline_controller,
-    _reset_rag_service,
     mcp,
 )
 
@@ -33,13 +31,6 @@ def _default_mock_settings(**overrides: object) -> MagicMock:
     }
     defaults.update(overrides)
     return MagicMock(**defaults)
-
-
-@pytest.fixture(autouse=True)
-def _reset_global_state() -> None:
-    """各テスト前にグローバル状態をリセットする."""
-    _reset_rag_service()
-    _reset_pipeline_controller()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_upload_auth.py
+++ b/tests/test_upload_auth.py
@@ -18,8 +18,6 @@ import pytest
 
 from rag.server import (
     _check_api_key_registered,
-    _reset_pipeline_controller,
-    _reset_rag_service,
     _validate_bind_address,
     mcp,
 )
@@ -33,13 +31,6 @@ def _default_mock_settings(**overrides: object) -> MagicMock:
     }
     defaults.update(overrides)
     return MagicMock(**defaults)
-
-
-@pytest.fixture(autouse=True)
-def _reset_global_state() -> None:
-    """各テスト前にグローバル状態をリセットする."""
-    _reset_rag_service()
-    _reset_pipeline_controller()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] refactor: リファクタリング
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- 検索系5ツール（rag_search, rag_get_document, rag_search_aozora, rag_list_recent, rag_stats）をインプロセス実行から CLI サブプロセス委譲に移行
- server.py から RAGKnowledgeService/PipelineController のグローバル状態管理を完全に除去（約720行削減）
- cli.py の get-document コマンドに `--output json` 対応を追加
- 仕様書に MCP 薄層アダプターパターンの設計方針を追記、mermaid 図を更新
- テストを CLI 委譲モック方式に全面移行

## Test plan

- [x] pytest 156件全パス（test_rag_mcp_server, test_rebuild_stats, test_scrapy_site_ingest, test_upload_api, test_upload_auth）
- [x] ruff lint クリーン
- [x] mypy 型チェッククリーン
- [x] コードレビュー・ドキュメントレビュー通過

## Related issues

Closes #480