### PR TITLE
docs(indexer,converter,pipeline-controller,source-store,search-response,rebuild-stats): AI-native 構造移行 (#515)

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -28,8 +28,8 @@
 
 ## 制約
 
-- **ファイル形式の判定は拡張子ベース**: source_store 内のファイル拡張子で変換方式を決定する。拡張子が同一であれば source_type（web, bluesky, zenn, youtube, aozora, local, journal）に関わらず同じ変換方式を適用する。ただし、source_type 固有の前処理が必要な場合は source_type に応じた分岐を許容する
-- **source_type の判定**: ファイルの source_store 内トップレベルディレクトリから判定する（`web/`, `bluesky/`, `zenn/`, `youtube/`, `aozora/`, `local/`, `journal/`）
+- **ファイル形式の判定は拡張子ベース**: source_store 内のファイル拡張子で変換方式を決定する。拡張子が同一であれば source_type に関わらず同じ変換方式を適用する。ただし、source_type 固有の前処理が必要な場合は source_type に応じた分岐を許容する
+- **source_type の判定**: ファイルの source_store 内トップレベルディレクトリから判定する（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照）
 - **変換対象外ファイル**: `.meta` サイドカーファイルおよび `metadata.db` は変換対象外とする（スキップする）
 - **変換結果は UTF-8 テキスト**: 変換処理（HTML → Markdown、PDF テキスト抽出、JSON → テキスト）の出力は UTF-8 エンコーディングとする。パススルーファイルはバイト列コピーであり、この制約の対象外（元のエンコーディングをそのまま保持する）
 - **converted_store は git 管理しない**: 再生成可能な派生データであるため、git 管理対象外とする
@@ -78,6 +78,11 @@
 未対応の拡張子のファイルは変換をスキップし、警告ログを出力する。
 
 ### 変換フロー
+
+1. source_store からファイルを読み込む
+2. 拡張子に応じた変換処理を選択する（HTML → Markdown / PDF → テキスト抽出 / JSON → テキスト抽出 / パススルー）
+3. 変換結果にテキスト正規化を適用する（パススルーは正規化なし）
+4. converted_store に配置する
 
 ```mermaid
 flowchart TD
@@ -378,17 +383,17 @@ Zenn スクラップの JSON（`scrap` オブジェクト）から `comments` �
 
 ### 設定項目
 
-| 設定項目 | 型 | 保管先 | デフォルト | 許容範囲 | 説明 |
-|---------|-----|--------|-----------|---------|------|
-| `rag_pdf_backend` | str | `config.toml` | `auto` | `auto`, `pymupdf4llm`, `mineru` | PDF バックエンド選択 |
-| `rag_pdf_mineru_mfd_conf_thres` | float | `config.toml` | `0.6` | — | MinerU MFD 信頼度閾値 |
-| `rag_pdf_quality_ufffd_threshold` | float | `config.toml` | `0.10` | — | Unicode 置換文字率の閾値 |
-| `rag_pdf_quality_greek_threshold` | float | `config.toml` | `0.15` | — | ギリシャ文字率の閾値 |
-| `rag_pdf_quality_cjk_min_threshold` | float | `config.toml` | `0.05` | — | CJK 文字率の下限閾値 |
-| `rag_pdf_quality_min_chars_per_page` | int | `config.toml` | `10` | — | ページあたり最低文字数 |
-| `rag_pdf_quality_sample_pages` | int | `config.toml` | `10` | — | 品質サンプリングページ数 |
-| `rag_youtube_merge_gap_sec` | float | `config.toml` | `2.0` | — | YouTube スニペット結合の間隔閾値（秒） |
-| `rag_youtube_merge_max_chars` | int | `config.toml` | `300` | — | YouTube スニペット結合の最大文字数 |
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `rag_pdf_backend` | 共通設定値 | PDF バックエンド選択。環境のGPU有無やPDF特性に応じて切り替える |
+| `rag_pdf_mineru_mfd_conf_thres` | 共通設定値 | MinerU MFD 信頼度閾値。数式検出の感度を制御する |
+| `rag_pdf_quality_ufffd_threshold` | 共通設定値 | Unicode 置換文字率の閾値。テキスト抽出品質の判定基準 |
+| `rag_pdf_quality_greek_threshold` | 共通設定値 | ギリシャ文字率の閾値。数式含有の判定基準 |
+| `rag_pdf_quality_cjk_min_threshold` | 共通設定値 | CJK 文字率の下限閾値。CJK テキスト検出の判定基準 |
+| `rag_pdf_quality_min_chars_per_page` | 共通設定値 | ページあたり最低文字数。テキスト抽出品質の判定基準 |
+| `rag_pdf_quality_sample_pages` | 共通設定値 | 品質サンプリングページ数。判定の精度とコストのバランス |
+| `rag_youtube_merge_gap_sec` | 共通設定値 | YouTube スニペット結合の間隔閾値。段落分割の粒度を制御する |
+| `rag_youtube_merge_max_chars` | 共通設定値 | YouTube スニペット結合の最大文字数。段落サイズの上限 |
 
 `CONVERTED_STORE_DIR` は [pipeline-controller.md](pipeline-controller.md) の設定項目で定義済み。
 

--- a/docs/specs/indexer.md
+++ b/docs/specs/indexer.md
@@ -150,15 +150,6 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 | 最悪ケース所要時間 | Embedding プロバイダーの応答時間 × active ファイル総数。参考値: 1,000 ファイル × 1 秒/コール = 約 17 分 |
 | 想定エラー率 | 同上 |
 
-## 安全制約
-
-| 制約名 | 種別 | 値 | 解除可否 |
-|--------|------|-----|---------|
-| Embedding API レート制限 | 設定値 | OpenAI SDK の組み込みリトライ・バックオフ機構で制御（SDK のランタイム機構による L2 制御） | SDK 設定に依存 |
-| Embedding プロバイダー疎通確認 | ハードリミット | インデックス処理開始前にプロバイダーの疎通を確認し、接続不可の場合は即座にエラーを返す | 不可 |
-| チャンクサイズのトークン安全上限 | ハードリミット | Embedding に渡る最終テキストを 731 文字以内に制限する。各チャンカーにはオーバーヘッド差し引き済みの実効サイズを渡す。算出方法は「チャンキング制約」セクションを参照 | 不可 |
-| BM25 永続化のアトミック性 | ハードリミット | 一時ディレクトリ + リネームによるアトミックスワップ。中間状態でのインデックス破損を防止する | 不可 |
-
 ## インターフェース
 
 ### インデックス操作
@@ -198,6 +189,14 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 
 ### インデックス構築フロー
 
+1. converted_store からファイルを読み込む
+2. metadata.db からメタデータを取得する
+3. コンテンツタイプを検出する（テーブル / 見出し付き・混在 / 散文）
+4. コンテンツタイプに応じたチャンカーでチャンキングする
+5. チャンクメタデータ（`section_path` 等）を付与する
+6. Embedding を生成し ChromaDB に upsert する（本文のみ）
+7. BM25 インデックスに追加する（`section_path` + 本文）
+
 ```mermaid
 flowchart TD
     INPUT["converted_store のファイル"]
@@ -229,6 +228,11 @@ flowchart TD
 
 インデックス更新時、チャンク数が減少した場合に旧チャンクを削除する。
 
+1. 新チャンクを upsert する
+2. source_id で既存チャンク ID を取得する
+3. 新チャンク ID に含まれない ID を特定する
+4. stale チャンクを削除する
+
 ```mermaid
 flowchart LR
     UPSERT["新チャンクを upsert"] --> GET["source_id で既存チャンク ID 取得"]
@@ -255,7 +259,7 @@ flowchart LR
 | フィールド | 型 | 内容 |
 |-----------|-----|------|
 | `source_id` | str | ソース識別子。[source-store.md](source-store.md) の source_id 決定方式に準拠 |
-| `source_type` | str | 媒体種別（`web`, `zenn`, `bluesky`, `youtube`, `local`, `journal`, `aozora`） |
+| `source_type` | str | 媒体種別（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
 | `title` | str | コンテンツのタイトル。metadata.db の `title` から取得 |
 | `chunk_index` | int | チャンクの連番（0 始まり） |
 | `total_chunks` | int | 当該ソースのチャンク総数（新規フィールド。既存の rag-knowledge.md には未定義） |
@@ -333,26 +337,26 @@ BM25 のトークナイズには日本語形態素解析（fugashi）を使用�
 
 #### `config.toml`（共通設定値）
 
-| 設定項目 | 型 | 保管先 | デフォルト | 許容範囲 | 説明 |
-|---------|-----|--------|-----------|---------|------|
-| `rag_chunk_size` | int | `config.toml` | 200 | — | チャンクの最大文字数 |
-| `rag_chunk_overlap` | int | `config.toml` | 30 | — | チャンク間のオーバーラップ文字数 |
-| `rag_embedding_context_length` | int | `config.toml` | 512 | — | Embedding モデルのコンテキスト長（トークン数） |
-| `rag_worst_token_char_ratio` | float | `config.toml` | 0.7 | — | 最悪ケーストークン/文字比率。導出手順は「トークン/文字比率の導出手順」を参照 |
-| `embedding_model_local` | str | `config.toml` | `text-embedding-nomic-embed-text-v2-moe` | — | ローカル Embedding モデル名 |
-| `embedding_model_online` | str | `config.toml` | `text-embedding-3-small` | — | オンライン Embedding モデル名 |
-| `embedding_prefix_enabled` | bool | `config.toml` | `true` | — | Embedding プレフィックスの付与 |
-| `rag_bm25_k1` | float | `config.toml` | 2.5 | — | BM25 の用語頻度飽和パラメータ |
-| `rag_bm25_b` | float | `config.toml` | 0.50 | — | BM25 の文書長正規化パラメータ |
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `rag_chunk_size` | 共通設定値 | チャンクの最大文字数。検索精度とコンテキスト量のバランスを制御する |
+| `rag_chunk_overlap` | 共通設定値 | チャンク間のオーバーラップ文字数。文脈の断絶を防ぐ |
+| `rag_embedding_context_length` | 共通設定値 | Embedding モデルのコンテキスト長（トークン数）。トークン安全上限の算出基準 |
+| `rag_worst_token_char_ratio` | 共通設定値 | 最悪ケーストークン/文字比率。導出手順は「トークン/文字比率の導出手順」を参照 |
+| `embedding_model_local` | 共通設定値 | ローカル Embedding モデル名 |
+| `embedding_model_online` | 共通設定値 | オンライン Embedding モデル名 |
+| `embedding_prefix_enabled` | 共通設定値 | Embedding プレフィックス付与の有無。モデルの推奨設定に従う |
+| `rag_bm25_k1` | 共通設定値 | BM25 の用語頻度飽和パラメータ。検索精度チューニング用 |
+| `rag_bm25_b` | 共通設定値 | BM25 の文書長正規化パラメータ。検索精度チューニング用 |
 
 #### `.env`（環境依存値）
 
-| 設定項目 | 型 | 保管先 | デフォルト | 許容範囲 | 説明 |
-|---------|-----|--------|-----------|---------|------|
-| `EMBEDDING_PROVIDER` | str | `.env` | `local` | `local`, `online` | Embedding プロバイダー |
-| `LMSTUDIO_BASE_URL` | str | `.env` | `http://localhost:1234/v1` | — | LM Studio の接続先 URL |
-| `CHROMADB_PERSIST_DIR` | str | `.env` | `./chroma_db` | — | ChromaDB の永続化ディレクトリパス |
-| `BM25_PERSIST_DIR` | str | `.env` | `./bm25_index` | — | BM25 インデックスの永続化ディレクトリパス |
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `EMBEDDING_PROVIDER` | 環境依存値 | Embedding プロバイダーの選択。デプロイ環境に応じてローカル/オンラインを切り替える |
+| `LMSTUDIO_BASE_URL` | 環境依存値 | LM Studio の接続先 URL。ホスト・ポートが環境により異なる |
+| `CHROMADB_PERSIST_DIR` | 環境依存値 | ChromaDB の永続化ディレクトリパス。環境ごとにストレージ配置が異なる |
+| `BM25_PERSIST_DIR` | 環境依存値 | BM25 インデックスの永続化ディレクトリパス。環境ごとにストレージ配置が異なる |
 
 ## 外部連携
 

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -76,7 +76,9 @@
 | `[Index]` | チャンキング・Embedding・インデックス登録 | `run_index_only` |
 | `[Convert & Index]` | 変換とインデックスの一体処理 | `_process_changes`（差分更新）、`run_full_rebuild` |
 
-> **TODO:#495** MCP 経由の進捗通知では、Claude Code が `report_progress` の `message` パラメータを表示しないため、フェーズ名はユーザーに見えない（Claude Code の MCP クライアント側の制約。上流: anthropics/claude-code#3174）。CLI の `--output json` モードでは `current` フィールドにフェーズ名が含まれる。
+> **TODO:#495** MCP 経由の進捗通知では、Claude Code が `report_progress` の `message` パラメータを表示しないため、フェーズ名はユーザーに見えない
+> （Claude Code の MCP クライアント側の制約。上流: anthropics/claude-code#3174）。
+> CLI の `--output json` モードでは `current` フィールドにフェーズ名が含まれる。
 
 ### 未コミット変更の扱い
 
@@ -129,6 +131,15 @@ git diff から取得する変更ファイルリストの各エントリが持�
 
 ### パイプラインフロー（差分更新）
 
+1. 未コミットの変更がある場合、自動コミットを実行する
+2. `pipeline_history` から `last_commit_id` を取得する
+3. `last_commit_id` が null commit hash（初回）の場合は全ファイルを対象とする。通常のコミット ID の場合は `git diff` で変更ファイルを取得する
+4. 変更ファイルがなければ終了する
+5. 変更ファイルを種別（追加・変更 / 削除）ごとに分類する
+6. 追加・変更ファイルはコンバーターで変換後、インデクサーでインデックスに追加・更新する
+7. 削除ファイルはインデクサーでインデックスから削除し、metadata.db で論理削除する
+8. `pipeline_history` に実行履歴を追加する
+
 ```mermaid
 flowchart TD
     START["パイプライン開始"]
@@ -171,6 +182,15 @@ flowchart TD
 ```
 
 ### パイプラインフロー（全再構築）
+
+1. 未コミットの変更がある場合、エラーとして rebuild を拒否する
+2. source_store スキャンで metadata.db を再構築する
+3. converted_store をクリアする
+4. ChromaDB + BM25 をクリアする
+5. source_store の全ファイルをスキャンし、status が active のファイルを抽出する
+6. コンバーターで全ファイルをテキスト変換する
+7. インデクサーで全ファイルをインデックス構築する
+8. `pipeline_history` に実行履歴を追加する
 
 ```mermaid
 flowchart TD
@@ -263,7 +283,7 @@ source_store 内の以下のファイルは、git diff で検出されてもパ�
 | 手動ファイル配置後（local） | `ingest(local): manual update` |
 | 差分更新時の自動コミット | `auto-commit: incremental` |
 
-`source_type` の取りうる値は [source-store.md](source-store.md) の「source_id の決定方式」を参照（`web`, `bluesky`, `zenn`, `youtube`, `aozora`, `local`, `journal`）。
+`source_type` の取りうる値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照。
 
 ## エッジケース
 
@@ -285,9 +305,9 @@ source_store 内の以下のファイルは、git diff で検出されてもパ�
 
 ### 設定項目
 
-| 設定項目 | 型 | 保管先 | デフォルト | 許容範囲 | 説明 |
-|---------|-----|--------|-----------|---------|------|
-| `CONVERTED_STORE_DIR` | str | `.env` | なし（必須） | — | converted_store のディレクトリパス |
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `CONVERTED_STORE_DIR` | 環境依存値 | converted_store のディレクトリパス。環境ごとにストレージ配置が異なる |
 
 source_store のパスや metadata.db の参照は [source-store.md](source-store.md) の設定項目を使用する。
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -54,7 +54,7 @@
 | パラメータ | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `mode` | str | はい | 再構築モード（下表参照） |
-| `source_type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`youtube`、`aozora`、`local`、`journal`。未指定時は全媒体 |
+| `source_type` | str | いいえ | 対象媒体フィルタ（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照）。未指定時は全媒体 |
 
 再構築モード:
 
@@ -86,7 +86,7 @@ uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>]
 | オプション | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `--mode` | str | はい | 再構築モード: `full`、`convert`、`index`、`incremental` |
