### PR TITLE
fix(bluesky): --force 時に新規投稿の YouTube URL がスキップされるバグを修正

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -415,7 +415,7 @@ embed の `$type` が `app.bsky.embed.recordWithMedia` の場合、メディア�
 1. **投稿 JSON**: 既存ファイルを上書きする（通常モードではスキップ）
 2. **メディアファイル**: 画像・動画を再 DL する
 3. **投稿内 Web URL**: site_ingest で再取得する
-4. **投稿内 YouTube URL**: `rag_bluesky_force_youtube_reingest` が `true` の場合のみ再取得する。デフォルトは再取得しない（YouTube の再取り込みは字幕取得・音声 DL 等のコストが高いため）
+4. **投稿内 YouTube URL**: 投稿が新規（初回取り込み）の場合は常に取り込む。投稿が上書き（既存ファイルの再取得）の場合は `rag_bluesky_force_youtube_reingest` が `true` の場合のみ再取得する。デフォルトは再取得しない（YouTube の再取り込みは字幕取得・音声 DL 等のコストが高いため）
 
 `--force` は既存データの更新が必要な場合に使用する。主な用途:
 
@@ -648,7 +648,7 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | 画像の CDN URL が 404 | エラーをログに記録し、当該画像の DL をスキップする。投稿 JSON の取り込みには影響しない |
 | HLS プレイリストの取得に失敗 | エラーをログに記録し、当該動画の DL をスキップする |
 | ts セグメントの一部が DL に失敗 | エラーをログに記録し、当該動画の DL をスキップする（部分的な動画は保存しない） |
-| `--force` 時に YouTube 再取り込みが `rag_bluesky_force_youtube_reingest` で抑制されている | YouTube URL をスキップし、Web URL とメディアのみ再取得する |
+| `--force` 時に上書き投稿の YouTube 再取り込みが `rag_bluesky_force_youtube_reingest` で抑制されている | 上書き投稿の YouTube URL をスキップし、Web URL とメディアのみ再取得する。新規投稿の YouTube URL は常に取り込む |
 | メディアが添付されていない投稿 | メディア DL フェーズをスキップし、JSON のみ配置する（既存動作と同じ） |
 
 ## 関連ドキュメント

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2359,7 +2359,6 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
                 url_stats = await bluesky_ingester.follow_urls(
                     placed_items,
                     youtube_ingester=youtube_ingester,
-                    force=force,
                     force_youtube_reingest=settings.rag_bluesky_force_youtube_reingest,
                 )
     except (ValueError, TypeError) as e:

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -388,7 +388,8 @@ class BlueskyIngester:
                 seen_paths.add(rel_path)
 
                 dest = self._store.root_dir / rel_path
-                if dest.exists() and not force:
+                is_overwrite = dest.exists()
+                if is_overwrite and not force:
                     result.skipped += 1
                     continue
 
@@ -454,7 +455,9 @@ class BlueskyIngester:
                         metadata=metadata,
                     )
                     result.placed += 1
-                    placed_items.append(item)
+                    placed_items.append(
+                        {**item, "_is_overwrite": is_overwrite},
+                    )
                 except Exception:
                     logger.exception("投稿の配置に失敗しました: %s", rel_path)
                     result.errors += 1
@@ -584,7 +587,6 @@ class BlueskyIngester:
         placed_items: list[dict[str, Any]],
         *,
         youtube_ingester: YoutubeIngester | None = None,
