### PR TITLE
fix(rebuild-stats): パイプライン async 化で Embedding リトライを解消 (#533)

### DIFF
--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -616,14 +616,14 @@ def main() -> None:
         "ingest-aozora": run_ingest_aozora,
         "ingest-aozora-author": run_ingest_aozora_author,
         "add-journal": run_add_journal,
+        "rebuild": run_rebuild,
+        "delete": run_delete,
     }
     _SYNC_COMMANDS: dict[str, object] = {
         "get-document": run_get_document,
-        "rebuild": run_rebuild,
         "stats": run_stats,
         "list-recent": run_list_recent,
         "search": run_search,
-        "delete": run_delete,
         "search-aozora": run_search_aozora,
         "migrate-journal": run_migrate_journal,
         "generate-api-key": run_generate_api_key,
@@ -1216,7 +1216,7 @@ def _show_error_dialog(message: str) -> None:
         logger.warning("Windows ダイアログの表示に失敗しました")
 
 
-def run_rebuild(args: argparse.Namespace) -> None:
+async def run_rebuild(args: argparse.Namespace) -> None:
     """再構築を実行する.
 
     仕様: docs/specs/rebuild-stats.md
@@ -1327,22 +1327,22 @@ def run_rebuild(args: argparse.Namespace) -> None:
                 logger.info("source_store に変更なし（コミットなし）")
 
         if mode == "full":
-            summary = controller.run_full_rebuild(
+            summary = await controller.run_full_rebuild(
                 source_type=source_type,
                 progress_callback=progress_cb,
             )
         elif mode == "convert":
-            summary = controller.run_convert_only(
+            summary = await controller.run_convert_only(
                 source_type=source_type,
                 progress_callback=progress_cb,
             )
         elif mode == "index":
-            summary = controller.run_index_only(
+            summary = await controller.run_index_only(
                 source_type=source_type,
                 progress_callback=progress_cb,
             )
         else:
-            summary = controller.run_incremental(
+            summary = await controller.run_incremental(
                 progress_callback=progress_cb,
             )
 
@@ -1749,7 +1749,7 @@ def run_search(args: argparse.Namespace) -> None:
         print(format_raw_search_results(raw))
 
 
-def run_delete(args: argparse.Namespace) -> None:
+async def run_delete(args: argparse.Namespace) -> None:
     """ソースをナレッジベースから削除する.
 
     MCP ツール rag_delete と同等の削除を CLI で実行する。
@@ -1774,7 +1774,7 @@ def run_delete(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     try:
-        summary = controller.ingest_and_index(
+        summary = await controller.ingest_and_index(
             f"delete: {source_id}",
             progress_callback=progress_cb,
         )
@@ -1871,7 +1871,7 @@ async def run_add_journal(args: argparse.Namespace) -> None:
             print(f"エラー: {ingest_result.error_details[0]}", file=sys.stderr)
             raise SystemExit(1)
 
-        pipeline_summary = controller.ingest_and_index(
+        pipeline_summary = await controller.ingest_and_index(
             f"ingest(journal): add {args.title}",
             progress_callback=progress_cb,
         )
@@ -2131,7 +2131,7 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
         _print_ingest_result(ingest_result, None, context=f"動画: {args.video_url}", json_output=json_out)
         return
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(youtube): {args.video_url}",
         progress_callback=progress_cb,
     )
@@ -2177,7 +2177,7 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
         _print_ingest_result(ingest_result, None, context=f"プレイリスト: {args.playlist_url}", json_output=json_out)
         return
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(youtube-playlist): {args.playlist_url}",
         progress_callback=progress_cb,
     )
@@ -2252,7 +2252,7 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
         logger.error("エラー: %s", e)
         sys.exit(1)
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(bluesky): {args.handle}",
         progress_callback=progress_cb,
     )
@@ -2327,7 +2327,7 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
             print(f"コンテンツが見つかりませんでした（ユーザー: {args.username}）")
         return
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(zenn): {args.username}",
         progress_callback=progress_cb,
     )
@@ -2462,7 +2462,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
             print(f"エラー: {ingest_result.error_details[0]}", file=sys.stderr)
             raise SystemExit(1)
 
-        pipeline_summary = controller.ingest_and_index(
+        pipeline_summary = await controller.ingest_and_index(
             f"ingest(local): add {filename}",
             progress_callback=progress_cb,
         )
@@ -2510,7 +2510,7 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
         print(f"エラー: {ingest_result.error_details[0]}", file=sys.stderr)
         raise SystemExit(1)
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(local): crawl {args.dir_path}",
         progress_callback=progress_cb,
     )
@@ -2643,7 +2643,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     pipeline_summary = None
     has_changes = (bridge_result.ingest.placed + bridge_result.ingest.overwritten) > 0
     if has_changes and not args.download_only:
-        pipeline_summary = controller.ingest_and_index(
+        pipeline_summary = await controller.ingest_and_index(
             f"ingest(web): site-ingest {display_url}",
             progress_callback=progress_cb,
         )
@@ -2802,7 +2802,7 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
         logger.error("エラー: %s", e)
         sys.exit(1)
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(aozora): book_id={args.book_id}",
         progress_callback=progress_cb,
     )
@@ -2845,7 +2845,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
         logger.error("エラー: %s", e)
         sys.exit(1)
 
