### PR TITLE
fix(indexer): BM25 add 時の毎回 rebuild を deferred save で最適化 (#548)

### DIFF
--- a/docs/specs/indexer.md
+++ b/docs/specs/indexer.md
@@ -122,6 +122,7 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 - ChromaDB は upsert 方式で冪等性を確保する。同一チャンク ID で再実行しても結果が変わらない
 - BM25 インデックスはドキュメント追加・削除後にインメモリインデックスの再構築が必要（lazy rebuild: 検索実行時に自動再構築）
 - BM25 の永続化はアトミックスワップ（一時ディレクトリ + リネーム）で破損を防止する
+- バッチ処理（全再構築・インデックス再構築・差分更新）時、パイプライン制御は BM25 の遅延 save モードを有効にし、個別の add/delete ごとの rebuild + 永続化をスキップする。バッチ完了後に一括で rebuild + 永続化を実行する。これにより N 件のソース処理で N 回発生していた BM25 rebuild が 1 回に削減される
 
 ### バッチサイズ
 
@@ -133,7 +134,7 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 
 インデックス再構築（`run_index_only` / `run_full_rebuild` のインデクサーフェーズ）では、複数ソースの Embedding を並列で実行できる。`asyncio.Semaphore` で同時実行数を制限し、`asyncio.gather` で並列処理する。
 
-- 並列処理の対象は Embedding API リクエスト。ChromaDB upsert・BM25 インデックス追加は各ソースの Embedding 完了後に実行される
+- 並列処理の対象は Embedding API リクエスト。ChromaDB upsert・BM25 のインメモリデータ構造への追加は各ソースの Embedding 完了後に実行される。BM25 の rebuild + 永続化はバッチ完了後に一括実行される（遅延 save モード）
 - 並列数は `.env` の `RAG_EMBEDDING_CONCURRENCY` で設定する。LM Studio のリクエストキュー飽和を考慮し、環境に応じて調整する
 - 差分更新（`_process_changes`）やコンバートのみ再実行（`run_convert_only`）は直列のまま（並列化の効果が小さいため）
 

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -101,6 +101,9 @@ class BM25Index:
         # 再構築フラグ
         self._needs_rebuild = True
 
+        # 遅延 save モード: バッチ処理中は save をスキップし flush() で一括実行
+        self._deferred_save = False
+
         # 永続化ディレクトリからロード
         if self._persist_dir is not None:
             self._load()
@@ -147,7 +150,8 @@ class BM25Index:
             logger.debug(
                 "BM25 index: added %d, updated %d documents", added, updated
             )
-            self._save()
+            if not self._deferred_save:
+                self._save()
 
         return added
 
@@ -269,7 +273,8 @@ class BM25Index:
                 len(to_delete),
                 source_url,
             )
-            self._save()
+            if not self._deferred_save:
+                self._save()
 
         return len(to_delete)
 
@@ -301,7 +306,8 @@ class BM25Index:
                 len(to_delete),
                 source_type,
             )
-            self._save()
+            if not self._deferred_save:
+                self._save()
 
         return len(to_delete)
 
@@ -354,7 +360,8 @@ class BM25Index:
 
         if stale_ids:
             self._needs_rebuild = True
-            self._save()
+            if not self._deferred_save:
+                self._save()
 
         return len(stale_ids)
 
@@ -368,6 +375,33 @@ class BM25Index:
         self._bm25 = None
         self._needs_rebuild = True
         self._save()
+
+    def set_deferred_save(self, enabled: bool) -> None:
+        """遅延 save モードの有効/無効を切り替える.
+
+        有効にすると add/delete 操作で _save() を呼ばなくなる。
+        バッチ処理完了後に flush() で一括 rebuild + 永続化する。
+
+        Args:
+            enabled: True で遅延モード有効
+        """
+        self._deferred_save = enabled
+
+    def flush(self) -> None:
+        """未保存の変更を rebuild + 永続化する.
+
+        遅延 save モード中に蓄積された変更を一括で反映する。
+        _needs_rebuild が False（変更なし）の場合は何もしない。
+        """
+        if not self._needs_rebuild:
+            return
+
+        if self._persist_dir is not None:
+            self._save()
+        else:
+            # インメモリモードでは _save() が早期リターンするため
+            # rebuild のみ実行して _needs_rebuild をリセットする
+            self._rebuild_index()
 
     def _rebuild_index(self) -> None:
         """BM25インデックスを再構築する."""

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -438,6 +438,7 @@ class BM25Index:
             if self._persist_dir.exists():
                 shutil.rmtree(self._persist_dir)
                 logger.debug("Removed empty BM25 persist dir: %s", self._persist_dir)
