### PR TITLE
fix(pipeline-controller): git diff のネット差分で検出されない中間変更を補完 (#571)

### DIFF
--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -117,6 +117,7 @@
 | リポジトリ初期化 | source_store パス | なし | source_store ディレクトリで `git init` を実行する。既に初期化済みの場合は何もしない |
 | ステージング＋コミット | コミットメッセージ、対象パス（任意） | コミット ID | source_store 内の変更をステージング＋コミットする。対象パス指定時は `git add {対象パス}/` でそのパス配下のみをステージングする。未指定時は `git add -A` で全体をステージングする。変更がない場合はスキップする。CLI `rebuild --commit-message` 指定時は再構築前にこの操作を実行する |
 | 差分取得 | 基準コミット ID | 変更ファイルリスト | `git diff --name-status <基準ID>..HEAD` で変更ファイル（追加・変更・削除・リネーム）を取得する |
+| 中間コミット全触ファイル取得 | 基準コミット ID | ファイルパスの集合 | `git log --name-only --pretty=format: <基準ID>..HEAD` で中間コミットで1回でも変更されたファイルパスを返す。ネット差分では検出できない「削除→同一内容再追加」の補完に使用する |
 
 ### 変更ファイルリストの構造
 
@@ -135,11 +136,12 @@ git diff から取得する変更ファイルリストの各エントリが持�
 1. 未コミットの変更がある場合、自動コミットを実行する
 2. `pipeline_history` から `last_commit_id` を取得する
 3. `last_commit_id` が null commit hash（初回）の場合は全ファイルを対象とする。通常のコミット ID の場合は `git diff` で変更ファイルを取得する
-4. 変更ファイルがなければ終了する
-5. 変更ファイルを種別（追加・変更 / 削除）ごとに分類する。BlueSky の `bluesky/.../media/{rkey}/` 配下のファイルが追加・変更された場合、対応する親ファイル（`{rkey}.json`）が diff に含まれていなくても `modified` として処理対象に追加する
-6. 追加・変更ファイルはコンバーターで変換後、インデクサーでインデックスに追加・更新する
-7. 削除ファイルはインデクサーでインデックスから削除し、metadata.db で論理削除する
-8. `pipeline_history` に実行履歴を追加する
+4. ネット差分で検出されない中間変更を補完する。`git log --name-only` で中間コミットの全触ファイルを取得し、ネット差分に含まれないが HEAD に存在するファイルを `modified` として追加する。HEAD に存在しないファイル（一時的に追加→削除）は除外する
+5. 変更ファイルがなければ終了する
+6. 変更ファイルを種別（追加・変更 / 削除）ごとに分類する。BlueSky の `bluesky/.../media/{rkey}/` 配下のファイルが追加・変更された場合、対応する親ファイル（`{rkey}.json`）が diff に含まれていなくても `modified` として処理対象に追加する
+7. 追加・変更ファイルはコンバーターで変換後、インデクサーでインデックスに追加・更新する
+8. 削除ファイルはインデクサーでインデックスから削除し、metadata.db で論理削除する
+9. `pipeline_history` に実行履歴を追加する
 
 ```mermaid
 flowchart TD
@@ -149,6 +151,7 @@ flowchart TD
     GET_STATE["pipeline_history から last_commit_id 取得"]
     CHECK["last_commit_id が null commit hash か"]
     DIFF["git diff last_commit_id..HEAD"]
+    SUPPLEMENT["中間コミットの全触ファイルで補完"]
     FULL["全ファイルを対象とする"]
     HAS_CHANGES["変更ファイルあり"]
     NO_CHANGES["変更なし → 終了"]
@@ -173,7 +176,8 @@ flowchart TD
     GET_STATE --> CHECK
     CHECK -->|通常のコミット ID| DIFF
     CHECK -->|null commit hash（初回）| FULL
-    DIFF --> HAS_CHANGES
+    DIFF --> SUPPLEMENT
+    SUPPLEMENT --> HAS_CHANGES
     FULL --> HAS_CHANGES
     HAS_CHANGES -->|あり| CLASSIFY
     HAS_CHANGES -->|なし| NO_CHANGES
@@ -298,6 +302,7 @@ source_store 内の以下のファイルは、git diff で検出されてもパ�
 | `last_commit_id` が null commit hash（初回実行） | source_store 全ファイルを対象として処理する |
 | `last_commit_id` が指す commit が git 履歴に存在しない | 警告ログを出力し、全ファイルを対象として処理する |
 | git diff の結果が空（変更なし） | 何もせず正常終了する |
+| ネット差分で検出されない中間変更（削除→同一内容再追加等） | `git log --name-only` で中間コミットの全触ファイルを取得し、ネット差分に含まれないが HEAD に存在するファイルを `modified` として追加する。HEAD に存在しないファイル（一時的に追加→削除）は除外する |
 | パイプライン処理中にエラーが発生した場合 | エラーが発生したファイルをスキップし、残りのファイルの処理を続行する。pipeline_history にレコードを追加しないことで `last_commit_id` が前回値のまま保持される（次回再実行で再処理される） |
 | コンバーターが変換スキップを返したファイル（空テキスト、0バイト、未対応拡張子等） | 該当ファイルをスキップし、処理結果サマリの `warnings` に記録する（`errors` ではない）。非致命的なスキップであり、パイプライン全体の成否には影響しない |
 | コンバーターが予期しない例外を発生させたファイル | 該当ファイルのインデックス追加をスキップし、処理結果サマリの `errors` に記録する |

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -177,6 +177,9 @@ class PipelineController:
             changes = self._scan_all_as_added()
         else:
             raw_diff = self._git.get_diff(last_commit_id)
+            raw_diff = self._supplement_hidden_changes(
+                raw_diff, last_commit_id,
+            )
             changes = self._classify_changes(raw_diff)
 
         if not changes:
@@ -522,6 +525,38 @@ class PipelineController:
                 file_path=f,
             ))
         return entries
+
+    def _supplement_hidden_changes(
+        self,
+        raw_diff: list[tuple[str, str, str]],
+        from_commit_id: str,
+    ) -> list[tuple[str, str, str]]:
+        """ネット差分で検出されない中間変更を補完する.
+
+        git diff（ネット差分）では「削除→同一内容再追加」が差分ゼロになる。
+        git log で中間コミットの全触ファイルを取得し、ネット差分に含まれないが
+        HEAD に存在するファイルを MODIFIED として追加する。
+        """
+        touched = self._git.get_files_touched_in_range(from_commit_id)
+        if not touched:
+            return raw_diff
+
+        net_files = {entry[1] for entry in raw_diff}
+        hidden = touched - net_files
+        if not hidden:
+            return raw_diff
+
+        head_files = set(self._git.list_all_files())
+        supplemented = list(raw_diff)
+        for file_path in hidden:
+            if file_path in head_files:
+                logger.info(
+                    "中間コミットで変更されたがネット差分に出ないファイルを"
+                    "MODIFIED として追加: %s",
+                    file_path,
+                )
+                supplemented.append(("M", file_path, ""))
+        return supplemented
 
     def _classify_changes(
         self,

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -548,14 +548,22 @@ class PipelineController:
 
         head_files = set(self._git.list_all_files())
         supplemented = list(raw_diff)
-        for file_path in hidden:
+        added_count = 0
+        for file_path in sorted(hidden):
             if file_path in head_files:
-                logger.info(
+                logger.debug(
                     "中間コミットで変更されたがネット差分に出ないファイルを"
                     "MODIFIED として追加: %s",
                     file_path,
                 )
                 supplemented.append(("M", file_path, ""))
+                added_count += 1
+        if added_count:
+            logger.info(
+                "中間コミットで変更されたがネット差分に出ないファイルを"
+                "MODIFIED として %d 件追加",
+                added_count,
+            )
         return supplemented
 
     def _classify_changes(

--- a/src/rag/pipeline/git_ops.py
+++ b/src/rag/pipeline/git_ops.py
@@ -150,6 +150,35 @@ class GitOperations:
         ])
         return self._parse_diff_output(result.stdout)
 
+    def get_files_touched_in_range(self, from_commit_id: str) -> set[str]:
+        """中間コミットで触れた全ファイルを取得する.
+
+        git log --name-only で from_commit_id..HEAD の間に
+        1回でも変更されたファイルパスを返す。
+        get_diff（ネット差分）では検出できない
+        「削除→同一内容再追加」のようなケースを補完するために使用する。
+
+        Args:
+            from_commit_id: 基準コミット ID（40桁の16進ハッシュ）
+
+        Returns:
+            中間コミットで触れたファイルパスの集合
+        """
+        result = self._run([
+            "git",
+            "-c",
+            "core.quotepath=false",
+            "log",
+            "--name-only",
+            "--pretty=format:",
+            f"{from_commit_id}..HEAD",
+        ])
+        return {
+            line
+            for line in result.stdout.strip().splitlines()
+            if line
+        }
+
     def list_all_files(self) -> list[str]:
         """HEAD で追跡されている全ファイルを列挙する.
 

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -542,6 +542,101 @@ class TestDeleteAndReAdd:
         assert "local/b.txt" in indexer.added
 
 
+class TestHiddenChangesSupplementation:
+    """ネット差分で検出されない中間変更の補完テスト (#571)."""
+
+    async def test_delete_then_readd_same_content_without_pipeline_run(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """パイプライン未実行の削除→同一内容再追加が MODIFIED として検出される."""
+        ctrl, converter, indexer = controller
+        content = "same content"
+
+        # 1. 初回追加 → パイプライン実行（last_commit_id = A）
+        _place_local_file(workspace["source"], "local/a.txt", content)
+        ctrl.commit("add a")
+        await ctrl.run_incremental()
+        assert "local/a.txt" in indexer.added
+
+        indexer.added.clear()
+        converter.converted.clear()
+
+        # 2. 削除 → コミット（パイプライン未実行、last_commit_id は A のまま）
+        (workspace["source"] / "local" / "a.txt").unlink()
+        ctrl.commit("delete a")
+
+        # 3. 同一内容で再追加 → コミット
+        _place_local_file(workspace["source"], "local/a.txt", content)
+        ctrl.source_store._db.register_source(
+            source_id="local/a.txt",
+            source_type="local",
+            title="a",
+            content_hash="dummy",
+            file_size=len(content),
+            collected_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+        ctrl.commit("readd a")
+
+        # 4. パイプライン実行 → git diff A..HEAD はネット差分ゼロだが検出される
+        summary = await ctrl.run_incremental()
+        assert summary.processed >= 1
+        assert "local/a.txt" in converter.converted
+
+    async def test_temporarily_added_then_deleted_file_is_excluded(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """一時的に追加→削除されたファイルは処理対象外."""
+        ctrl, converter, indexer = controller
+
+        # 1. 初回コミット → パイプライン実行
+        _place_local_file(workspace["source"], "local/base.txt", "base")
+        ctrl.commit("initial")
+        await ctrl.run_incremental()
+
+        converter.converted.clear()
+        indexer.added.clear()
+
+        # 2. 新規ファイルを追加 → コミット（パイプライン未実行）
+        _place_local_file(workspace["source"], "local/temp.txt", "temp")
+        ctrl.commit("add temp")
+
+        # 3. そのファイルを削除 → コミット
+        (workspace["source"] / "local" / "temp.txt").unlink()
+        ctrl.commit("delete temp")
+
+        # 4. パイプライン実行 → temp.txt は HEAD に存在しないので処理されない
+        await ctrl.run_incremental()
+        assert "local/temp.txt" not in converter.converted
+
+    async def test_normal_diff_not_affected(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """通常の差分更新は影響を受けない."""
+        ctrl, converter, indexer = controller
+
+        # 1. 初回コミット → パイプライン実行
+        _place_local_file(workspace["source"], "local/a.txt", "v1")
+        ctrl.commit("add a")
+        await ctrl.run_incremental()
+
+        converter.converted.clear()
+        indexer.added.clear()
+
+        # 2. 通常の変更 → パイプライン実行
+        _place_local_file(workspace["source"], "local/a.txt", "v2")
+        ctrl.commit("modify a")
+        summary = await ctrl.run_incremental()
+        assert summary.processed == 1
+        assert "local/a.txt" in converter.converted
+
+
 class TestRemoveFile:
     """source_store.remove_file のテスト."""
 

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -582,7 +582,7 @@ class TestHiddenChangesSupplementation:
 
         # 4. パイプライン実行 → git diff A..HEAD はネット差分ゼロだが検出される
         summary = await ctrl.run_incremental()
-        assert summary.processed >= 1
+        assert summary.processed == 1
         assert "local/a.txt" in converter.converted
 
     async def test_temporarily_added_then_deleted_file_is_excluded(

--- a/tests/test_pipeline_git_ops.py
+++ b/tests/test_pipeline_git_ops.py
@@ -241,6 +241,64 @@ class TestGetDiff:
         assert diff[0] == ("A", "web/example.com/page.html", "")
 
 
+class TestGetFilesTouchedInRange:
+    """get_files_touched_in_range のテスト."""
+
+    def test_returns_all_touched_files(self, git_repo: Path) -> None:
+        ops = GitOperations(git_repo)
+        ops.init_repo()
+        (git_repo / "a.txt").write_text("v1", encoding="utf-8")
+        first = ops.commit("first")
+        assert first is not None
+        (git_repo / "b.txt").write_text("new", encoding="utf-8")
+        ops.commit("add b")
+        (git_repo / "a.txt").write_text("v2", encoding="utf-8")
+        ops.commit("modify a")
+        touched = ops.get_files_touched_in_range(first)
+        assert "a.txt" in touched
+        assert "b.txt" in touched
+
+    def test_includes_deleted_then_readded_file(self, git_repo: Path) -> None:
+        """削除→同一内容再追加されたファイルが含まれること."""
+        ops = GitOperations(git_repo)
+        ops.init_repo()
+        f = git_repo / "data.txt"
+        f.write_text("content", encoding="utf-8")
+        first = ops.commit("first")
+        assert first is not None
+        f.unlink()
+        ops.commit("delete")
+        f.write_text("content", encoding="utf-8")
+        ops.commit("re-add same content")
+        # ネット差分はゼロだが touched には含まれる
+        diff = ops.get_diff(first)
+        assert len(diff) == 0
+        touched = ops.get_files_touched_in_range(first)
+        assert "data.txt" in touched
+
+    def test_no_changes(self, git_repo: Path) -> None:
+        """基準コミット以降に変更がない場合、空集合を返す."""
+        ops = GitOperations(git_repo)
+        ops.init_repo()
+        (git_repo / "a.txt").write_text("content", encoding="utf-8")
+        commit_id = ops.commit("first")
+        assert commit_id is not None
+        touched = ops.get_files_touched_in_range(commit_id)
+        assert touched == set()
+
+    def test_returns_tracked_files_only(self, git_repo: Path) -> None:
+        """追跡対象のファイルのみを返す."""
+        ops = GitOperations(git_repo)
+        ops.init_repo()
+        (git_repo / "a.txt").write_text("init", encoding="utf-8")
+        first = ops.commit("first")
+        assert first is not None
+        (git_repo / "b.txt").write_text("new", encoding="utf-8")
+        ops.commit("add b")
+        touched = ops.get_files_touched_in_range(first)
+        assert "b.txt" in touched
+
+
 class TestListAllFiles:
     """list_all_files のテスト."""
 

--- a/tests/test_pipeline_git_ops.py
+++ b/tests/test_pipeline_git_ops.py
@@ -286,17 +286,22 @@ class TestGetFilesTouchedInRange:
         touched = ops.get_files_touched_in_range(commit_id)
         assert touched == set()
 
-    def test_returns_tracked_files_only(self, git_repo: Path) -> None:
-        """追跡対象のファイルのみを返す."""
+    def test_deduplicates_same_path_touched_multiple_times(
+        self, git_repo: Path,
+    ) -> None:
+        """同一パスが複数回変更されても1回だけ含まれる."""
         ops = GitOperations(git_repo)
         ops.init_repo()
-        (git_repo / "a.txt").write_text("init", encoding="utf-8")
+        target = git_repo / "a.txt"
+        target.write_text("v1", encoding="utf-8")
         first = ops.commit("first")
         assert first is not None
-        (git_repo / "b.txt").write_text("new", encoding="utf-8")
-        ops.commit("add b")
+        target.write_text("v2", encoding="utf-8")
+        ops.commit("modify a once")
+        target.write_text("v3", encoding="utf-8")
+        ops.commit("modify a twice")
         touched = ops.get_files_touched_in_range(first)
-        assert "b.txt" in touched
+        assert touched == {"a.txt"}
 
 
 class TestListAllFiles:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正
- [x] docs: ドキュメント更新

## Summary

- `git_ops.py` に `get_files_touched_in_range` メソッドを追加（`git log --name-only` で中間コミットの全触ファイルを取得）
- `controller.py` に `_supplement_hidden_changes` メソッドを追加し、ネット差分に出ないが中間で変更がありHEADに存在するファイルをMODIFIEDとして補完
- 単体テスト7件追加（git_ops 4件 + controller 3件）
- 仕様書 `pipeline-controller.md` にステップ・mermaid図・エッジケース・git操作テーブルを追加

## Test plan

- [x] pytest 85 passed
- [x] ruff check — All checks passed
- [x] mypy — 型エラーなし
- [x] 統合テスト: BlueSky ingester で再現シナリオ確認（git rm → --force で Vision API が呼ばれる）
- [x] --force のみでは誤検出なし（不要な再処理が起きない）
- [x] 検索 QA: ベクトル検索・BM25 検索が正常動作

## Related issues

Closes #571