-        force: bool = False,
         force_youtube_reingest: bool = False,
     ) -> dict[str, int]:
         """配置済み投稿から URL を抽出し、site_ingest/YouTube インジェスターに委譲する.
@@ -594,12 +596,14 @@ class BlueskyIngester:
         Web URL は CLI の site-ingest コマンド（複数 URL モード）でバッチ取得する。
         YouTube URL は個別に YoutubeIngester で取り込む。
 
+        各 placed_item の ``_is_overwrite`` フラグにより新規/上書きを判定する。
+        上書き投稿の YouTube URL は ``force_youtube_reingest`` が True の場合のみ
+        再取得する。新規投稿の YouTube URL は常に取り込む。
+
         Args:
-            placed_items: 配置済みフィードアイテムのリスト
+            placed_items: 配置済みフィードアイテムのリスト（``_is_overwrite`` フラグ付き）
             youtube_ingester: YoutubeIngester インスタンス
-            force: 上書き再取得モード。site-ingest 側の重複判定に委譲するため
-                Web URL には直接影響しない。YouTube 再取得の制御に使用する
-            force_youtube_reingest: force 時に YouTube URL を再取得するか
+            force_youtube_reingest: 上書き投稿の YouTube URL を再取得するか
 
         Returns:
             {"web_placed": N, "youtube_placed": N, "skipped": N, "errors": N}
@@ -611,31 +615,35 @@ class BlueskyIngester:
             "errors": 0,
         }
 
-        # 全投稿から URL を一括抽出・重複排除
-        all_urls: list[str] = []
-        seen: set[str] = set()
-        for item in placed_items:
-            for url in extract_urls_from_item(item):
-                if url not in seen:
-                    seen.add(url)
-                    all_urls.append(url)
-
-        if not all_urls:
-            return stats
-
-        logger.info("投稿内から %d 件の URL を抽出しました", len(all_urls))
-
-        # URL を種別ごとに分類
+        # 全投稿から URL を一括抽出・重複排除・種別分類
+        # YouTube URL は投稿の is_overwrite 情報を保持する（新規投稿由来は常に取り込むため）
+        # 同一 URL が新規と上書き両方に存在する場合は安全側（新規=取り込む）に倒す
         web_urls: list[str] = []
         youtube_urls: list[str] = []
-        for url in all_urls:
-            url_type = classify_url(url)
-            if url_type == "web":
-                web_urls.append(url)
-            elif url_type == "youtube":
-                youtube_urls.append(url)
-            else:
-                stats["skipped"] += 1
+        seen: set[str] = set()
+        youtube_url_overwrite: dict[str, bool] = {}
+        for item in placed_items:
+            item_is_overwrite = item.get("_is_overwrite", False)
+            for url in extract_urls_from_item(item):
+                url_type = classify_url(url)
+                if url_type == "youtube":
+                    youtube_url_overwrite[url] = (
+                        youtube_url_overwrite.get(url, True) and item_is_overwrite
+                    )
+                if url not in seen:
+                    seen.add(url)
+                    if url_type == "web":
+                        web_urls.append(url)
+                    elif url_type == "youtube":
+                        youtube_urls.append(url)
+                    else:
+                        stats["skipped"] += 1
+
+        all_url_count = len(web_urls) + len(youtube_urls) + stats["skipped"]
+        if all_url_count == 0:
+            return stats
+
+        logger.info("投稿内から %d 件の URL を抽出しました", all_url_count)
 
         # Web URL をバッチ取得（site-ingest 複数 URL モード、download_only）
         if web_urls:
@@ -644,14 +652,24 @@ class BlueskyIngester:
             stats["errors"] += web_errors
 
         # YouTube URL を個別取り込み（URL 間にレート制限スリープを挿入）
-        # force 時は force_youtube_reingest 設定に従う
-        if force and not force_youtube_reingest:
-            logger.info(
-                "force モードですが YouTube 再取り込みは無効です（%d 件スキップ）",
-                len(youtube_urls),
-            )
-            stats["skipped"] += len(youtube_urls)
-        else:
+        # 上書き投稿の YouTube URL は force_youtube_reingest 設定に従う
+        # 新規投稿の YouTube URL は常に取り込む
+        if not force_youtube_reingest:
+            new_youtube_urls = [
+                u for u in youtube_urls if not youtube_url_overwrite.get(u, False)
+            ]
+            skipped_count = len(youtube_urls) - len(new_youtube_urls)
+            if skipped_count > 0:
+                logger.info(
+                    "上書き投稿の YouTube 再取り込みは無効です"
+                    "（%d 件スキップ、新規 %d 件は取り込み）",
+                    skipped_count,
+                    len(new_youtube_urls),
+                )
+                stats["skipped"] += skipped_count
+            youtube_urls = new_youtube_urls
+
+        if youtube_urls:
             for i, url in enumerate(youtube_urls):
                 if youtube_ingester is not None:
                     try:

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -987,14 +987,15 @@ class TestForceMode:
 
 
 @pytest.mark.asyncio()
-class TestFollowUrlsForce:
-    """follow_urls の force モード関連テスト."""
+class TestFollowUrlsYoutubeOverwrite:
+    """follow_urls の上書き/新規投稿における YouTube スキップ判定テスト."""
 
-    async def test_force_youtube_reingest_disabled(
+    async def test_overwrite_item_youtube_reingest_disabled(
         self, source_store: SourceStore,
     ) -> None:
-        """force=True かつ force_youtube_reingest=False で YouTube がスキップされること."""
+        """上書き投稿かつ force_youtube_reingest=False で YouTube がスキップされること."""
         item = _make_feed_item()
+        item["_is_overwrite"] = True
         item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1015,20 +1016,20 @@ class TestFollowUrlsForce:
         stats = await ingester.follow_urls(
             [item],
             youtube_ingester=mock_yt,
-            force=True,
             force_youtube_reingest=False,
         )
 
-        # YouTube は呼ばれずスキップされる
+        # 上書き投稿の YouTube は呼ばれずスキップされる
         mock_yt.ingest_video.assert_not_called()
         assert stats["skipped"] == 1
         assert stats["youtube_placed"] == 0
 
-    async def test_force_youtube_reingest_enabled(
+    async def test_overwrite_item_youtube_reingest_enabled(
         self, source_store: SourceStore,
     ) -> None:
-        """force=True かつ force_youtube_reingest=True で YouTube が再取り込みされること."""
+        """上書き投稿かつ force_youtube_reingest=True で YouTube が再取り込みされること."""
         item = _make_feed_item()
+        item["_is_overwrite"] = True
         item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1050,9 +1051,91 @@ class TestFollowUrlsForce:
         stats = await ingester.follow_urls(
             [item],
             youtube_ingester=mock_yt,
-            force=True,
             force_youtube_reingest=True,
         )
 
         mock_yt.ingest_video.assert_called_once()
         assert stats["youtube_placed"] == 1
+
+    async def test_new_item_youtube_always_ingested(
+        self, source_store: SourceStore,
+    ) -> None:
+        """新規投稿の YouTube URL は force_youtube_reingest=False でも取り込まれること."""
+        item = _make_feed_item()
+        item["_is_overwrite"] = False
+        item["post"]["record"]["facets"] = [
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=new123",
+                    }
+                ]
+            }
+        ]
+
+        mock_yt = AsyncMock()
+        mock_yt.ingest_video = AsyncMock(
+            return_value=MagicMock(placed=1, errors=0)
+        )
+
+        ingester = make_bluesky_ingester(source_store)
+        stats = await ingester.follow_urls(
+            [item],
+            youtube_ingester=mock_yt,
+            force_youtube_reingest=False,
+        )
+
+        # 新規投稿の YouTube は常に取り込まれる
+        mock_yt.ingest_video.assert_called_once()
+        assert stats["youtube_placed"] == 1
+        assert stats["skipped"] == 0
+
+    async def test_mixed_new_and_overwrite_items(
+        self, source_store: SourceStore,
+    ) -> None:
+        """新規と上書きが混在する場合、新規の YouTube のみ取り込まれること."""
+        new_item = _make_feed_item()
+        new_item["_is_overwrite"] = False
+        new_item["post"]["record"]["facets"] = [
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=new456",
+                    }
+                ]
+            }
+        ]
+
+        overwrite_item = _make_feed_item()
+        overwrite_item["_is_overwrite"] = True
+        overwrite_item["post"]["record"]["facets"] = [
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=old789",
+                    }
+                ]
+            }
+        ]
+
+        mock_yt = AsyncMock()
+        mock_yt.ingest_video = AsyncMock(
+            return_value=MagicMock(placed=1, errors=0)
+        )
+
+        ingester = make_bluesky_ingester(source_store)
+        stats = await ingester.follow_urls(
+            [new_item, overwrite_item],
+            youtube_ingester=mock_yt,
+            force_youtube_reingest=False,
+        )
+
+        # 新規の YouTube のみ取り込まれ、上書きはスキップ
+        mock_yt.ingest_video.assert_called_once_with(
+            video_url="https://www.youtube.com/watch?v=new456"
+        )
+        assert stats["youtube_placed"] == 1
+        assert stats["skipped"] == 1


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [x] fix: バグ修正 ★
- [ ] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- `--force` モードで `force_youtube_reingest=false` の場合、新規投稿の YouTube URL もスキップされるバグを修正
- `crawl_bluesky` で `placed_items` に `_is_overwrite` フラグを付与し、`follow_urls` で新規/上書きを区別
- `follow_urls` から `force` パラメータを削除し、`_is_overwrite` フラグのみで判定するようシンプル化
- 同一 YouTube URL が新規投稿と上書き投稿の両方に存在する場合は安全側（新規=取り込む）に倒す
- 仕様書の --force セクションに新規/上書きの区別を反映

## Test plan

- [x] 上書き投稿の YouTube URL が `force_youtube_reingest=false` でスキップされること
- [x] 上書き投稿の YouTube URL が `force_youtube_reingest=true` で取り込まれること
- [x] 新規投稿の YouTube URL が `force_youtube_reingest=false` でも取り込まれること
- [x] 新規と上書きが混在する場合、新規の YouTube のみ取り込まれること
- [x] pytest 59 passed, ruff/mypy クリーン

## Related issues

Closes #565