+            self._needs_rebuild = False
             return
 
         # インデックスが未構築なら構築

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -8,7 +8,9 @@ converted_store のテキストファイルからチャンキング・Embedding�
 
 from __future__ import annotations
 
+import contextlib
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 
 from rag.bm25_index import BM25Index
@@ -208,6 +210,33 @@ class Indexer:
         logger.info(
             "メタデータを更新: %s (%d チャンク)", source_id, total_chunks,
         )
+
+    def set_bm25_deferred_save(self, enabled: bool) -> None:
+        """BM25 の遅延 save モードを切り替える.
+
+        Args:
+            enabled: True で遅延モード有効
+        """
+        self._bm25.set_deferred_save(enabled)
+
+    def flush_bm25(self) -> None:
+        """BM25 の未保存変更を一括 rebuild + 永続化する."""
+        self._bm25.flush()
+
+    @contextlib.contextmanager
+    def bm25_deferred(self) -> Iterator[None]:
+        """BM25 遅延 save のコンテキストマネージャ.
+
+        バッチ処理中は個別の rebuild + 永続化をスキップし、
+        ブロック終了時に一括で実行する。
+        エラー時も処理済み分を永続化する（部分失敗は PipelineSummary.errors で管理）。
+        """
+        self.set_bm25_deferred_save(True)
+        try:
+            yield
+        finally:
+            self.set_bm25_deferred_save(False)
+            self.flush_bm25()
 
     async def clear(self, source_type: SourceType | None = None) -> None:
         """インデックスをクリアする.

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -267,18 +267,19 @@ class PipelineController:
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
-        summary = await self._run_processing_loop(
-            records,
-            process_fn=_convert_and_index,
-            get_file_path=lambda r: r.source_id,
-            phase=PHASE_CONVERT_AND_INDEX,
-            mode=PipelineMode.FULL_REBUILD,
-            log_prefix="全再構築中に",
-            progress_callback=progress_callback,
-            from_commit_id=NULL_COMMIT_HASH,
-            to_commit_id=to_commit,
-            concurrency=concurrency,
-        )
+        with self._indexer.bm25_deferred():
+            summary = await self._run_processing_loop(
+                records,
+                process_fn=_convert_and_index,
+                get_file_path=lambda r: r.source_id,
+                phase=PHASE_CONVERT_AND_INDEX,
+                mode=PipelineMode.FULL_REBUILD,
+                log_prefix="全再構築中に",
+                progress_callback=progress_callback,
+                from_commit_id=NULL_COMMIT_HASH,
+                to_commit_id=to_commit,
+                concurrency=concurrency,
+            )
 
         # pipeline_history に記録（正常完了時のみ）
         if not summary.errors and to_commit:
@@ -436,16 +437,17 @@ class PipelineController:
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
-        summary = await self._run_processing_loop(
-            records,
-            process_fn=_index_single,
-            get_file_path=lambda r: r.source_id,
-            phase=PHASE_INDEX,
-            mode=PipelineMode.INDEX_ONLY,
-            log_prefix="インデックス再構築中に",
-            progress_callback=progress_callback,
-            concurrency=concurrency,
-        )
+        with self._indexer.bm25_deferred():
+            summary = await self._run_processing_loop(
+                records,
+                process_fn=_index_single,
+                get_file_path=lambda r: r.source_id,
+                phase=PHASE_INDEX,
+                mode=PipelineMode.INDEX_ONLY,
+                log_prefix="インデックス再構築中に",
+                progress_callback=progress_callback,
+                concurrency=concurrency,
+            )
 
         # pipeline_history に記録（正常完了時のみ）
         if not summary.errors and to_commit:
@@ -624,17 +626,19 @@ class PipelineController:
         progress_callback: ProgressCallback | None = None,
     ) -> PipelineSummary:
         """変更エントリを処理する."""
-        return await self._run_processing_loop(
-            changes,
-            process_fn=self._process_single_change,
-            get_file_path=lambda e: e.file_path,
-            phase=PHASE_CONVERT_AND_INDEX,
-            mode=mode,
-            log_prefix="パイプライン処理中に",
-            progress_callback=progress_callback,
-            from_commit_id=from_commit_id,
-            to_commit_id=to_commit_id,
-        )
+        with self._indexer.bm25_deferred():
+            summary = await self._run_processing_loop(
+                changes,
+                process_fn=self._process_single_change,
+                get_file_path=lambda e: e.file_path,
+                phase=PHASE_CONVERT_AND_INDEX,
+                mode=mode,
+                log_prefix="パイプライン処理中に",
+                progress_callback=progress_callback,
+                from_commit_id=from_commit_id,
+                to_commit_id=to_commit_id,
+            )
+        return summary
 
     async def _process_single_change(self, entry: ChangeEntry) -> None:
         """1ファイルの変更を処理する."""

--- a/src/rag/pipeline/protocols.py
+++ b/src/rag/pipeline/protocols.py
@@ -8,6 +8,8 @@ Protocol で抽象化し、スタブで動作可能にする。
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Protocol
 
@@ -121,6 +123,23 @@ class IndexerProtocol(Protocol):
             source_id: ソース識別子
             metadata: ソースメタデータ
         """
