### PR TITLE
feat(source-store): metadata.db の sources テーブルに meta JSON カラムを追加 (#580)

### DIFF
--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -442,6 +442,8 @@ source_store 内の全ファイルのメタデータ索引。
 | `file_size` | INTEGER | NOT NULL | ファイルサイズ（バイト） |
 | `collected_at` | TEXT | NOT NULL | 初回取り込み日時（ISO 8601） |
 | `updated_at` | TEXT | NOT NULL | 最終更新日時（ISO 8601）。`register_source` の呼び出し時に現在時刻で設定される（新規登録・再取り込み時の上書きの両方） |
+| `published_at` | TEXT | NOT NULL, DEFAULT '' | 公開日時（ISO 8601）。source_type ごとの `.meta` フィールドから解決する。空の場合は `collected_at` を使用する |
+| `meta` | TEXT | NOT NULL, DEFAULT '{}' | `.meta` ファイルの内容を JSON 文字列として格納する索引。`json_extract()` でフィルタ可能。`.meta` が原本であり、本カラムは検索用の索引 |
 
 #### pipeline_history テーブル
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2009,7 +2009,7 @@ def run_migrate(args: argparse.Namespace) -> None:
     db = MetadataDB(db_path)
     try:
         db.initialize()
-        applied = db.migrate()
+        applied = db.migrate(source_store_dir=Path(source_store_dir))
     finally:
         db.close()
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import inspect
+import json
 import logging
 import subprocess
 from collections.abc import Awaitable, Callable, Sequence
@@ -858,11 +859,15 @@ class PipelineController:
                 title = str(meta_data.get("title", ""))
                 if title:
                     now = datetime.now(timezone.utc).isoformat()
+                    meta_json = json.dumps(
+                        meta_data, ensure_ascii=False, default=str,
+                    )
                     try:
                         self.db.update_source(
                             source_id,
                             title=title,
                             updated_at=now,
+                            meta=meta_json,
                         )
                     except KeyError:
                         logger.warning(
@@ -904,6 +909,12 @@ class PipelineController:
             source_type, meta_dict, collected_at,
         )
 
+        meta_json = (
+            json.dumps(meta_dict, ensure_ascii=False, default=str)
+            if meta_dict
+            else "{}"
+        )
+
         self.db.register_source(
             source_id=source_id,
             source_type=source_type,
@@ -913,6 +924,7 @@ class PipelineController:
             collected_at=collected_at,
             updated_at=now,
             published_at=published_at,
+            meta=meta_json,
         )
 
     def _update_in_db(self, file_path: str) -> None:

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -8,7 +8,9 @@ WAL モードで運用し、source_store のファイルと .meta から再構�
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -23,6 +25,9 @@ from rag.store.models import (
 
 logger = logging.getLogger(__name__)
 
+# json_extract の JSON パスに埋め込むキー名の許容パターン
+_VALID_FILTER_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sources (
     source_id    TEXT PRIMARY KEY,
@@ -33,7 +38,8 @@ CREATE TABLE IF NOT EXISTS sources (
     file_size    INTEGER NOT NULL,
     collected_at TEXT NOT NULL,
     updated_at   TEXT NOT NULL,
-    published_at TEXT NOT NULL DEFAULT ''
+    published_at TEXT NOT NULL DEFAULT '',
+    meta         TEXT NOT NULL DEFAULT '{}'
 );
 
 CREATE TABLE IF NOT EXISTS pipeline_history (
@@ -78,12 +84,18 @@ class MetadataDB:
             self._conn.close()
             self._conn = None
 
-    def migrate(self) -> list[str]:
+    def migrate(
+        self, *, source_store_dir: Path | None = None,
+    ) -> list[str]:
         """既存テーブルのスキーマをマイグレーションする.
 
         CLI の migrate コマンドから明示的に呼び出す。
         initialize() からは呼び出されない。
         各種機能は最新スキーマを前提とし、旧スキーマへのフォールバックは行わない。
+
+        Args:
+            source_store_dir: source_store のルートディレクトリ。
+                meta カラムマイグレーションで .meta ファイルを読み取るために必要。
 
         Returns:
             適用されたマイグレーションの説明リスト（適用なしなら空リスト）
@@ -149,8 +161,77 @@ class MetadataDB:
                 "sources テーブルから file_path カラムを削除し"
                 " source_id を file_path ベースに移行しました"
             )
+            # 再取得（テーブル再作成後のカラム情報を反映）
+            cursor = self._connection.execute("PRAGMA table_info(sources)")
+            src_columns = {row["name"] for row in cursor.fetchall()}
+
+        # sources に meta 列を追加し、.meta ファイルからデータを充填
+        if "meta" not in src_columns:
+            self._connection.execute(
+                "ALTER TABLE sources"
+                " ADD COLUMN meta TEXT NOT NULL DEFAULT '{}'"
+            )
+            self._connection.commit()
+
+            filled = self._fill_meta_from_files(source_store_dir)
+            applied.append(
+                f"sources に meta 列を追加（{filled} 件の .meta データを充填）"
+            )
+            logger.info(
+                "sources に meta 列を追加しました（%d 件充填）", filled,
+            )
 
         return applied
+
+    def _fill_meta_from_files(
+        self, source_store_dir: Path | None,
+    ) -> int:
+        """source_store の .meta ファイルを読み取り meta カラムに充填する.
+
+        Args:
+            source_store_dir: source_store のルートディレクトリ。
+                None の場合は充填をスキップする。
+
+        Returns:
+            充填した件数
+        """
+        if source_store_dir is None:
+            logger.warning(
+                "source_store_dir が未指定のため"
+                " meta カラムのデータ充填をスキップします"
+            )
+            return 0
+
+        from rag.store.meta import meta_path_for, read_meta
+
+        rows = self._connection.execute(
+            "SELECT source_id FROM sources WHERE meta = '{}'"
+        ).fetchall()
+
+        filled = 0
+        for row in rows:
+            source_id = row["source_id"]
+            file_path = source_store_dir / source_id
+            meta_file = meta_path_for(file_path)
+            if meta_file.exists():
+                try:
+                    meta_dict = read_meta(file_path)
+                    meta_json = json.dumps(
+                        meta_dict, ensure_ascii=False, default=str,
+                    )
+                    self._connection.execute(
+                        "UPDATE sources SET meta = ? WHERE source_id = ?",
+                        (meta_json, source_id),
+                    )
+                    filled += 1
+                except Exception:
+                    logger.warning(
+                        ".meta ファイルの読み取りに失敗: %s", source_id,
+                        exc_info=True,
+                    )
+
+        self._connection.commit()
+        return filled
 
     def __enter__(self) -> MetadataDB:
         return self
@@ -171,6 +252,7 @@ class MetadataDB:
         collected_at: str,
         updated_at: str,
         published_at: str = "",
+        meta: str = "{}",
     ) -> None:
         """ソースを登録する.
 
@@ -184,6 +266,7 @@ class MetadataDB:
             published_at も同様に INSERT 時のみ使用される。
             local 媒体の git 由来時刻への補正は、パイプライン制御層が
             update_source() で後から実施する。
+            meta は .meta ファイルの内容を JSON 文字列として格納する。
         """
         # published_at 未指定時は collected_at を使用
         if not published_at:
@@ -193,15 +276,17 @@ class MetadataDB:
             """\
             INSERT INTO sources
                 (source_id, source_type, title, status,
-                 content_hash, file_size, collected_at, updated_at, published_at)
-            VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?)
+                 content_hash, file_size, collected_at, updated_at,
+                 published_at, meta)
+            VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)
             ON CONFLICT(source_id) DO UPDATE SET
                 source_type = excluded.source_type,
                 title = excluded.title,
                 status = 'active',
                 content_hash = excluded.content_hash,
                 file_size = excluded.file_size,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                meta = excluded.meta
             """,
             (
                 source_id,
@@ -212,6 +297,7 @@ class MetadataDB:
                 collected_at,
                 updated_at,
                 published_at,
+                meta,
             ),
         )
         self._connection.commit()
@@ -240,6 +326,7 @@ class MetadataDB:
             "collected_at",
             "updated_at",
             "published_at",
+            "meta",
         }
         invalid = set(fields.keys()) - allowed
         if invalid:
@@ -419,30 +506,94 @@ class MetadataDB:
             ).fetchone()
         return int(row["cnt"]) if row else 0
 
+    @staticmethod
+    def _build_meta_filter_conditions(
+        filters: dict[str, str],
+        conditions: list[str],
+        params: list[Any],
+    ) -> None:
+        """filters dict から meta カラム用の WHERE 条件を構築する.
+
+        キー名は英数字・アンダースコアのみ許可し、
+        SQL インジェクションを防止する。
+
+        Raises:
+            ValueError: キー名に不正な文字が含まれる場合
+        """
+        for key, value in filters.items():
+            if not _VALID_FILTER_KEY_RE.match(key):
+                msg = (
+                    f"フィルタキー名に不正な文字が含まれています: {key!r}"
+                    "（英数字・アンダースコアのみ許可）"
+                )
+                raise ValueError(msg)
+            conditions.append(f"json_extract(meta, '$.{key}') = ?")
+            params.append(value)
+
     def list_sources(
         self,
         *,
         source_type: SourceType,
         limit: int,
         ascending: bool = False,
+        filters: dict[str, str] | None = None,
     ) -> list[SourceRecord]:
-        """指定 source_type の active ソースを published_at でソートして取得する."""
+        """指定 source_type の active ソースを published_at でソートして取得する.
+
+        Args:
+            source_type: ソース種別
+            limit: 取得件数
+            ascending: True で古い順、False で新しい順
+            filters: メタデータフィルタ（key=value 形式）。
+                meta JSON カラムの json_extract でフィルタする。
+
+        Raises:
+            ValueError: filters のキー名に不正な文字が含まれる場合
+        """
         direction = "ASC" if ascending else "DESC"
+        conditions = ["source_type = ?", "status = 'active'"]
+        params: list[Any] = [source_type]
+
+        if filters:
+            self._build_meta_filter_conditions(filters, conditions, params)
+
+        where = " AND ".join(conditions)
+        params.append(limit)
+
         rows = self._connection.execute(
-            "SELECT * FROM sources"
-            " WHERE source_type = ? AND status = 'active'"
+            f"SELECT * FROM sources WHERE {where}"  # noqa: S608
             f" ORDER BY published_at {direction}"
             " LIMIT ?",
-            (source_type, limit),
+            params,
         ).fetchall()
         return [_row_to_source_record(r) for r in rows]
 
-    def count_sources_by_type(self, *, source_type: SourceType) -> int:
-        """指定 source_type の active ソース件数を返す."""
+    def count_sources_by_type(
+        self,
+        *,
+        source_type: SourceType,
+        filters: dict[str, str] | None = None,
+    ) -> int:
+        """指定 source_type の active ソース件数を返す.
+
+        Args:
+            source_type: ソース種別
+            filters: メタデータフィルタ（key=value 形式）。
+                meta JSON カラムの json_extract でフィルタする。
+
+        Raises:
+            ValueError: filters のキー名に不正な文字が含まれる場合
+        """
+        conditions = ["source_type = ?", "status = 'active'"]
+        params: list[Any] = [source_type]
+
+        if filters:
+            self._build_meta_filter_conditions(filters, conditions, params)
+
+        where = " AND ".join(conditions)
         row = self._connection.execute(
-            "SELECT COUNT(*) as cnt FROM sources"
-            " WHERE source_type = ? AND status = 'active'",
-            (source_type,),
+            f"SELECT COUNT(*) as cnt FROM sources WHERE {where}",  # noqa: S608
+            params,
         ).fetchone()
         return int(row["cnt"]) if row else 0
 
@@ -459,4 +610,5 @@ def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
         collected_at=row["collected_at"],
         updated_at=row["updated_at"],
         published_at=row["published_at"],
+        meta=row["meta"],
     )

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -32,6 +32,7 @@ class SourceRecord:
     collected_at: str
     updated_at: str
     published_at: str = ""
+    meta: str = "{}"
 
 
 @dataclass(frozen=True)

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -9,6 +9,7 @@ git 操作はパイプライン制御層の責務であり、このモジュー�
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import shutil
 from datetime import datetime, timezone
@@ -137,6 +138,12 @@ class SourceStore:
             source_type, metadata, collected_at,
         )
 
+        meta_json = (
+            json.dumps(metadata, ensure_ascii=False, default=str)
+            if metadata
+            else "{}"
+        )
+
         self._db.register_source(
             source_id=source_id,
             source_type=source_type,
@@ -146,6 +153,7 @@ class SourceStore:
             collected_at=collected_at,
             updated_at=now,
             published_at=published_at,
+            meta=meta_json,
         )
 
         return dest
@@ -421,6 +429,12 @@ class SourceStore:
                 detected_type, meta_dict or None, collected_at,
             )
 
+            meta_json = (
+                json.dumps(meta_dict, ensure_ascii=False, default=str)
+                if meta_dict
+                else "{}"
+            )
+
             self._db.register_source(
                 source_id=source_id,
                 source_type=detected_type,
@@ -430,6 +444,7 @@ class SourceStore:
                 collected_at=collected_at,
                 updated_at=now,
                 published_at=published_at,
+                meta=meta_json,
             )
             count += 1
 

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -3,13 +3,16 @@
 テスト方針:
 - migrate() を明示的に呼び出してスキーマ変更を適用
 - initialize() ではマイグレーションが走らないことを確認
-- published_at 列の追加、file_path → source_id 移行を検証
+- published_at 列の追加、file_path → source_id 移行、meta 列追加を検証
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
+
+import yaml
 
 from rag.store.metadata_db import MetadataDB
 
@@ -103,8 +106,8 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # 3件のマイグレーションが適用される
-        assert len(applied) == 3
+        # 4件のマイグレーションが適用される
+        assert len(applied) == 4
 
         # file_path カラムが削除されている
         cursor = db._connection.execute("PRAGMA table_info(sources)")
@@ -160,7 +163,7 @@ class TestMigrateExplicit:
         db.initialize()
 
         first = db.migrate()
-        assert len(first) == 3
+        assert len(first) == 4
 
         second = db.migrate()
         assert len(second) == 0
@@ -218,12 +221,131 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # published_at + file_path 移行の 2 件
-        assert len(applied) == 2
+        # published_at + file_path 移行 + meta の 3 件
+        assert len(applied) == 3
 
         for i in range(3):
             record = db.get_source(f"web/s{i}.html")
             assert record is not None
             assert record.published_at == f"2026-01-{i+1:02d}T00:00:00Z"
+
+        db.close()
+
+
+class TestMetaMigration:
+    """meta カラムマイグレーションのテスト."""
+
+    def _create_pre_meta_db(self, db_path: Path) -> None:
+        """meta カラムなしの DB を作成する."""
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""\
+            CREATE TABLE sources (
+                source_id    TEXT PRIMARY KEY,
+                source_type  TEXT NOT NULL,
+                title        TEXT NOT NULL,
+                status       TEXT NOT NULL DEFAULT 'active',
+                content_hash TEXT NOT NULL,
+                file_size    INTEGER NOT NULL,
+                collected_at TEXT NOT NULL,
+                updated_at   TEXT NOT NULL,
+                published_at TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE pipeline_history (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_commit_id TEXT NOT NULL,
+                to_commit_id   TEXT NOT NULL,
+                processed_at   TEXT NOT NULL,
+                mode           TEXT NOT NULL DEFAULT 'incremental'
+            );
+        """)
+        conn.close()
+
+    def test_migrate_adds_meta_column(self, tmp_path: Path) -> None:
+        """migrate() で meta カラムが追加される."""
+        db_path = tmp_path / "metadata.db"
+        self._create_pre_meta_db(db_path)
+
+        db = MetadataDB(db_path)
+        db.initialize()
+        applied = db.migrate()
+
+        assert len(applied) == 1
+        assert "meta" in applied[0]
+
+        cursor = db._connection.execute("PRAGMA table_info(sources)")
+        columns = {row["name"] for row in cursor.fetchall()}
+        assert "meta" in columns
+
+        db.close()
+
+    def test_migrate_fills_meta_from_files(self, tmp_path: Path) -> None:
+        """migrate() が .meta ファイルからデータを充填する."""
+        source_store = tmp_path / "source_store"
+        source_store.mkdir()
+        db_path = source_store / "metadata.db"
+        self._create_pre_meta_db(db_path)
+
+        # ソースレコードを事前登録
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("journal/repo-a/entry.md", "journal", "Entry", "active",
+             "hash", 100, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z",
+             "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        # .meta ファイルを作成
+        journal_dir = source_store / "journal" / "repo-a"
+        journal_dir.mkdir(parents=True)
+        (journal_dir / "entry.md").write_text("content")
+        meta_content = {
+            "title": "Entry",
+            "repository": "repo-a",
+            "collected_at": "2026-01-01T00:00:00Z",
+        }
+        with open(journal_dir / "entry.md.meta", "w", encoding="utf-8") as f:
+            yaml.safe_dump(meta_content, f)
+
+        db = MetadataDB(db_path)
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        assert len(applied) == 1
+        assert "1 件" in applied[0]
+
+        record = db.get_source("journal/repo-a/entry.md")
+        assert record is not None
+        meta = json.loads(record.meta)
+        assert meta["repository"] == "repo-a"
+
+        db.close()
+
+    def test_migrate_without_source_store_dir(self, tmp_path: Path) -> None:
+        """source_store_dir なしでもカラム追加は行われる（データ充填はスキップ）."""
+        db_path = tmp_path / "metadata.db"
+        self._create_pre_meta_db(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("local/test.md", "local", "Test", "active",
+             "hash", 10, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z",
+             "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+        conn.close()
+
+        db = MetadataDB(db_path)
+        db.initialize()
+        applied = db.migrate()
+
+        assert len(applied) == 1
+        assert "0 件" in applied[0]
+
+        record = db.get_source("local/test.md")
+        assert record is not None
+        assert record.meta == "{}"
 
         db.close()

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -239,6 +240,195 @@ class TestSourcesCRUD:
         assert db.source_count() == 2
         assert db.source_count(status="active") == 1
         assert db.source_count(status="deleted") == 1
+
+
+class TestMetaColumn:
+    """meta JSON カラムのテスト."""
+
+    def test_register_with_meta(self, db: MetadataDB) -> None:
+        """meta パラメータ付きで登録できる."""
+        meta = json.dumps({"repository": "test-repo", "author": "alice"})
+        db.register_source(
+            source_id="journal/test-repo/entry.md",
+            source_type="journal",
+            title="Test Entry",
+            content_hash="h",
+            file_size=100,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+            meta=meta,
+        )
+
+        record = db.get_source("journal/test-repo/entry.md")
+        assert record is not None
+        assert json.loads(record.meta) == {"repository": "test-repo", "author": "alice"}
+
+    def test_register_default_meta(self, db: MetadataDB) -> None:
+        """meta 未指定時は空 JSON オブジェクトがデフォルト."""
+        db.register_source(
+            source_id="local/test.md",
+            source_type="local",
+            title="Test",
+            content_hash="h",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        record = db.get_source("local/test.md")
+        assert record is not None
+        assert record.meta == "{}"
+
+    def test_upsert_updates_meta(self, db: MetadataDB) -> None:
+        """再登録で meta が更新される."""
+        db.register_source(
+            source_id="journal/repo/e.md",
+            source_type="journal",
+            title="Entry",
+            content_hash="h1",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+            meta=json.dumps({"repository": "old"}),
+        )
+        db.register_source(
+            source_id="journal/repo/e.md",
+            source_type="journal",
+            title="Entry Updated",
+            content_hash="h2",
+            file_size=20,
+            collected_at="2026-01-02T00:00:00Z",
+            updated_at="2026-01-02T00:00:00Z",
+            meta=json.dumps({"repository": "new"}),
+        )
+
+        record = db.get_source("journal/repo/e.md")
+        assert record is not None
+        assert json.loads(record.meta)["repository"] == "new"
+
+    def test_list_sources_with_filter(self, db: MetadataDB) -> None:
+        """filters で meta の値を絞り込める."""
+        for repo in ("repo-a", "repo-b"):
+            db.register_source(
+                source_id=f"journal/{repo}/entry.md",
+                source_type="journal",
+                title=f"Entry {repo}",
+                content_hash="h",
+                file_size=10,
+                collected_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+                published_at="2026-01-01T00:00:00Z",
+                meta=json.dumps({"repository": repo}),
+            )
+
+        results = db.list_sources(
+            source_type="journal",
+            limit=10,
+            filters={"repository": "repo-a"},
+        )
+        assert len(results) == 1
+        assert results[0].source_id == "journal/repo-a/entry.md"
+
+    def test_list_sources_without_filter(self, db: MetadataDB) -> None:
+        """filters 未指定で全件返る."""
+        for i in range(3):
+            db.register_source(
+                source_id=f"journal/repo/e{i}.md",
+                source_type="journal",
+                title=f"Entry {i}",
+                content_hash="h",
+                file_size=10,
+                collected_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+                published_at=f"2026-01-0{i+1}T00:00:00Z",
+            )
+
+        results = db.list_sources(source_type="journal", limit=10)
+        assert len(results) == 3
+
+    def test_count_sources_by_type_with_filter(self, db: MetadataDB) -> None:
+        """count_sources_by_type が filters で絞り込める."""
+        entries = [
+            ("journal/repo-a/e1.md", "repo-a"),
+            ("journal/repo-a/e2.md", "repo-a"),
+            ("journal/repo-b/e1.md", "repo-b"),
+        ]
+        for source_id, repo in entries:
+            db.register_source(
+                source_id=source_id,
+                source_type="journal",
+                title="Entry",
+                content_hash="h",
+                file_size=10,
+                collected_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+                meta=json.dumps({"repository": repo}),
+            )
+
+        assert db.count_sources_by_type(
+            source_type="journal",
+            filters={"repository": "repo-a"},
+        ) == 2
+        assert db.count_sources_by_type(
+            source_type="journal",
+            filters={"repository": "repo-b"},
+        ) == 1
+
+    def test_filter_nonexistent_key(self, db: MetadataDB) -> None:
+        """存在しないキーでフィルタすると 0 件."""
+        db.register_source(
+            source_id="journal/repo/e.md",
+            source_type="journal",
+            title="Entry",
+            content_hash="h",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+            meta=json.dumps({"repository": "test"}),
+        )
+
+        results = db.list_sources(
+            source_type="journal",
+            limit=10,
+            filters={"nonexistent": "value"},
+        )
+        assert len(results) == 0
+
+    def test_filter_key_validation_rejects_injection(self, db: MetadataDB) -> None:
+        """フィルタキー名に SQL インジェクション文字列が含まれる場合 ValueError."""
+        with pytest.raises(ValueError, match="不正な文字"):
+            db.list_sources(
+                source_type="journal",
+                limit=10,
+                filters={"') OR 1=1 --": "value"},
+            )
+
+    def test_filter_key_validation_rejects_dot(self, db: MetadataDB) -> None:
+        """フィルタキー名にドットが含まれる場合 ValueError."""
+        with pytest.raises(ValueError, match="不正な文字"):
+            db.count_sources_by_type(
+                source_type="journal",
+                filters={"nested.key": "value"},
+            )
+
+    def test_update_source_meta(self, db: MetadataDB) -> None:
+        """update_source で meta を更新できる."""
+        db.register_source(
+            source_id="journal/repo/e.md",
+            source_type="journal",
+            title="Entry",
+            content_hash="h",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        new_meta = json.dumps({"repository": "updated"})
+        db.update_source("journal/repo/e.md", meta=new_meta)
+
+        record = db.get_source("journal/repo/e.md")
+        assert record is not None
+        assert json.loads(record.meta)["repository"] == "updated"
 
 
 class TestPipelineHistory:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- metadata.db の `sources` テーブルに `meta TEXT NOT NULL DEFAULT '{}'` カラムを追加
- `migrate` コマンドでカラム追加と `.meta` ファイルからのデータ充填を一括実行
- `rebuild_db` および通常インジェスト時にも `meta` カラムが正しく設定される
- `list_sources` / `count_sources_by_type` に `filters` パラメータを追加し、`json_extract()` によるメタデータフィルタを実現
- フィルタキー名のバリデーション（SQL インジェクション防止）を追加
- 仕様書（source-store.md）の sources テーブル定義に `meta` カラムと欠落していた `published_at` カラムを追記

## Test plan

- [x] `TestMetaColumn`: meta CRUD、upsert 更新、フィルタ絞り込み、件数カウント、存在しないキー、キー名バリデーション（8 テスト）
- [x] `TestMetaMigration`: カラム追加、`.meta` データ充填、source_store_dir 未指定時のスキップ（3 テスト）
- [x] 既存マイグレーションテスト更新（期待件数調整）
- [x] 既存 list_recent テスト（21 テスト通過）
- [x] ruff / mypy 通過
- [x] QA: 本番 source_store（1561 件）に対する migrate 実行で 1416 件充填を確認

## Related issues

Closes #580