### PR TITLE
feat(source-store): metadata.db マイグレーションを CLI migrate コマンドに分離 (#540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ HTTP モード（`/mcp` パスが必要）:
 | `list-recent` | 指定 source_type のソースを新しい順で一覧取得 |
 | `delete` | ソースをナレッジベースから論理削除 |
 | `rebuild` | ナレッジベースを再構築 |
+| `migrate` | metadata.db のスキーマをマイグレーション |
 | `evaluate` | RAG 検索精度を評価 |
 | `init-test-db` | テスト用 ChromaDB・BM25 初期化 |
 | `generate-api-key` | Upload HTTP API 用の API キーを生成 |

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -66,6 +66,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 - SQLite WAL モードで運用する
 - metadata.db が破損した場合、source_store のファイルと `.meta` からの再構築が可能であること
 - バックアップ時は metadata.db の WAL をフラッシュするため、事前に `PRAGMA wal_checkpoint(TRUNCATE)` を実行すること
+- スキーマ変更（マイグレーション）は CLI `migrate` コマンドで明示的に実行する。`initialize()` はテーブル作成（`CREATE TABLE IF NOT EXISTS`）のみ行い、スキーマ変更は行わない
 
 本コンポーネントは外部 API 通信を行わないため、想定プロファイル・安全制約セクションは省略する。
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1955,10 +1955,14 @@ def run_migrate(args: argparse.Namespace) -> None:
 
     settings = get_settings()
     source_store_dir = settings.source_store_dir
+    if not source_store_dir:
+        print("エラー: source_store_dir が設定されていません", file=sys.stderr)
+        raise SystemExit(1)
+
     db_path = Path(source_store_dir) / "metadata.db"
     if not db_path.exists():
-        print(f"metadata.db が見つかりません: {db_path}")
-        return
+        print(f"エラー: metadata.db が見つかりません: {db_path}", file=sys.stderr)
+        raise SystemExit(1)
 
     db = MetadataDB(db_path)
     try:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -424,6 +424,13 @@ def main() -> None:
         help="インデックス再構築の並列数（未指定時は .env の RAG_EMBEDDING_CONCURRENCY）",
     )
     _add_output_option(rebuild_parser)
+
+    # migrate サブコマンド
+    subparsers.add_parser(
+        "migrate",
+        help="metadata.db のスキーマをマイグレーションする",
+    )
+
     # stats サブコマンド
     stats_parser = subparsers.add_parser("stats", help="ナレッジベースの統計情報を表示")
     _add_output_option(stats_parser)
@@ -632,6 +639,7 @@ def main() -> None:
         "search": run_search,
         "search-aozora": run_search_aozora,
         "migrate-journal": run_migrate_journal,
+        "migrate": run_migrate,
         "generate-api-key": run_generate_api_key,
     }
 
@@ -1938,6 +1946,33 @@ def run_migrate_journal(args: argparse.Namespace) -> None:
             )
     finally:
         store.close()
+
+
+def run_migrate(args: argparse.Namespace) -> None:
+    """metadata.db のスキーマをマイグレーションする."""
+    from rag.config import get_settings
+    from rag.store.metadata_db import MetadataDB
+
+    settings = get_settings()
+    source_store_dir = settings.source_store_dir
+    db_path = Path(source_store_dir) / "metadata.db"
+    if not db_path.exists():
+        print(f"metadata.db が見つかりません: {db_path}")
+        return
+
+    db = MetadataDB(db_path)
+    try:
+        db.initialize()
+        applied = db.migrate()
+    finally:
+        db.close()
+
+    if applied:
+        print(f"マイグレーション完了（{len(applied)} 件適用）:")
+        for desc in applied:
+            print(f"  - {desc}")
+    else:
+        print("マイグレーション不要（スキーマは最新です）")
 
 
 def run_generate_api_key(args: argparse.Namespace) -> None:

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -65,9 +65,12 @@ class MetadataDB:
         return self._conn
 
     def initialize(self) -> None:
-        """スキーマを初期化する."""
+        """スキーマを初期化する.
+
+        CREATE TABLE IF NOT EXISTS のみ実行する。
+        スキーマ変更は migrate() で明示的に実行すること。
+        """
         self._connection.executescript(_SCHEMA_SQL)
-        self._migrate()
 
     def close(self) -> None:
         """接続を閉じる."""
@@ -75,8 +78,16 @@ class MetadataDB:
             self._conn.close()
             self._conn = None
 