+        ...
+
+    def set_bm25_deferred_save(self, enabled: bool) -> None:
+        """BM25 の遅延 save モードを切り替える.
+
+        Args:
+            enabled: True で遅延モード有効
+        """
+        ...
+
+    def flush_bm25(self) -> None:
+        """BM25 の未保存変更を一括 rebuild + 永続化する."""
+        ...
+
+    @contextlib.contextmanager
+    def bm25_deferred(self) -> Iterator[None]:
+        """BM25 遅延 save のコンテキストマネージャ."""
         ...
 
     async def clear(self, source_type: SourceType | None = None) -> None:

--- a/src/rag/pipeline/protocols.py
+++ b/src/rag/pipeline/protocols.py
@@ -9,7 +9,6 @@ Protocol で抽象化し、スタブで動作可能にする。
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator
 from pathlib import Path
 from typing import Protocol
 
@@ -137,8 +136,7 @@ class IndexerProtocol(Protocol):
         """BM25 の未保存変更を一括 rebuild + 永続化する."""
         ...
 
-    @contextlib.contextmanager
-    def bm25_deferred(self) -> Iterator[None]:
+    def bm25_deferred(self) -> contextlib.AbstractContextManager[None]:
         """BM25 遅延 save のコンテキストマネージャ."""
         ...
 

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -334,3 +334,124 @@ class TestBM25IndexPersistence:
         # 空状態で再ロードしてもエラーなし
         index2 = make_bm25_index(persist_dir=persist_dir)
         assert index2.get_document_count() == 0
