### PR TITLE
feat(content-listing): list-recent のソート基準を published_at に変更し逆順取得オプションを追加 (#526)

### DIFF
--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -2,13 +2,13 @@
 
 ## 概要
 
-指定された `source_type` のソースを新しい順（`collected_at` 降順）で一覧取得する機能を MCP ツールおよび CLI サブコマンドとして提供する。
+指定された `source_type` のソースを公開日時（`published_at`）順で一覧取得する機能を MCP ツールおよび CLI サブコマンドとして提供する。
 
 スコープ:
 
 - ソース単位の一覧取得（MCP ツール + CLI サブコマンド）
 - `source_type` 指定による絞り込み
-- `collected_at` 降順のソート
+- `published_at` によるソート（降順/昇順切り替え可能）
 - 取得件数の制限
 
 スコープ外:
@@ -22,16 +22,33 @@
 - 既存の検索機能（`rag_search`）はクエリベースの検索であり、「最近取り込んだコンテンツを一覧する」用途には対応していない
 - 直近の情報を参照しやすくすることで、ナレッジベースの運用・確認が容易になる
 - `rag_stats` はドメイン別の集計情報を提供するが、個別ソースの時系列的な一覧は提供していない
+- `collected_at`（取込時刻）はインジェスターの処理順に依存するため、ユーザーが期待する「コンテンツの公開日時順」にならないケースがある。source_type ごとの公開日時（`published_at`）でソートすることで、直感的な一覧を提供する
 
 ## 制約
 
-- **ソース単位の返却**: チャンク単位ではなくソース単位で返却する。1ソース = 1エントリとして title、source_id、collected_at、file_size のメタデータを返す
+- **ソース単位の返却**: チャンク単位ではなくソース単位で返却する。1ソース = 1エントリとして title、source_id、published_at、file_size のメタデータを返す
 - **データソースの限定**: 全データを MetadataDB から取得する。VectorStore や BM25 インデックスへの追加クエリは発行しない
 - **source_type 必須**: `source_type` パラメータは必須とする。全 source_type 横断の一覧取得は提供しない
-- **ソート基準の固定**: `collected_at` 降順でソートする。ソート基準の切り替えは提供しない
+- **ソート基準**: `published_at` でソートする。デフォルトは降順（新しい順）。`order` パラメータで昇順に切り替え可能
 - **論理削除済みソースの除外**: `status` が `deleted` のソースは一覧に含めない
 - **MCP + CLI 両提供**: MCP ツールと CLI サブコマンドの両方で提供する。内部ロジックは共通関数とする
 - **レスポンス形式**: MCP ツールのレスポンスはプレーンテキスト形式とする（既存ツールと統一）
+
+## published_at の決定ロジック
+
+`published_at` は source_type ごとの `.meta` フィールドから公開日時を抽出し、MetadataDB の `published_at` 列に格納する。
+
+| source_type | .meta フィールド | 変換 | フォールバック |
+|---|---|---|---|
+| bluesky | `created_at` | そのまま（ISO 8601） | `collected_at` |
+| zenn | `published_at` | そのまま（ISO 8601） | `collected_at` |
+| youtube | `upload_date` | YYYYMMDD → ISO 8601 | `collected_at` |
+| aozora | — | — | `collected_at` |
+| journal | — | — | `collected_at` |
+| local | — | — | `collected_at` |
+| web | — | — | `collected_at` |
+
+解決ロジックは `rag.store.resolve.resolve_published_at()` に一元化されている。
 
 ## インターフェース
 
@@ -39,18 +56,18 @@
 
 | 操作 | 種別 | 提供方式 | 概要 |
 |------|------|---------|------|
-| rag_list_recent | 新規 | MCP ツール + CLI | 指定 source_type のソースを新しい順で一覧取得する |
+| rag_list_recent | 既存 | MCP ツール + CLI | 指定 source_type のソースを公開日時順で一覧取得する |
 
 ### MCP ツール
 
 #### rag_list_recent
 
-指定された `source_type` のソースを `collected_at` の降順で取得する。
+指定された `source_type` のソースを `published_at` 順で取得する。
 
 | 項目 | 内容 |
 |------|------|
 | ツール名 | `rag_list_recent` |
-| 説明 | 指定した source_type のソースを新しい順で一覧取得する |
+| 説明 | 指定した source_type のソースを公開日時順で一覧取得する |
 
 パラメータ:
 
@@ -58,35 +75,37 @@
 |-----------|-----|------|------|
 | `source_type` | str | はい | ソース種別（値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `source_type` を参照） |
 | `limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml） |
+| `order` | str | いいえ | ソート順。`"desc"`（新しい順、デフォルト）または `"asc"`（古い順） |
 
 バリデーション:
 
 - `source_type` が有効値でない場合、エラーメッセージを返す（有効値の一覧を含める）
 - `limit` が許容範囲外の場合、エラーメッセージを返す。許容範囲は `src/rag/config.py` の pydantic Field 制約に従う
+- `order` が `"asc"` / `"desc"` 以外の場合、エラーメッセージを返す
 
 出力:
 
-プレーンテキスト形式。ヘッダー行にソース種別と件数を表示し、各ソースのメタデータを出力する。
+プレーンテキスト形式。ヘッダー行にソース種別・件数・ソート順を表示し、各ソースのメタデータを出力する。
 
 ```
-source_type: web（5件 / 全80件）
+source_type: web（5件 / 全80件, 新しい順）
 
 1. Sample Documentation Site
    Source: https://example.com/docs
-   Collected: 2025-06-15T10:30:00+09:00
+   Published: 2025-06-15T10:30:00+09:00
    Size: 45.2 KB
 
 2. Another Page Title
    Source: https://example.com/guide
-   Collected: 2025-06-14T08:00:00+09:00
+   Published: 2025-06-14T08:00:00+09:00
    Size: 12.8 KB
 ```
 
-- ヘッダー行: `source_type: {type}（{表示件数}件 / 全{該当source_typeの総件数}件）`
+- ヘッダー行: `source_type: {type}（{表示件数}件 / 全{該当source_typeの総件数}件, {ソート順}）`
   - 総件数: MetadataDB の `sources` テーブルに対して同一 `source_type` + `status = 'active'` 条件の `COUNT(*)` で取得する
-- 各エントリ: 番号付きリスト。タイトル、source_id、collected_at、ファイルサイズを表示
+- 各エントリ: 番号付きリスト。タイトル、source_id、published_at、ファイルサイズを表示
   - ファイルサイズ: MetadataDB の `file_size` カラムから取得する。人間が読みやすい単位（KB / MB）でフォーマットする
-- 該当するソースが0件の場合: `source_type: {type}（0件 / 全0件）`
+- 該当するソースが0件の場合: `source_type: {type}（0件 / 全0件）`（ソート順は省略する）
 - Source の値形式は source_type によって異なる（URL、AT URI、ファイルパス等。詳細は [source-store.md](../source-store.md) の source_id 決定方式を参照）
 - クエリコスト: 一覧取得 1 クエリ + 総件数 COUNT 1 クエリの最大 2 クエリで完結する。全データは MetadataDB から取得し、VectorStore への追加クエリは発行しない
 
@@ -95,13 +114,14 @@ source_type: web（5件 / 全80件）
 #### list-recent コマンド
 
 ```
-uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>]
+uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>] [--order asc|desc]
 ```
 
 | オプション | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `--source-type` | str | はい | ソース種別（値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `source_type` を参照） |
 | `--limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml） |