-    def _migrate(self) -> None:
-        """既存テーブルのスキーマをマイグレーションする."""
+    def migrate(self) -> list[str]:
+        """既存テーブルのスキーマをマイグレーションする.
+
+        CLI の migrate コマンドから明示的に呼び出す。
+        initialize() からは呼び出されない。
+
+        Returns:
+            適用されたマイグレーションの説明リスト（適用なしなら空リスト）
+        """
+        applied: list[str] = []
         # pipeline_history に mode 列を追加（既存レコードは incremental 扱い）
         cursor = self._connection.execute("PRAGMA table_info(pipeline_history)")
         ph_columns = {row["name"] for row in cursor.fetchall()}
@@ -86,6 +97,7 @@ class MetadataDB:
                 " ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'"
             )
             self._connection.commit()
+            applied.append("pipeline_history に mode 列を追加")
             logger.info("pipeline_history に mode 列を追加しました")
 
         # sources に published_at 列を追加（既存レコードは collected_at で埋める）
@@ -101,6 +113,7 @@ class MetadataDB:
                 " WHERE published_at = ''"
             )
             self._connection.commit()
+            applied.append("sources に published_at 列を追加")
             logger.info("sources に published_at 列を追加しました")
 
         # source_id = file_path 統合: file_path カラムが残っている旧スキーマを移行
@@ -129,10 +142,13 @@ class MetadataDB:
                 ALTER TABLE sources_new RENAME TO sources;
             """)
             self._connection.commit()
+            applied.append("sources の source_id を file_path ベースに移行")
             logger.info(
                 "sources テーブルから file_path カラムを削除し"
                 " source_id を file_path ベースに移行しました"
             )
+
+        return applied
 
     def __enter__(self) -> MetadataDB:
         return self

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -83,11 +83,13 @@ class MetadataDB:
 
         CLI の migrate コマンドから明示的に呼び出す。
         initialize() からは呼び出されない。
+        各種機能は最新スキーマを前提とし、旧スキーマへのフォールバックは行わない。
 
         Returns:
             適用されたマイグレーションの説明リスト（適用なしなら空リスト）
         """
         applied: list[str] = []
+
         # pipeline_history に mode 列を追加（既存レコードは incremental 扱い）
         cursor = self._connection.execute("PRAGMA table_info(pipeline_history)")
         ph_columns = {row["name"] for row in cursor.fetchall()}

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -1,9 +1,9 @@
 """metadata.db マイグレーションのテスト.
 
 テスト方針:
-- published_at 列がない既存 DB に対するマイグレーション
-- マイグレーション後に published_at が collected_at で埋められること
-- file_path カラムがある旧スキーマの source_id 移行
+- migrate() を明示的に呼び出してスキーマ変更を適用
+- initialize() ではマイグレーションが走らないことを確認
+- published_at 列の追加、file_path → source_id 移行を検証
 """
 
 from __future__ import annotations
@@ -14,11 +14,11 @@ from pathlib import Path
 from rag.store.metadata_db import MetadataDB
 
 
-class TestPublishedAtMigration:
-    """published_at 列のマイグレーションテスト."""
+class TestMigrateExplicit:
+    """明示的な migrate() 呼び出しのテスト."""
 
-    def test_migration_adds_published_at_column(self, tmp_path: Path) -> None:
-        """published_at 列がない DB で initialize すると列が追加される."""
+    def test_initialize_does_not_run_migration(self, tmp_path: Path) -> None:
+        """initialize() だけではマイグレーションが走らない."""
         db_path = tmp_path / "metadata.db"
 
         # published_at なし + file_path ありの旧スキーマで DB を手動作成
@@ -39,8 +39,7 @@ class TestPublishedAtMigration:
                 id             INTEGER PRIMARY KEY AUTOINCREMENT,
                 from_commit_id TEXT NOT NULL,
                 to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL,
