### PR TITLE
docs(qa-skill): MCP 運用を HTTP モードに統一 (#489)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -58,15 +58,16 @@ QA 検証グループ:
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する
 7. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
-8. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
+8. ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）
+9. MCP フェーズを含む場合、worktree で MCP サーバーを HTTP モードで起動する: `cd <worktree-path> && uv run python -m rag.server &`。メインリポジトリの MCP サーバーが起動中の場合はポート競合するため先に停止すること。`.mcp.json` は `url` ベース（`http://localhost:<RAG_HTTP_PORT>/mcp`）のため変更不要
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
 ### 4. 環境確認
 
 - 現在のブランチ・作業ディレクトリを表示
-- MCP サーバーの状態確認（CLI 検証時は disabled 推奨、MCP 検証時は enabled であることを確認）
-- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認。「MCP のみ」選択時はスキップ
+- MCP サーバーの状態確認（CLI 検証時は停止推奨、MCP 検証時は HTTP モードで起動中であることを確認）
+- ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認
 - 問題があればユーザーに報告し、解決してから続行
@@ -96,12 +97,11 @@ qa スキル自身はステップ間の制御（次ステップへの遷移、ST
 
 インターフェース選択に応じた実行方針:
 
-- **CLI のみ**: MCP disabled を確認し、全グループを CLI で実行
-- **MCP のみ**: MCP enabled を確認し、全グループを MCP で実行
+- **CLI のみ**: MCP サーバーが停止していることを確認し、全グループを CLI で実行
+- **MCP のみ**: MCP サーバーが HTTP モードで起動中であることを確認し、全グループを MCP で実行
 - **both**: 2フェーズで実行
-  1. CLI フェーズ: MCP disabled を確認 → 全グループを CLI で実行
-  2. 切り替え: ユーザーに `/mcp` で enabled に切り替えてもらう
-  3. MCP フェーズ: MCP enabled を確認 → 全グループを MCP で実行
+  1. CLI フェーズ: 全グループを CLI で実行
+  2. MCP フェーズ: MCP サーバーが HTTP モードで起動中であることを確認 → 全グループを MCP で実行
 
 **全ステップ共通ルール:**
 
@@ -219,9 +219,13 @@ MCP 対応コマンド:
 | CLI コマンド | MCP ツール |
 |------------|-----------|
 | `add-document --file <path>` | `rag_add_document` |
-| `crawl-documents <dir>` | `rag_crawl_documents` |
+| `crawl-documents <dir>` | `rag_crawl_documents`（HTTP モード非対応、CLI のみ） |
 | `add-journal --title <t> --file <f> --repository <r>` | `rag_add_journal` |
 | `migrate-journal --dir <d> --repository <r>` | （CLI のみ） |
+
+**MCP テスト時の注意:**
+- A-2 (PDF): 大きい PDF は MCP パラメータサイズ制約で失敗する場合がある。失敗時は CLI で代替実行する
+- A-4 (crawl-documents): HTTP モード非対応のため MCP テスト時はスキップする
 
 ### B) Web
 
@@ -266,14 +270,9 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
 
 #### グループ準備
 
-1. `.env` の `RAG_TRANSPORT` の現在の値を退避し、`http` に変更する:
+MCP サーバーが HTTP モードで起動中であること（worktree セットアップで起動済み）。
 
-   ```bash
-   grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
-   sed -i 's/^RAG_TRANSPORT=.*/RAG_TRANSPORT=http/' .env
-   ```
-
-2. API キーが keyring に登録済みか確認する:
+1. API キーが keyring に登録済みか確認する:
 
    ```bash
    uv run python -c "
@@ -296,21 +295,6 @@ MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_aozora`
    " > /tmp/qa_api_key.txt
    chmod 600 /tmp/qa_api_key.txt
    ```
-
-4. HTTP サーバーを起動し、PID を記録する:
-
-   ```bash
-   uv run python -m rag.server &
-   echo $! > /tmp/qa_rag_server.pid
-   ```
-
-5. サーバーの起動を待機する（起動に数秒かかる場合がある）:
-
-   ```bash
-   sleep 5
-   ```
-
-   起動確認は F-1（最初のリクエスト）で HTTP 200 が返ることをもって行う。
 
 ベース URL: `http://localhost:<RAG_HTTP_PORT>`（デフォルト: `8081`）
 
@@ -340,9 +324,7 @@ cat /tmp/upload_bg.txt
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する（起動時に記録した PID を使用。`taskkill //T` でプロセスツリーごと停止する）: `if [ -f /tmp/qa_rag_server.pid ]; then taskkill //PID "$(cat /tmp/qa_rag_server.pid)" //T //F > /dev/null 2>&1 || true; rm -f /tmp/qa_rag_server.pid; fi`
-2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する: `if [ -f /tmp/qa_original_transport.txt ]; then sed -i "s/^RAG_TRANSPORT=.*/RAG_TRANSPORT=$(cat /tmp/qa_original_transport.txt)/" .env; fi`
-3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
+1. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 
 ### G) Eval（CLI 固定）
 
@@ -400,5 +382,7 @@ QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等�
 
 - テストデータの作成時、実在の著作物・キャラクター情報を使用しない（`~/.claude/rules/invariants.md`）
 - 各グループの実行中にエラーが発生した場合、そのステップを NG として記録し、次のステップに進む。グループ全体を中断しない
-- MCP ツールの検証では、MCP サーバーが enabled であることを確認してから実行する。disabled の場合はユーザーに `/mcp` での状態変更を依頼する
-- **MCP と CLI の共存**: HttpClient + ファイルベースロックにより MCP と CLI の同時アクセスは技術的に可能だが、QA では検証環境の単純化のため CLI 検証時は MCP disabled を推奨する
+- MCP ツールの検証では、MCP サーバーが HTTP モードで起動中であることを確認してから実行する。起動していない場合はユーザーに起動を依頼する
+- **MCP と CLI の共存**: HttpClient + ファイルベースロックにより MCP と CLI の同時アクセスは技術的に可能だが、QA では検証環境の単純化のため CLI 検証時は MCP サーバーを停止推奨
+- **HTTP モード非対応ツール**: `crawl-documents` は HTTP モードでは実行不可（クライアントとサーバーが別マシンの可能性がありローカルパスを解決できないため）。MCP テスト時はスキップし、CLI テスト時のみ実行する
+- **大きいバイナリファイルの MCP テスト制約**: MCP の `content` パラメータに大きいファイル（PDF 等）を base64 で渡す場合、クライアント側のパラメータサイズ制約により失敗することがある。MCP テスト時は小さいファイルを使用するか、スキップして CLI で代替する

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -66,7 +66,7 @@ QA 検証グループ:
 ### 4. 環境確認
 
 - 現在のブランチ・作業ディレクトリを表示
-- MCP サーバーの状態確認（CLI 検証時は停止推奨、MCP 検証時は HTTP モードで起動中であることを確認）
+- MCP サーバーの状態確認（CLI 検証時は停止推奨、MCP 検証時は HTTP モードで起動中かつ `/mcp` で enabled であることを確認）。disabled の場合はユーザーに有効化を依頼する
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,7 @@
 {
   "mcpServers": {
     "rag-knowledge": {
-      "command": "uv",
-      "args": ["run", "python", "-m", "rag.server"],
-      "env": {
-        "RAG_TRANSPORT": "stdio"
-      }
+      "url": "http://localhost:8081/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ worktree で開発中のコードを MCP サーバーとして動作確認する
 
 3. `.mcp.json` の `url` は `http://localhost:<RAG_HTTP_PORT>/mcp` のまま変更不要（worktree のサーバーが同じポートで起動するため）。メインリポジトリの MCP サーバーが起動中の場合はポート競合するため、先に停止すること
 
-4. `/mcp` で reconnect（サーバー再接続）。`.mcp.json` を変更した場合はセッション再起動が必要
+4. `/mcp` で disabled の場合は enable、enabled の場合は reconnect（サーバー再接続）。`.mcp.json` を変更した場合はセッション再起動が必要
 
 5. 動作確認完了後、worktree のサーバープロセスを停止する
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,32 +7,32 @@
 
 ## MCP サーバー運用ルール
 
-本リポジトリは MCP サーバーの実装リポジトリであり、`.mcp.json` で Claude Code の MCP サーバーとして登録されている。MCP サーバーが enabled の場合、Claude Code セッション中はサーバープロセスが常駐する。
+本リポジトリは MCP サーバーの実装リポジトリであり、`.mcp.json` で Claude Code の MCP サーバーとして登録されている。MCP サーバーは HTTP モード（`RAG_TRANSPORT=http`）で運用し、`.mcp.json` は `url` ベースで接続する。サーバーは別プロセスで起動しておく必要がある。
 
 ### セッション開始時の状態確認
 
-作業開始時に MCP サーバーの状態を確認すること。前回セッションの状態が引き継がれるため、意図しない状態で作業を始めるリスクがある。
+作業開始時に MCP サーバーの状態を確認すること。HTTP モードではサーバーは別プロセスで動作するため、enabled であってもサーバープロセスが停止していればツールは使えない。
 
-- **enabled の場合**: MCP サーバーが稼働中。CLI 操作はファイルベースロックにより共存可能だが、テスト実行は DB 分離のため disabled 推奨
-- **disabled の場合**: MCP ツールは使用できないが、CLI・テスト・開発作業は自由に行える
+- **サーバー起動中 + enabled の場合**: MCP ツールが使用可能。CLI 操作はファイルベースロックにより共存可能
+- **サーバー停止中 or disabled の場合**: MCP ツールは使用できないが、CLI・テスト・開発作業は自由に行える
 
-状態に応じて必要なら、ユーザーに `/mcp` での状態変更を依頼する。`/mcp` での状態変更はエージェントからは実行できない。
+MCP の接続状態の変更はユーザーに `/mcp` での操作を依頼する。サーバープロセスの起動・停止はエージェントから実行可能。
 
 ### MCP サーバーと他プロセスの共存
 
 ChromaDB は HttpClient 経由でサーバーに接続するため、MCP と CLI の同時アクセスが可能。書き込み操作はファイルベースロック（fcntl/msvcrt）でプロセス間排他制御される。
 
-| 作業 | 必要な MCP 状態 |
-|------|---------------|
-| 通常開発・CLI 操作 | enabled / disabled どちらでも可 |
-| テスト実行 | disabled 推奨（テスト用 DB との分離のため） |
-| MCP ツールの動作確認 | enabled |
+| 作業 | MCP サーバー | 備考 |
+|------|-------------|------|
+| 通常開発・CLI 操作 | 起動中 / 停止中どちらでも可 | |
+| テスト実行 | 停止推奨 | テスト用 DB との分離のため |
+| MCP ツールの動作確認 | 起動中 + enabled | |
 
 **注意**: BM25 インデックスは単一プロセス前提のインメモリキャッシュを持つ。MCP 経由の書き込み後はキャッシュが自動リセットされるが、CLI 直接実行で BM25 を更新した場合、MCP 側の検索結果に反映されるのは次回のサービスリセット後となる。
 
 ### DB 破損時の復旧
 
-MCP を disable → ChromaDB サーバーが起動していることを確認（停止していれば `uv run chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。
+MCP サーバープロセスを停止 → ChromaDB サーバーが起動していることを確認（停止していれば `uv run chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。
 
 ### worktree 環境セットアップ
 
@@ -66,7 +66,7 @@ worktree で CLI 操作・動作確認を行う場合、以下のセットアッ
    mkdir -p <worktree-path>/.tmp
    ```
 
-5. ChromaDB サーバーを起動する（メインリポジトリの MCP が enabled の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
+5. ChromaDB サーバーを起動する（メインリポジトリの MCP サーバーが起動中の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
 
    ```bash
    uv run chroma run --path <worktree-path>/.tmp/test_chroma_db --port <別ポート>
@@ -98,23 +98,23 @@ uv run python -m rag.cli search --query "<クエリ>"
 
 worktree で開発中のコードを MCP サーバーとして動作確認する手順:
 
-1. `.mcp.json` の `args` に `--directory` を追加し、worktree の絶対パスを指定する:
-
-   ```json
-   "args": ["--directory", "D:\\GitHub\\becky3\\rag-knowledge-wt-XXX", "run", "python", "-m", "rag.server"]
-   ```
-
-2. worktree の `.env` でストレージパスを絶対パスに変更する（相対パスだとメインリポジトリのストレージを参照してしまう）:
+1. worktree の `.env` でストレージパスを絶対パスに変更する（相対パスだとメインリポジトリのストレージを参照してしまう）:
 
    ```
    CHROMADB_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_chroma_db
    ```
 
-3. `/mcp` で disable → enable（プロセス再起動が必要。reconnect では `.env` が再読み込みされない）
+2. worktree で MCP サーバーを HTTP モードで起動する:
 
-4. 動作確認完了後、`.mcp.json` を元に戻す（`--directory` を削除）
+   ```bash
+   cd <worktree-path> && uv run python -m rag.server &
+   ```
 
-注意: `--directory .` は MCP サーバー起動時の cwd に依存するため使用不可。絶対パスを指定すること。
+3. `.mcp.json` の `url` は `http://localhost:<RAG_HTTP_PORT>/mcp` のまま変更不要（worktree のサーバーが同じポートで起動するため）。メインリポジトリの MCP サーバーが起動中の場合はポート競合するため、先に停止すること
+
+4. `/mcp` で reconnect（サーバー再接続）。`.mcp.json` を変更した場合はセッション再起動が必要
+
+5. 動作確認完了後、worktree のサーバープロセスを停止する
 
 ## Claude Code 拡張機能
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -25,7 +25,9 @@ MCP ツール・CLI コマンド・HTTP API の機能を実際に実行し、正
 ## 制約
 
 - **worktree 環境での実行**: 本番ストレージに影響を与えないよう、worktree 環境で実行する。ストレージパスは worktree 内の絶対パスを使用する
-- **MCP サーバーの分離**: MCP ツール検証時は MCP サーバーを enabled にする。CLI 検証時は disabled を推奨する（HttpClient + ファイルベースロックにより同時アクセスは技術的に可能だが、検証環境の単純化のため分離する）
+- **MCP サーバーの分離**: MCP ツール検証時は MCP サーバーを HTTP モードで起動する。CLI 検証時は停止を推奨する（HttpClient + ファイルベースロックにより同時アクセスは技術的に可能だが、検証環境の単純化のため分離する）
+- **HTTP モード非対応ツール**: `crawl-documents`（`rag_crawl_documents`）は HTTP モードでは実行不可（クライアントとサーバーが別マシンの可能性がありローカルパスを解決できないため）。MCP テスト時はスキップし、CLI テスト時のみ実行する
+- **大きいバイナリファイルの MCP テスト制約**: MCP の `content` パラメータに大きいファイル（PDF 等）を渡す場合、クライアント側のパラメータサイズ制約により失敗することがある。MCP テスト時は小さいファイルを使用するか、CLI で代替する
 - **YouTube の実行制限**: YouTube グループ（D）を選択した場合、実行直前にユーザー確認を必ず挟む。IP ブロックリスクがあるため
 - **外部 API への最小アクセス**: 外部 API を使用するグループでは、取り込み件数を最小限に制限する（具体値は検証リソース定義に従う）
 - **エラー時の継続動作**: 各ステップでエラーが発生した場合、NG として記録し次のステップに進む。グループ全体を中断しない
@@ -114,15 +116,16 @@ QA 検証グループ:
 4. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 5. `.tmp` ディレクトリを作成する
 6. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
-7. CLI フェーズを含む場合、ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）。「MCP のみ」選択時は MCP サーバーが自動起動するためスキップする
+7. ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）
+8. MCP フェーズを含む場合、worktree で MCP サーバーを HTTP モードで起動する: `cd <worktree-path> && uv run python -m rag.server &`。メインリポジトリの MCP サーバーが起動中の場合はポート競合するため先に停止すること。`.mcp.json` は `url` ベースのため変更不要
 
 以降の全コマンドは worktree ディレクトリで実行する。
 
 ### ステップ 4: 環境確認
 
 - 現在のブランチ・ディレクトリを確認する
-- MCP サーバーの状態を確認する（CLI 検証時は disabled 推奨）
-- ChromaDB サーバー疎通確認（CLI フェーズを含む場合のみ）: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する。「MCP のみ」選択時はスキップする
+- MCP サーバーの状態を確認する（MCP フェーズでは HTTP モードで起動中であること、CLI 検証時は停止推奨）
+- ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認する
 
@@ -157,12 +160,11 @@ qa スキルが qa-execute を経由せず直接実行してよい操作を以�
 
 #### インターフェース選択に応じた実行方針
 
-- **CLI のみ**: MCP サーバーが disabled であることを確認し、全グループを CLI で実行する
-- **MCP のみ**: MCP サーバーが enabled であることを確認し、全グループを MCP で実行する
+- **CLI のみ**: MCP サーバーを停止し、全グループを CLI で実行する
+- **MCP のみ**: MCP サーバーが HTTP モードで起動中であることを確認し、全グループを MCP で実行する
 - **both**: 2フェーズで実行する
-  1. **CLI フェーズ**: MCP disabled を確認し、全グループを CLI で実行する
-  2. **切り替え**: ユーザーに `/mcp` で MCP サーバーを enabled に切り替えてもらう
-  3. **MCP フェーズ**: MCP enabled を確認し、全グループを MCP で実行する
+  1. **CLI フェーズ**: MCP サーバーを停止し、全グループを CLI で実行する
+  2. **MCP フェーズ**: MCP サーバーを HTTP モードで起動し、全グループを MCP で実行する
 
 MCP フェーズでの追加確認（書き込み系ツール実行時）:
 
@@ -238,9 +240,13 @@ CLI / MCP 対応:
 | CLI コマンド | MCP ツール |
 |------------|-----------|
 | `add-document --file <path>` | `rag_add_document` |
-| `crawl-documents <dir>` | `rag_crawl_documents` |
+| `crawl-documents <dir>` | `rag_crawl_documents`（HTTP モード非対応、CLI のみ） |
 | `add-journal --title <t> --file <f> --repository <r>` | `rag_add_journal` |
 | `migrate-journal --dir <d> --repository <r>` | （CLI のみ） |
+
+**MCP テスト時の注意:**
+- A-2 (PDF): 大きい PDF は MCP パラメータサイズ制約で失敗する場合がある。失敗時は CLI で代替実行する
+- A-4 (crawl-documents): HTTP モード非対応のため MCP テスト時はスキップする
 
 ### B) Web
 
@@ -291,18 +297,11 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
 
 ### F) Upload
 
-目的: HTTP Upload API の動作確認。HTTP モードでの MCP サーバー起動が必要。
+目的: HTTP Upload API の動作確認。MCP サーバーが HTTP モードで起動中であること（worktree セットアップで起動済み）。
 
 #### グループ準備
 
-1. `.env` の `RAG_TRANSPORT` の現在の値を退避し、`http` に変更する:
-
-   ```bash
-   grep '^RAG_TRANSPORT=' .env | cut -d= -f2 > /tmp/qa_original_transport.txt
-   sed -i 's/^RAG_TRANSPORT=.*/RAG_TRANSPORT=http/' .env
-   ```
-
-2. API キーが keyring に登録済みか確認する:
+1. API キーが keyring に登録済みか確認する:
 
    ```bash
    uv run python -c "
@@ -324,19 +323,6 @@ CLI / MCP 対応: `rag_update_aozora_catalog` / `rag_search_aozora` / `rag_add_a
    print(keyring.get_password(UPLOAD_API_KEY_SERVICE, UPLOAD_API_KEY_NAME))
    " > /tmp/qa_api_key.txt
    chmod 600 /tmp/qa_api_key.txt
-   ```
-
-4. HTTP サーバーを起動し、PID を記録する:
-
-   ```bash
-   uv run python -m rag.server &
-   echo $! > /tmp/qa_rag_server.pid
-   ```
-
-5. サーバーの起動を待機する（起動に数秒かかる場合がある）:
-
-   ```bash
-   sleep 5
    ```
 
    起動確認は F-1（最初のリクエスト）で HTTP 200 が返ることをもって行う。
@@ -369,9 +355,7 @@ cat /tmp/upload_bg.txt
 
 #### グループ片付け
 
-1. HTTP サーバーを停止する（起動時に記録した PID を使用。`taskkill //T` でプロセスツリーごと停止する）: `if [ -f /tmp/qa_rag_server.pid ]; then taskkill //PID "$(cat /tmp/qa_rag_server.pid)" //T //F > /dev/null 2>&1 || true; rm -f /tmp/qa_rag_server.pid; fi`
-2. `.env` の `RAG_TRANSPORT` を起動前の値に復元する: `if [ -f /tmp/qa_original_transport.txt ]; then sed -i "s/^RAG_TRANSPORT=.*/RAG_TRANSPORT=$(cat /tmp/qa_original_transport.txt)/" .env; fi`
-3. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt /tmp/qa_original_transport.txt`
+1. テンポラリファイルを削除する: `rm -f /tmp/qa_api_key.txt /tmp/upload_bg.txt`
 
 ### G) Eval
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -124,7 +124,7 @@ QA 検証グループ:
 ### ステップ 4: 環境確認
 
 - 現在のブランチ・ディレクトリを確認する
-- MCP サーバーの状態を確認する（MCP フェーズでは HTTP モードで起動中であること、CLI 検証時は停止推奨）
+- MCP サーバーの状態を確認する（MCP フェーズでは HTTP モードで起動中かつ `/mcp` で enabled であること、CLI 検証時は停止推奨）。disabled の場合はユーザーに有効化を依頼する
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認する

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -509,7 +509,8 @@ async def rag_crawl_documents(
     knowledge base, ingest, document directory, bulk import, glob.
     指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、
     一括でナレッジベースに取り込む。
-    stdio モード専用。HTTP モードでは無効。
+    CLI 専用。HTTP モードではクライアントとサーバーが別マシンの可能性があり、
+    ローカルパスを解決できないため無効。
 
     Args:
         dir_path: 取り込み対象ディレクトリのパス（絶対パスまたは相対パス）
@@ -520,7 +521,7 @@ async def rag_crawl_documents(
         取り込み結果のサマリーテキスト
     """
     if get_settings().rag_transport == "http":
-        return "エラー: rag_crawl_documents は HTTP モードでは無効です（セキュリティ上の制約）"
+        return "エラー: rag_crawl_documents は HTTP モードでは無効です（クライアントとサーバーが別マシンの可能性があり、ローカルパスを解決できないため）"
 
     args: list[str] = [dir_path]
     if pattern != "**/*":

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -509,7 +509,7 @@ async def rag_crawl_documents(
     knowledge base, ingest, document directory, bulk import, glob.
     指定ディレクトリ内のドキュメントファイルを glob パターンで検索し、
     一括でナレッジベースに取り込む。
-    CLI 専用。HTTP モードではクライアントとサーバーが別マシンの可能性があり、
+    stdio モード専用。HTTP モードではクライアントとサーバーが別マシンの可能性があり、
     ローカルパスを解決できないため無効。
 
     Args:


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新 ★
- [x] fix: バグ修正（エラーメッセージ修正）

## Summary

- `.mcp.json` を `command` + `args`（stdio 前提）から `url` ベース（HTTP モード）に変更
- CLAUDE.md の MCP 運用ルールを HTTP モード前提に統一（セッション状態確認・共存テーブル・DB 復旧・worktree 動作確認手順）
- CLAUDE.md の reconnect 誤記載を修正（reconnect で再起動可、.mcp.json 変更時のみセッション再起動）
- QA スキル（SKILL.md + 仕様書）の worktree セットアップ手順を HTTP モード前提に更新
- QA スキルに HTTP モード非対応ツール（crawl-documents）と PDF サイズ制約の注記を追加
- QA スキルのグループ F (Upload) から不要な RAG_TRANSPORT 退避・復元手順を削除
- `crawl-documents` のエラーメッセージを「セキュリティ上の制約」から技術的な制約に修正

## Test plan

- [x] pytest 48件パス（server.py 関連テスト）
- [x] ruff lint クリーン
- [x] mypy 型チェッククリーン

## Related issues

Closes #489