### PR TITLE
chore: .mcp.json を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+.mcp.json
 .venv
 env/
 venv/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "rag-knowledge": {
-      "url": "http://localhost:8081/mcp"
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- `.mcp.json` を `.gitignore` に追加し、`git rm --cached` で追跡解除
- ローカル IP アドレス等の環境依存情報を含むため、`.env` と同様に Git 管理から除外

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)