### PR TITLE
refactor(pipeline-controller): run_full_rebuild を全 convert → 全 index の2フェーズに分離 (#543)

### DIFF
--- a/_schema/enums.yml
+++ b/_schema/enums.yml
@@ -26,8 +26,6 @@ pipeline_mode:
   values:
     - value: incremental
       description: 差分更新（git diff ベース）
-    - value: full
-      description: 全件再構築
     - value: convert
       description: 変換のみ（インデックス構築なし）
     - value: index

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -52,14 +52,15 @@
 | インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラー |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
 
-全操作は処理結果サマリを返す。サマリの構造:
+差分更新・コンバートのみ再実行・インデックスのみ再構築は処理結果サマリ（`PipelineSummary`）を返す。全再構築は convert フェーズと index フェーズそれぞれの `PipelineSummary` を保持する `FullRebuildResult` を返す。
+
+サマリの構造:
 
 | フィールド | 型 | 説明 |
 |-----------|-----|------|
-| `mode` | str | 実行モード（`incremental`, `full`, `convert`, `index`） |
+| `mode` | str | 実行モード（`incremental`, `convert`, `index`） |
 | `total_files` | int | 処理対象ファイル総数 |
 | `processed` | int | 正常処理されたファイル数 |
-| `skipped` | int | スキップされたファイル数（warnings + errors の合計） |
 | `errors` | list[str] | 予期しない例外が発生したファイルパスのリスト |
 | `warnings` | list[str] | 非致命的スキップの詳細リスト（ファイルパス + 理由） |
 | `from_commit_id` | str | 処理開始時点のコミット ID |
@@ -72,9 +73,9 @@
 | フェーズ名 | 意味 | 付与箇所 |
 |-----------|------|---------|
 | `[Fetch]` | 外部ソースからのデータ取得 | CLI がインジェスターに渡す callback をラップして付与 |
-| `[Convert]` | ソースファイルのテキスト変換 | `run_convert_only` |
-| `[Index]` | チャンキング・Embedding・インデックス登録 | `run_index_only` |
-| `[Convert & Index]` | 変換とインデックスの一体処理 | `_process_changes`（差分更新）、`run_full_rebuild` |
+| `[Convert]` | ソースファイルのテキスト変換 | `run_convert_only`、`run_full_rebuild`（Phase 1） |
+| `[Index]` | チャンキング・Embedding・インデックス登録 | `run_index_only`、`run_full_rebuild`（Phase 2） |
+| `[Convert & Index]` | 変換とインデックスの一体処理 | `_process_changes`（差分更新） |
 
 > **TODO:#495** MCP 経由の進捗通知では、Claude Code が `report_progress` の `message` パラメータを表示しないため、フェーズ名はユーザーに見えない
 > （Claude Code の MCP クライアント側の制約。上流: anthropics/claude-code#3174）。
@@ -183,41 +184,46 @@ flowchart TD
 
 ### パイプラインフロー（全再構築）
 
+全再構築は「全 convert → 全 index」の2フェーズで処理する。convert フェーズで失敗したファイルは index フェーズから除外される。
+
 1. 未コミットの変更がある場合、エラーとして rebuild を拒否する
 2. source_store スキャンで metadata.db を再構築する
-3. converted_store をクリアする
-4. ChromaDB + BM25 をクリアする
-5. source_store の全ファイルをスキャンし、status が active のファイルを抽出する
-6. コンバーターで全ファイルをテキスト変換する
-7. インデクサーで全ファイルをインデックス構築する
-8. `pipeline_history` に実行履歴を追加する
+3. source_store の全ファイルをスキャンし、status が active のファイルを抽出する
+4. **Phase 1 (Convert)**: converted_store をクリアし、全ファイルをテキスト変換する
+5. **Phase 2 (Index)**: ChromaDB + BM25 をクリアし、convert 成功分のみインデックス構築する
+6. 両フェーズともエラーなしの場合、`pipeline_history` に実行履歴を追加する
 
 ```mermaid
 flowchart TD
     START["全再構築開始"]
     CHECK_DIRTY{"未コミットの変更あり?"}
     ERROR_DIRTY["エラー: rebuild 拒否"]
-    CLEAR_CONV["converted_store をクリア"]
-    CLEAR_IDX["ChromaDB + BM25 をクリア"]
-    SCAN["source_store 全ファイルをスキャン"]
-    FILTER["status が active のファイルを抽出"]
-    CONVERT["コンバーター: 全ファイルをテキスト変換"]
-    INDEX["インデクサー: 全ファイルをインデックス構築"]
+    REBUILD_DB["metadata.db 再構築（source_store スキャン）"]
+    SCAN["全 active ファイルを抽出"]
+
+    subgraph PHASE1["Phase 1: Convert"]
+        CLEAR_CONV["converted_store をクリア"]
+        CONVERT["全ファイルをテキスト変換"]
+    end
+
+    EXCLUDE["convert 失敗分を除外"]
+
+    subgraph PHASE2["Phase 2: Index"]
+        CLEAR_IDX["ChromaDB + BM25 をクリア"]
+        INDEX["convert 成功分をインデックス構築"]
+    end
+
     UPDATE["pipeline_history に実行履歴を追加"]
     END_NODE["全再構築完了"]
-
-    REBUILD_DB["metadata.db 再構築（source_store スキャン）"]
 
     START --> CHECK_DIRTY
     CHECK_DIRTY -- Yes --> ERROR_DIRTY
     CHECK_DIRTY -- No --> REBUILD_DB
-    REBUILD_DB --> CLEAR_CONV
-    CLEAR_CONV --> CLEAR_IDX
-    CLEAR_IDX --> SCAN
-    SCAN --> FILTER
-    FILTER --> CONVERT
-    CONVERT --> INDEX
-    INDEX --> UPDATE
+    REBUILD_DB --> SCAN
+    SCAN --> PHASE1
+    PHASE1 --> EXCLUDE
+    EXCLUDE --> PHASE2
+    PHASE2 --> UPDATE
     UPDATE --> END_NODE
 ```
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -66,7 +66,7 @@
 | `incremental` | 差分更新 | 適用不可（git diff に従う） | 通常運用。未コミット変更は自動コミットされる |
 
 - `source_type` フィルタが適用不可のモード（`incremental`）で `source_type` が指定された場合、エラーを返す
-- 戻り値: 処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）をテキストで返す
+- 戻り値: 処理結果サマリ（処理件数、エラー件数、所要時間）をテキストで返す。`full` モードは Convert / Index の2フェーズ結果を表示する
 
 #### rag_stats（拡張）
 
@@ -152,7 +152,7 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 | `type` 値 | 出力タイミング | フィールド |
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
-| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `skipped`, `errors`, `elapsed` 等） |
+| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割） |
 | `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`message`（str） |
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
@@ -175,7 +175,7 @@ MCP サーバー（server.py）は stdout を行単位で読み取り、`progres
 
 | メソッド | 対象ループ |
 |---------|-----------|
-| `run_full_rebuild` | 全レコードのコンバート + インデックス |
+| `run_full_rebuild` | Phase 1: 全レコードのコンバート、Phase 2: convert 成功分のインデックス |
 | `run_convert_only` | 全レコードのコンバート |
 | `run_index_only` | 全レコードのインデックス |
 | `_process_changes` | 差分変更エントリの処理 |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -179,11 +179,36 @@ def _ingest_result_to_dict(
             "mode": pipeline_summary.mode.value,
             "total_files": pipeline_summary.total_files,
             "processed": pipeline_summary.processed,
-            "skipped": pipeline_summary.skipped,
             "errors": pipeline_summary.errors,
             "warnings": pipeline_summary.warnings,
         }
     return data
+
+
+def _summary_to_dict(summary: "PipelineSummary") -> dict[str, object]:
+    """PipelineSummary を JSON 出力用 dict に変換する."""
+    return {
+        "mode": summary.mode.value,
+        "total_files": summary.total_files,
+        "processed": summary.processed,
+        "errors": summary.errors,
+        "warnings": summary.warnings,
+    }
+
+
+def _log_phase_summary(phase: str, summary: "PipelineSummary") -> None:
+    """フェーズ別の PipelineSummary をログ出力する."""
+    logger.info(
+        "[%s] %d 処理 / %d エラー / %d 警告",
+        phase,
+        summary.processed,
+        len(summary.errors),
+        len(summary.warnings),
+    )
+    for warn in summary.warnings:
+        logger.warning("  [%s] 警告: %s", phase, warn)
+    for err_file in summary.errors:
+        logger.error("  [%s] エラーファイル: %s", phase, err_file)
 
 
 def _add_output_option(parser: argparse.ArgumentParser) -> None:
@@ -1353,7 +1378,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
             sys.exit(1)
 
         if mode == "full":
-            summary = await controller.run_full_rebuild(
+            full_result = await controller.run_full_rebuild(
                 source_type=source_type,
                 progress_callback=progress_cb,
                 concurrency=concurrency,
@@ -1376,41 +1401,59 @@ async def run_rebuild(args: argparse.Namespace) -> None:
 
         elapsed = time.monotonic() - start
 
-        if json_out:
-            _output_result({
-                "mode": summary.mode.value,
-                "total_files": summary.total_files,
-                "processed": summary.processed,
-                "skipped": summary.skipped,
-                "errors": summary.errors,
-                "warnings": summary.warnings,
-                "elapsed": round(elapsed, 1),
-            })
+        if mode == "full":
+            all_errors = full_result.convert.errors + full_result.index.errors
+            if json_out:
+                _output_result({
+                    "mode": "full",
+                    "convert": _summary_to_dict(full_result.convert),
+                    "index": _summary_to_dict(full_result.index),
+                    "elapsed": round(elapsed, 1),
+                })
+                if all_errors:
+                    has_error = True
+                    if if_needed:
+                        error_files = ", ".join(all_errors)
+                        _show_error_dialog(
+                            f"rebuild --mode {mode} でエラーが発生しました。\n"
+                            f"エラーファイル: {error_files}"
+                        )
+                return
+
+            _log_phase_summary("Convert", full_result.convert)
+            _log_phase_summary("Index", full_result.index)
+            logger.info("所要時間: %s", _format_elapsed(elapsed))
+            if all_errors:
+                has_error = True
+        else:
+            if json_out:
+                _output_result(_summary_to_dict(summary) | {
+                    "elapsed": round(elapsed, 1),
+                })
+                if summary.errors:
+                    has_error = True
+                    if if_needed:
+                        error_files = ", ".join(summary.errors)
+                        _show_error_dialog(
+                            f"rebuild --mode {mode} でエラーが発生しました。\n"
+                            f"エラーファイル: {error_files}"
+                        )
+                return
+
+            logger.info(
+                "再構築完了: %d 処理 / %d エラー / %d 警告 / %s",
+                summary.processed,
+                len(summary.errors),
+                len(summary.warnings),
+                _format_elapsed(elapsed),
+            )
+            if summary.warnings:
+                for warn in summary.warnings:
+                    logger.warning("  警告: %s", warn)
             if summary.errors:
                 has_error = True
-                if if_needed:
-                    error_files = ", ".join(summary.errors)
-                    _show_error_dialog(
-                        f"rebuild --mode {mode} でエラーが発生しました。\n"
-                        f"エラーファイル: {error_files}"
-                    )
-            return
-
-        logger.info(
-            "再構築完了: %d 処理 / %d スキップ / %d エラー / %d 警告 / %s",
-            summary.processed,
-            summary.skipped,
-            len(summary.errors),
-            len(summary.warnings),
-            _format_elapsed(elapsed),
-        )
-        if summary.warnings:
-            for warn in summary.warnings:
-                logger.warning("  警告: %s", warn)
-        if summary.errors:
-            has_error = True
-            for err_file in summary.errors:
-                logger.error("  エラーファイル: %s", err_file)
+                for err_file in summary.errors:
+                    logger.error("  エラーファイル: %s", err_file)
     except Exception as e:
         has_error = True
         if if_needed:
@@ -1419,7 +1462,12 @@ async def run_rebuild(args: argparse.Namespace) -> None:
     else:
         # 処理エラー（例外なしだがエラーファイルあり）
         if has_error and if_needed:
-            error_files = ", ".join(summary.errors)
+            all_err = (
+                full_result.convert.errors + full_result.index.errors
+                if mode == "full"
+                else summary.errors
+            )
+            error_files = ", ".join(all_err)
             _show_error_dialog(
                 f"rebuild --mode {mode} でエラーが発生しました。\n"
                 f"エラーファイル: {error_files}"
@@ -1819,14 +1867,7 @@ async def run_delete(args: argparse.Namespace) -> None:
     if json_out:
         _output_result({
             "deleted": True,
-            "pipeline": {
-                "mode": summary.mode.value,
-                "total_files": summary.total_files,
-                "processed": summary.processed,
-                "skipped": summary.skipped,
-                "errors": summary.errors,
-                "warnings": summary.warnings,
-            },
+            "pipeline": _summary_to_dict(summary),
         })
         return
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -281,7 +281,15 @@ class PipelineController:
         await self._indexer.clear(source_type)
 
         convert_failed = set(convert_summary.errors)
-        convert_warned = {w.split(": ", 1)[0] for w in convert_summary.warnings}
+        convert_warned: set[str] = set()
+        for w in convert_summary.warnings:
+            source_id, sep, _reason = w.partition(": ")
+            if sep and source_id:
+                convert_warned.add(source_id)
+            else:
+                logger.warning(
+                    "Convert warning の形式が不正なため index 除外対象外: %s", w,
+                )
         convert_excluded = convert_failed | convert_warned
         index_records = [r for r in records if r.source_id not in convert_excluded]
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -27,6 +27,7 @@ from rag.pipeline.models import (
     PHASE_INDEX,
     ChangeEntry,
     ChangeStatus,
+    FullRebuildResult,
     PipelineMode,
     PipelineSummary,
     detect_source_type,
@@ -149,7 +150,6 @@ class PipelineController:
                 mode=PipelineMode.INCREMENTAL,
                 total_files=0,
                 processed=0,
-                skipped=0,
             )
 
         last_commit_id = self.db.get_last_commit_id()
@@ -161,7 +161,6 @@ class PipelineController:
                 mode=PipelineMode.INCREMENTAL,
                 total_files=0,
                 processed=0,
-                skipped=0,
                 from_commit_id=last_commit_id,
                 to_commit_id=head_commit,
             )
@@ -185,7 +184,6 @@ class PipelineController:
                 mode=PipelineMode.INCREMENTAL,
                 total_files=0,
                 processed=0,
-                skipped=0,
                 from_commit_id=last_commit_id,
                 to_commit_id=head_commit,
             )
@@ -212,14 +210,16 @@ class PipelineController:
         *,
         progress_callback: ProgressCallback | None = None,
         concurrency: int = 1,
-    ) -> PipelineSummary:
+    ) -> FullRebuildResult:
         """全再構築を実行する.
 
-        converted_store とインデックスをクリアし、
-        source_store 全ファイルをパイプライン処理する。
+        全 convert → 全 index の2フェーズで処理する。
+        convert 失敗分は index から除外される。
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
+            progress_callback: 進捗コールバック
+            concurrency: index フェーズの同時実行数
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
@@ -230,13 +230,7 @@ class PipelineController:
         # 1. metadata.db 再構築
         self._source_store.rebuild_db(source_type)
 
-        # 2. converted_store クリア
-        self._converter.clear(self._converted_store_dir, source_type)
-
-        # 3. インデックスクリア
-        await self._indexer.clear(source_type)
-
-        # 4. active ファイルをスキャン（パイプライン対象外ファイルを除外）
+        # 2. active ファイルをスキャン（パイプライン対象外ファイルを除外）
         records = [
             r for r in self.db.search_sources(
                 source_type=source_type,
@@ -245,44 +239,90 @@ class PipelineController:
             if r.source_id not in _PIPELINE_EXCLUDE_FILES
         ]
 
-        if not records:
-            return PipelineSummary(
-                mode=PipelineMode.FULL_REBUILD,
-                total_files=0,
-                processed=0,
-                skipped=0,
-            )
+        empty_convert = PipelineSummary(
+            mode=PipelineMode.CONVERT_ONLY,
+            total_files=0,
+            processed=0,
+        )
+        empty_index = PipelineSummary(
+            mode=PipelineMode.INDEX_ONLY,
+            total_files=0,
+            processed=0,
+        )
 
-        # 5-6. コンバート + インデックス
-        async def _convert_and_index(record: SourceRecord) -> None:
-            converted_path = self._converter.convert(
-                record.source_id,
-                self._source_store.root_dir,
-                self._converted_store_dir,
-            )
-            metadata = self._build_metadata_from_record(record)
-            await self._indexer.add(record.source_id, converted_path, metadata)
+        if not records:
+            return FullRebuildResult(convert=empty_convert, index=empty_index)
 
         to_commit = ""
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
+        # --- Phase 1: Convert ---
+        self._converter.clear(self._converted_store_dir, source_type)
+
+        def _convert_single(record: SourceRecord) -> None:
+            self._converter.convert(
+                record.source_id,
+                self._source_store.root_dir,
+                self._converted_store_dir,
+            )
+
+        convert_summary = await self._run_processing_loop(
+            records,
+            process_fn=_convert_single,
+            get_file_path=lambda r: r.source_id,
+            phase=PHASE_CONVERT,
+            mode=PipelineMode.CONVERT_ONLY,
+            log_prefix="全再構築(Convert)中に",
+            progress_callback=progress_callback,
+        )
+
+        # --- Phase 2: Index (convert 成功分のみ) ---
+        await self._indexer.clear(source_type)
+
+        convert_failed = set(convert_summary.errors)
+        convert_warned = {w.split(": ", 1)[0] for w in convert_summary.warnings}
+        convert_excluded = convert_failed | convert_warned
+        index_records = [r for r in records if r.source_id not in convert_excluded]
+
+        if not index_records:
+            return FullRebuildResult(
+                convert=convert_summary,
+                index=PipelineSummary(
+                    mode=PipelineMode.INDEX_ONLY,
+                    total_files=0,
+                    processed=0,
+                    from_commit_id=NULL_COMMIT_HASH,
+                    to_commit_id=to_commit,
+                ),
+            )
+
+        async def _index_single(record: SourceRecord) -> None:
+            converted_rel = get_converted_rel_path(record.source_id)
+            converted_path = self._converted_store_dir / converted_rel
+            if not converted_path.exists():
+                raise ConversionSkippedError(
+                    f"converted file not found: {converted_path}",
+                )
+            metadata = self._build_metadata_from_record(record)
+            await self._indexer.add(record.source_id, converted_path, metadata)
+
         with self._indexer.bm25_deferred():
-            summary = await self._run_processing_loop(
-                records,
-                process_fn=_convert_and_index,
+            index_summary = await self._run_processing_loop(
+                index_records,
+                process_fn=_index_single,
                 get_file_path=lambda r: r.source_id,
-                phase=PHASE_CONVERT_AND_INDEX,
-                mode=PipelineMode.FULL_REBUILD,
-                log_prefix="全再構築中に",
+                phase=PHASE_INDEX,
+                mode=PipelineMode.INDEX_ONLY,
+                log_prefix="全再構築(Index)中に",
                 progress_callback=progress_callback,
                 from_commit_id=NULL_COMMIT_HASH,
                 to_commit_id=to_commit,
                 concurrency=concurrency,
             )
 
-        # pipeline_history に記録（正常完了時のみ）
-        if not summary.errors and to_commit:
+        # pipeline_history に記録（両フェーズともエラーなしの場合のみ）
+        if not convert_summary.errors and not index_summary.errors and to_commit:
             self.db.add_pipeline_history(
                 from_commit_id=NULL_COMMIT_HASH,
                 to_commit_id=to_commit,
@@ -290,7 +330,7 @@ class PipelineController:
                 mode="full",
             )
 
-        return summary
+        return FullRebuildResult(convert=convert_summary, index=index_summary)
 
     def _check_uncommitted_changes(
         self,
@@ -360,7 +400,6 @@ class PipelineController:
                 mode=PipelineMode.CONVERT_ONLY,
                 total_files=0,
                 processed=0,
-                skipped=0,
             )
 
         # 3. 全ファイルをコンバート
@@ -419,7 +458,6 @@ class PipelineController:
                 mode=PipelineMode.INDEX_ONLY,
                 total_files=0,
                 processed=0,
-                skipped=0,
             )
 
         # 3. converted_store からインデックス再構築
@@ -557,13 +595,12 @@ class PipelineController:
 
         sem = asyncio.Semaphore(concurrency)
         processed = 0
-        skipped = 0
         errors: list[str] = []
         warnings: list[str] = []
         lock = asyncio.Lock()
 
         async def _process_one(item: _T) -> None:
-            nonlocal processed, skipped
+            nonlocal processed
             file_path = get_file_path(item)
             async with sem:
                 try:
@@ -580,17 +617,15 @@ class PipelineController:
                     )
                     async with lock:
                         warnings.append(f"{file_path}: {e}")
-                        skipped += 1
                 except Exception:
                     logger.exception(
                         "%sエラー: %s", log_prefix, file_path,
                     )
                     async with lock:
                         errors.append(file_path)
-                        skipped += 1
                 if progress_callback is not None:
                     async with lock:
-                        completed = processed + skipped
+                        completed = processed + len(errors) + len(warnings)
                     try:
                         progress_callback(
                             completed, len(items),
@@ -608,7 +643,6 @@ class PipelineController:
             mode=mode,
             total_files=len(items),
             processed=processed,
-            skipped=skipped,
             errors=errors,
             warnings=warnings,
             from_commit_id=from_commit_id,

--- a/src/rag/pipeline/models.py
+++ b/src/rag/pipeline/models.py
@@ -34,7 +34,6 @@ class PipelineMode(Enum):
     """パイプライン実行モード."""
 
     INCREMENTAL = "incremental"
-    FULL_REBUILD = "full"
     CONVERT_ONLY = "convert"
     INDEX_ONLY = "index"
 
@@ -46,11 +45,21 @@ class PipelineSummary:
     mode: PipelineMode
     total_files: int
     processed: int
-    skipped: int
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     from_commit_id: str = ""
     to_commit_id: str = ""
+
+
+@dataclass
+class FullRebuildResult:
+    """全再構築の2フェーズ結果.
+
+    convert フェーズと index フェーズそれぞれの PipelineSummary を保持する。
+    """
+
+    convert: PipelineSummary
+    index: PipelineSummary
 
 
 # プログレス通知のフェーズ名

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -819,10 +819,32 @@ _VALID_PIPELINE_SOURCE_TYPES: frozenset[str] = frozenset({
 })
 
 
+def _format_phase_summary(phase: str, summary: PipelineSummary) -> list[str]:
+    """1フェーズの PipelineSummary をテキスト行リストに変換する."""
+    parts = [
+        f"  [{phase}]",
+        f"    処理件数: {summary.processed}",
+        f"    警告: {len(summary.warnings)}",
+        f"    エラー: {len(summary.errors)}",
+    ]
+    if summary.warnings:
+        parts.append("    警告詳細:")
+        for warn in summary.warnings[:10]:
+            parts.append(f"      - {warn}")
+        if len(summary.warnings) > 10:
+            parts.append(f"      ... 他 {len(summary.warnings) - 10} 件")
+    if summary.errors:
+        parts.append("    エラーファイル:")
+        for err_file in summary.errors[:10]:
+            parts.append(f"      - {err_file}")
+        if len(summary.errors) > 10:
+            parts.append(f"      ... 他 {len(summary.errors) - 10} 件")
+    return parts
+
+
 def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
     """PipelineSummary をテキストに変換する."""
     mode_names = {
-        PipelineMode.FULL_REBUILD: "全再構築",
         PipelineMode.CONVERT_ONLY: "コンバートのみ再実行",
         PipelineMode.INDEX_ONLY: "インデックスのみ再構築",
         PipelineMode.INCREMENTAL: "差分更新",
@@ -832,7 +854,6 @@ def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
     parts = [
         f"再構築完了 ({mode_name})",
         f"  処理件数: {summary.processed}",
-        f"  スキップ: {summary.skipped}",
         f"  警告: {len(summary.warnings)}",
         f"  エラー: {len(summary.errors)}",
         f"  所要時間: {elapsed:.1f} 秒",
@@ -850,6 +871,19 @@ def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
         if len(summary.errors) > 10:
             parts.append(f"    ... 他 {len(summary.errors) - 10} 件")
 
+    return "\n".join(parts)
+
+
+def _format_full_rebuild_summary(
+    convert: PipelineSummary,
+    index: PipelineSummary,
+    elapsed: float,
+) -> str:
+    """FullRebuildResult の2フェーズ結果をテキストに変換する."""
+    parts = ["再構築完了 (全再構築)"]
+    parts.extend(_format_phase_summary("Convert", convert))
+    parts.extend(_format_phase_summary("Index", index))
+    parts.append(f"  所要時間: {elapsed:.1f} 秒")
     return "\n".join(parts)
 
 
@@ -882,7 +916,7 @@ async def rag_rebuild(
             未指定時は全媒体。incremental モードでは指定不可。
 
     Returns:
-        処理結果サマリ（処理件数、スキップ件数、エラー件数、所要時間）
+        処理結果サマリ（処理件数、エラー件数、所要時間）
     """
     args: list[str] = ["--mode", mode]
     if source_type is not None:
@@ -890,12 +924,25 @@ async def rag_rebuild(
 
     try:
         result = await _run_cli_subprocess("rebuild", args, ctx=ctx)
+        elapsed = float(result.get("elapsed", 0.0))
 
-        # result dict → フォーマット済みテキスト
+        # full モードは2フェーズ結果
+        if mode == "full":
+            convert_data = result.get("convert")
+            index_data = result.get("index")
+            if convert_data and index_data:
+                convert_summary = _parse_pipeline_summary(convert_data)
+                index_summary = _parse_pipeline_summary(index_data)
+                if convert_summary and index_summary:
+                    return _format_full_rebuild_summary(
+                        convert_summary, index_summary, elapsed,
+                    )
+            return "再構築完了（結果の解析に失敗）"
+
+        # その他のモードは単一 PipelineSummary
         summary = _parse_pipeline_summary(result)
-        elapsed = result.get("elapsed", 0.0)
         if summary is not None:
-            return _format_rebuild_summary(summary, float(elapsed))
+            return _format_rebuild_summary(summary, elapsed)
         return "再構築完了（結果の解析に失敗）"
     except CLISubprocessError as e:
         if e.lock_conflict:
@@ -1117,7 +1164,6 @@ def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
             mode=PipelineMode(data.get("mode", "incremental")),
             total_files=data.get("total_files", 0),
             processed=data.get("processed", 0),
-            skipped=data.get("skipped", 0),
             errors=data.get("errors", []),
             warnings=data.get("warnings", []),
         )

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -937,6 +937,15 @@ async def rag_rebuild(
                     return _format_full_rebuild_summary(
                         convert_summary, index_summary, elapsed,
                     )
+            missing = []
+            if not convert_data:
+                missing.append("convert")
+            if not index_data:
+                missing.append("index")
+            logger.error(
+                "full rebuild 結果の解析に失敗: 欠落キー=%s, result_keys=%s",
+                missing or "parse_error", list(result.keys()),
+            )
             return "再構築完了（結果の解析に失敗）"
 
         # その他のモードは単一 PipelineSummary

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -131,14 +131,15 @@ class TestIngestResultToDict:
         pipeline_summary.mode.value = "incremental"
         pipeline_summary.total_files = 5
         pipeline_summary.processed = 3
-        pipeline_summary.skipped = 2
         pipeline_summary.errors = []
+        pipeline_summary.warnings = []
 
         result = _ingest_result_to_dict(ingest_result, pipeline_summary)
         assert result["placed"] == 1
         assert "pipeline" in result
         assert result["pipeline"]["mode"] == "incremental"
         assert result["pipeline"]["processed"] == 3
+        assert "skipped" not in result["pipeline"]
 
 
 class TestCommandsHaveOutputOption:

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -416,7 +416,6 @@ class TestRunIncremental:
 
         summary = await ctrl.run_incremental()
         assert summary.processed == 1
-        assert summary.skipped == 1
         assert len(summary.errors) == 1
 
         # pipeline_history は記録されない
@@ -654,10 +653,12 @@ class TestRunFullRebuild:
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = await ctrl.run_full_rebuild()
+        result = await ctrl.run_full_rebuild()
 
-        assert summary.mode == PipelineMode.FULL_REBUILD
-        assert summary.processed == 2
+        assert result.convert.mode == PipelineMode.CONVERT_ONLY
+        assert result.convert.processed == 2
+        assert result.index.mode == PipelineMode.INDEX_ONLY
+        assert result.index.processed == 2
         assert len(converter.converted) == 2
         assert len(indexer.added) == 2
         assert converter.cleared == [None]
@@ -677,9 +678,9 @@ class TestRunFullRebuild:
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = await ctrl.run_full_rebuild(source_type="local")
+        result = await ctrl.run_full_rebuild(source_type="local")
 
-        assert summary.processed == 1
+        assert result.convert.processed == 1
         assert converter.converted == ["local/a.txt"]
         assert converter.cleared == ["local"]
         assert indexer.cleared == ["local"]
@@ -696,9 +697,9 @@ class TestRunFullRebuild:
         ctrl, _, _ = controller
         ctrl.init_repo()
         ctrl.commit("initial")
-        summary = await ctrl.run_full_rebuild()
-        assert summary.total_files == 0
-        assert summary.processed == 0
+        result = await ctrl.run_full_rebuild()
+        assert result.convert.total_files == 0
+        assert result.index.total_files == 0
 
     async def test_concurrent_full_rebuild(
         self,
@@ -715,12 +716,59 @@ class TestRunFullRebuild:
         converter.converted.clear()
         indexer.added.clear()
 
-        summary = await ctrl.run_full_rebuild(concurrency=3)
+        result = await ctrl.run_full_rebuild(concurrency=3)
 
-        assert summary.mode == PipelineMode.FULL_REBUILD
-        assert summary.processed == 3
+        assert result.convert.processed == 3
+        assert result.index.processed == 3
         assert len(converter.converted) == 3
         assert len(indexer.added) == 3
+
+    async def test_convert_error_excludes_from_index(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """convert 失敗分は index フェーズから除外される."""
+        ctrl, converter, indexer = controller
+        _place_local_file(workspace["source"], "local/good.txt")
+        _place_local_file(workspace["source"], "local/bad.txt")
+        ctrl.commit("initial")
+
+        converter.fail_on.add("local/bad.txt")
+
+        result = await ctrl.run_full_rebuild()
+
+        # convert: 1 成功, 1 エラー
+        assert result.convert.processed == 1
+        assert len(result.convert.errors) == 1
+        assert "local/bad.txt" in result.convert.errors
+
+        # index: convert 成功分のみ
+        assert result.index.total_files == 1
+        assert result.index.processed == 1
+        assert len(result.index.errors) == 0
+
+        # indexer に bad.txt は渡されない
+        assert "local/bad.txt" not in indexer.added
+        assert "local/good.txt" in indexer.added
+
+    async def test_pipeline_history_requires_both_phases_clean(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """convert エラーがあると pipeline_history に記録されない."""
+        ctrl, converter, _ = controller
+        _place_local_file(workspace["source"], "local/a.txt")
+        _place_local_file(workspace["source"], "local/b.txt")
+        ctrl.commit("initial")
+
+        converter.fail_on.add("local/b.txt")
+
+        await ctrl.run_full_rebuild()
+
+        history = ctrl.db.get_pipeline_history()
+        assert len(history) == 0
 
 
 class TestRunConvertOnly:
@@ -850,7 +898,7 @@ class TestRunIndexOnly:
         workspace["converted"].mkdir()
 
         summary = await ctrl.run_index_only()
-        assert summary.skipped == 1
+        assert len(summary.warnings) == 1
         assert summary.processed == 0
 
     async def test_concurrent_index_only(
@@ -871,7 +919,7 @@ class TestRunIndexOnly:
 
         assert summary.mode == PipelineMode.INDEX_ONLY
         assert summary.processed == 3
-        assert summary.skipped == 0
+        assert len(summary.errors) == 0
         assert len(indexer.added) == 3
 
     async def test_concurrent_index_handles_errors(
@@ -892,7 +940,6 @@ class TestRunIndexOnly:
         summary = await ctrl.run_index_only(concurrency=4)
 
         assert summary.processed == 2
-        assert summary.skipped == 1
         assert len(summary.errors) == 1
 
 
@@ -1167,5 +1214,5 @@ class TestUncommittedChanges:
         )
 
         # source_type="local" で rebuild → web の変更は無視されるので成功する
-        summary = await ctrl.run_full_rebuild(source_type="local")
-        assert summary.mode == PipelineMode.FULL_REBUILD
+        result = await ctrl.run_full_rebuild(source_type="local")
+        assert result.convert.mode == PipelineMode.CONVERT_ONLY

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -218,6 +218,8 @@ site_ingest_max_pages = 500
 site_ingest_download_timeout = 30
 site_ingest_timeout_sec = 7200
 site_ingest_error_count = 10
+rag_embedding_retry_count = 3
+rag_embedding_retry_base_delay = 1.0
 """
 
     def _set_all_env(self, monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -641,7 +641,7 @@ class TestFormatCliIngestResult:
             "errors": 0, "error_details": [],
             "pipeline": {
                 "mode": "incremental",
-                "total_files": 1, "processed": 1, "skipped": 0, "errors": [],
+                "total_files": 1, "processed": 1, "errors": [],
             },
         }
         text = mod._format_cli_ingest_result(result)
@@ -698,7 +698,7 @@ class TestRagRebuildTool:
         mod = import_module("rag.server")
         mock_result = {
             "mode": "incremental",
-            "total_files": 10, "processed": 8, "skipped": 2, "errors": [],
+            "total_files": 10, "processed": 8, "errors": [], "warnings": [],
             "elapsed": 5.5,
         }
         with patch.object(
@@ -717,7 +717,14 @@ class TestRagRebuildTool:
         mod = import_module("rag.server")
         mock_result = {
             "mode": "full",
-            "total_files": 5, "processed": 5, "skipped": 0, "errors": [],
+            "convert": {
+                "mode": "convert",
+                "total_files": 5, "processed": 5, "errors": [], "warnings": [],
+            },
+            "index": {
+                "mode": "index",
+                "total_files": 5, "processed": 5, "errors": [], "warnings": [],
+            },
             "elapsed": 10.0,
         }
         with patch.object(

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -17,6 +17,7 @@ from rag.pipeline.models import PipelineMode, PipelineSummary
 from rag.rag_knowledge import format_file_size
 from rag.server import (
     CLISubprocessError,
+    _format_full_rebuild_summary,
     _format_rebuild_summary,
 )
 
@@ -53,15 +54,13 @@ class TestFormatRebuildSummary:
 
     def test_success_summary(self) -> None:
         summary = PipelineSummary(
-            mode=PipelineMode.FULL_REBUILD,
+            mode=PipelineMode.INDEX_ONLY,
             total_files=10,
             processed=8,
-            skipped=2,
         )
         result = _format_rebuild_summary(summary, 12.5)
-        assert "全再構築" in result
+        assert "インデックスのみ再構築" in result
         assert "処理件数: 8" in result
-        assert "スキップ: 2" in result
         assert "エラー: 0" in result
         assert "12.5 秒" in result
 
@@ -70,7 +69,6 @@ class TestFormatRebuildSummary:
             mode=PipelineMode.INDEX_ONLY,
             total_files=5,
             processed=3,
-            skipped=2,
             errors=["file1.txt", "file2.txt"],
         )
         result = _format_rebuild_summary(summary, 5.0)
@@ -79,19 +77,40 @@ class TestFormatRebuildSummary:
         assert "file1.txt" in result
         assert "file2.txt" in result
 
-    def test_all_modes(self) -> None:
+    def test_all_non_full_modes(self) -> None:
         mode_labels = {
-            PipelineMode.FULL_REBUILD: "全再構築",
             PipelineMode.CONVERT_ONLY: "コンバートのみ再実行",
             PipelineMode.INDEX_ONLY: "インデックスのみ再構築",
             PipelineMode.INCREMENTAL: "差分更新",
         }
         for mode, label in mode_labels.items():
             summary = PipelineSummary(
-                mode=mode, total_files=0, processed=0, skipped=0,
+                mode=mode, total_files=0, processed=0,
             )
             result = _format_rebuild_summary(summary, 0.0)
             assert label in result
+
+    def test_full_rebuild_format(self) -> None:
+        convert = PipelineSummary(
+            mode=PipelineMode.CONVERT_ONLY,
+            total_files=10,
+            processed=8,
+            errors=["bad.txt"],
+            warnings=["warn.txt: skipped"],
+        )
+        index = PipelineSummary(
+            mode=PipelineMode.INDEX_ONLY,
+            total_files=7,
+            processed=7,
+        )
+        result = _format_full_rebuild_summary(convert, index, 15.0)
+        assert "全再構築" in result
+        assert "[Convert]" in result
+        assert "[Index]" in result
+        assert "処理件数: 8" in result
+        assert "処理件数: 7" in result
+        assert "15.0 秒" in result
+        assert "bad.txt" in result
 
 
 # --- rag_rebuild MCP ツールテスト ---
@@ -102,16 +121,26 @@ class TestRagRebuild:
 
     @pytest.mark.asyncio
     async def test_full_rebuild_success(self) -> None:
-        """CLI サブプロセス経由の full rebuild が正常結果を返すこと."""
+        """CLI サブプロセス経由の full rebuild が2フェーズ結果を返すこと."""
         from rag.server import rag_rebuild
 
         mock_cli_result: dict[str, object] = {
             "type": "result",
             "mode": "full",
-            "total_files": 5,
-            "processed": 5,
-            "skipped": 0,
-            "errors": [],
+            "convert": {
+                "mode": "convert",
+                "total_files": 5,
+                "processed": 5,
+                "errors": [],
+                "warnings": [],
+            },
+            "index": {
+                "mode": "index",
+                "total_files": 5,
+                "processed": 5,
+                "errors": [],
+                "warnings": [],
+            },
             "elapsed": 1.2,
         }
 
@@ -120,6 +149,8 @@ class TestRagRebuild:
 
         assert "再構築完了" in result
         assert "全再構築" in result
+        assert "[Convert]" in result
+        assert "[Index]" in result
         assert "処理件数: 5" in result
 
     @pytest.mark.asyncio
@@ -132,8 +163,8 @@ class TestRagRebuild:
             "mode": "convert",
             "total_files": 3,
             "processed": 3,
-            "skipped": 0,
             "errors": [],
+            "warnings": [],
             "elapsed": 0.5,
         }
 
@@ -159,8 +190,8 @@ class TestRagRebuild:
             "mode": "incremental",
             "total_files": 2,
             "processed": 2,
-            "skipped": 0,
             "errors": [],
+            "warnings": [],
             "elapsed": 0.3,
         }
 


### PR DESCRIPTION
## Change type

- [x] refactor（機能変更なし）

## Summary

- `run_full_rebuild` を「全 convert → 全 index」の2フェーズに分離。convert 失敗分は index から除外される
- 戻り値を `FullRebuildResult(convert, index)` に変更し、各フェーズの `PipelineSummary` を個別に返す
- `PipelineSummary.skipped` フィールドを廃止（`errors` + `warnings` で表現）
- `PipelineMode.FULL_REBUILD` enum 値を削除（参照ゼロのデッドコード）
- CLI・MCP の表示を2フェーズ対応に更新
- 仕様書（pipeline-controller.md, rebuild-stats.md）を更新
- config テストの既存バグ修正（#541 で追加された設定値がテストフィクスチャに未反映）

## Test plan

- [x] 全1369テスト通過（pytest）
- [x] ruff lint 通過
- [x] mypy 型チェック通過
- [x] コードレビュー・ドキュメントレビュー通過
- [x] MCP 経由で全 rebuild モード（full/convert/index/incremental）の動作確認済み

## Related issues

Closes #543