### PR TITLE
fix(qa-skill): worktree クリーンアップ時の未コミット変更保護を追加 (#546)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -370,7 +370,7 @@ QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等�
 2. worktree 内の未コミット変更を確認する:
 
    ```bash
-   git -C <worktree-path> status --porcelain
+   git -C "<worktree-path>" status --porcelain
    ```
 
    - **出力が空の場合**: 未コミット変更なし。ステップ 3 に進む
@@ -391,10 +391,10 @@ QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等�
 
    ```bash
    # 未コミット変更がない場合
-   git worktree remove <worktree-path>
+   git worktree remove "<worktree-path>"
 
    # 未コミット変更ありでユーザーが削除を承認した場合のみ
-   git worktree remove --force <worktree-path>
+   git worktree remove --force "<worktree-path>"
    ```
 
    `--force` はステップ 2 でユーザーが明示的に削除を承認した場合にのみ使用する。未確認の状態で `--force` を使用してはならない。

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -224,6 +224,7 @@ MCP 対応コマンド:
 | `migrate-journal --dir <d> --repository <r>` | （CLI のみ） |
 
 **MCP テスト時の注意:**
+
 - A-2 (PDF): 大きい PDF は MCP パラメータサイズ制約で失敗する場合がある。失敗時は CLI で代替実行する
 - A-4 (crawl-documents): HTTP モード非対応のため MCP テスト時はスキップする
 
@@ -366,13 +367,39 @@ QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等�
    taskkill //PID <pid> //T //F
    ```
 
-2. worktree ディレクトリを削除する:
+2. worktree 内の未コミット変更を確認する:
 
    ```bash
-   git worktree remove <worktree-path>
+   git -C <worktree-path> status --porcelain
    ```
 
-3. worktree の参照をクリーンアップする:
+   - **出力が空の場合**: 未コミット変更なし。ステップ 3 に進む
+   - **出力がある場合**: 未コミット変更あり。以下の警告をユーザーに表示し、確認を取る:
+
+     ```
+     worktree に未コミットの変更があります:
+     <git status --porcelain の出力>
+
+     この worktree を削除すると上記の変更は失われます。
+     削除しますか？ (y/n)
+     ```
+
+     - ユーザーが `n` を選択した場合: worktree の削除をスキップし、パスを表示して手動対応を促す
+     - ユーザーが `y` を選択した場合: ステップ 3 に進む（`--force` の使用を許可）
+
+3. worktree ディレクトリを削除する:
+
+   ```bash
+   # 未コミット変更がない場合
+   git worktree remove <worktree-path>
+
+   # 未コミット変更ありでユーザーが削除を承認した場合のみ
+   git worktree remove --force <worktree-path>
+   ```
+
+   `--force` はステップ 2 でユーザーが明示的に削除を承認した場合にのみ使用する。未確認の状態で `--force` を使用してはならない。
+
+4. worktree の参照をクリーンアップする:
 
    ```bash
    git worktree prune

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -393,8 +393,9 @@ CLI / MCP 対応: `rag_stats` / `rag_list_recent` / `rag_search` / `rag_get_docu
 QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等のプロセスがファイルをロックしているため、先にプロセスを停止する必要がある。
 
 1. worktree パスを参照する全プロセスを特定・停止する（`wmic process where "CommandLine like '%<worktree-path>%'" get ProcessId,CommandLine` で特定し、`taskkill //PID <pid> //T //F` でプロセスツリーごと停止）
-2. worktree ディレクトリを削除する: `git worktree remove <worktree-path>`
-3. worktree の参照をクリーンアップする: `git worktree prune`
+2. worktree 内の未コミット変更を確認する（`git -C <worktree-path> status --porcelain`）。未コミット変更がある場合はユーザーに警告し、削除の確認を取る。ユーザーが拒否した場合は worktree の削除をスキップする
+3. worktree ディレクトリを削除する: `git worktree remove <worktree-path>`。未コミット変更ありでユーザーが削除を承認した場合のみ `--force` を使用する。未確認の状態で `--force` を使用してはならない
+4. worktree の参照をクリーンアップする: `git worktree prune`
 
 ## 入出力
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -393,8 +393,8 @@ CLI / MCP 対応: `rag_stats` / `rag_list_recent` / `rag_search` / `rag_get_docu
 QA 完了後、worktree 環境を片付ける。ChromaDB・HTTP サーバー等のプロセスがファイルをロックしているため、先にプロセスを停止する必要がある。
 
 1. worktree パスを参照する全プロセスを特定・停止する（`wmic process where "CommandLine like '%<worktree-path>%'" get ProcessId,CommandLine` で特定し、`taskkill //PID <pid> //T //F` でプロセスツリーごと停止）
-2. worktree 内の未コミット変更を確認する（`git -C <worktree-path> status --porcelain`）。未コミット変更がある場合はユーザーに警告し、削除の確認を取る。ユーザーが拒否した場合は worktree の削除をスキップする
-3. worktree ディレクトリを削除する: `git worktree remove <worktree-path>`。未コミット変更ありでユーザーが削除を承認した場合のみ `--force` を使用する。未確認の状態で `--force` を使用してはならない
+2. worktree 内の未コミット変更を確認する（`git -C "<worktree-path>" status --porcelain`）。未コミット変更がある場合はユーザーに警告し、削除の確認を取る。ユーザーが拒否した場合は worktree の削除をスキップする
+3. worktree ディレクトリを削除する: `git worktree remove "<worktree-path>"`。未コミット変更ありでユーザーが削除を承認した場合のみ `--force` を使用する。未確認の状態で `--force` を使用してはならない
 4. worktree の参照をクリーンアップする: `git worktree prune`
 
 ## 入出力


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- QA スキルのクリーンアップ手順（ステップ7）に worktree 削除前の未コミット変更チェックを追加
- 未コミット変更がある場合はユーザーに警告し、明示的な確認なしに `--force` 削除されないよう保護
- 対応する仕様書（qa-skill.md）も同期更新
- markdownlint 指摘（リスト前の空行不足）を修正

## Test plan

- [x] ドキュメントレビュー通過
- [x] markdownlint 通過

## Related issues

Closes #546