-                mode           TEXT NOT NULL DEFAULT 'incremental'
+                processed_at   TEXT NOT NULL
             );
         """)
         conn.execute(
@@ -51,18 +50,137 @@ class TestPublishedAtMigration:
         conn.commit()
         conn.close()
 
-        # MetadataDB で初期化（マイグレーション実行: published_at 追加 + source_id 移行）
         db = MetadataDB(db_path)
         db.initialize()
 
-        # マイグレーションで source_id が file_path の値に更新される
+        # file_path カラムがまだ残っている（マイグレーション未適用）
+        cursor = db._connection.execute("PRAGMA table_info(sources)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        assert "file_path" in columns
+
+        # source_id は旧値のまま（SQL で直接確認。get_source は旧スキーマでは動作しない）
+        row = db._connection.execute(
+            "SELECT source_id FROM sources WHERE source_id = ?", ("s1",)
+        ).fetchone()
+        assert row is not None
+
+        db.close()
+
+    def test_migrate_applies_all_migrations(self, tmp_path: Path) -> None:
+        """migrate() で全マイグレーションが適用される."""
+        db_path = tmp_path / "metadata.db"
+
+        # published_at なし + mode なし + file_path ありの最古スキーマ
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""\
+            CREATE TABLE sources (
+                source_id    TEXT PRIMARY KEY,
+                source_type  TEXT NOT NULL,
+                file_path    TEXT NOT NULL UNIQUE,
+                title        TEXT NOT NULL,
+                status       TEXT NOT NULL DEFAULT 'active',
+                content_hash TEXT NOT NULL,
+                file_size    INTEGER NOT NULL,
+                collected_at TEXT NOT NULL,
+                updated_at   TEXT NOT NULL
+            );
+            CREATE TABLE pipeline_history (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_commit_id TEXT NOT NULL,
+                to_commit_id   TEXT NOT NULL,
+                processed_at   TEXT NOT NULL
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("s1", "web", "web/s1.html", "Title", "active",
+             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        db = MetadataDB(db_path)
+        db.initialize()
+        applied = db.migrate()
+
+        # 3件のマイグレーションが適用される
+        assert len(applied) == 3
+
+        # file_path カラムが削除されている
+        cursor = db._connection.execute("PRAGMA table_info(sources)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        assert "file_path" not in columns
+        assert "published_at" in columns
+
+        # source_id が file_path ベースに移行されている
         record = db.get_source("web/s1.html")
         assert record is not None
         assert record.published_at == "2026-01-15T10:00:00Z"
+
+        # pipeline_history に mode 列が追加されている
+        cursor = db._connection.execute("PRAGMA table_info(pipeline_history)")
+        ph_columns = {row["name"] for row in cursor.fetchall()}
+        assert "mode" in ph_columns
+
         db.close()
 
-    def test_migration_fills_published_at_from_collected_at(self, tmp_path: Path) -> None:
-        """マイグレーションで複数レコードの published_at が collected_at で埋まる."""
+    def test_migrate_is_idempotent(self, tmp_path: Path) -> None:
+        """migrate() を2回呼んでも2回目は何もしない."""
+        db_path = tmp_path / "metadata.db"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""\
+            CREATE TABLE sources (
+                source_id    TEXT PRIMARY KEY,
+                source_type  TEXT NOT NULL,
+                file_path    TEXT NOT NULL UNIQUE,
+                title        TEXT NOT NULL,
+                status       TEXT NOT NULL DEFAULT 'active',
+                content_hash TEXT NOT NULL,
+                file_size    INTEGER NOT NULL,
+                collected_at TEXT NOT NULL,
+                updated_at   TEXT NOT NULL
+            );
+            CREATE TABLE pipeline_history (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_commit_id TEXT NOT NULL,
+                to_commit_id   TEXT NOT NULL,
+                processed_at   TEXT NOT NULL
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("s1", "web", "web/s1.html", "Title", "active",
+             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        db = MetadataDB(db_path)
+        db.initialize()
+
+        first = db.migrate()
+        assert len(first) == 3
+
+        second = db.migrate()
+        assert len(second) == 0
+
+        db.close()
+
+    def test_migrate_on_latest_schema(self, tmp_path: Path) -> None:
+        """最新スキーマの DB に対して migrate() は何もしない."""
+        db_path = tmp_path / "metadata.db"
+
+        db = MetadataDB(db_path)
+        db.initialize()
+
+        applied = db.migrate()
+        assert len(applied) == 0
+
+        db.close()
+
+    def test_migrate_multiple_records(self, tmp_path: Path) -> None:
+        """複数レコードの published_at が collected_at で埋まる."""
         db_path = tmp_path / "metadata.db"
 
         conn = sqlite3.connect(str(db_path))
@@ -98,8 +216,11 @@ class TestPublishedAtMigration:
 
         db = MetadataDB(db_path)
         db.initialize()
+        applied = db.migrate()
 
-        # マイグレーションで source_id が file_path の値に更新される
+        # published_at + file_path 移行の 2 件
+        assert len(applied) == 2
+
         for i in range(3):
             record = db.get_source(f"web/s{i}.html")
             assert record is not None


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `initialize()` から `_migrate()` 呼び出しを削除。読み取り専用操作での意図しないスキーマ変更を防止
- `_migrate()` を public `migrate()` に変更し、適用結果のリストを返す設計に
- CLI `migrate` サブコマンドを追加（MCP は非対応）
- 既存の後方互換マイグレーション（published_at / mode カラム追加）も `migrate()` に統合
- マイグレーション未実行の旧スキーマ DB でもクラッシュしないことを確認済み

## Test plan

- [x] pytest 1349 passed
- [x] ruff check: 違反なし
- [x] mypy: 型エラーなし
- [x] コードレビュー通過（Critical 0件）
- [x] QA: 本番同等データで migrate → rebuild → Core 操作を検証済み
- [x] QA: マイグレーション未実行時の旧スキーマ DB で stats / list-recent / get-document が正常動作することを確認

## Related issues

Closes #540