### PR TITLE
fix(source-store): delete が media サブディレクトリを削除しない問題を修正 (#574)

### DIFF
--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -80,7 +80,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | .meta 読み取り | ファイルパス | メタデータ辞書 | 指定ファイルの .meta サイドカーを YAML として読み取る |
 | .meta 書き込み | ファイルパス、メタデータ辞書 | なし | 指定ファイルの .meta サイドカーを YAML として書き込む |
 | ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを列挙する。source_type 指定時はそのディレクトリのみ。`.meta`、`metadata.db`、`.git/`、`.gitignore`、ロックファイル（`.ingest.lock`、`.rebuild.lock`）は除外する |
-| ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
+| ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。BlueSky 投稿の場合は対応する `media/{rkey}/` サブディレクトリも再帰削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
 | 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。パイプライン制御の内部処理で使用 |
 | 論理削除解除 | source_id | なし | metadata.db のステータスを `active` に戻す |
 | ファイル取得 | source_id | ファイルデータ + メタデータ / `None` | source_id に対応するファイルと .meta を返す。物理削除済み（ファイル欠落）の場合は警告ログを出力して `None` を返す（復元が必要な場合は source_store の git リポジトリから `git checkout` で復元する） |

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -341,6 +342,22 @@ class SourceStore:
         meta_file = meta_path_for(file_path)
         if meta_file.exists():
             meta_file.unlink()
+
+        # BlueSky 投稿の media サブディレクトリを削除
+        # JSON: bluesky/{did}/{year}/{month}/{rkey}.json
+        # Media: bluesky/{did}/{year}/{month}/media/{rkey}/
+        self._remove_media_dir(file_path)
+
+    def _remove_media_dir(self, file_path: Path) -> None:
+        """BlueSky 投稿の JSON に対応する media/{rkey}/ サブディレクトリを削除する."""
+        if file_path.suffix != ".json":
+            return
+        rel = file_path.relative_to(self._root)
+        if rel.parts[0] != "bluesky":
+            return
+        media_dir = file_path.parent / "media" / file_path.stem
+        if media_dir.is_dir():
+            shutil.rmtree(media_dir)
 
     def soft_delete(self, source_id: str) -> None:
         """ソースを論理削除する.

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -713,6 +713,75 @@ class TestRemoveFile:
         # エラーにならない
         source_store.remove_file("local/ghost.txt")
 
+    def test_remove_file_deletes_media_subdir(
+        self,
+        workspace: dict[str, Path],
+    ) -> None:
+        """BlueSky 投稿削除時に media/{rkey}/ ディレクトリも削除する."""
+        source_dir = workspace["source"]
+        source_store = SourceStore(source_dir)
+        source_store.initialize()
+
+        rel = "bluesky/testdid/2026/03/testrkey.json"
+        full = source_dir / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text('{"text":"test"}', encoding="utf-8")
+        meta = full.with_name(full.name + ".meta")
+        meta.write_text("source_type: bluesky\n", encoding="utf-8")
+
+        # media ディレクトリ配置
+        media_dir = source_dir / "bluesky/testdid/2026/03/media/testrkey"
+        media_dir.mkdir(parents=True, exist_ok=True)
+        (media_dir / "video_0.ts").write_bytes(b"dummy")
+        (media_dir / "image_0.jpg").write_bytes(b"dummy")
+
+        source_store._db.register_source(
+            source_id=rel,
+            source_type="bluesky",
+            title="test",
+            content_hash="dummy",
+            file_size=15,
+            collected_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        source_store.remove_file(rel)
+
+        assert not full.exists()
+        assert not meta.exists()
+        assert not media_dir.exists()
+
+    def test_remove_file_without_media_dir_is_safe(
+        self,
+        workspace: dict[str, Path],
+    ) -> None:
+        """media ディレクトリが存在しない投稿の削除でエラーにならない."""
+        source_dir = workspace["source"]
+        source_store = SourceStore(source_dir)
+        source_store.initialize()
+
+        rel = "bluesky/testdid/2026/03/norkey.json"
+        full = source_dir / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text('{"text":"no media"}', encoding="utf-8")
+        meta = full.with_name(full.name + ".meta")
+        meta.write_text("source_type: bluesky\n", encoding="utf-8")
+
+        source_store._db.register_source(
+            source_id=rel,
+            source_type="bluesky",
+            title="no media",
+            content_hash="dummy",
+            file_size=19,
+            collected_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+
+        source_store.remove_file(rel)
+
+        assert not full.exists()
+        assert not meta.exists()
+
 
 class TestRunFullRebuild:
     """全再構築のテスト."""


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正
- [x] docs: ドキュメント更新

## Summary

- `remove_file` で BlueSky 投稿の JSON/.meta 削除時に、対応する `media/{rkey}/` サブディレクトリも再帰削除するよう修正
- `_remove_media_dir` メソッドを追加（bluesky パスチェック付き）
- テスト追加: media ディレクトリ削除の正常系・media なし時の安全性
- 仕様書 `source-store.md` のファイル削除の記述に media 削除を追記

## Test plan

- [x] pytest TestRemoveFile 5件全て通過
- [x] ruff / mypy 問題なし
- [x] QA: 実際の BlueSky 投稿（画像付き）を取り込み → delete → 検索で削除を確認

## Related issues

Closes #574