### PR TITLE
chore(rag-knowledge): 検索結果件数 (rag_retrieval_count) を 3 → 10 に引き上げ (#578)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ rag_embedding_context_length = 512
 rag_worst_token_char_ratio = 0.7
 
 # 検索
-rag_retrieval_count = 3
+rag_retrieval_count = 10
 # rag_similarity_threshold = (未設定時は None)
 
 # ChromaDB コレクション名


### PR DESCRIPTION
## Change type

- [x] chore: 設定値の変更

## Summary

- `config.toml` の `rag_retrieval_count` を `3` → `10` に変更
- 関連ソースをざっと眺める用途で件数が増えた方が望ましいとの Issue #578 に対応
- 値は既存の pydantic Field (`src/rag/config.py`) で SSoT 管理されており、設定値のみの変更で完結

## Test plan

- [x] 品質チェック通過済み（test-runner）
- [x] pydantic Field 制約 `ge=1` 範囲内であることを確認
- [x] テスト用設定は独立しており、本番 config 変更の影響なし

## Related issues

Closes #578