-    pipeline_summary = controller.ingest_and_index(
+    pipeline_summary = await controller.ingest_and_index(
         f"ingest(aozora): person_id={args.person_id}",
         progress_callback=progress_cb,
     )

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -8,11 +8,8 @@ converted_store のテキストファイルからチャンキング・Embedding�
 
 from __future__ import annotations
 
-import asyncio
-import concurrent.futures
 import logging
 from pathlib import Path
-from typing import Any
 
 from rag.bm25_index import BM25Index
 from rag.chunker import chunk_text
@@ -78,7 +75,7 @@ class Indexer:
         # overlap が実効サイズ以上だと chunk_text が ValueError になるためクランプ
         self._effective_overlap = min(chunk_overlap, self._effective_size_prose - 1)
 
-    def add(
+    async def add(
         self,
         source_id: str,
         converted_path: Path,
@@ -96,7 +93,7 @@ class Indexer:
             ConnectionError: Embedding プロバイダーに接続できない場合
         """
         _validate_source_id(source_id, metadata)
-        self._check_embedding_available()
+        await self._check_embedding_available()
         text = self._read_file(converted_path)
         if not text.strip():
             logger.info("空ファイルのためスキップ: %s", converted_path)
@@ -106,12 +103,12 @@ class Indexer:
         if not chunk_texts:
             return
 
-        self._add_to_indices(source_id, chunk_texts, metadata)
+        await self._add_to_indices(source_id, chunk_texts, metadata)
         logger.info(
             "インデックスに追加: %s (%d チャンク)", source_id, len(chunk_texts),
         )
 
-    def update(
+    async def update(
         self,
         source_id: str,
         converted_path: Path,
@@ -132,16 +129,16 @@ class Indexer:
             ConnectionError: Embedding プロバイダーに接続できない場合
         """
         _validate_source_id(source_id, metadata)
-        self._check_embedding_available()
+        await self._check_embedding_available()
         text = self._read_file(converted_path)
 
         if not text.strip():
-            self.delete(source_id)
+            await self.delete(source_id)
             return
 
         chunk_texts = self._chunk_text(text)
         if not chunk_texts:
-            self.delete(source_id)
+            await self.delete(source_id)
             return
 
         # 新チャンク ID を算出
@@ -150,29 +147,27 @@ class Indexer:
         }
 
         # 新チャンクを upsert
-        self._add_to_indices(source_id, chunk_texts, metadata)
+        await self._add_to_indices(source_id, chunk_texts, metadata)
 
         # stale チャンクを削除
-        _run_async(
-            self._vector_store.delete_stale_chunks(source_id, new_chunk_ids),
-        )
+        await self._vector_store.delete_stale_chunks(source_id, new_chunk_ids)
         self._bm25.delete_stale_docs(source_id, new_chunk_ids)
 
         logger.info(
             "インデックスを更新: %s (%d チャンク)", source_id, len(chunk_texts),
         )
 
-    def delete(self, source_id: str) -> None:
+    async def delete(self, source_id: str) -> None:
         """インデックスから削除する.
 
         Args:
             source_id: ソース識別子
         """
-        _run_async(self._vector_store.delete_by_source(source_id))
+        await self._vector_store.delete_by_source(source_id)
         self._bm25.delete_by_source(source_id)
         logger.info("インデックスから削除: %s", source_id)
 
-    def upsert_metadata(
+    async def upsert_metadata(
         self,
         source_id: str,
         metadata: SourceMetadata,
@@ -183,9 +178,7 @@ class Indexer:
             source_id: ソース識別子
             metadata: ソースメタデータ
         """
-        chunk_ids = _run_async(
-            self._vector_store.get_chunk_ids_for_source(source_id),
-        )
+        chunk_ids = await self._vector_store.get_chunk_ids_for_source(source_id)
         if not chunk_ids:
             logger.warning(
                 "メタデータ更新対象のチャンクが存在しません: %s", source_id,
@@ -195,8 +188,8 @@ class Indexer:
         total_chunks = len(chunk_ids)
 
         # 既存チャンクの section_path を保持する（メタデータのみ更新時に消さない）
-        existing_meta_map = _run_async(
-            self._vector_store.get_metadata_by_ids(chunk_ids),
+        existing_meta_map = await self._vector_store.get_metadata_by_ids(
+            chunk_ids,
         )
 
         metadatas = []
@@ -210,26 +203,26 @@ class Indexer:
             )
             metadatas.append(meta)
 
-        _run_async(self._vector_store.update_metadata(chunk_ids, metadatas))
+        await self._vector_store.update_metadata(chunk_ids, metadatas)
 
         logger.info(
             "メタデータを更新: %s (%d チャンク)", source_id, total_chunks,
         )
 
-    def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(self, source_type: SourceType | None = None) -> None:
         """インデックスをクリアする.
 
         Args:
             source_type: 指定時はその媒体のみクリア
         """
         if source_type is None:
-            self._clear_all()
+            await self._clear_all()
         else:
-            self._clear_by_source_type(source_type)
+            await self._clear_by_source_type(source_type)
 
     # --- 内部メソッド ---
 
-    def _check_embedding_available(self) -> None:
+    async def _check_embedding_available(self) -> None:
         """Embedding プロバイダーの疎通を確認する.
 
         初回呼び出し時のみ実際にチェックし、結果をキャッシュする。
@@ -240,7 +233,7 @@ class Indexer:
         """
         if self._embedding_checked:
             return
-        available = _run_async(self._vector_store.is_embedding_available())
+        available = await self._vector_store.is_embedding_available()
         if not available:
             msg = "Embedding プロバイダーに接続できません"
             raise ConnectionError(msg)
@@ -287,7 +280,7 @@ class Indexer:
         )
         return [(c, "") for c in prose_chunks]
 
-    def _add_to_indices(
+    async def _add_to_indices(
         self,
         source_id: str,
         chunk_texts: list[tuple[str, str]],
@@ -326,23 +319,23 @@ class Indexer:
             ))
             bm25_metadata_list.append(meta)
 
-        # ChromaDB に upsert（async → sync ブリッジ）
-        _run_async(self._vector_store.add_documents(doc_chunks))
+        # ChromaDB に upsert
+        await self._vector_store.add_documents(doc_chunks)
 
         # BM25 に追加
         self._bm25.add_documents(bm25_docs, metadata_list=bm25_metadata_list)
 
-    def _clear_all(self) -> None:
+    async def _clear_all(self) -> None:
         """全インデックスをクリアする."""
-        _run_async(self._vector_store.clear())
+        await self._vector_store.clear()
         self._bm25.clear()
         logger.info("全インデックスをクリアしました")
 
-    def _clear_by_source_type(self, source_type: SourceType) -> None:
+    async def _clear_by_source_type(self, source_type: SourceType) -> None:
         """指定 source_type のインデックスをクリアする."""
         records = self._metadata_db.search_sources(source_type=source_type)
         for record in records:
-            self.delete(record.source_id)
+            await self.delete(record.source_id)
 
         logger.info(
             "source_type=%s のインデックスをクリア (%d 件)",
@@ -358,19 +351,3 @@ def _validate_source_id(source_id: str, metadata: SourceMetadata) -> None:
             f"metadata.source_id={metadata.source_id}"
         )
         raise ValueError(msg)
-
-
-def _run_async(coro: Any) -> Any:
-    """async コルーチンを sync コンテキストから実行する.
-
-    パイプライン制御は sync で呼び出すため通常は asyncio.run() パスを使用する。
-    既存ループ内からの呼び出し時は新スレッドで実行する（MCP サーバー等）。
-    """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-    # 既存ループ内からの呼び出し（MCP サーバー等）
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(asyncio.run, coro)
-        return future.result()

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -9,9 +9,10 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import logging
 import subprocess
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeVar
@@ -109,7 +110,7 @@ class PipelineController:
         self._git.init_repo()
         return self._git.commit(message)
 
-    def ingest_and_index(
+    async def ingest_and_index(
         self,
         message: str,
         progress_callback: ProgressCallback | None = None,
@@ -126,11 +127,11 @@ class PipelineController:
             パイプライン処理結果サマリ
         """
         self.commit(message)
-        return self.run_incremental(progress_callback=progress_callback)
+        return await self.run_incremental(progress_callback=progress_callback)
 
     # --- パイプライン実行 ---
 
-    def run_incremental(self, progress_callback: ProgressCallback | None = None) -> PipelineSummary:
+    async def run_incremental(self, progress_callback: ProgressCallback | None = None) -> PipelineSummary:
         """差分更新を実行する.
 
         source_store に未コミットの変更がある場合は自動コミットし、
@@ -188,7 +189,7 @@ class PipelineController:
                 to_commit_id=head_commit,
             )
 
-        summary = self._process_changes(
+        summary = await self._process_changes(
             changes, PipelineMode.INCREMENTAL, last_commit_id, head_commit,
             progress_callback=progress_callback,
         )
@@ -204,7 +205,7 @@ class PipelineController:
 
         return summary
 
-    def run_full_rebuild(
+    async def run_full_rebuild(
         self,
         source_type: SourceType | None = None,
         *,
@@ -231,7 +232,7 @@ class PipelineController:
         self._converter.clear(self._converted_store_dir, source_type)
 
         # 3. インデックスクリア
-        self._indexer.clear(source_type)
+        await self._indexer.clear(source_type)
 
         # 4. active ファイルをスキャン（パイプライン対象外ファイルを除外）
         records = [
@@ -251,20 +252,20 @@ class PipelineController:
             )
 
         # 5-6. コンバート + インデックス
-        def _convert_and_index(record: SourceRecord) -> None:
+        async def _convert_and_index(record: SourceRecord) -> None:
             converted_path = self._converter.convert(
                 record.file_path,
                 self._source_store.root_dir,
                 self._converted_store_dir,
             )
             metadata = self._build_metadata_from_record(record)
-            self._indexer.add(record.source_id, converted_path, metadata)
+            await self._indexer.add(record.source_id, converted_path, metadata)
 
         to_commit = ""
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
-        summary = self._run_processing_loop(
+        summary = await self._run_processing_loop(
             records,
             process_fn=_convert_and_index,
             get_file_path=lambda r: r.file_path,
@@ -318,7 +319,7 @@ class PipelineController:
         if commit_id:
             logger.info("自動コミット完了: %s", commit_id)
 
-    def run_convert_only(
+    async def run_convert_only(
         self,
         source_type: SourceType | None = None,
         *,
@@ -366,7 +367,7 @@ class PipelineController:
                 self._converted_store_dir,
             )
 
-        return self._run_processing_loop(
+        return await self._run_processing_loop(
             records,
             process_fn=_convert_single,
             get_file_path=lambda r: r.file_path,
@@ -376,7 +377,7 @@ class PipelineController:
             progress_callback=progress_callback,
         )
 
-    def run_index_only(
+    async def run_index_only(
         self,
         source_type: SourceType | None = None,
         *,
@@ -397,7 +398,7 @@ class PipelineController:
         self._check_uncommitted_changes(source_type)
 
         # 1. インデックスクリア
-        self._indexer.clear(source_type)
+        await self._indexer.clear(source_type)
 
         # 2. active なレコードを取得（パイプライン対象外ファイルを除外）
         records = [
@@ -417,7 +418,7 @@ class PipelineController:
             )
 
         # 3. converted_store からインデックス再構築
-        def _index_single(record: SourceRecord) -> None:
+        async def _index_single(record: SourceRecord) -> None:
             converted_rel = get_converted_rel_path(record.file_path)
             converted_path = self._converted_store_dir / converted_rel
             if not converted_path.exists():
@@ -425,13 +426,13 @@ class PipelineController:
                     f"converted file not found: {converted_path}",
                 )
             metadata = self._build_metadata_from_record(record)
-            self._indexer.add(record.source_id, converted_path, metadata)
+            await self._indexer.add(record.source_id, converted_path, metadata)
 
         to_commit = ""
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
-        summary = self._run_processing_loop(
+        summary = await self._run_processing_loop(
             records,
             process_fn=_index_single,
             get_file_path=lambda r: r.file_path,
@@ -518,11 +519,11 @@ class PipelineController:
 
     # --- 共通処理ループ ---
 
-    def _run_processing_loop(
+    async def _run_processing_loop(
         self,
         items: Sequence[_T],
         *,
-        process_fn: Callable[[_T], None],
+        process_fn: Callable[[_T], Awaitable[None]] | Callable[[_T], None],
         get_file_path: Callable[[_T], str],
         phase: str,
         mode: PipelineMode,
@@ -535,7 +536,10 @@ class PipelineController:
 
         各パイプラインモードで共通する
         ループ + try/except + progress + PipelineSummary 組み立てを一元化する。
+        process_fn は sync / async どちらも受け付ける。
         """
+        is_async = inspect.iscoroutinefunction(process_fn)
+
         processed = 0
         skipped = 0
         errors: list[str] = []
@@ -544,7 +548,9 @@ class PipelineController:
         for item in items:
             file_path = get_file_path(item)
             try:
-                process_fn(item)
+                result = process_fn(item)
+                if is_async:
+                    await result  # type: ignore[misc]
                 processed += 1
             except ConversionSkippedError as e:
                 logger.warning(
@@ -577,7 +583,7 @@ class PipelineController:
 
     # --- 変更処理 ---
 
-    def _process_changes(
+    async def _process_changes(
         self,
         changes: list[ChangeEntry],
         mode: PipelineMode,
@@ -586,7 +592,7 @@ class PipelineController:
         progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """変更エントリを処理する."""
-        return self._run_processing_loop(
+        return await self._run_processing_loop(
             changes,
             process_fn=self._process_single_change,
             get_file_path=lambda e: e.file_path,
@@ -598,7 +604,7 @@ class PipelineController:
             to_commit_id=to_commit_id,
         )
 
-    def _process_single_change(self, entry: ChangeEntry) -> None:
+    async def _process_single_change(self, entry: ChangeEntry) -> None:
         """1ファイルの変更を処理する."""
         handler = {
             ChangeStatus.ADDED: self._handle_added,
@@ -607,9 +613,9 @@ class PipelineController:
             ChangeStatus.RENAMED: self._handle_renamed,
             ChangeStatus.META_ONLY: self._handle_meta_only,
         }
-        handler[entry.status](entry)
+        await handler[entry.status](entry)
 
-    def _handle_added(self, entry: ChangeEntry) -> None:
+    async def _handle_added(self, entry: ChangeEntry) -> None:
         """追加ファイルを処理する."""
         # 論理削除済みファイルは処理をスキップ
         # （DB=active / インデックス未登録の不整合を防止）
@@ -625,9 +631,9 @@ class PipelineController:
             self._converted_store_dir,
         )
         metadata = self._build_metadata(entry.file_path)
-        self._indexer.add(source_id, converted_path, metadata)
+        await self._indexer.add(source_id, converted_path, metadata)
 
-    def _handle_modified(self, entry: ChangeEntry) -> None:
+    async def _handle_modified(self, entry: ChangeEntry) -> None:
         """変更ファイルを処理する."""
         self._update_in_db(entry.file_path)
         converted_path = self._converter.convert(
@@ -637,13 +643,13 @@ class PipelineController:
         )
         source_id = self._resolve_source_id(entry.file_path)
         metadata = self._build_metadata(entry.file_path)
-        self._indexer.update(source_id, converted_path, metadata)
+        await self._indexer.update(source_id, converted_path, metadata)
 
-    def _handle_deleted(self, entry: ChangeEntry) -> None:
+    async def _handle_deleted(self, entry: ChangeEntry) -> None:
         """削除ファイルを処理する."""
         source_id = self._resolve_source_id(entry.file_path)
         self._converter.delete(entry.file_path, self._converted_store_dir)
-        self._indexer.delete(source_id)
+        await self._indexer.delete(source_id)
         try:
             self.db.set_status(source_id, "deleted")
         except KeyError:
@@ -651,7 +657,7 @@ class PipelineController:
                 "削除対象が metadata.db に存在しません: %s", source_id,
             )
 
-    def _handle_renamed(self, entry: ChangeEntry) -> None:
+    async def _handle_renamed(self, entry: ChangeEntry) -> None:
         """リネームファイルを処理する."""
         old_source_id = self._resolve_source_id(entry.old_path)
         source_type = detect_source_type(entry.file_path)
@@ -667,10 +673,10 @@ class PipelineController:
         self._converter.delete(entry.old_path, self._converted_store_dir)
 
         # インデクサー: 旧パス削除 + 新パス追加
-        self._indexer.delete(old_source_id)
+        await self._indexer.delete(old_source_id)
         new_source_id = self._resolve_source_id(entry.file_path)
         metadata = self._build_metadata(entry.file_path)
-        self._indexer.add(new_source_id, converted_path, metadata)
+        await self._indexer.add(new_source_id, converted_path, metadata)
 
         # metadata.db 更新
         if source_type == "local":
@@ -696,7 +702,7 @@ class PipelineController:
             except KeyError:
                 self._register_in_db(entry.file_path)
 
-    def _handle_meta_only(self, entry: ChangeEntry) -> None:
+    async def _handle_meta_only(self, entry: ChangeEntry) -> None:
         """.meta のみ変更を処理する."""
         source_id = self._resolve_source_id(entry.file_path)
         source_type = detect_source_type(entry.file_path)
@@ -725,7 +731,7 @@ class PipelineController:
 
         # インデクサー: メタデータのみ更新
         metadata = self._build_metadata(entry.file_path)
-        self._indexer.upsert_metadata(source_id, metadata)
+        await self._indexer.upsert_metadata(source_id, metadata)
 
     # --- metadata 操作ヘルパー ---
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -538,8 +538,6 @@ class PipelineController:
         ループ + try/except + progress + PipelineSummary 組み立てを一元化する。
         process_fn は sync / async どちらも受け付ける。
         """
-        is_async = inspect.iscoroutinefunction(process_fn)
-
         processed = 0
         skipped = 0
         errors: list[str] = []
@@ -549,8 +547,8 @@ class PipelineController:
             file_path = get_file_path(item)
             try:
                 result = process_fn(item)
-                if is_async:
-                    await result  # type: ignore[misc]
+                if inspect.isawaitable(result):
+                    await result
                 processed += 1
             except ConversionSkippedError as e:
                 logger.warning(

--- a/src/rag/pipeline/protocols.py
+++ b/src/rag/pipeline/protocols.py
@@ -72,7 +72,7 @@ class IndexerProtocol(Protocol):
     converted_store からチャンキング・Embedding・インデックス構築を行う。
     """
 
-    def add(
+    async def add(
         self,
         source_id: str,
         converted_path: Path,
@@ -87,7 +87,7 @@ class IndexerProtocol(Protocol):
         """
         ...
 
-    def update(
+    async def update(
         self,
         source_id: str,
         converted_path: Path,
@@ -102,7 +102,7 @@ class IndexerProtocol(Protocol):
         """
         ...
 
-    def delete(self, source_id: str) -> None:
+    async def delete(self, source_id: str) -> None:
         """インデックスから削除する.
 
         Args:
@@ -110,7 +110,7 @@ class IndexerProtocol(Protocol):
         """
         ...
 
-    def upsert_metadata(
+    async def upsert_metadata(
         self,
         source_id: str,
         metadata: SourceMetadata,
@@ -123,7 +123,7 @@ class IndexerProtocol(Protocol):
         """
         ...
 
-    def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(self, source_type: SourceType | None = None) -> None:
         """インデックスをクリアする.
 
         Args:

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -109,13 +109,13 @@ def _write_text_file(tmp_path: Path, filename: str, content: str) -> Path:
 class TestAdd:
     """Indexer.add のテスト."""
 
-    def test_adds_prose_to_chromadb(
+    async def test_adds_prose_to_chromadb(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Sample prose text for testing.")
         meta = _make_metadata(source_id="src-1")
 
-        indexer.add("src-1", path, meta)
+        await indexer.add("src-1", path, meta)
 
         # ChromaDB にチャンクが追加されたか確認
         result = vector_store._collection.get(
@@ -123,30 +123,30 @@ class TestAdd:
         )
         assert len(result["ids"]) >= 1
 
-    def test_adds_prose_to_bm25(
+    async def test_adds_prose_to_bm25(
         self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Sample prose text for testing.")
         meta = _make_metadata(source_id="src-1")
 
-        indexer.add("src-1", path, meta)
+        await indexer.add("src-1", path, meta)
 
         assert bm25_index.get_document_count() >= 1
 
-    def test_skips_empty_file(
+    async def test_skips_empty_file(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "empty.txt", "   \n  ")
         meta = _make_metadata(source_id="src-empty")
 
-        indexer.add("src-empty", path, meta)
+        await indexer.add("src-empty", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-empty"}, include=[],
         )
         assert len(result["ids"]) == 0
 
-    def test_chunk_metadata_has_required_fields(
+    async def test_chunk_metadata_has_required_fields(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Short text for metadata check.")
@@ -157,7 +157,7 @@ class TestAdd:
             collected_at="2025-06-01T00:00:00Z",
         )
 
-        indexer.add("src-meta", path, meta)
+        await indexer.add("src-meta", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-meta"}, include=["metadatas"],
@@ -171,7 +171,7 @@ class TestAdd:
         assert chunk_meta["total_chunks"] >= 1
         assert chunk_meta["collected_at"] == "2025-06-01T00:00:00Z"
 
-    def test_custom_metadata_fields(
+    async def test_custom_metadata_fields(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Text with custom metadata.")
@@ -180,7 +180,7 @@ class TestAdd:
             extra={"author": "Alice", "category": "tech"},
         )
 
-        indexer.add("src-custom", path, meta)
+        await indexer.add("src-custom", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-custom"}, include=["metadatas"],
@@ -189,21 +189,21 @@ class TestAdd:
         assert chunk_meta["custom:author"] == "Alice"
         assert chunk_meta["custom:category"] == "tech"
 
-    def test_heading_text_uses_heading_chunker(
+    async def test_heading_text_uses_heading_chunker(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         text = "# Section A\n\nContent of section A.\n\n# Section B\n\nContent of section B."
         path = _write_text_file(tmp_path, "heading.txt", text)
         meta = _make_metadata(source_id="src-heading")
 
-        indexer.add("src-heading", path, meta)
+        await indexer.add("src-heading", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-heading"}, include=["documents"],
         )
         assert len(result["ids"]) >= 2
 
-    def test_section_path_in_metadata(
+    async def test_section_path_in_metadata(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         """section_path がメタデータに含まれること."""
@@ -211,7 +211,7 @@ class TestAdd:
         path = _write_text_file(tmp_path, "heading.txt", text)
         meta = _make_metadata(source_id="src-sp")
 
-        indexer.add("src-sp", path, meta)
+        await indexer.add("src-sp", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-sp"}, include=["metadatas"],
@@ -220,7 +220,7 @@ class TestAdd:
         section_paths = [m.get("section_path", "") for m in result["metadatas"]]
         assert any("Parent" in sp for sp in section_paths)
 
-    def test_embedding_receives_content_only(
+    async def test_embedding_receives_content_only(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         """Embedding（ChromaDB の documents）には本文のみが格納されること."""
@@ -228,7 +228,7 @@ class TestAdd:
         path = _write_text_file(tmp_path, "heading.txt", text)
         meta = _make_metadata(source_id="src-emb")
 
-        indexer.add("src-emb", path, meta)
+        await indexer.add("src-emb", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-emb"},
@@ -245,7 +245,7 @@ class TestAdd:
             assert "[" not in doc  # 旧形式の breadcrumb
             assert "# " not in doc  # 旧形式の見出しプレフィックス
 
-    def test_bm25_receives_section_path_plus_content(
+    async def test_bm25_receives_section_path_plus_content(
         self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
         """BM25 には section_path + 本文が渡されること."""
@@ -253,13 +253,13 @@ class TestAdd:
         path = _write_text_file(tmp_path, "heading.txt", text)
         meta = _make_metadata(source_id="src-bm25-sp")
 
-        indexer.add("src-bm25-sp", path, meta)
+        await indexer.add("src-bm25-sp", path, meta)
 
         # BM25 で見出しキーワードで検索できる
         results = bm25_index.search("MyHeading", n_results=5)
         assert len(results) > 0
 
-    def test_table_text_uses_table_chunker(
+    async def test_table_text_uses_table_chunker(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         text = (
@@ -272,20 +272,20 @@ class TestAdd:
         path = _write_text_file(tmp_path, "table.txt", text)
         meta = _make_metadata(source_id="src-table")
 
-        indexer.add("src-table", path, meta)
+        await indexer.add("src-table", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-table"}, include=[],
         )
         assert len(result["ids"]) >= 1
 
-    def test_chunk_ids_follow_spec_format(
+    async def test_chunk_ids_follow_spec_format(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Text for ID format check.")
         meta = _make_metadata(source_id="src-id-fmt")
 
-        indexer.add("src-id-fmt", path, meta)
+        await indexer.add("src-id-fmt", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-id-fmt"}, include=[],
@@ -300,17 +300,17 @@ class TestAdd:
 class TestUpdate:
     """Indexer.update のテスト."""
 
-    def test_updates_existing_chunks(
+    async def test_updates_existing_chunks(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Original content.")
         meta = _make_metadata(source_id="src-upd")
 
-        indexer.add("src-upd", path, meta)
+        await indexer.add("src-upd", path, meta)
 
         # 更新
         path.write_text("Updated content with new information.", encoding="utf-8")
-        indexer.update("src-upd", path, meta)
+        await indexer.update("src-upd", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-upd"}, include=["documents"],
@@ -318,7 +318,7 @@ class TestUpdate:
         assert len(result["ids"]) >= 1
         assert any("Updated" in doc for doc in result["documents"])
 
-    def test_stale_chunks_deleted_when_count_decreases(
+    async def test_stale_chunks_deleted_when_count_decreases(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         """複数チャンク → 少数チャンクで stale チャンクが削除される."""
@@ -327,7 +327,7 @@ class TestUpdate:
         path = _write_text_file(tmp_path, "doc.txt", long_text)
         meta = _make_metadata(source_id="src-stale")
 
-        indexer.add("src-stale", path, meta)
+        await indexer.add("src-stale", path, meta)
         initial_result = vector_store._collection.get(
             where={"source_id": "src-stale"}, include=[],
         )
@@ -336,41 +336,41 @@ class TestUpdate:
 
         # 短いテキスト（1チャンク）に更新
         path.write_text("Short updated text.", encoding="utf-8")
-        indexer.update("src-stale", path, meta)
+        await indexer.update("src-stale", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-stale"}, include=[],
         )
         assert len(result["ids"]) < initial_count
 
-    def test_stale_chunks_deleted_from_bm25(
+    async def test_stale_chunks_deleted_from_bm25(
         self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
         long_text = " ".join(["Long paragraph content."] * 200)
         path = _write_text_file(tmp_path, "doc.txt", long_text)
         meta = _make_metadata(source_id="src-bm25-stale")
 
-        indexer.add("src-bm25-stale", path, meta)
+        await indexer.add("src-bm25-stale", path, meta)
         initial_count = bm25_index.get_document_count()
         assert initial_count > 1
 
         # 短いテキスト
         path.write_text("Short.", encoding="utf-8")
-        indexer.update("src-bm25-stale", path, meta)
+        await indexer.update("src-bm25-stale", path, meta)
 
         assert bm25_index.get_document_count() < initial_count
 
-    def test_update_empty_file_deletes_all(
+    async def test_update_empty_file_deletes_all(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Some content.")
         meta = _make_metadata(source_id="src-empty-upd")
 
-        indexer.add("src-empty-upd", path, meta)
+        await indexer.add("src-empty-upd", path, meta)
 
         # 空ファイルに更新
         path.write_text("", encoding="utf-8")
-        indexer.update("src-empty-upd", path, meta)
+        await indexer.update("src-empty-upd", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-empty-upd"}, include=[],
@@ -384,39 +384,39 @@ class TestUpdate:
 class TestDelete:
     """Indexer.delete のテスト."""
 
-    def test_deletes_from_chromadb(
+    async def test_deletes_from_chromadb(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content to be deleted.")
         meta = _make_metadata(source_id="src-del")
 
-        indexer.add("src-del", path, meta)
-        indexer.delete("src-del")
+        await indexer.add("src-del", path, meta)
+        await indexer.delete("src-del")
 
         result = vector_store._collection.get(
             where={"source_id": "src-del"}, include=[],
         )
         assert len(result["ids"]) == 0
 
-    def test_deletes_from_bm25(
+    async def test_deletes_from_bm25(
         self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content to be deleted.")
         meta = _make_metadata(source_id="src-del-bm25")
 
-        indexer.add("src-del-bm25", path, meta)
+        await indexer.add("src-del-bm25", path, meta)
         assert bm25_index.get_document_count() >= 1
 
-        indexer.delete("src-del-bm25")
+        await indexer.delete("src-del-bm25")
         assert bm25_index.get_document_count() == 0
 
-    def test_delete_nonexistent_source_no_error(
+    async def test_delete_nonexistent_source_no_error(
         self, indexer: Indexer,
     ) -> None:
         """存在しない source_id の削除はエラーにならない."""
-        indexer.delete("nonexistent-source")
+        await indexer.delete("nonexistent-source")
 
-    def test_delete_only_affects_target_source(
+    async def test_delete_only_affects_target_source(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path_a = _write_text_file(tmp_path, "a.txt", "Content A.")
@@ -424,10 +424,10 @@ class TestDelete:
         meta_a = _make_metadata(source_id="src-a")
         meta_b = _make_metadata(source_id="src-b")
 
-        indexer.add("src-a", path_a, meta_a)
-        indexer.add("src-b", path_b, meta_b)
+        await indexer.add("src-a", path_a, meta_a)
+        await indexer.add("src-b", path_b, meta_b)
 
-        indexer.delete("src-a")
+        await indexer.delete("src-a")
 
         result_a = vector_store._collection.get(
             where={"source_id": "src-a"}, include=[],
@@ -445,17 +445,17 @@ class TestDelete:
 class TestUpsertMetadata:
     """Indexer.upsert_metadata のテスト."""
 
-    def test_updates_metadata_without_changing_text(
+    async def test_updates_metadata_without_changing_text(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content for metadata upsert.")
         original_meta = _make_metadata(source_id="src-meta-up", title="Old Title")
 
-        indexer.add("src-meta-up", path, original_meta)
+        await indexer.add("src-meta-up", path, original_meta)
 
         # メタデータのみ更新
         updated_meta = _make_metadata(source_id="src-meta-up", title="New Title")
-        indexer.upsert_metadata("src-meta-up", updated_meta)
+        await indexer.upsert_metadata("src-meta-up", updated_meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-meta-up"},
@@ -465,7 +465,7 @@ class TestUpsertMetadata:
         # テキストは維持される
         assert result["documents"][0] is not None
 
-    def test_updates_custom_fields(
+    async def test_updates_custom_fields(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content with custom meta.")
@@ -474,13 +474,13 @@ class TestUpsertMetadata:
             extra={"author": "Alice"},
         )
 
-        indexer.add("src-custom-up", path, original_meta)
+        await indexer.add("src-custom-up", path, original_meta)
 
         updated_meta = _make_metadata(
             source_id="src-custom-up",
             extra={"author": "Bob", "version": 2},
         )
-        indexer.upsert_metadata("src-custom-up", updated_meta)
+        await indexer.upsert_metadata("src-custom-up", updated_meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-custom-up"},
@@ -490,12 +490,12 @@ class TestUpsertMetadata:
         assert meta["custom:author"] == "Bob"
         assert meta["custom:version"] == 2
 
-    def test_nonexistent_source_logs_warning(
+    async def test_nonexistent_source_logs_warning(
         self, indexer: Indexer,
     ) -> None:
         """存在しない source_id のメタデータ更新はエラーにならない."""
         meta = _make_metadata(source_id="nonexistent")
-        indexer.upsert_metadata("nonexistent", meta)
+        await indexer.upsert_metadata("nonexistent", meta)
 
 
 # --- テスト: clear ---
@@ -504,7 +504,7 @@ class TestUpsertMetadata:
 class TestClear:
     """Indexer.clear のテスト."""
 
-    def test_clear_all(
+    async def test_clear_all(
         self, indexer: Indexer, vector_store: VectorStore,
         bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
@@ -513,15 +513,15 @@ class TestClear:
         meta_a = _make_metadata(source_id="src-a", source_type="web")
         meta_b = _make_metadata(source_id="src-b", source_type="zenn")
 
-        indexer.add("src-a", path_a, meta_a)
-        indexer.add("src-b", path_b, meta_b)
+        await indexer.add("src-a", path_a, meta_a)
+        await indexer.add("src-b", path_b, meta_b)
 
-        indexer.clear()
+        await indexer.clear()
 
         assert vector_store._collection.count() == 0
         assert bm25_index.get_document_count() == 0
 
-    def test_clear_by_source_type(
+    async def test_clear_by_source_type(
         self, indexer: Indexer, vector_store: VectorStore,
         metadata_db: MetadataDB, tmp_path: Path,
     ) -> None:
@@ -552,11 +552,11 @@ class TestClear:
         meta_web = _make_metadata(source_id="src-web", source_type="web")
         meta_zenn = _make_metadata(source_id="src-zenn", source_type="zenn")
 
-        indexer.add("src-web", path_web, meta_web)
-        indexer.add("src-zenn", path_zenn, meta_zenn)
+        await indexer.add("src-web", path_web, meta_web)
+        await indexer.add("src-zenn", path_zenn, meta_zenn)
 
         # web のみクリア
-        indexer.clear("web")
+        await indexer.clear("web")
 
         result_web = vector_store._collection.get(
             where={"source_id": "src-web"}, include=[],
@@ -567,22 +567,22 @@ class TestClear:
         assert len(result_web["ids"]) == 0
         assert len(result_zenn["ids"]) >= 1
 
-    def test_clear_empty_index_no_error(
+    async def test_clear_empty_index_no_error(
         self, indexer: Indexer,
     ) -> None:
         """空インデックスの clear はエラーにならない."""
-        indexer.clear()
+        await indexer.clear()
 
-    def test_clear_all_then_add(
+    async def test_clear_all_then_add(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,
     ) -> None:
         """clear 後に再追加できる."""
         path = _write_text_file(tmp_path, "doc.txt", "Content.")
         meta = _make_metadata(source_id="src-re")
 
-        indexer.add("src-re", path, meta)
-        indexer.clear()
-        indexer.add("src-re", path, meta)
+        await indexer.add("src-re", path, meta)
+        await indexer.clear()
+        await indexer.add("src-re", path, meta)
 
         result = vector_store._collection.get(
             where={"source_id": "src-re"}, include=[],
@@ -596,30 +596,30 @@ class TestClear:
 class TestSourceIdValidation:
     """source_id と metadata.source_id の一致バリデーションテスト."""
 
-    def test_add_raises_on_mismatch(
+    async def test_add_raises_on_mismatch(
         self, indexer: Indexer, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content.")
         meta = _make_metadata(source_id="different-id")
 
         with pytest.raises(ValueError, match="source_id の不一致"):
-            indexer.add("src-mismatch", path, meta)
+            await indexer.add("src-mismatch", path, meta)
 
-    def test_update_raises_on_mismatch(
+    async def test_update_raises_on_mismatch(
         self, indexer: Indexer, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content.")
         meta = _make_metadata(source_id="different-id")
 
         with pytest.raises(ValueError, match="source_id の不一致"):
-            indexer.update("src-mismatch", path, meta)
+            await indexer.update("src-mismatch", path, meta)
 
-    def test_matching_ids_no_error(
+    async def test_matching_ids_no_error(
         self, indexer: Indexer, tmp_path: Path,
     ) -> None:
         path = _write_text_file(tmp_path, "doc.txt", "Content.")
         meta = _make_metadata(source_id="src-ok")
-        indexer.add("src-ok", path, meta)
+        await indexer.add("src-ok", path, meta)
 
 
 # --- テスト: Embedding 疎通確認 ---
@@ -638,7 +638,7 @@ class UnavailableEmbeddingProvider(EmbeddingProvider):
 class TestEmbeddingAvailability:
     """Embedding プロバイダー疎通確認のテスト."""
 
-    def test_add_raises_when_embedding_unavailable(
+    async def test_add_raises_when_embedding_unavailable(
         self, bm25_index: BM25Index, metadata_db: MetadataDB, tmp_path: Path,
     ) -> None:
         """add 時に Embedding プロバイダーが接続不可ならエラーになること."""
@@ -655,9 +655,9 @@ class TestEmbeddingAvailability:
         meta = _make_metadata(source_id="src-unavail")
 
         with pytest.raises(ConnectionError, match="Embedding"):
-            idx.add("src-unavail", path, meta)
+            await idx.add("src-unavail", path, meta)
 
-    def test_update_raises_when_embedding_unavailable(
+    async def test_update_raises_when_embedding_unavailable(
         self, bm25_index: BM25Index, metadata_db: MetadataDB, tmp_path: Path,
     ) -> None:
         """update 時に Embedding プロバイダーが接続不可ならエラーになること."""
@@ -674,21 +674,21 @@ class TestEmbeddingAvailability:
         meta = _make_metadata(source_id="src-unavail-upd")
 
         with pytest.raises(ConnectionError, match="Embedding"):
-            idx.update("src-unavail-upd", path, meta)
+            await idx.update("src-unavail-upd", path, meta)
 
-    def test_delete_does_not_check_embedding(
+    async def test_delete_does_not_check_embedding(
         self, indexer: Indexer,
     ) -> None:
         """delete は Embedding チェックを行わないこと（エラーにならない）."""
-        indexer.delete("nonexistent-source")
+        await indexer.delete("nonexistent-source")
 
-    def test_clear_does_not_check_embedding(
+    async def test_clear_does_not_check_embedding(
         self, indexer: Indexer,
     ) -> None:
         """clear は Embedding チェックを行わないこと（エラーにならない）."""
-        indexer.clear()
+        await indexer.clear()
 
-    def test_check_cached_after_first_success(
+    async def test_check_cached_after_first_success(
         self, indexer: Indexer, tmp_path: Path,
     ) -> None:
         """疎通確認は初回成功後にキャッシュされ、2回目以降はスキップされること."""
@@ -696,7 +696,7 @@ class TestEmbeddingAvailability:
         path = _write_text_file(tmp_path, "doc.txt", "Content for cache test.")
         meta = _make_metadata(source_id="src-cache")
 
-        indexer.add("src-cache", path, meta)
+        await indexer.add("src-cache", path, meta)
 
         # 初回 add 後にキャッシュされている
         assert indexer._embedding_checked is True
@@ -708,7 +708,7 @@ class TestEmbeddingAvailability:
 class TestProtocolConformance:
     """IndexerProtocol へのプロトコル適合性テスト."""
 
-    def test_conforms_to_protocol(self, indexer: Indexer) -> None:
+    async def test_conforms_to_protocol(self, indexer: Indexer) -> None:
         """Indexer が IndexerProtocol のメソッドシグネチャを満たす."""
         from rag.pipeline.protocols import IndexerProtocol
 

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -9,7 +9,7 @@ import argparse
 import io
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -404,7 +404,7 @@ class TestAddDocumentFilenamePriority:
         ):
             mock_controller = MagicMock()
             mock_controller.source_store.root_dir = tmp_path
-            mock_controller.ingest_and_index.return_value = self._make_pipeline_summary_mock()
+            mock_controller.ingest_and_index = AsyncMock(return_value=self._make_pipeline_summary_mock())
             mock_settings = MagicMock()
             mock_settings.rag_document_supported_extensions = ".md,.txt,.pdf,.adoc"
             mock_ctrl.return_value = (mock_controller, mock_settings)
@@ -445,7 +445,7 @@ class TestAddDocumentFilenamePriority:
         ):
             mock_controller = MagicMock()
             mock_controller.source_store.root_dir = tmp_path
-            mock_controller.ingest_and_index.return_value = self._make_pipeline_summary_mock()
+            mock_controller.ingest_and_index = AsyncMock(return_value=self._make_pipeline_summary_mock())
             mock_settings = MagicMock()
             mock_settings.rag_document_supported_extensions = ".md,.txt,.pdf,.adoc"
             mock_ctrl.return_value = (mock_controller, mock_settings)

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -89,7 +89,7 @@ class StubIndexer:
         self.cleared: list[SourceType | None] = []
         self.fail_on: set[str] = set()
 
-    def add(
+    async def add(
         self,
         source_id: str,
         converted_path: Path,
@@ -100,7 +100,7 @@ class StubIndexer:
             raise RuntimeError(msg)
         self.added.append(source_id)
 
-    def update(
+    async def update(
         self,
         source_id: str,
         converted_path: Path,
@@ -108,17 +108,17 @@ class StubIndexer:
     ) -> None:
         self.updated.append(source_id)
 
-    def delete(self, source_id: str) -> None:
+    async def delete(self, source_id: str) -> None:
         self.deleted_ids.append(source_id)
 
-    def upsert_metadata(
+    async def upsert_metadata(
         self,
         source_id: str,
         metadata: SourceMetadata,
     ) -> None:
         self.upserted.append(source_id)
 
-    def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(self, source_type: SourceType | None = None) -> None:
         self.cleared.append(source_type)
 
 
@@ -219,17 +219,17 @@ class TestCommit:
 class TestRunIncremental:
     """差分更新のテスト."""
 
-    def test_no_commits_returns_empty(
+    async def test_no_commits_returns_empty(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
     ) -> None:
         ctrl, _, _ = controller
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.mode == PipelineMode.INCREMENTAL
         assert summary.total_files == 0
         assert summary.processed == 0
 
-    def test_first_run_processes_all(
+    async def test_first_run_processes_all(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -239,7 +239,7 @@ class TestRunIncremental:
         _place_local_file(workspace["source"], "local/b.txt", "content b")
         ctrl.commit("ingest(local): manual update")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
 
         assert summary.mode == PipelineMode.INCREMENTAL
         assert summary.processed == 2
@@ -252,7 +252,7 @@ class TestRunIncremental:
         assert len(history) == 1
         assert history[0].from_commit_id == NULL_COMMIT_HASH
 
-    def test_incremental_detects_added(
+    async def test_incremental_detects_added(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -260,7 +260,7 @@ class TestRunIncremental:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
         indexer.added.clear()
@@ -268,12 +268,12 @@ class TestRunIncremental:
         _place_local_file(workspace["source"], "local/b.txt")
         ctrl.commit("add b")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         assert converter.converted == ["local/b.txt"]
         assert "local/b.txt" in indexer.added
 
-    def test_incremental_detects_modified(
+    async def test_incremental_detects_modified(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -281,19 +281,19 @@ class TestRunIncremental:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt", "v1")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
 
         _place_local_file(workspace["source"], "local/a.txt", "v2")
         ctrl.commit("modify a")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         assert converter.converted == ["local/a.txt"]
         assert "local/a.txt" in indexer.updated
 
-    def test_incremental_detects_deleted(
+    async def test_incremental_detects_deleted(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -301,12 +301,12 @@ class TestRunIncremental:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         (workspace["source"] / "local" / "a.txt").unlink()
         ctrl.commit("delete a")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         assert "local/a.txt" in converter.deleted
         assert "local/a.txt" in indexer.deleted_ids
@@ -316,7 +316,7 @@ class TestRunIncremental:
         assert record is not None
         assert record.status == "deleted"
 
-    def test_incremental_detects_renamed(
+    async def test_incremental_detects_renamed(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -324,20 +324,20 @@ class TestRunIncremental:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/old.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         src = workspace["source"] / "local" / "old.txt"
         src.rename(workspace["source"] / "local" / "new.txt")
         ctrl.commit("rename")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         assert "local/new.txt" in converter.converted
         assert "local/old.txt" in converter.deleted
         assert "local/old.txt" in indexer.deleted_ids
         assert "local/new.txt" in indexer.added
 
-    def test_no_changes_returns_empty(
+    async def test_no_changes_returns_empty(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -345,13 +345,13 @@ class TestRunIncremental:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.total_files == 0
         assert summary.processed == 0
 
-    def test_meta_only_change(
+    async def test_meta_only_change(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -364,7 +364,7 @@ class TestRunIncremental:
             source_id="web/example.com/page.html",
         )
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
         indexer.added.clear()
@@ -386,14 +386,14 @@ class TestRunIncremental:
             yaml.safe_dump(meta, f, allow_unicode=True)
         ctrl.commit("update meta")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         # コンバーターは呼ばれない
         assert converter.converted == []
         # インデクサーはメタデータ更新のみ
         assert "web/example.com/page.html" in indexer.upserted
 
-    def test_error_skips_file_no_history(
+    async def test_error_skips_file_no_history(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -404,7 +404,7 @@ class TestRunIncremental:
         converter.fail_on.add("local/bad.txt")
         ctrl.commit("first")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.processed == 1
         assert summary.skipped == 1
         assert len(summary.errors) == 1
@@ -413,7 +413,7 @@ class TestRunIncremental:
         history = ctrl.db.get_pipeline_history()
         assert len(history) == 0
 
-    def test_invalid_last_commit_processes_all(
+    async def test_invalid_last_commit_processes_all(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -432,7 +432,7 @@ class TestRunIncremental:
         _place_local_file(workspace["source"], "local/b.txt")
         ctrl.commit("second")
 
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         # 全ファイル処理（a.txt + b.txt）
         assert summary.processed == 2
         assert "local/a.txt" in converter.converted
@@ -442,7 +442,7 @@ class TestRunIncremental:
 class TestDeleteAndReAdd:
     """物理削除 → 再追加フローのテスト."""
 
-    def test_delete_and_readd_same_content(
+    async def test_delete_and_readd_same_content(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -454,13 +454,13 @@ class TestDeleteAndReAdd:
         # 1. 初回追加
         _place_local_file(workspace["source"], "local/a.txt", content)
         ctrl.commit("add a")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
         assert "local/a.txt" in indexer.added
 
         # 2. 物理削除（remove_file 相当: ファイル削除 + commit + pipeline）
         (workspace["source"] / "local" / "a.txt").unlink()
         ctrl.commit("delete a")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
         assert "local/a.txt" in indexer.deleted_ids
         record = ctrl.db.get_source("local/a.txt")
         assert record is not None
@@ -485,7 +485,7 @@ class TestDeleteAndReAdd:
             updated_at="2026-01-01T00:00:00+00:00",
         )
         ctrl.commit("readd a")
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
 
         # git diff は A（追加）として検知し、パイプラインが処理する
         assert summary.processed == 1
@@ -494,7 +494,7 @@ class TestDeleteAndReAdd:
         assert record is not None
         assert record.status == "active"
 
-    def test_delete_and_readd_different_content(
+    async def test_delete_and_readd_different_content(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -505,12 +505,12 @@ class TestDeleteAndReAdd:
         # 1. 初回追加
         _place_local_file(workspace["source"], "local/b.txt", "original")
         ctrl.commit("add b")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # 2. 物理削除
         (workspace["source"] / "local" / "b.txt").unlink()
         ctrl.commit("delete b")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         indexer.added.clear()
         indexer.deleted_ids.clear()
@@ -529,7 +529,7 @@ class TestDeleteAndReAdd:
             updated_at="2026-01-01T00:00:00+00:00",
         )
         ctrl.commit("readd b with new content")
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
 
         assert summary.processed == 1
         assert "local/b.txt" in indexer.added
@@ -617,7 +617,7 @@ class TestRemoveFile:
 class TestRunFullRebuild:
     """全再構築のテスト."""
 
-    def test_rebuild_rejects_uncommitted_changes(
+    async def test_rebuild_rejects_uncommitted_changes(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -632,9 +632,9 @@ class TestRunFullRebuild:
         _place_local_file(workspace["source"], "local/uncommitted.txt")
 
         with pytest.raises(RuntimeError, match="未コミットの変更があります"):
-            ctrl.run_full_rebuild()
+            await ctrl.run_full_rebuild()
 
-    def test_rebuilds_all(
+    async def test_rebuilds_all(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -643,12 +643,12 @@ class TestRunFullRebuild:
         _place_local_file(workspace["source"], "local/a.txt", "content a")
         _place_local_file(workspace["source"], "local/b.txt", "content b")
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = ctrl.run_full_rebuild()
+        summary = await ctrl.run_full_rebuild()
 
         assert summary.mode == PipelineMode.FULL_REBUILD
         assert summary.processed == 2
@@ -657,7 +657,7 @@ class TestRunFullRebuild:
         assert converter.cleared == [None]
         assert indexer.cleared == [None]
 
-    def test_source_type_filter(
+    async def test_source_type_filter(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -666,12 +666,12 @@ class TestRunFullRebuild:
         _place_local_file(workspace["source"], "local/a.txt")
         _place_web_file(workspace["source"], "web/example.com/page.html")
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = ctrl.run_full_rebuild(source_type="local")
+        summary = await ctrl.run_full_rebuild(source_type="local")
 
         assert summary.processed == 1
         assert converter.converted == ["local/a.txt"]
@@ -683,14 +683,14 @@ class TestRunFullRebuild:
         assert web_record is not None
         assert web_record.source_type == "web"
 
-    def test_no_files_returns_empty(
+    async def test_no_files_returns_empty(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
     ) -> None:
         ctrl, _, _ = controller
         ctrl.init_repo()
         ctrl.commit("initial")
-        summary = ctrl.run_full_rebuild()
+        summary = await ctrl.run_full_rebuild()
         assert summary.total_files == 0
         assert summary.processed == 0
 
@@ -698,7 +698,7 @@ class TestRunFullRebuild:
 class TestRunConvertOnly:
     """コンバートのみ再実行のテスト."""
 
-    def test_reconverts_all(
+    async def test_reconverts_all(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -707,12 +707,12 @@ class TestRunConvertOnly:
         _place_local_file(workspace["source"], "local/a.txt")
         _place_local_file(workspace["source"], "local/b.txt")
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = ctrl.run_convert_only()
+        summary = await ctrl.run_convert_only()
 
         assert summary.mode == PipelineMode.CONVERT_ONLY
         assert summary.processed == 2
@@ -724,7 +724,7 @@ class TestRunConvertOnly:
 class TestRunIndexOnly:
     """インデックスのみ再構築のテスト."""
 
-    def test_reindexes_all(
+    async def test_reindexes_all(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -732,21 +732,21 @@ class TestRunIndexOnly:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         indexer.added.clear()
 
         # converted_store にファイルがあることを確認
         assert (workspace["converted"] / "local" / "a.txt").exists()
 
-        summary = ctrl.run_index_only()
+        summary = await ctrl.run_index_only()
 
         assert summary.mode == PipelineMode.INDEX_ONLY
         assert summary.processed == 1
         assert indexer.cleared == [None]
         assert "local/a.txt" in indexer.added
 
-    def test_html_source_maps_to_md_converted(
+    async def test_html_source_maps_to_md_converted(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -759,7 +759,7 @@ class TestRunIndexOnly:
             source_id="https://example.com/page",
         )
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         indexer.added.clear()
 
@@ -768,12 +768,12 @@ class TestRunIndexOnly:
         converted_md.parent.mkdir(parents=True, exist_ok=True)
         converted_md.write_text("converted content", encoding="utf-8")
 
-        summary = ctrl.run_index_only()
+        summary = await ctrl.run_index_only()
 
         assert summary.processed == 1
         assert "https://example.com/page" in indexer.added
 
-    def test_json_source_maps_to_md_converted(
+    async def test_json_source_maps_to_md_converted(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -794,7 +794,7 @@ class TestRunIndexOnly:
         with open(meta_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(meta, f, allow_unicode=True)
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         indexer.added.clear()
 
@@ -803,12 +803,12 @@ class TestRunIndexOnly:
         converted_md.parent.mkdir(parents=True, exist_ok=True)
         converted_md.write_text("converted content", encoding="utf-8")
 
-        summary = ctrl.run_index_only()
+        summary = await ctrl.run_index_only()
 
         assert summary.processed == 1
         assert "zenn/articles/article1" in indexer.added
 
-    def test_skips_missing_converted(
+    async def test_skips_missing_converted(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -816,13 +816,13 @@ class TestRunIndexOnly:
         ctrl, _, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("initial")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # converted_store をクリアしてからインデックス再構築
         shutil.rmtree(workspace["converted"])
         workspace["converted"].mkdir()
 
-        summary = ctrl.run_index_only()
+        summary = await ctrl.run_index_only()
         assert summary.skipped == 1
         assert summary.processed == 0
 
@@ -830,7 +830,7 @@ class TestRunIndexOnly:
 class TestPipelineHistory:
     """pipeline_history のテスト."""
 
-    def test_history_recorded_on_success(
+    async def test_history_recorded_on_success(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -838,13 +838,13 @@ class TestPipelineHistory:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         history = ctrl.db.get_pipeline_history()
         assert len(history) == 1
         assert history[0].from_commit_id == NULL_COMMIT_HASH
 
-    def test_history_not_recorded_on_error(
+    async def test_history_not_recorded_on_error(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -853,12 +853,12 @@ class TestPipelineHistory:
         _place_local_file(workspace["source"], "local/a.txt")
         converter.fail_on.add("local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         history = ctrl.db.get_pipeline_history()
         assert len(history) == 0
 
-    def test_incremental_uses_last_commit_id(
+    async def test_incremental_uses_last_commit_id(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -866,13 +866,13 @@ class TestPipelineHistory:
         ctrl, converter, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         converter.converted.clear()
 
         _place_local_file(workspace["source"], "local/b.txt")
         ctrl.commit("second")
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
 
         # 2回目は b.txt のみ処理
         assert summary.processed == 1
@@ -929,7 +929,7 @@ class TestClassifyChanges:
 class TestRenamedLocalSourceId:
     """local リネーム時の source_id 更新テスト."""
 
-    def test_local_rename_deletes_old_inserts_new(
+    async def test_local_rename_deletes_old_inserts_new(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -937,7 +937,7 @@ class TestRenamedLocalSourceId:
         ctrl, _, indexer = controller
         _place_local_file(workspace["source"], "local/old.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         old_record = ctrl.db.get_source("local/old.txt")
         assert old_record is not None
@@ -946,7 +946,7 @@ class TestRenamedLocalSourceId:
         src = workspace["source"] / "local" / "old.txt"
         src.rename(workspace["source"] / "local" / "new.txt")
         ctrl.commit("rename")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # 旧レコードは論理削除
         old_record = ctrl.db.get_source("local/old.txt")
@@ -966,7 +966,7 @@ class TestRenamedLocalSourceId:
 class TestUncommittedChanges:
     """未コミット変更の扱いのテスト."""
 
-    def test_incremental_auto_commits_uncommitted_changes(
+    async def test_incremental_auto_commits_uncommitted_changes(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -975,7 +975,7 @@ class TestUncommittedChanges:
         ctrl, converter, indexer = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # 未コミットのファイルを追加
         _place_local_file(workspace["source"], "local/new.txt")
@@ -984,11 +984,11 @@ class TestUncommittedChanges:
         indexer.added.clear()
 
         # incremental は自動コミットして差分処理する
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.mode == PipelineMode.INCREMENTAL
         assert summary.processed == 1  # new.txt のみ（差分）
 
-    def test_incremental_auto_commit_message_format(
+    async def test_incremental_auto_commit_message_format(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -997,12 +997,12 @@ class TestUncommittedChanges:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # 未コミットのファイルを追加
         _place_local_file(workspace["source"], "local/new.txt")
 
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # git log で最新コミットメッセージを確認
         result = subprocess.run(
@@ -1015,7 +1015,7 @@ class TestUncommittedChanges:
         )
         assert result.stdout.strip() == "auto-commit: incremental"
 
-    def test_incremental_no_uncommitted_changes(
+    async def test_incremental_no_uncommitted_changes(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -1024,14 +1024,14 @@ class TestUncommittedChanges:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # 変更なしで再実行 → 差分なしで正常終了
-        summary = ctrl.run_incremental()
+        summary = await ctrl.run_incremental()
         assert summary.mode == PipelineMode.INCREMENTAL
         assert summary.processed == 0
 
-    def test_full_rebuild_with_uncommitted_raises(
+    async def test_full_rebuild_with_uncommitted_raises(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -1044,9 +1044,9 @@ class TestUncommittedChanges:
         _place_local_file(workspace["source"], "local/uncommitted.txt")
 
         with pytest.raises(RuntimeError, match="未コミットの変更があります"):
-            ctrl.run_full_rebuild()
+            await ctrl.run_full_rebuild()
 
-    def test_convert_only_with_uncommitted_raises(
+    async def test_convert_only_with_uncommitted_raises(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -1055,14 +1055,14 @@ class TestUncommittedChanges:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         _place_local_file(workspace["source"], "local/a.txt", "updated")
 
         with pytest.raises(RuntimeError, match="未コミットの変更があります"):
-            ctrl.run_convert_only()
+            await ctrl.run_convert_only()
 
-    def test_index_only_with_uncommitted_raises(
+    async def test_index_only_with_uncommitted_raises(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -1071,14 +1071,14 @@ class TestUncommittedChanges:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         _place_local_file(workspace["source"], "local/a.txt", "updated")
 
         with pytest.raises(RuntimeError, match="未コミットの変更があります"):
-            ctrl.run_index_only()
+            await ctrl.run_index_only()
 
-    def test_uncommitted_check_scoped_by_source_type(
+    async def test_uncommitted_check_scoped_by_source_type(
         self,
         controller: tuple[PipelineController, StubConverter, StubIndexer],
         workspace: dict[str, Path],
@@ -1087,7 +1087,7 @@ class TestUncommittedChanges:
         ctrl, _, _ = controller
         _place_local_file(workspace["source"], "local/a.txt")
         ctrl.commit("first")
-        ctrl.run_incremental()
+        await ctrl.run_incremental()
 
         # web に未コミット変更を追加（local は変更なし）
         _place_web_file(
@@ -1098,5 +1098,5 @@ class TestUncommittedChanges:
         )
 
         # source_type="local" で rebuild → web の変更は無視されるので成功する
-        summary = ctrl.run_full_rebuild(source_type="local")
+        summary = await ctrl.run_full_rebuild(source_type="local")
         assert summary.mode == PipelineMode.FULL_REBUILD

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -437,7 +437,7 @@ class TestCliSiteIngestFlow:
 
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
-        mock_controller.ingest_and_index.return_value = mock_pipeline_summary
+        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
         args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
 
@@ -495,7 +495,7 @@ class TestCliSiteIngestFlow:
 
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
-        mock_controller.ingest_and_index.return_value = mock_pipeline_summary
+        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
         args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] refactor: リファクタリング

## Summary

- `_run_async` (毎回 `asyncio.run()` で新イベントループを作成) を廃止し、Indexer・PipelineController を async 化
- CLI の rebuild / delete コマンドを `_ASYNC_COMMANDS` に移動し、単一イベントループで動作するように変更
- 全 Embedding リクエストで発生していたリトライ（~0.4秒/回）が解消
- 23ソース/408チャンクで rebuild 24.4秒 → 6.5秒（約3.7倍高速化）

## Test plan

- [x] pytest 1344件全パス
- [x] ruff lint パス
- [x] mypy 型チェックパス
- [x] worktree 環境で rebuild 実行し、`Retrying request to /embeddings` が 0 回であることを確認
- [x] rebuild 後の stats / search / list-recent でデータ整合性を確認

## Related issues

Closes #534