+| `--order` | str | いいえ | ソート順。`asc`（古い順）/ `desc`（新しい順、デフォルト） |
 
 MCP ツール `rag_list_recent` と同じバリデーション・振る舞いを適用する。出力形式も同一。
 
@@ -128,7 +148,7 @@ flowchart TD
     VALIDATE -->|不正| ERROR["エラー返却"]
     VALIDATE -->|正常| SERVICE
     SERVICE --> METADB
-    METADB -->|"source_type フィルタ + collected_at DESC + COUNT"| SERVICE
+    METADB -->|"source_type フィルタ + published_at ソート + COUNT"| SERVICE
     SERVICE --> FORMAT
     FORMAT --> RESPONSE
 ```
@@ -136,10 +156,10 @@ flowchart TD
 ### データ取得フロー
 
 1. MCP ツールまたは CLI からパラメータを受け取る
-2. `source_type` と `limit` のバリデーションを実行する
+2. `source_type`、`limit`、`order` のバリデーションを実行する
 3. `rag_knowledge.py` の共通関数 `list_recent_sources` を呼び出す
 4. `MetadataDB` から以下の 2 クエリを発行する:
-   - 一覧取得: `source_type` + `status = 'active'` でフィルタし、`collected_at` 降順で `limit` 件取得
+   - 一覧取得: `source_type` + `status = 'active'` でフィルタし、`published_at` でソート（`order` に応じて昇順/降順）して `limit` 件取得
    - 総件数取得: 同条件の `COUNT(*)` で該当 source_type の全件数を取得
 5. 結果をテキスト形式にフォーマットして返却する（file_size は人間が読みやすい単位に変換）
 
@@ -150,7 +170,8 @@ flowchart TD
 | `src/rag/server.py` | MCP ツール定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/cli.py` | CLI サブコマンド定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/rag_knowledge.py` | 共通ロジック。MetadataDB へのクエリとフォーマット処理 |
-| `src/rag/store/metadata_db.py` | MetadataDB。`source_type` フィルタ + `collected_at` 降順ソートのクエリ |
+| `src/rag/store/metadata_db.py` | MetadataDB。`source_type` フィルタ + `published_at` ソートのクエリ |
+| `src/rag/store/resolve.py` | `resolve_published_at()` — source_type ごとの公開日時解決 |
 | `src/rag/config.py` | `rag_list_recent_limit` 設定の定義 |
 | `config.toml` | `rag_list_recent_limit` のデフォルト値 |
 
@@ -162,8 +183,10 @@ flowchart TD
 | limit が該当ソース件数より大きい | 全件返却する（エラーにはしない） |
 | 無効な source_type を指定 | エラーメッセージを返す（有効値の一覧を含める） |
 | limit が許容範囲外 | エラーメッセージを返す |
+| 無効な order を指定 | エラーメッセージを返す |
 | 論理削除済みソースが存在 | 一覧に含めない（`status = 'active'` のみ対象） |
-| `collected_at` が同一の複数ソース | ソート順序は不定（同一タイムスタンプ内の順序は保証しない） |
+| `published_at` が同一の複数ソース | ソート順序は不定（同一タイムスタンプ内の順序は保証しない） |
+| `published_at` が空文字列（マイグレーション前のデータ） | マイグレーション時に `collected_at` で自動補完される |
 
 ## 関連ドキュメント
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -445,6 +445,12 @@ def main() -> None:
         default=None,
         help="取得件数（1〜100、未指定時は設定値を使用）",
     )
+    list_recent_parser.add_argument(
+        "--order",
+        choices=["asc", "desc"],
+        default="desc",
+        help="ソート順（asc: 古い順, desc: 新しい順。デフォルト: desc）",
+    )
     _add_output_option(list_recent_parser)
 
     # search サブコマンド
@@ -1594,7 +1600,7 @@ def run_stats(args: argparse.Namespace) -> None:
 
 
 def run_list_recent(args: argparse.Namespace) -> None:
-    """指定 source_type のソースを新しい順で一覧取得する.
+    """指定 source_type のソースを published_at でソートして一覧取得する.
 
     MCP ツール rag_list_recent と同等の一覧取得を CLI で実行する。
 
@@ -1606,6 +1612,7 @@ def run_list_recent(args: argparse.Namespace) -> None:
     json_out = _is_json_output(args)
     settings = get_settings()
     limit: int = args.limit if args.limit is not None else settings.rag_list_recent_limit
+    ascending = args.order == "asc"
 
     if json_out:
         from .store.metadata_db import MetadataDB
@@ -1633,7 +1640,7 @@ def run_list_recent(args: argparse.Namespace) -> None:
         try:
             db.initialize()
             st = cast(SourceType, args.source_type)
-            sources = db.list_sources(source_type=st, limit=limit)
+            sources = db.list_sources(source_type=st, limit=limit, ascending=ascending)
             total = db.count_sources_by_type(source_type=st)
         finally:
             db.close()
@@ -1643,17 +1650,20 @@ def run_list_recent(args: argparse.Namespace) -> None:
                 {
                     "source_id": s.source_id,
                     "title": s.title,
-                    "collected_at": s.collected_at,
+                    "published_at": s.published_at,
                     "file_size": s.file_size,
                 }
                 for s in sources
             ],
             "count": len(sources),
             "total": total,
+            "order": args.order,
         })
     else:
         from .rag_knowledge import list_recent_sources
-        print(list_recent_sources(settings.source_store_dir, args.source_type, limit))
+        print(list_recent_sources(
+            settings.source_store_dir, args.source_type, limit, ascending=ascending,
+        ))
 
 
 def run_search(args: argparse.Namespace) -> None:

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -38,7 +38,7 @@ from rag.store.models import (
     SourceRecord,
     SourceType,
 )
-from rag.store.resolve import resolve_source_id, resolve_title
+from rag.store.resolve import resolve_published_at, resolve_source_id, resolve_title
 from rag.store.source_store import SourceStore
 
 from rag.pipeline.ingesters._common import ProgressCallback
@@ -754,6 +754,10 @@ class PipelineController:
         else:
             collected_at = now
 
+        published_at = resolve_published_at(
+            source_type, meta_dict, collected_at,
+        )
+
         self.db.register_source(
             source_id=source_id,
             source_type=source_type,
@@ -763,6 +767,7 @@ class PipelineController:
             file_size=len(data),
             collected_at=collected_at,
             updated_at=now,
+            published_at=published_at,
         )
 
     def _update_in_db(self, file_path: str) -> None:

--- a/src/rag/pipeline/ingesters/journal.py
+++ b/src/rag/pipeline/ingesters/journal.py
@@ -138,11 +138,13 @@ class JournalIngester:
                 title = self._parse_title_from_filename(entry_id)
                 data = fp.read_bytes()
 
-                # collected_at はファイルの更新日時を使用
-                mtime = fp.stat().st_mtime
-                collected_at = datetime.fromtimestamp(
-                    mtime, tz=timezone.utc,
-                ).isoformat()
+                # collected_at: ファイル名の日時 > mtime のフォールバック
+                collected_at = _parse_datetime_from_entry_id(entry_id)
+                if collected_at is None:
+                    mtime = fp.stat().st_mtime
+                    collected_at = datetime.fromtimestamp(
+                        mtime, tz=timezone.utc,
+                    ).isoformat()
 
                 rel_path = f"journal/{repository}/{entry_id}.md"
                 metadata = {
@@ -212,6 +214,22 @@ class JournalIngester:
             # YYYYMMDD-HHMMSS- プレフィックスを除去
             return entry_id[16:]
         return entry_id
+
+
+def _parse_datetime_from_entry_id(entry_id: str) -> str | None:
+    """ファイル名の YYYYMMDD-HHMMSS プレフィックスから ISO 8601 日時を生成する.
+
+    Returns:
+        ISO 8601 形式の日時文字列。パースできない場合は None。
+    """
+    if not _ENTRY_ID_PATTERN.match(entry_id):
+        return None
+    try:
+        dt = datetime.strptime(entry_id[:15], "%Y%m%d-%H%M%S")  # noqa: DTZ007
+        dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+    except ValueError:
+        return None
 
 
 def _sanitize_topic(title: str) -> str:

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -983,8 +983,9 @@ def list_recent_sources(
     source_store_dir: str,
     source_type: str,
     limit: int,
+    ascending: bool = False,
 ) -> str:
-    """指定 source_type のソースを新しい順で一覧取得する（MCP/CLI 共通ロジック）.
+    """指定 source_type のソースを published_at でソートして一覧取得する（MCP/CLI 共通ロジック）.
 
     仕様: docs/specs/infrastructure/content-listing.md
 
@@ -992,6 +993,7 @@ def list_recent_sources(
         source_store_dir: source_store のルートディレクトリパス
         source_type: ソース種別
         limit: 取得件数
+        ascending: True で昇順（古い順）、False で降順（新しい順、デフォルト）
 
     Returns:
         フォーマット済みテキスト
@@ -1008,20 +1010,24 @@ def list_recent_sources(
         from .store.models import SourceType
 
         st = cast(SourceType, source_type)
-        sources = db.list_sources(source_type=st, limit=limit)
+        sources = db.list_sources(source_type=st, limit=limit, ascending=ascending)
         total = db.count_sources_by_type(source_type=st)
     finally:
         db.close()
 
+    if not sources:
+        return f"source_type: {source_type}（0件 / 全0件）"
+
+    order_label = "古い順" if ascending else "新しい順"
     lines: list[str] = [
-        f"source_type: {source_type}（{len(sources)}件 / 全{total}件）",
+        f"source_type: {source_type}（{len(sources)}件 / 全{total}件, {order_label}）",
     ]
 
     for i, src in enumerate(sources, 1):
         lines.append("")
         lines.append(f"{i}. {src.title}")
         lines.append(f"   Source: {src.source_id}")
-        lines.append(f"   Collected: {src.collected_at}")
+        lines.append(f"   Published: {src.published_at}")
         lines.append(f"   Size: {format_file_size(src.file_size)}")
 
     return "\n".join(lines)

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1233,16 +1233,18 @@ def _format_cli_list_recent_result(result: dict[str, Any]) -> str:
     if not sources:
         return f"{source_type}: 0 件"
 
-    lines = [f"{source_type}: {count} 件（全 {total} 件中）", ""]
+    order = result.get("order", "desc")
+    order_label = "古い順" if order == "asc" else "新しい順"
+    lines = [f"{source_type}: {count} 件（全 {total} 件中, {order_label}）", ""]
     for s in sources:
         title = s.get("title", "(無題)")
         source_id = s.get("source_id", "")
-        collected_at = s.get("collected_at", "")
+        published_at = s.get("published_at", "")
         file_size = s.get("file_size", 0)
         size_str = format_file_size(file_size) if file_size else ""
         line = f"- {title}"
-        if collected_at:
-            line += f"  [{collected_at}]"
+        if published_at:
+            line += f"  [{published_at}]"
         if size_str:
             line += f"  ({size_str})"
         lines.append(line)
@@ -1317,8 +1319,9 @@ def _format_cli_stats_result(result: dict[str, Any]) -> str:
 async def rag_list_recent(
     source_type: str,
     limit: int | None = None,
+    order: str = "desc",
 ) -> str:
-    """[rag-knowledge] List recent sources - 指定した source_type のソースを新しい順で一覧取得する.
+    """[rag-knowledge] List recent sources - 指定した source_type のソースを公開日時順で一覧取得する.
 
     content listing, recent sources, source list, browse.
     ナレッジベースに取り込んだコンテンツを source_type 別に一覧で確認できる。
@@ -1327,9 +1330,10 @@ async def rag_list_recent(
     Args:
         source_type: ソース種別: "web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"
         limit: 取得件数（1〜100、未指定時は設定値を使用）
+        order: ソート順（"desc": 新しい順（デフォルト）, "asc": 古い順）
 
     Returns:
-        ソース一覧テキスト（タイトル、source_id、collected_at、ファイルサイズ）
+        ソース一覧テキスト（タイトル、source_id、published_at、ファイルサイズ）
     """
     if source_type not in _VALID_SOURCE_TYPES:
         valid = ", ".join(sorted(_VALID_SOURCE_TYPES))
@@ -1338,9 +1342,13 @@ async def rag_list_recent(
     if limit is not None and (limit < 1 or limit > 100):
         return "エラー: limit は 1〜100 の範囲で指定してください"
 
+    if order not in ("asc", "desc"):
+        return f"エラー: order は 'asc' または 'desc' を指定してください（指定値: {order!r}）"
+
     args: list[str] = ["--source-type", source_type]
     if limit is not None:
         args.extend(["--limit", str(limit)])
+    args.extend(["--order", order])
 
     try:
         result = await _run_cli_subprocess("list-recent", args)

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS sources (
     content_hash TEXT NOT NULL,
     file_size    INTEGER NOT NULL,
     collected_at TEXT NOT NULL,
-    updated_at   TEXT NOT NULL
+    updated_at   TEXT NOT NULL,
+    published_at TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS pipeline_history (
@@ -79,14 +80,29 @@ class MetadataDB:
         """既存テーブルのスキーマをマイグレーションする."""
         # pipeline_history に mode 列を追加（既存レコードは incremental 扱い）
         cursor = self._connection.execute("PRAGMA table_info(pipeline_history)")
-        columns = {row["name"] for row in cursor.fetchall()}
-        if "mode" not in columns:
+        ph_columns = {row["name"] for row in cursor.fetchall()}
+        if "mode" not in ph_columns:
             self._connection.execute(
                 "ALTER TABLE pipeline_history"
                 " ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'"
             )
             self._connection.commit()
             logger.info("pipeline_history に mode 列を追加しました")
+
+        # sources に published_at 列を追加（既存レコードは collected_at で埋める）
+        cursor = self._connection.execute("PRAGMA table_info(sources)")
+        src_columns = {row["name"] for row in cursor.fetchall()}
+        if "published_at" not in src_columns:
+            self._connection.execute(
+                "ALTER TABLE sources"
+                " ADD COLUMN published_at TEXT NOT NULL DEFAULT ''"
+            )
+            self._connection.execute(
+                "UPDATE sources SET published_at = collected_at"
+                " WHERE published_at = ''"
+            )
+            self._connection.commit()
+            logger.info("sources に published_at 列を追加しました")
 
     def __enter__(self) -> MetadataDB:
         return self
@@ -107,6 +123,7 @@ class MetadataDB:
         file_size: int,
         collected_at: str,
         updated_at: str,
+        published_at: str = "",
     ) -> None:
         """ソースを登録する.
 
@@ -118,9 +135,14 @@ class MetadataDB:
         Note:
             collected_at は新規 INSERT 時のみ使用される。既存レコードの
             更新時は元の collected_at が保持される（ON CONFLICT で更新対象外）。
+            published_at も同様に INSERT 時のみ使用される。
             local 媒体の git 由来時刻への補正は、パイプライン制御層が
             update_source() で後から実施する。
         """
+        # published_at 未指定時は collected_at を使用
+        if not published_at:
+            published_at = collected_at
+
         # file_path UNIQUE 競合の防止: 異なる source_id で同じ file_path を持つ旧レコードを削除
         self._connection.execute(
             "DELETE FROM sources WHERE file_path = ? AND source_id != ?",
@@ -130,8 +152,8 @@ class MetadataDB:
             """\
             INSERT INTO sources
                 (source_id, source_type, file_path, title, status,
-                 content_hash, file_size, collected_at, updated_at)
-            VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)
+                 content_hash, file_size, collected_at, updated_at, published_at)
+            VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)
             ON CONFLICT(source_id) DO UPDATE SET
                 source_type = excluded.source_type,
                 file_path = excluded.file_path,
@@ -150,6 +172,7 @@ class MetadataDB:
                 file_size,
                 collected_at,
                 updated_at,
+                published_at,
             ),
         )
         self._connection.commit()
@@ -178,6 +201,7 @@ class MetadataDB:
             "file_size",
             "collected_at",
             "updated_at",
+            "published_at",
         }
         invalid = set(fields.keys()) - allowed
         if invalid:
@@ -364,12 +388,14 @@ class MetadataDB:
         *,
         source_type: SourceType,
         limit: int,
+        ascending: bool = False,
     ) -> list[SourceRecord]:
-        """指定 source_type の active ソースを collected_at 降順で取得する."""
+        """指定 source_type の active ソースを published_at でソートして取得する."""
+        direction = "ASC" if ascending else "DESC"
         rows = self._connection.execute(
             "SELECT * FROM sources"
             " WHERE source_type = ? AND status = 'active'"
-            " ORDER BY collected_at DESC"
+            f" ORDER BY published_at {direction}"
             " LIMIT ?",
             (source_type, limit),
         ).fetchall()
@@ -397,4 +423,5 @@ def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
         file_size=row["file_size"],
         collected_at=row["collected_at"],
         updated_at=row["updated_at"],
+        published_at=row["published_at"],
     )

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -28,6 +28,7 @@ class SourceRecord:
     file_size: int
     collected_at: str
     updated_at: str
+    published_at: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/rag/store/resolve.py
+++ b/src/rag/store/resolve.py
@@ -54,3 +54,49 @@ def resolve_title(
     if metadata and "title" in metadata:
         return str(metadata["title"])
     return Path(rel_path).stem
+
+
+# source_type ごとの公開日時フィールド名
+_PUBLISHED_AT_FIELDS: dict[str, str] = {
+    "bluesky": "created_at",
+    "zenn": "published_at",
+    "youtube": "upload_date",
+}
+
+
+def resolve_published_at(
+    source_type: str,
+    metadata: dict[str, Any] | None,
+    collected_at: str,
+) -> str:
+    """公開日時を決定する.
+
+    source_type ごとに .meta の公開日時フィールドを参照する。
+    該当フィールドがない source_type（aozora, journal, local, web）は
+    collected_at をそのまま使用する。
+
+    youtube の upload_date は YYYYMMDD 形式のため ISO 8601 に変換する。
+
+    Args:
+        source_type: 媒体種別
+        metadata: .meta から読み取ったメタデータ辞書
+        collected_at: 取込時刻（フォールバック用）
+
+    Returns:
+        ISO 8601 形式の公開日時文字列
+    """
+    field_name = _PUBLISHED_AT_FIELDS.get(source_type)
+    if field_name is None or metadata is None:
+        return collected_at
+
+    raw_value = metadata.get(field_name)
+    if not raw_value:
+        return collected_at
+
+    raw_str = str(raw_value)
+
+    # youtube の upload_date: YYYYMMDD → ISO 8601
+    if source_type == "youtube" and len(raw_str) == 8 and raw_str.isdigit():
+        return f"{raw_str[:4]}-{raw_str[4:6]}-{raw_str[6:8]}T00:00:00+00:00"
+
+    return raw_str

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -132,6 +132,10 @@ class SourceStore:
         else:
             collected_at = now
 
+        published_at = resolve_published_at(
+            source_type, metadata, collected_at,
+        )
+
         self._db.register_source(
             source_id=source_id,
             source_type=source_type,
@@ -141,6 +145,7 @@ class SourceStore:
             file_size=len(data),
             collected_at=collected_at,
             updated_at=now,
+            published_at=published_at,
         )
 
         return dest

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -24,7 +24,7 @@ from rag.store.models import (
     SourceType,
 )
 from rag.store.path_converter import url_to_path
-from rag.store.resolve import resolve_source_id, resolve_title
+from rag.store.resolve import resolve_published_at, resolve_source_id, resolve_title
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +389,9 @@ class SourceStore:
             source_id = self._resolve_source_id(source_type, rel_str, meta_dict or None)
             title = self._resolve_title(source_type, rel_str, meta_dict or None)
             collected_at = meta_dict.get("collected_at", now)
+            published_at = resolve_published_at(
+                source_type, meta_dict or None, collected_at,
+            )
 
             self._db.register_source(
                 source_id=source_id,
@@ -399,6 +402,7 @@ class SourceStore:
                 file_size=len(data),
                 collected_at=collected_at,
                 updated_at=now,
+                published_at=published_at,
             )
             count += 1
 
@@ -443,6 +447,10 @@ class SourceStore:
             return "bluesky"
         if rel_path.startswith("zenn/"):
             return "zenn"
+        if rel_path.startswith("youtube/"):
+            return "youtube"
+        if rel_path.startswith("aozora/"):
+            return "aozora"
         if rel_path.startswith("journal/"):
             return "journal"
         return "local"

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -376,6 +376,7 @@ class TestAddDocumentFilenamePriority:
         mock.processed = 1
         mock.skipped = 0
         mock.errors = []
+        mock.warnings = []
         return mock
 
     def test_filename_overrides_file_path_name(self, tmp_path: Path) -> None:

--- a/tests/test_journal_migration_datetime.py
+++ b/tests/test_journal_migration_datetime.py
@@ -1,0 +1,39 @@
+"""journal migration のファイル名日時パースのテスト.
+
+テスト方針:
+- YYYYMMDD-HHMMSS パターンのファイル名から正しく日時が抽出される
+- パターンにマッチしないファイル名は None を返す
+"""
+
+from __future__ import annotations
+
+from rag.pipeline.ingesters.journal import _parse_datetime_from_entry_id
+
+
+class TestParseDatetimeFromEntryId:
+    """_parse_datetime_from_entry_id のテスト."""
+
+    def test_standard_entry_id(self) -> None:
+        """YYYYMMDD-HHMMSS-topic 形式から日時を抽出する."""
+        result = _parse_datetime_from_entry_id("20260404-012030-some-topic")
+        assert result == "2026-04-04T01:20:30+00:00"
+
+    def test_entry_id_without_topic(self) -> None:
+        """YYYYMMDD-HHMMSS- のみ（トピック部分が短い）でもパース可能."""
+        result = _parse_datetime_from_entry_id("20260101-000000-x")
+        assert result == "2026-01-01T00:00:00+00:00"
+
+    def test_non_matching_entry_id(self) -> None:
+        """パターンにマッチしないファイル名は None を返す."""
+        result = _parse_datetime_from_entry_id("some-random-name")
+        assert result is None
+
+    def test_partial_date_pattern(self) -> None:
+        """日付部分のみでハイフン区切り後がない場合は None."""
+        result = _parse_datetime_from_entry_id("20260404")
+        assert result is None
+
+    def test_invalid_date_values(self) -> None:
+        """正規表現にマッチするが無効な日時値の場合は None."""
+        result = _parse_datetime_from_entry_id("99991399-999999-invalid")
+        assert result is None

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -5,7 +5,7 @@
 テスト方針:
 - MetadataDB の list_sources / count_sources_by_type メソッドの単体テスト
 - list_recent_sources 共通関数のフォーマット・統合テスト
-- エッジケース: 0件、limit > 該当件数、論理削除除外、ソート順
+- エッジケース: 0件、limit > 該当件数、論理削除除外、ソート順、昇順/降順
 """
 
 from __future__ import annotations
@@ -31,6 +31,7 @@ def _register(
     source_type: str = "web",
     title: str = "Test",
     collected_at: str = "2026-01-01T00:00:00Z",
+    published_at: str = "",
     file_size: int = 1024,
     status: str = "active",
 ) -> None:
@@ -44,6 +45,7 @@ def _register(
         file_size=file_size,
         collected_at=collected_at,
         updated_at=collected_at,
+        published_at=published_at,
     )
     if status == "deleted":
         db.set_status(source_id, "deleted")
@@ -66,19 +68,55 @@ class TestListSources:
         assert len(result) == 1
         assert result[0].source_id == "web1"
 
-    def test_order_by_collected_at_desc(self, db: MetadataDB) -> None:
-        """collected_at 降順でソートされる."""
-        _register(db, "old", collected_at="2026-01-01T00:00:00Z")
-        _register(db, "mid", collected_at="2026-01-15T00:00:00Z")
-        _register(db, "new", collected_at="2026-02-01T00:00:00Z")
+    def test_order_by_published_at_desc(self, db: MetadataDB) -> None:
+        """published_at 降順でソートされる（デフォルト）."""
+        _register(db, "old", published_at="2026-01-01T00:00:00Z")
+        _register(db, "mid", published_at="2026-01-15T00:00:00Z")
+        _register(db, "new", published_at="2026-02-01T00:00:00Z")
 
         result = db.list_sources(source_type="web", limit=10)
         assert [r.source_id for r in result] == ["new", "mid", "old"]
 
+    def test_order_by_published_at_asc(self, db: MetadataDB) -> None:
+        """ascending=True で昇順ソート."""
+        _register(db, "old", published_at="2026-01-01T00:00:00Z")
+        _register(db, "mid", published_at="2026-01-15T00:00:00Z")
+        _register(db, "new", published_at="2026-02-01T00:00:00Z")
+
+        result = db.list_sources(source_type="web", limit=10, ascending=True)
+        assert [r.source_id for r in result] == ["old", "mid", "new"]
+
+    def test_published_at_differs_from_collected_at(self, db: MetadataDB) -> None:
+        """published_at が collected_at と異なる場合、published_at でソートされる."""
+        _register(
+            db, "early_pub_late_collect",
+            collected_at="2026-03-01T00:00:00Z",
+            published_at="2026-01-01T00:00:00Z",
+        )
+        _register(
+            db, "late_pub_early_collect",
+            collected_at="2026-01-01T00:00:00Z",
+            published_at="2026-03-01T00:00:00Z",
+        )
+
+        result = db.list_sources(source_type="web", limit=10)
+        assert result[0].source_id == "late_pub_early_collect"
+        assert result[1].source_id == "early_pub_late_collect"
+
+    def test_published_at_fallback_to_collected_at(self, db: MetadataDB) -> None:
+        """published_at 未指定時は collected_at が使われる."""
+        _register(db, "no_pub", collected_at="2026-02-01T00:00:00Z")
+
+        result = db.list_sources(source_type="web", limit=10)
+        assert result[0].published_at == "2026-02-01T00:00:00Z"
+
     def test_limit(self, db: MetadataDB) -> None:
         """limit で取得件数が制限される."""
         for i in range(5):
-            _register(db, f"web{i}", collected_at=f"2026-01-{i+1:02d}T00:00:00Z")
+            _register(
+                db, f"web{i}",
+                published_at=f"2026-01-{i+1:02d}T00:00:00Z",
+            )
 
         result = db.list_sources(source_type="web", limit=2)
         assert len(result) == 2
@@ -142,17 +180,32 @@ class TestListRecentSources:
         db.initialize()
         _register(
             db, "https://example.com/page", title="Sample Page",
-            collected_at="2026-06-15T10:30:00+09:00", file_size=46285,
+            collected_at="2026-06-15T10:30:00+09:00",
+            published_at="2026-06-15T10:30:00+09:00",
+            file_size=46285,
         )
         db.close()
 
         result = list_recent_sources(str(source_store_dir), "web", 10)
 
-        assert "source_type: web（1件 / 全1件）" in result
+        assert "source_type: web（1件 / 全1件" in result
         assert "1. Sample Page" in result
         assert "Source: https://example.com/page" in result
-        assert "Collected: 2026-06-15T10:30:00+09:00" in result
+        assert "Published: 2026-06-15T10:30:00+09:00" in result
         assert "Size: 45.2 KB" in result
+
+    def test_format_output_ascending(self, tmp_path: Path) -> None:
+        """昇順指定時のヘッダー表示."""
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        _register(db, "web1", collected_at="2026-01-01T00:00:00Z")
+        db.close()
+
+        result = list_recent_sources(str(source_store_dir), "web", 10, ascending=True)
+        assert "古い順" in result
 
     def test_zero_results(self, tmp_path: Path) -> None:
         """0件の場合のフォーマット."""
@@ -179,12 +232,12 @@ class TestListRecentSources:
         for i in range(5):
             _register(
                 db, f"https://example.com/p{i}", title=f"Page {i}",
-                collected_at=f"2026-01-{i+1:02d}T00:00:00Z",
+                published_at=f"2026-01-{i+1:02d}T00:00:00Z",
             )
         db.close()
 
         result = list_recent_sources(str(source_store_dir), "web", 2)
-        assert "source_type: web（2件 / 全5件）" in result
+        assert "source_type: web（2件 / 全5件" in result
         assert "1. Page 4" in result
         assert "2. Page 3" in result
         assert "3." not in result

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -1,0 +1,105 @@
+"""metadata.db マイグレーションのテスト.
+
+テスト方針:
+- published_at 列がない既存 DB に対するマイグレーション
+- マイグレーション後に published_at が collected_at で埋められること
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from rag.store.metadata_db import MetadataDB
+
+
+class TestPublishedAtMigration:
+    """published_at 列のマイグレーションテスト."""
+
+    def test_migration_adds_published_at_column(self, tmp_path: Path) -> None:
+        """published_at 列がない DB で initialize すると列が追加される."""
+        db_path = tmp_path / "metadata.db"
+
+        # published_at なしのスキーマで DB を手動作成
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""\
+            CREATE TABLE sources (
+                source_id    TEXT PRIMARY KEY,
+                source_type  TEXT NOT NULL,
+                file_path    TEXT NOT NULL UNIQUE,
+                title        TEXT NOT NULL,
+                status       TEXT NOT NULL DEFAULT 'active',
+                content_hash TEXT NOT NULL,
+                file_size    INTEGER NOT NULL,
+                collected_at TEXT NOT NULL,
+                updated_at   TEXT NOT NULL
+            );
+            CREATE TABLE pipeline_history (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_commit_id TEXT NOT NULL,
+                to_commit_id   TEXT NOT NULL,
+                processed_at   TEXT NOT NULL,
+                mode           TEXT NOT NULL DEFAULT 'incremental'
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("s1", "web", "web/s1.html", "Title", "active",
+             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        # MetadataDB で初期化（マイグレーション実行）
+        db = MetadataDB(db_path)
+        db.initialize()
+
+        record = db.get_source("s1")
+        assert record is not None
+        assert record.published_at == "2026-01-15T10:00:00Z"
+        db.close()
+
+    def test_migration_fills_published_at_from_collected_at(self, tmp_path: Path) -> None:
+        """マイグレーションで複数レコードの published_at が collected_at で埋まる."""
+        db_path = tmp_path / "metadata.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""\
+            CREATE TABLE sources (
+                source_id    TEXT PRIMARY KEY,
+                source_type  TEXT NOT NULL,
+                file_path    TEXT NOT NULL UNIQUE,
+                title        TEXT NOT NULL,
+                status       TEXT NOT NULL DEFAULT 'active',
+                content_hash TEXT NOT NULL,
+                file_size    INTEGER NOT NULL,
+                collected_at TEXT NOT NULL,
+                updated_at   TEXT NOT NULL
+            );
+            CREATE TABLE pipeline_history (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_commit_id TEXT NOT NULL,
+                to_commit_id   TEXT NOT NULL,
+                processed_at   TEXT NOT NULL,
+                mode           TEXT NOT NULL DEFAULT 'incremental'
+            );
+        """)
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (f"s{i}", "web", f"web/s{i}.html", f"Title {i}", "active",
+                 "hash", 100, f"2026-01-{i+1:02d}T00:00:00Z",
+                 f"2026-01-{i+1:02d}T00:00:00Z"),
+            )
+        conn.commit()
+        conn.close()
+
+        db = MetadataDB(db_path)
+        db.initialize()
+
+        for i in range(3):
+            record = db.get_source(f"s{i}")
+            assert record is not None
+            assert record.published_at == f"2026-01-{i+1:02d}T00:00:00Z"
+
+        db.close()

--- a/tests/test_resolve_published_at.py
+++ b/tests/test_resolve_published_at.py
@@ -29,7 +29,7 @@ class TestResolvePublishedAt:
         result = resolve_published_at("youtube", meta, "2026-04-01T00:00:00Z")
         assert result == "2026-01-15T00:00:00+00:00"
 
-    def test_youtube_non_8digit_falls_back(self) -> None:
+    def test_youtube_non_8digit_returns_raw_value(self) -> None:
         """upload_date が 8桁数値でない場合はそのまま返す."""
         meta = {"upload_date": "2026-01-15"}
         result = resolve_published_at("youtube", meta, "2026-04-01T00:00:00Z")

--- a/tests/test_resolve_published_at.py
+++ b/tests/test_resolve_published_at.py
@@ -1,0 +1,70 @@
+"""resolve_published_at のテスト.
+
+テスト方針:
+- source_type ごとの公開日時フィールド抽出
+- フォールバック（フィールド欠損時に collected_at を使用）
+- youtube の YYYYMMDD → ISO 8601 変換
+"""
+
+from __future__ import annotations
+
+from rag.store.resolve import resolve_published_at
+
+
+class TestResolvePublishedAt:
+    """resolve_published_at のテスト."""
+
+    def test_bluesky_uses_created_at(self) -> None:
+        meta = {"created_at": "2026-03-15T12:00:00+00:00"}
+        result = resolve_published_at("bluesky", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-03-15T12:00:00+00:00"
+
+    def test_zenn_uses_published_at(self) -> None:
+        meta = {"published_at": "2026-02-20T09:30:00+09:00"}
+        result = resolve_published_at("zenn", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-02-20T09:30:00+09:00"
+
+    def test_youtube_converts_upload_date(self) -> None:
+        meta = {"upload_date": "20260115"}
+        result = resolve_published_at("youtube", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-01-15T00:00:00+00:00"
+
+    def test_youtube_non_8digit_falls_back(self) -> None:
+        """upload_date が 8桁数値でない場合はそのまま返す."""
+        meta = {"upload_date": "2026-01-15"}
+        result = resolve_published_at("youtube", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-01-15"
+
+    def test_aozora_falls_back_to_collected_at(self) -> None:
+        meta = {"title": "some title"}
+        result = resolve_published_at("aozora", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_journal_falls_back_to_collected_at(self) -> None:
+        result = resolve_published_at("journal", {}, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_local_falls_back_to_collected_at(self) -> None:
+        result = resolve_published_at("local", None, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_web_falls_back_to_collected_at(self) -> None:
+        meta = {"url": "https://example.com"}
+        result = resolve_published_at("web", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_none_metadata_falls_back(self) -> None:
+        result = resolve_published_at("bluesky", None, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_empty_field_value_falls_back(self) -> None:
+        """フィールドが存在するが空文字の場合はフォールバック."""
+        meta = {"created_at": ""}
+        result = resolve_published_at("bluesky", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"
+
+    def test_missing_field_falls_back(self) -> None:
+        """対象フィールドが .meta にない場合はフォールバック."""
+        meta = {"title": "test"}
+        result = resolve_published_at("bluesky", meta, "2026-04-01T00:00:00Z")
+        assert result == "2026-04-01T00:00:00Z"


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [ ] fix: バグ修正
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [ ] test: テスト追加・修正

## Summary

- metadata.db に `published_at` 列を追加（既存DB向けマイグレーション付き）
- source_type ごとの .meta フィールドから公開日時を抽出する `resolve_published_at()` を追加（bluesky: `created_at`, zenn: `published_at`, youtube: `upload_date` YYYYMMDD変換）
- `list-recent` CLI に `--order asc|desc` オプション、MCP ツールに `order` パラメータを追加
- journal migration でファイル名の YYYYMMDD-HHMMSS から日時をパース（mtime フォールバック）
- `source_store._detect_source_type` に youtube/aozora の欠落を修正
- `test_cli_stdin` の既存テスト失敗を修正（warnings Mock 未設定）
- 仕様書 content-listing.md を published_at ソート + order パラメータに更新

## Test plan

- [x] 新規テスト: resolve_published_at（全source_type、フォールバック、youtube変換）
- [x] 新規テスト: metadata_db マイグレーション（列追加、collected_at からの自動補完）
- [x] 新規テスト: journal migration ファイル名日時パース
- [x] 既存テスト修正: list_recent（published_at ソート、昇順/降順、フォールバック）
- [x] 全テスト通過: 1291 passed
- [x] ruff / mypy クリーン
- [x] 動作確認: 既存 source_store で rebuild 後に bluesky/youtube/zenn の published_at ソートを確認

## Related issues

Closes #526