### PR TITLE
feat(content-listing): rag_list_recent にメタデータフィルタを追加 (#579)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -361,6 +361,7 @@ A〜G の取り込みデータを使ってパイプライン基盤を検証す�
 | 1 | `stats` | 統計情報が表示される | `none` |
 | 2 | `list-recent --source-type local` | 取り込み済み local ソースが一覧に表示される | `none` |
 | 3 | `list-recent --source-type journal` | 取り込み済み journal ソースが一覧に表示される | `none` |
+| 3a | `list-recent --source-type journal --filters repository=rag-knowledge` | journal がリポジトリ名で絞り込まれる | `none` |
 | 4 | `search --query <取り込み内容に関連するワード>` | ベクトル検索・BM25 の両方で結果が返る | `none` |
 | 5a | `get-document <source_id> --format text`（`source_id` は positional 引数） | A) の README.md の全文がテキスト形式で取得できる | `none` |
 | 5b | `get-document <source_id> --format original` | A) の README.md の全文がオリジナル形式で取得できる | `none` |
@@ -368,7 +369,9 @@ A〜G の取り込みデータを使ってパイプライン基盤を検証す�
 | 7 | `rebuild --mode incremental` | 差分再構築が成功する | `none` |
 | 8 | `stats` | 再構築後の統計が更新されている | `none` |
 
-MCP 対応: `rag_stats` / `rag_list_recent` / `rag_search` / `rag_get_document` / `rag_delete` / `rag_rebuild`
+MCP 対応: `rag_stats` / `rag_list_recent` (+ filters) / `rag_search` / `rag_get_document` / `rag_delete` / `rag_rebuild`
+
+> MCP `rag_list_recent` の filters 確認: `rag_list_recent(source_type="journal", filters="repository=rag-knowledge")` で journal がリポジトリ名で絞り込まれること。
 
 ### 7. クリーンアップ
 

--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -8,6 +8,7 @@
 
 - ソース単位の一覧取得（MCP ツール + CLI サブコマンド）
 - `source_type` 指定による絞り込み
+- メタデータフィルタ（`filters`）による絞り込み
 - `published_at` によるソート（降順/昇順切り替え可能）
 - 取得件数の制限
 
@@ -76,12 +77,14 @@
 | `source_type` | str | はい | ソース種別（値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `source_type` を参照） |
 | `limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml） |
 | `order` | str | いいえ | ソート順。`"desc"`（新しい順、デフォルト）または `"asc"`（古い順） |
+| `filters` | str | いいえ | メタデータフィルタ（`key=value` 形式、カンマ区切りで複数指定可）。`.meta` のカスタムフィールドで絞り込む。完全一致。例: `"repository=rag-knowledge"`。[search-response.md](../search-response.md) の `rag_search` の `filters` と同一形式 |
 
 バリデーション:
 
 - `source_type` が有効値でない場合、エラーメッセージを返す（有効値の一覧を含める）
 - `limit` が許容範囲外の場合、エラーメッセージを返す。許容範囲は `src/rag/config.py` の pydantic Field 制約に従う
 - `order` が `"asc"` / `"desc"` 以外の場合、エラーメッセージを返す
+- `filters` のキー名が不正な場合、エラーメッセージを返す
 
 出力:
 
@@ -102,7 +105,7 @@ source_type: web（5件 / 全80件, 新しい順）
 ```
 
 - ヘッダー行: `source_type: {type}（{表示件数}件 / 全{該当source_typeの総件数}件, {ソート順}）`
-  - 総件数: MetadataDB の `sources` テーブルに対して同一 `source_type` + `status = 'active'` 条件の `COUNT(*)` で取得する
+  - 総件数: MetadataDB の `sources` テーブルに対して同一 `source_type` + `status = 'active'` + `filters` 条件の `COUNT(*)` で取得する。`filters` 指定時は絞り込み後の件数を反映する
 - 各エントリ: 番号付きリスト。タイトル、source_id、published_at、ファイルサイズを表示
   - ファイルサイズ: MetadataDB の `file_size` カラムから取得する。人間が読みやすい単位（KB / MB）でフォーマットする
 - 該当するソースが0件の場合: `source_type: {type}（0件 / 全0件）`（ソート順は省略する）
