### PR TITLE
docs(rag-knowledge): CLAUDE.md の BM25 キャッシュに関する古い記述を削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,6 @@ ChromaDB は HttpClient 経由でサーバーに接続するため、MCP と CLI
 | テスト実行 | 停止推奨 | テスト用 DB との分離のため |
 | MCP ツールの動作確認 | 起動中 + enabled | |
 
-**注意**: BM25 インデックスは単一プロセス前提のインメモリキャッシュを持つ。MCP 経由の書き込み後はキャッシュが自動リセットされるが、CLI 直接実行で BM25 を更新した場合、MCP 側の検索結果に反映されるのは次回のサービスリセット後となる。
-
 ### DB 破損時の復旧
 
 MCP サーバープロセスを停止 → ChromaDB サーバーが起動していることを確認（停止していれば `uv run chroma run --path <CHROMADB_PERSIST_DIR>` で手動起動）→ CLI `rebuild --mode full` で復旧する。


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- CLAUDE.md の「MCP サーバーと他プロセスの共存」セクションから、BM25 インメモリキャッシュに関する古い注意書きを削除
- 現在の MCP サーバーは全操作を CLI サブプロセス（`_run_cli_subprocess()`）に委譲しており、検索のたびに新しいプロセスが BM25 インデックスをディスクから読み直すため、キャッシュの古さに関する注意は不要

## Test plan

- 軽微なドキュメント修正のため省略

## Related issues

Closes #569