### PR TITLE
fix(source-store): list_files から BlueSky 添付メディアを除外 (#577)

### DIFF
--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -79,7 +79,7 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 | ファイル配置 | source_type、ファイルデータ、メタデータ | 配置先パス | source_type に応じたディレクトリにファイルを配置し、.meta を生成する（local 以外） |
 | .meta 読み取り | ファイルパス | メタデータ辞書 | 指定ファイルの .meta サイドカーを YAML として読み取る |
 | .meta 書き込み | ファイルパス、メタデータ辞書 | なし | 指定ファイルの .meta サイドカーを YAML として書き込む |
-| ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを列挙する。source_type 指定時はそのディレクトリのみ。`.meta`、`metadata.db`、`.git/`、`.gitignore`、ロックファイル（`.ingest.lock`、`.rebuild.lock`）は除外する |
+| ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを列挙する。source_type 指定時はそのディレクトリのみ。`.meta`、`metadata.db`、`.git/`、`.gitignore`、ロックファイル（`.ingest.lock`、`.rebuild.lock`）は除外する。BlueSky の `media/` 配下（添付画像・動画）は親投稿の変換時に参照されるため、独立ソースとしては列挙しない |
 | ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。BlueSky 投稿の場合は対応する `media/{rkey}/` サブディレクトリも再帰削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
 | 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。パイプライン制御の内部処理で使用 |
 | 論理削除解除 | source_id | なし | metadata.db のステータスを `active` に戻す |

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -285,6 +286,8 @@ class SourceStore:
         """source_store 内のファイルを列挙する.
 
         .meta ファイル、metadata.db、.git 配下、.gitignore、ロックファイルは除外する。
+        BlueSky の media/ 配下（添付画像・動画）は親投稿の変換時に参照されるため、
+        独立ソースとしては列挙しない。
 
         Args:
             source_type: 指定時はそのディレクトリのみ
@@ -300,12 +303,20 @@ class SourceStore:
         if not search_dir.exists():
             return []
 
-        import os
-
+        is_bluesky = source_type == "bluesky"
         result: list[Path] = []
         for dirpath, dirnames, filenames in os.walk(search_dir):
+            rel_dir = Path(dirpath).relative_to(self._root).as_posix()
             # .git ディレクトリを走査段階で除外（性能最適化）
-            dirnames[:] = [d for d in dirnames if d != ".git"]
+            # BlueSky の media/ ディレクトリも除外（添付メディアは親投稿変換時に参照）
+            dirnames[:] = [
+                d for d in dirnames
+                if d != ".git"
+                and not (
+                    d == "media"
+                    and (is_bluesky or rel_dir.startswith("bluesky/"))
+                )
+            ]
             for fname in filenames:
                 full = Path(dirpath) / fname
                 rel = full.relative_to(self._root)

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -282,6 +282,46 @@ class TestListFiles:
         assert ".rebuild.lock" not in paths
         assert "local/a.md" in paths
 
+    def test_excludes_bluesky_media(self, store: SourceStore) -> None:
+        """BlueSky の media/ 配下はリストに含まれない."""
+        store.place_file(
+            source_type="bluesky",
+            data=b"post",
+            rel_path="bluesky/did/2026/04/rkey1.json",
+            metadata={
+                "source_type": "bluesky",
+                "title": "post",
+                "collected_at": "2026-04-01T00:00:00Z",
+                "at_uri": "at://did/app.bsky.feed.post/rkey1",
+            },
+        )
+        # media/ 配下に画像を直接配置（インジェスターの挙動を模倣）
+        media_dir = store.root_dir / "bluesky" / "did" / "2026" / "04" / "media" / "rkey1"
+        media_dir.mkdir(parents=True, exist_ok=True)
+        (media_dir / "image_0.webp").write_bytes(b"img0")
+        (media_dir / "image_1.jpg").write_bytes(b"img1")
+
+        # source_type 指定なし
+        all_files = store.list_files()
+        all_paths = [f.as_posix() for f in all_files]
+        assert "bluesky/did/2026/04/rkey1.json" in all_paths
+        assert not any("media/" in p for p in all_paths)
+
+        # source_type=bluesky 指定
+        bs_files = store.list_files(source_type="bluesky")
+        bs_paths = [f.as_posix() for f in bs_files]
+        assert "bluesky/did/2026/04/rkey1.json" in bs_paths
+        assert not any("media/" in p for p in bs_paths)
+
+    def test_local_media_dir_not_excluded(self, store: SourceStore) -> None:
+        """local の media/ ディレクトリは除外されない."""
+        store.place_file(
+            source_type="local", data=b"img", rel_path="local/media/photo.jpg",
+        )
+        files = store.list_files()
+        paths = [f.as_posix() for f in files]
+        assert "local/media/photo.jpg" in paths
+
 
 class TestSoftDelete:
     """論理削除テスト."""


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `list_files()` で BlueSky の `media/` 配下（添付画像・動画）を列挙対象から除外
- 二重変換（独立変換 + 親投稿変換時の埋め込み）とインデックス重複を解消
- `import os` をメソッド内からファイル先頭に移動
- 仕様書（source-store.md）にメディア除外の記述を追加
- テスト2件追加（BlueSky media 除外 / local media 非除外）

## Test plan

- [x] pytest 全テストパス（28 passed）
- [x] ruff lint エラーなし
- [x] mypy 型エラーなし
- [x] 本番相当データ（間引き6件）で full rebuild 動作確認済み

## Related issues

Closes #577