### PR TITLE
fix(bluesky): follow_urls() の YouTube URL 取り込みにリクエスト間隔を追加 (#503)

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -433,7 +433,7 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）
 3. URL 種別を判定し、Web / YouTube / スキップに分類する
 4. Web URL を全てバッチ収集し、CLI の `site-ingest` コマンド（複数 URL モード）で 1 回の Scrapy subprocess として取り込む。`--download-only` を指定し、パイプライン処理は BlueSky 側で一括実行する
-5. YouTube インジェスターで動画を取り込む（個別処理）
+5. YouTube インジェスターで動画を取り込む（個別処理、URL 間に `rag_youtube_request_interval` に基づくスリープを挿入）
 6. 全 URL の処理が完了した後、パイプライン制御に取り込み完了を通知する
 
 #### エラーハンドリング
@@ -442,11 +442,12 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 - BlueSky 投稿自体の取り込みは URL 先の失敗に影響されない
 - URL 先の取り込み結果は別途ログ出力する（BlueSky 投稿の IngestResult とは分離）
 
-#### site_ingest との連携
+#### 外部インジェスターとの連携
 
 - Web URL の取り込みは CLI の `site-ingest` コマンドを subprocess で呼び出す。Scrapy が独自に HTTP リクエストを管理するため、ConstrainedClient のバジェットは消費しない
 - BlueSky API 呼び出しのみ ConstrainedClient のバジェットを消費する
 - YouTube インジェスターは内部で `youtube-transcript-api` / `yt-dlp` を使用しており、ConstrainedClient は適用外
+- YouTube URL を複数処理する場合、URL 間に YouTube インジェスターの `request_interval`（デフォルト 5.0 秒）のスリープを挿入する。最後の URL の後はスリープしない。これはプレイリスト処理と同様のレート制御であり、連続リクエストによる IP ブロックを防止する
 
 ## 外部連携
 

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -449,8 +449,8 @@ class BlueskyIngester:
             stats["web_placed"] = web_placed
             stats["errors"] += web_errors
 
-        # YouTube URL を個別取り込み
-        for url in youtube_urls:
+        # YouTube URL を個別取り込み（URL 間にレート制限スリープを挿入）
+        for i, url in enumerate(youtube_urls):
             if youtube_ingester is not None:
                 try:
                     yt_result = await youtube_ingester.ingest_video(video_url=url)
@@ -460,6 +460,9 @@ class BlueskyIngester:
                 except Exception:
                     logger.exception("YouTube URL の取り込みに失敗: %s", url)
                     stats["errors"] += 1
+                # リクエスト間隔待機（次の URL がある場合のみ）
+                if i < len(youtube_urls) - 1:
+                    await asyncio.sleep(youtube_ingester.request_interval)
             else:
                 logger.warning("YouTube インジェスターが未指定: %s", url)
                 stats["skipped"] += 1

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -133,6 +133,11 @@ class YoutubeIngester:
         self._whisper_model_instance: Any = None  # 遅延初期化キャッシュ
         self._whisper_lock = threading.Lock()  # スレッドセーフなモデルアクセス
 
+    @property
+    def request_interval(self) -> float:
+        """リクエスト間隔（秒）."""
+        return self._request_interval
+
     async def ingest_video(
         self,
         video_url: str,

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -510,6 +510,57 @@ class TestFollowUrls:
         )
         assert stats["youtube_placed"] == 1
 
+    async def test_youtube_url_sleep_between_urls(
+        self, source_store: SourceStore
+    ) -> None:
+        """複数 YouTube URL の処理時に URL 間でスリープが挿入されること."""
+        item = _make_feed_item()
+        item["post"]["record"]["facets"] = [
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=vid1",
+                    }
+                ]
+            },
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=vid2",
+                    }
+                ]
+            },
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=vid3",
+                    }
+                ]
+            },
+        ]
+
+        mock_yt = AsyncMock()
+        mock_yt.ingest_video = AsyncMock(
+            return_value=MagicMock(placed=1, errors=0)
+        )
+        mock_yt.request_interval = 5.0
+
+        ingester = make_bluesky_ingester(source_store)
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            stats = await ingester.follow_urls(
+                [item],
+                youtube_ingester=mock_yt,
+            )
+
+        assert mock_yt.ingest_video.call_count == 3
+        assert stats["youtube_placed"] == 3
+        # 最後の URL の後はスリープしない → 3 - 1 = 2 回
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(5.0)
+
     async def test_bsky_url_skipped(self, source_store: SourceStore) -> None:
         """BlueSky URL がスキップされること."""
         item = _make_feed_item()


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [x] fix: バグ修正 ★
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- `follow_urls()` の YouTube URL ループに `request_interval`（デフォルト 5.0秒）のスリープを挿入し、連続リクエストによる IP ブロックを防止
- `YoutubeIngester` に `request_interval` プロパティを追加し、外部からの安全なアクセスを提供
- 仕様書のセクション名を「外部インジェスターとの連携」にリネームし、レート制御の記述を追加

## Test plan

- [x] 全 70 テストパス（bluesky + youtube）
- [x] ruff lint クリーン
- [x] mypy 型チェッククリーン
- [x] QA 動作確認: crawl-bluesky で YouTube 2件検出、URL 間に約7秒の間隔を確認

## Related issues

Closes #503