### PR TITLE
fix(content-listing): list_sources の ORDER BY datetime() を除去しマイクロ秒精度ソートを修正 (#525)

### DIFF
--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -369,7 +369,7 @@ class MetadataDB:
         rows = self._connection.execute(
             "SELECT * FROM sources"
             " WHERE source_type = ? AND status = 'active'"
-            " ORDER BY datetime(collected_at) DESC"
+            " ORDER BY collected_at DESC"
             " LIMIT ?",
             (source_type, limit),
         ).fetchall()


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- `MetadataDB.list_sources()` の `ORDER BY datetime(collected_at) DESC` から `datetime()` を除去
- SQLite の `datetime()` がマイクロ秒を切り捨てるため、同一秒内のレコードのソート順が不定だった
- ISO 8601 形式の文字列辞書順ソートにより、マイクロ秒精度の正しい降順ソートを実現

## Test plan

- [x] pytest（test_list_recent.py 17件パス）
- [x] ruff lint — 違反なし
- [x] mypy — 型エラーなし
- [x] 本番 MCP でソート順の不正を確認済み
- [x] worktree 環境で CLI 動作確認（crawl-bluesky 10件 + list-recent）

## Related issues

Closes #525