-| `--source-type` | str | いいえ | 対象媒体フィルタ: `web`、`bluesky`、`zenn`、`youtube`、`aozora`、`local`、`journal` |
+| `--source-type` | str | いいえ | 対象媒体フィルタ（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
 | `--if-needed` | flag | いいえ | 前回の index/full rebuild 以降に更新がなければスキップする。`--mode` が `index` または `full` の場合のみ有効 |
 
 MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適用する。`--if-needed` の詳細は [infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) を参照。
@@ -94,6 +94,12 @@ MCP ツール `rag_rebuild` と同じバリデーション・振る舞いを適�
 ## コンポーネント構成
 
 ### 再構築フロー
+
+1. MCP ツール または CLI からパラメータを受け取る
+2. パラメータを検証する（不正な場合はエラー返却）
+3. 排他ロックを取得する（取得失敗時は「別の再構築が実行中」エラー）
+4. MCP 経由の場合は CLI サブプロセスとして実行する。CLI 直接実行の場合はそのままパイプライン制御に委譲する
+5. 処理結果サマリを返却する（クラッシュ時はエラー返却、サーバーは生存）
 
 ```mermaid
 flowchart TD

--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -53,7 +53,7 @@ MCP クライアントからの rag_search ツール呼び出し。
 |-----------|-----|------|------|
 | `query` | str | Yes | 検索キーワード |
 | `n_results` | int | No | エンジンあたりの結果件数（未指定時は `rag_retrieval_count` 設定値を使用、1 以上） |
-| `source_type` | str | No | ソース種別フィルタ（`"web"`, `"zenn"`, `"bluesky"`, `"youtube"`, `"aozora"`, `"local"`, `"journal"`） |
+| `source_type` | str | No | ソース種別フィルタ（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
 | `filters` | str | No | カスタムメタデータフィルタ（`key=value` 形式、複数指定時はカンマ区切り）。`.meta` の extra フィールドで検索結果を絞り込む。完全一致。例: `repository=rag-knowledge` / `repository=rag-knowledge,tag=dev` |
 
 #### フィルタの動作

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -50,7 +50,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 
 ### .meta サイドカーファイル
 
-- 自動取り込み媒体（web、bluesky、zenn、youtube、aozora、journal）のファイルには `.meta` サイドカーファイルを同階層に配置する
+- 自動取り込み媒体（[`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` のうち `local` 以外）のファイルには `.meta` サイドカーファイルを同階層に配置する
 - local 媒体は `.meta` 不要。sources テーブルの各フィールドは以下から導出する:
   - `title`: ファイル名（拡張子除去）
   - `collected_at`: git の初回コミット日時
@@ -241,7 +241,7 @@ URL: `http://localhost:8080/api/docs`
 | フィールド | 型 | 内容 |
 |-----------|-----|------|
 | `source_id` | str | ソース識別子 |