+
+
+class TestBM25DeferredSave:
+    """BM25 遅延 save モードのテスト (#548)."""
+
+    def _sample_docs(self) -> list[tuple[str, str, str, str]]:
+        return [
+            ("doc1", "adventure quest rpg game journey", "source1", "web"),
+            ("doc2", "monster taming battle capture arena", "source2", "web"),
+            ("doc3", "hero legend sword shield quest", "source3", "zenn"),
+        ]
+
+    def test_deferred_save_skips_rebuild_on_add(self) -> None:
+        """遅延モード中は add_documents で _save が呼ばれない."""
+        index = make_bm25_index()
+        index.set_deferred_save(True)
+
+        index.add_documents(self._sample_docs())
+
+        # _needs_rebuild が True のまま（save されていない）
+        assert index._needs_rebuild is True
+
+    def test_flush_triggers_rebuild(self) -> None:
+        """flush() で rebuild + 永続化が実行される."""
+        index = make_bm25_index()
+        index.set_deferred_save(True)
+
+        index.add_documents(self._sample_docs())
+        assert index._needs_rebuild is True
+
+        index.flush()
+
+        # flush 後は _needs_rebuild が False
+        assert index._needs_rebuild is False
+
+    def test_search_works_after_flush(self) -> None:
+        """flush 後に検索結果が正しく返る."""
+        index = make_bm25_index()
+        index.set_deferred_save(True)
+
+        index.add_documents(self._sample_docs())
+        index.flush()
+
+        results = index.search("adventure quest", n_results=3)
+        assert len(results) > 0
+        assert any("adventure" in r.text for r in results)
+
+    def test_flush_with_no_changes_is_noop(self) -> None:
+        """変更がない状態で flush しても何も起きない."""
+        index = make_bm25_index()
+        index.add_documents(self._sample_docs())
+
+        # 変更なし状態で deferred → flush
+        index.set_deferred_save(True)
+        index.flush()  # _needs_rebuild=False なので noop
+
+        assert index._needs_rebuild is False
+
+    def test_deferred_save_with_persistence(self, tmp_path: Path) -> None:
+        """遅延モードで永続化が flush まで遅延される (#548)."""
+        persist_dir = str(tmp_path / "bm25_deferred")
+
+        index = make_bm25_index(persist_dir=persist_dir)
+        index.set_deferred_save(True)
+
+        index.add_documents(self._sample_docs())
+
+        # 遅延中は永続化されていない（ディレクトリが存在しない、または古い状態）
+        # flush 前の状態を記録
+        persist_path = Path(persist_dir)
+        existed_before_flush = persist_path.exists()
+
+        index.flush()
+
+        # flush 後は永続化される
+        assert persist_path.exists()
+
+        # 新しいインスタンスで復元できる
+        index2 = make_bm25_index(persist_dir=persist_dir)
+        assert index2.get_document_count() == 3
+
+        # 初期状態では永続化ディレクトリがなかったことを確認
+        assert not existed_before_flush
+
+    def test_deferred_delete_and_flush(self) -> None:
+        """遅延モード中の delete も flush まで save されない."""
+        index = make_bm25_index()
+        index.add_documents(self._sample_docs())
+
+        index.set_deferred_save(True)
+        index.delete_by_source("source1")
+
+        # _needs_rebuild が True（save されていない）
+        assert index._needs_rebuild is True
+        assert index.get_document_count() == 2
+
+        index.flush()
+        assert index._needs_rebuild is False
+
+        # 削除が反映されている
+        results = index.search("adventure", n_results=3)
+        assert not any("adventure" in r.text for r in results)
+
+    def test_multiple_adds_single_flush(self) -> None:
+        """複数回の add 後に1回の flush でまとめて反映される."""
+        index = make_bm25_index()
+        index.set_deferred_save(True)
+
+        # 3回に分けて add
+        index.add_documents([("doc1", "adventure quest rpg", "s1", "web")])
+        index.add_documents([("doc2", "monster taming battle", "s2", "web")])
+        index.add_documents([("doc3", "hero legend sword", "s3", "zenn")])
+
+        assert index.get_document_count() == 3
+        assert index._needs_rebuild is True
+
+        index.flush()
+        assert index._needs_rebuild is False
+
+        results = index.search("adventure", n_results=3)
+        assert len(results) > 0

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -13,8 +13,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import shutil
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -120,6 +122,16 @@ class StubIndexer:
 
     async def clear(self, source_type: SourceType | None = None) -> None:
         self.cleared.append(source_type)
+
+    def set_bm25_deferred_save(self, enabled: bool) -> None:
+        pass
+
+    def flush_bm25(self) -> None:
+        pass
+
+    @contextlib.contextmanager
+    def bm25_deferred(self) -> Iterator[None]:
+        yield
 
 
 # --- フィクスチャ ---


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- BM25Index に遅延 save モード（deferred save）を導入し、バッチ処理中の add/delete ごとの rebuild + 永続化をスキップ、完了後に一括実行するよう変更
- Indexer に `bm25_deferred()` コンテキストマネージャを追加し、パイプライン制御の3箇所（run_full_rebuild / run_index_only / _process_changes）で使用
- IndexerProtocol に `set_bm25_deferred_save` / `flush_bm25` / `bm25_deferred` を追加
- 仕様書（indexer.md）にバッチ処理時の遅延 save モードの振る舞いを追記
- テスト: TestBM25DeferredSave クラス（8テスト）追加、StubIndexer にプロトコル準拠メソッド追加

## Test plan

- [x] ruff check: パス
- [x] mypy src: パス
- [x] pytest tests/test_bm25_index.py: 28 passed
- [x] pytest tests/test_pipeline_controller.py: 43 passed
- [x] QA: rebuild --mode full --source-type web (219件, 1分41秒, BM25 rebuild 1回)
- [x] QA: rebuild --mode index --source-type web (219件, 1分49秒, BM25 rebuild 1回, 劣化なし)
- [x] QA: crawl-documents docs/specs/ (22件, _process_changes 経由, BM25 rebuild 1回)
- [x] QA: search 正常動作確認（ベクトル検索 + BM25 両方ヒット）

## Related issues

Closes #548