### PR TITLE
feat(site-ingest): クロール中の URL をリアルタイム通知する進捗機能を追加 (#490)

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -100,6 +100,12 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 - Scrapy の `CLOSESPIDER_ERRORCOUNT` 設定で制御する
 - 閾値到達後も JOBDIR が残存するため、再実行で続きから取得できる
 
+### 進捗通知
+
+- Scrapy subprocess は事前に総ページ数が不明なため、既存の `ProgressCallback(processed, total, current)` によるプログレスバー表示は適さない。代わりに `info` タイプの出力で、クロール中の URL をリアルタイムに通知する
+- CLI は Scrapy subprocess の待機中に、JSONL ファイル（追記モード）を定期ポーリングし、新しい行を検出するたびに `{"type": "info", "message": "..."}` を stdout に出力する
+- MCP サーバーは CLI の stdout から `"type": "info"` の JSON 行を検出し、`ctx.info(message)` のみを呼び出す（`ctx.report_progress()` は呼ばない）
+
 ### Windows エンコーディング
 
 - cp932 コンソールでの `UnicodeEncodeError` 対策として、subprocess 起動時に `PYTHONIOENCODING=utf-8` を環境変数に設定する
@@ -187,6 +193,18 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | source_store 配置結果 | 配置ファイル数、上書き数、スキップ数（重複等）、エラー数 |
 | パイプライン処理結果 | コンバート・インデックス構築の処理件数 |
 
+### 進捗通知の出力形式
+
+`--output json` モード時、Scrapy クロール中に以下の JSON Lines を stdout に出力する:
+
+```json
+{"type": "info", "message": "クロール中(3件目): https://example.com/docs/page3.html"}
+```
+
+`N件目` は JSONL ファイルの行番号（1始まり）を使用する。JSONL には 200 OK レスポンスのみが出力されるため、実質的にクロール成功ページ数と一致する。
+
+既存の `{"type": "progress", ...}` とは異なり、`processed` / `total` フィールドを持たない。MCP サーバーは `"type": "info"` を検出した場合、`ctx.info(message)` のみを呼び出し、`ctx.report_progress()` は呼ばない。
+
 ## コンポーネント構成
 
 ### 全体フロー
@@ -269,6 +287,13 @@ Scrapy プロセスの subprocess ラッパー。
 - 環境変数 `PYTHONIOENCODING=utf-8` を設定する
 - `process.wait()` でプロセスの終了を待機し、exit code で成否を判定する
 - exit code 0 以外の場合はエラーログを出力する（stderr ファイルの末尾を読み取り）
+
+進捗通知（JSONL ファイル監視）:
+
+- `process.wait()` の待機中に、asyncio タスクで JSONL ファイルの行数を定期ポーリングする（間隔: 1-2 秒）
+- 新しい行を検出するたびに、呼び出し元から渡された通知コールバック（URL 文字列を受け取る）で報告する
+- Scrapy プロセス終了時に監視タスクを停止し、未通知の残行を最終通知する
+- `--output json` モードでない場合（テキスト出力モード）は監視タスクを起動しない
 
 Scrapy に渡す設定:
 
@@ -404,7 +429,15 @@ sequenceDiagram
     CMD->>CMD: 一時保存ディレクトリ準備
     CMD->>RUNNER: Scrapy 起動要求
     RUNNER->>SPIDER: subprocess 起動
-    SPIDER->>SPIDER: クロール実行（HTML 保存 + JSONL 出力）
+    par クロール実行と進捗監視
+        SPIDER->>SPIDER: クロール実行（HTML 保存 + JSONL 出力）
+    and
+        loop JSONL ファイル監視（1-2秒間隔）
+            RUNNER->>RUNNER: 新しい JSONL 行を検出
+            RUNNER->>CMD: クロール中 URL を通知
+            CMD->>USER: info 出力（クロール中: URL）
+        end
+    end
     SPIDER->>RUNNER: プロセス終了（exit code）
     RUNNER->>CMD: クロール結果
     CMD->>BRIDGE: JSONL + HTML → source_store 変換

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -131,6 +131,11 @@ def _output_progress(processed: int, total: int, current: str) -> None:
     _output_json({"type": "progress", "processed": processed, "total": total, "current": current})
 
 
+def _output_info(message: str) -> None:
+    """info JSON を出力する（total 不明の進捗通知用）."""
+    _output_json({"type": "info", "message": message})
+
+
 def _wrap_progress(
     cb: Callable[[int, int, str], None] | None,
     phase: str,
@@ -2587,10 +2592,13 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
         error_count=settings.site_ingest_error_count,
     )
 
+    info_cb = _output_info if json_out else None
+
     if multi_url_mode:
         crawl_result = await runner.run(
             start_urls=validated_urls,
             allowed_domains=allowed_domains,
+            info_callback=info_cb,
         )
     else:
         crawl_result = await runner.run(
@@ -2599,6 +2607,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             url_pattern=args.url_pattern,
             max_pages=effective_max_pages,
             force=args.force,
+            info_callback=info_cb,
         )
 
     display_url = validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -19,7 +19,7 @@ import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -111,6 +111,7 @@ class ScrapyRunner:
         url_pattern: str = "",
         max_pages: int | None = None,
         force: bool = False,
+        info_callback: Callable[[str], None] | None = None,
     ) -> CrawlResult:
         """Scrapy Spider を subprocess で起動してクロールを実行する.
 
@@ -121,6 +122,7 @@ class ScrapyRunner:
             url_pattern: URL フィルタ正規表現（クロールモードのみ）
             max_pages: ページ数上限（None の場合はインスタンス設定値を使用）
             force: True の場合、クロールディレクトリ全体を削除して最初からクロール
+            info_callback: クロール中の URL を通知するコールバック（URL 文字列を受け取る）
 
         Returns:
             クロール実行結果
@@ -255,7 +257,22 @@ class ScrapyRunner:
                 stderr=stderr_file,
                 env=env,
             )
-            exit_code = await process.wait()
+            if info_callback is not None:
+                monitor_task = asyncio.create_task(
+                    self._monitor_jsonl(jsonl_path, info_callback),
+                )
+                try:
+                    exit_code = await process.wait()
+                finally:
+                    monitor_task.cancel()
+                    try:
+                        await monitor_task
+                    except asyncio.CancelledError:
+                        pass
+                    # 未通知の残行を最終通知
+                    self._flush_remaining_jsonl(jsonl_path, info_callback)
+            else:
+                exit_code = await process.wait()
         finally:
             stderr_file.close()
 
@@ -287,6 +304,50 @@ class ScrapyRunner:
             crawl_dir=crawl_dir,
             stderr_tail=stderr_tail,
         )
+
+    async def _monitor_jsonl(
+        self,
+        jsonl_path: Path,
+        callback: Callable[[str], None],
+    ) -> None:
+        """JSONL ファイルを定期ポーリングし、新しい行を検出して callback に通知する."""
+        self._jsonl_notified_count = 0
+        while True:
+            await asyncio.sleep(2)
+            self._notify_new_jsonl_lines(jsonl_path, callback)
+
+    def _notify_new_jsonl_lines(
+        self,
+        jsonl_path: Path,
+        callback: Callable[[str], None],
+    ) -> None:
+        """JSONL ファイルの未通知行を読み取り callback で通知する."""
+        if not jsonl_path.exists():
+            return
+        try:
+            lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return
+        new_lines = lines[self._jsonl_notified_count:]
+        for i, line in enumerate(new_lines, start=self._jsonl_notified_count + 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                url = data.get("url", "")
+                callback(f"クロール中({i}件目): {url}")
+            except json.JSONDecodeError:
+                pass
+        self._jsonl_notified_count = len(lines)
+
+    def _flush_remaining_jsonl(
+        self,
+        jsonl_path: Path,
+        callback: Callable[[str], None],
+    ) -> None:
+        """Scrapy 終了後、未通知の残行を最終通知する."""
+        self._notify_new_jsonl_lines(jsonl_path, callback)
 
     def _build_spider_script(self, *, params_path: Path) -> str:
         """Scrapy Spider を実行するインラインスクリプトを構築する.

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1009,6 +1009,10 @@ async def _run_cli_subprocess(
                                 message=current,
                             )
                         continue
+                    if msg_type == "info":
+                        if ctx is not None:
+                            await ctx.info(str(data.get("message", "")))
+                        continue
                     # result/error のみ最終結果として保持
                     if msg_type in {"result", "error"}:
                         _result_line = line


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- site-ingest の Scrapy クロール中に、取得した URL をリアルタイムで通知する進捗機能を追加
- CLI: JSONL ファイルの定期ポーリング（2秒間隔）で新規行を検出し、`{"type": "info", "message": "..."}` を stdout に出力
- MCP サーバー: `"type": "info"` のハンドリングを追加し、`ctx.info()` で MCP クライアントに通知
- 仕様書: 進捗通知の設計方針・出力形式・処理フローを追記

## Test plan

- [x] pytest 156 passed
- [x] ruff 違反なし
- [x] mypy 型エラーなし
- [x] markdownlint 違反なし

## Related issues

Closes #490