@@ -114,7 +117,7 @@ source_type: web（5件 / 全80件, 新しい順）
 #### list-recent コマンド
 
 ```
-uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>] [--order asc|desc]
+uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>] [--order asc|desc] [--filters <FILTERS>]
 ```
 
 | オプション | 型 | 必須 | 内容 |
@@ -122,6 +125,7 @@ uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>] [--order
 | `--source-type` | str | はい | ソース種別（値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `source_type` を参照） |
 | `--limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml） |
 | `--order` | str | いいえ | ソート順。`asc`（古い順）/ `desc`（新しい順、デフォルト） |
+| `--filters` | str | いいえ | メタデータフィルタ（`key=value` 形式、カンマ区切り）。MCP ツールの `filters` と同一形式 |
 
 MCP ツール `rag_list_recent` と同じバリデーション・振る舞いを適用する。出力形式も同一。
 
@@ -148,7 +152,7 @@ flowchart TD
     VALIDATE -->|不正| ERROR["エラー返却"]
     VALIDATE -->|正常| SERVICE
     SERVICE --> METADB
-    METADB -->|"source_type フィルタ + published_at ソート + COUNT"| SERVICE
+    METADB -->|"source_type + filters フィルタ + published_at ソート + COUNT"| SERVICE
     SERVICE --> FORMAT
     FORMAT --> RESPONSE
 ```
@@ -156,11 +160,11 @@ flowchart TD
 ### データ取得フロー
 
 1. MCP ツールまたは CLI からパラメータを受け取る
-2. `source_type`、`limit`、`order` のバリデーションを実行する
+2. `source_type`、`limit`、`order`、`filters` のバリデーションを実行する
 3. `rag_knowledge.py` の共通関数 `list_recent_sources` を呼び出す
 4. `MetadataDB` から以下の 2 クエリを発行する:
-   - 一覧取得: `source_type` + `status = 'active'` でフィルタし、`published_at` でソート（`order` に応じて昇順/降順）して `limit` 件取得
-   - 総件数取得: 同条件の `COUNT(*)` で該当 source_type の全件数を取得
+   - 一覧取得: `source_type` + `status = 'active'` + `filters`（指定時）でフィルタし、`published_at` でソート（`order` に応じて昇順/降順）して `limit` 件取得
+   - 総件数取得: 同条件の `COUNT(*)` で該当 source_type の全件数を取得（`filters` 指定時は絞り込み後の件数）
 5. 結果をテキスト形式にフォーマットして返却する（file_size は人間が読みやすい単位に変換）
 
 ### 関連ファイル
@@ -170,7 +174,8 @@ flowchart TD
 | `src/rag/server.py` | MCP ツール定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/cli.py` | CLI サブコマンド定義。パラメータ検証と共通関数呼び出し |
 | `src/rag/rag_knowledge.py` | 共通ロジック。MetadataDB へのクエリとフォーマット処理 |
-| `src/rag/store/metadata_db.py` | MetadataDB。`source_type` フィルタ + `published_at` ソートのクエリ |
+| `src/rag/filter_parser.py` | `parse_filters()` — `key=value` 文字列のパース（`rag_search` と共通） |
+| `src/rag/store/metadata_db.py` | MetadataDB。`source_type` + メタデータフィルタ + `published_at` ソートのクエリ |
 | `src/rag/store/resolve.py` | `resolve_published_at()` — source_type ごとの公開日時解決 |
 | `src/rag/config.py` | `rag_list_recent_limit` 設定の定義 |
 | `config.toml` | `rag_list_recent_limit` のデフォルト値 |
@@ -187,6 +192,9 @@ flowchart TD
 | 論理削除済みソースが存在 | 一覧に含めない（`status = 'active'` のみ対象） |
 | `published_at` が同一の複数ソース | ソート順序は不定（同一タイムスタンプ内の順序は保証しない） |
 | `published_at` が空文字列（マイグレーション前のデータ） | マイグレーション時に `collected_at` で自動補完される |
+| `filters` 指定で該当ソースが0件 | `source_type: {type}（0件 / 全0件）` を返す |
+| `filters` のキー名が不正 | エラーメッセージを返す |
+| `filters` 未指定 | 既存の動作（全件返却）を維持する |
 
 ## 関連ドキュメント
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -489,6 +489,11 @@ def main() -> None:
         default="desc",
         help="ソート順（asc: 古い順, desc: 新しい順。デフォルト: desc）",
     )
+    list_recent_parser.add_argument(
+        "--filters",
+        default=None,
+        help="メタデータフィルタ（key=value 形式、例: 'repository=rag-knowledge'）",
+    )
     _add_output_option(list_recent_parser)
 
     # search サブコマンド
@@ -1691,6 +1696,18 @@ def run_list_recent(args: argparse.Namespace) -> None:
     limit: int = args.limit if args.limit is not None else settings.rag_list_recent_limit
     ascending = args.order == "asc"
 
+    # filters パラメータのパース
+    parsed_filters: dict[str, str] | None = None
+    if args.filters is not None:
+        try:
+            parsed_filters = parse_filters(args.filters)
+        except ValueError as e:
+            if json_out:
+                _output_error(str(e))
+            else:
+                logger.error("エラー: %s", e)
+                sys.exit(1)
+
     if json_out:
         from .store.metadata_db import MetadataDB
         from .store.models import SourceType
@@ -1717,8 +1734,8 @@ def run_list_recent(args: argparse.Namespace) -> None:
         try:
             db.initialize()
             st = cast(SourceType, args.source_type)
-            sources = db.list_sources(source_type=st, limit=limit, ascending=ascending)
-            total = db.count_sources_by_type(source_type=st)
+            sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=parsed_filters)
+            total = db.count_sources_by_type(source_type=st, filters=parsed_filters)
         finally:
             db.close()
         _output_result({
@@ -1740,6 +1757,7 @@ def run_list_recent(args: argparse.Namespace) -> None:
         from .rag_knowledge import list_recent_sources
         print(list_recent_sources(
             settings.source_store_dir, args.source_type, limit, ascending=ascending,
+            filters=parsed_filters,
         ))
 
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1734,8 +1734,12 @@ def run_list_recent(args: argparse.Namespace) -> None:
         try:
             db.initialize()
             st = cast(SourceType, args.source_type)
-            sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=parsed_filters)
-            total = db.count_sources_by_type(source_type=st, filters=parsed_filters)
+            try:
+                sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=parsed_filters)
+                total = db.count_sources_by_type(source_type=st, filters=parsed_filters)
+            except ValueError as e:
+                _output_error(str(e))
+                return
         finally:
             db.close()
         _output_result({

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -999,6 +999,7 @@ def list_recent_sources(
     source_type: str,
     limit: int,
     ascending: bool = False,
+    filters: dict[str, str] | None = None,
 ) -> str:
     """指定 source_type のソースを published_at でソートして一覧取得する（MCP/CLI 共通ロジック）.
 
@@ -1009,6 +1010,7 @@ def list_recent_sources(
         source_type: ソース種別
         limit: 取得件数
         ascending: True で昇順（古い順）、False で降順（新しい順、デフォルト）
+        filters: メタデータフィルタ（key=value 形式）。meta JSON カラムで絞り込む
 
     Returns:
         フォーマット済みテキスト
@@ -1025,8 +1027,8 @@ def list_recent_sources(
         from .store.models import SourceType
 
         st = cast(SourceType, source_type)
-        sources = db.list_sources(source_type=st, limit=limit, ascending=ascending)
-        total = db.count_sources_by_type(source_type=st)
+        sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=filters)
+        total = db.count_sources_by_type(source_type=st, filters=filters)
     finally:
         db.close()
 

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -1010,7 +1010,7 @@ def list_recent_sources(
         source_type: ソース種別
         limit: 取得件数
         ascending: True で昇順（古い順）、False で降順（新しい順、デフォルト）
-        filters: メタデータフィルタ（key=value 形式）。meta JSON カラムで絞り込む
+        filters: メタデータフィルタ。パース済み辞書を受け取り meta JSON カラムで絞り込む
 
     Returns:
         フォーマット済みテキスト
@@ -1027,8 +1027,11 @@ def list_recent_sources(
         from .store.models import SourceType
 
         st = cast(SourceType, source_type)
-        sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=filters)
-        total = db.count_sources_by_type(source_type=st, filters=filters)
+        try:
+            sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=filters)
+            total = db.count_sources_by_type(source_type=st, filters=filters)
+        except ValueError as e:
+            return f"エラー: {e}"
     finally:
         db.close()
 

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1379,6 +1379,7 @@ async def rag_list_recent(
     source_type: str,
     limit: int | None = None,
     order: str = "desc",
+    filters: str | None = None,
 ) -> str:
     """[rag-knowledge] List recent sources - 指定した source_type のソースを公開日時順で一覧取得する.
 
@@ -1390,6 +1391,10 @@ async def rag_list_recent(
         source_type: ソース種別: "web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"
         limit: 取得件数（1〜100、未指定時は設定値を使用）
         order: ソート順（"desc": 新しい順（デフォルト）, "asc": 古い順）
+        filters: メタデータフィルタ（key=value 形式、カンマ区切りで複数指定可）。
+            .meta のカスタムフィールドで一覧を絞り込む。完全一致。
+            例: "repository=rag-knowledge" / "repository=rag-knowledge,tag=dev"
+            未指定時はフィルタなし。
 
     Returns:
         ソース一覧テキスト（タイトル、source_id、published_at、ファイルサイズ）
@@ -1408,6 +1413,8 @@ async def rag_list_recent(
     if limit is not None:
         args.extend(["--limit", str(limit)])
     args.extend(["--order", order])
+    if filters is not None:
+        args.extend(["--filters", filters])
 
     try:
         result = await _run_cli_subprocess("list-recent", args)

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -6,6 +6,7 @@
 - MetadataDB の list_sources / count_sources_by_type メソッドの単体テスト
 - list_recent_sources 共通関数のフォーマット・統合テスト
 - エッジケース: 0件、limit > 該当件数、論理削除除外、ソート順、昇順/降順
+- filters パラメータによるメタデータ絞り込み（list_sources / count / 共通関数）
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ def _register(
     published_at: str = "",
     file_size: int = 1024,
     status: str = "active",
+    meta: str = "{}",
 ) -> None:
     """テスト用ソース登録ヘルパー."""
     db.register_source(
@@ -45,6 +47,7 @@ def _register(
         collected_at=collected_at,
         updated_at=collected_at,
         published_at=published_at,
+        meta=meta,
     )
     if status == "deleted":
         db.set_status(source_id, "deleted")
@@ -137,6 +140,28 @@ class TestListSources:
         assert len(result) == 1
         assert result[0].source_id == "active1"
 
+    def test_filters_by_meta(self, db: MetadataDB) -> None:
+        """filters 指定時に該当レコードのみ返る."""
+        import json
+
+        _register(db, "j1", source_type="journal", meta=json.dumps({"repository": "rag-knowledge"}))
+        _register(db, "j2", source_type="journal", meta=json.dumps({"repository": "other-repo"}))
+        _register(db, "j3", source_type="journal")
+
+        result = db.list_sources(source_type="journal", limit=10, filters={"repository": "rag-knowledge"})
+        assert len(result) == 1
+        assert result[0].source_id == "j1"
+
+    def test_filters_none_returns_all(self, db: MetadataDB) -> None:
+        """filters=None は既存動作（全件返却）を維持する."""
+        import json
+
+        _register(db, "j1", source_type="journal", meta=json.dumps({"repository": "rag-knowledge"}))
+        _register(db, "j2", source_type="journal")
+
+        result = db.list_sources(source_type="journal", limit=10, filters=None)
+        assert len(result) == 2
+
 
 class TestCountSourcesByType:
     """MetadataDB.count_sources_by_type のテスト."""
@@ -157,6 +182,17 @@ class TestCountSourcesByType:
 
         assert db.count_sources_by_type(source_type="web") == 1
         assert db.count_sources_by_type(source_type="local") == 1
+
+    def test_counts_with_filters(self, db: MetadataDB) -> None:
+        """filters 指定時は絞り込み後の件数を返す."""
+        import json
+
+        _register(db, "j1", source_type="journal", meta=json.dumps({"repository": "rag-knowledge"}))
+        _register(db, "j2", source_type="journal", meta=json.dumps({"repository": "other-repo"}))
+        _register(db, "j3", source_type="journal")
+
+        assert db.count_sources_by_type(source_type="journal", filters={"repository": "rag-knowledge"}) == 1
+        assert db.count_sources_by_type(source_type="journal") == 3
 
 
 class TestListRecentSources:
@@ -240,6 +276,81 @@ class TestListRecentSources:
         assert "1. Page 4" in result
         assert "2. Page 3" in result
         assert "3." not in result
+
+    def test_filters_narrows_results_and_total(self, tmp_path: Path) -> None:
+        """filters 指定時に該当レコードのみ返り、総件数も絞り込み後の件数を反映する."""
+        import json
+
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        _register(
+            db, "j/entry1", source_type="journal", title="Entry 1",
+            published_at="2026-01-01T00:00:00Z",
+            meta=json.dumps({"repository": "rag-knowledge"}),
+        )
+        _register(
+            db, "j/entry2", source_type="journal", title="Entry 2",
+            published_at="2026-01-02T00:00:00Z",
+            meta=json.dumps({"repository": "other-repo"}),
+        )
+        _register(
+            db, "j/entry3", source_type="journal", title="Entry 3",
+            published_at="2026-01-03T00:00:00Z",
+            meta=json.dumps({"repository": "rag-knowledge"}),
+        )
+        db.close()
+
+        result = list_recent_sources(
+            str(source_store_dir), "journal", 10,
+            filters={"repository": "rag-knowledge"},
+        )
+        assert "source_type: journal（2件 / 全2件" in result
+        assert "Entry 3" in result
+        assert "Entry 1" in result
+        assert "Entry 2" not in result
+
+    def test_filters_no_match(self, tmp_path: Path) -> None:
+        """filters 指定で該当ソースが0件の場合."""
+        import json
+
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        _register(
+            db, "j/entry1", source_type="journal",
+            meta=json.dumps({"repository": "other-repo"}),
+        )
+        db.close()
+
+        result = list_recent_sources(
+            str(source_store_dir), "journal", 10,
+            filters={"repository": "rag-knowledge"},
+        )
+        assert result == "source_type: journal（0件 / 全0件）"
+
+    def test_filters_none_returns_all(self, tmp_path: Path) -> None:
+        """filters=None は全件返却（既存動作を維持）."""
+        import json
+
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+        db = MetadataDB(source_store_dir / "metadata.db")
+        db.initialize()
+        _register(
+            db, "j/entry1", source_type="journal", title="Entry 1",
+            meta=json.dumps({"repository": "rag-knowledge"}),
+        )
+        _register(db, "j/entry2", source_type="journal", title="Entry 2")
+        db.close()
+
+        result = list_recent_sources(str(source_store_dir), "journal", 10)
+        assert "全2件" in result
 
 
 class TestFormatFileSize:

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -352,6 +352,18 @@ class TestListRecentSources:
         result = list_recent_sources(str(source_store_dir), "journal", 10)
         assert "全2件" in result
 
+    def test_filters_invalid_key_returns_error(self, tmp_path: Path) -> None:
+        """filters のキー名が不正な場合、例外ではなくエラーメッセージを返す."""
+        from rag.rag_knowledge import list_recent_sources
+
+        source_store_dir = self._setup_db(tmp_path)
+
+        result = list_recent_sources(
+            str(source_store_dir), "journal", 10,
+            filters={"repo-name": "test"},
+        )
+        assert "エラー:" in result
+
 
 class TestFormatFileSize:
     """format_file_size のテスト."""


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `rag_list_recent` MCP ツール・CLI `list-recent` コマンドに `filters` パラメータを追加
- `.meta` のカスタムフィールドによる絞り込みが可能に（`key=value` 形式、`rag_search` と同一形式）
- 共通関数 `list_recent_sources()` に `filters` を追加し MetadataDB の `list_sources` / `count_sources_by_type` に伝搬
- 仕様書 `content-listing.md` を更新（パラメータ・バリデーション・エッジケース・データ取得フロー）
- QA スキルに `list-recent --filters` の検証ステップを追加
- filters 関連テストを追加（DB 単体 + 共通関数統合テスト）

## Test plan

- [x] `pytest tests/test_list_recent.py` 全 27 テスト通過
- [x] `ruff check` 違反なし
- [x] `mypy` 型エラーなし
- [x] CLI QA: `list-recent --source-type journal --filters repository=rag-knowledge` で絞り込み動作確認
- [x] CLI QA: `list-recent --source-type zenn --filters content_type=article` で article 55件に絞り込み確認
- [x] CLI QA: `list-recent --source-type zenn --filters content_type=scrap` で scrap 100件に絞り込み確認

## Related issues

Closes #579