-| `source_type` | str | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`, `aozora`, `journal`）。`local` は .meta を持たないため含まない |
+| `source_type` | str | 媒体種別（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照。`local` は .meta を持たないため含まない） |
 | `title` | str | コンテンツのタイトル |
 | `collected_at` | str | 取り込みタイムスタンプ（ISO 8601） |
 
@@ -427,7 +427,7 @@ source_store 内の全ファイルのメタデータ索引。
 | カラム | 型 | 制約 | 内容 |
 |--------|-----|------|------|
 | `source_id` | TEXT | PRIMARY KEY | ソース識別子 |
-| `source_type` | TEXT | NOT NULL | 媒体種別（`web`, `bluesky`, `zenn`, `youtube`, `aozora`, `local`, `journal`） |
+| `source_type` | TEXT | NOT NULL | 媒体種別（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
 | `file_path` | TEXT | NOT NULL, UNIQUE | source_store 内の相対パス |
 | `title` | TEXT | NOT NULL | コンテンツのタイトル |
 | `status` | TEXT | NOT NULL, DEFAULT 'active' | `active` または `deleted` |
@@ -454,9 +454,9 @@ source_store 内の全ファイルのメタデータ索引。
 
 ### 設定項目
 
-| 設定項目 | 型 | 保管先 | デフォルト | 許容範囲 | 説明 |
-|---------|-----|--------|-----------|---------|------|
-| `SOURCE_STORE_DIR` | str | `.env` | なし（必須） | — | source_store のディレクトリパス |
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `SOURCE_STORE_DIR` | 環境依存値 | source_store のディレクトリパス。環境ごとにストレージ配置が異なる |
 
 ## エッジケース
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- パイプライン・処理系仕様書 6 本を AI-native 構造に移行
  - 安全制約テーブル廃止（indexer.md: 4 行削除、情報は制約セクションに既存）
  - 設定項目テーブルを 3 列形式（項目名/層/設計意図）に変換（計 24 項目）
  - source_type 列挙値を enums.yml 参照に統一（計 10 箇所）
  - 処理フロー図に番号付きステップリストを追加（6 図）
- pipeline-controller.md の既存行長違反を修正（MD013）

## Test plan

- [x] doc-reviewer（diff モード）: 指摘なし
- [x] markdownlint: 変更ファイル内の違反なし
- [x] mermaid-lint（構文チェック）: 違反なし
- [x] mermaid GitHub 互換チェック: 違反なし

## Related issues

Closes #515