### PR TITLE
docs(source-store,pipeline-controller,rebuild-stats): ソース列挙経路の一元化と複合ソース概念の導入（フェーズ 1）(#601)

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -6,6 +6,9 @@ BlueSky（AT Protocol）の投稿を API 経由で取得し、source_store に�
 
 インジェスターの責務は「source_store へのファイル配置 + .meta サイドカーファイルの生成」に限定される。テキスト変換・チャンキング・インデックス構築は後続ステージ（コンバーター・インデクサー）が行う。
 
+BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親ソース（独立ソース）、`media/{rkey}/` 配下の画像・動画が attachment（独立ソースではない）として 1 論理ソースを構成する。
+詳細は [source-store.md](../source-store.md) の「用語定義」「複合ソースの構造」を、複合ソース全般のルールは [common.md](common.md) の「複合ソースの attachment 配置ルール」を参照。
+
 スコープ:
 
 - 指定ユーザーの統一タイムラインの取得（投稿・引用リポスト・リポスト・リプライ）
@@ -153,12 +156,32 @@ flowchart TB
 | BlueskyIngester | BlueSky 投稿取り込み用インジェスター。AT Protocol API 経由で投稿を取得し、source_store に JSON ファイルを配置する |
 | ConstrainedClient (py-common-lib) | 全外部 HTTP リクエストのゲートウェイ。ハードリミット・バジェット・サーキットブレーカーを統合する |
 
+### 複合ソース構造
+
+BlueSky 投稿は親ファイル（投稿 JSON）と attachment（画像・動画）からなる複合ソースとして扱われる。
+
+| 要素 | 位置付け | パス規則 | 独立ソース | `.meta` |
+|------|---------|---------|-----------|---------|
+| 投稿 JSON | 親 | `bluesky/{did}/{年}/{月}/{rkey}.json` | はい | `{rkey}.json.meta` に生成 |
+| 画像 | attachment（media） | `bluesky/{did}/{年}/{月}/media/{rkey}/image_N.{ext}` | いいえ | 生成しない |
+| 動画 | attachment（media） | `bluesky/{did}/{年}/{月}/media/{rkey}/video_N.{ext}` | いいえ | 生成しない |
+
+拡張子の決定規則は「メディア DL と配置」セクションを参照（現時点の実装では動画は `.ts` 固定、画像は CDN レスポンスの Content-Type に基づく）。
+
+- **独立ソースは親 JSON のみ**: 変換・インデックスの単位は親 JSON。attachment は [source-store.md](../source-store.md) の `is_source_file` で除外され、独立変換・独立インデックスの対象にならない
+- **attachment → 親の逆引き**: `bluesky/{did}/{年}/{月}/media/{rkey}/...` のパスから親 JSON を計算する resolver を [source-store.md](../source-store.md) の `resolve_attachment_parent` に登録する。
+  親パスは `bluesky/{did}/{年}/{月}/{rkey}.json` となる
+- **親の削除は attachment を伴う**: 親 JSON を削除する場合、対応する `media/{rkey}/` サブディレクトリも再帰削除する（[source-store.md](../source-store.md) のファイル削除仕様参照）
+- **attachment 変更は親の再変換トリガー**: attachment が追加・変更された場合、パイプライン制御が親 JSON を `modified` として処理対象に追加する（[pipeline-controller.md](../pipeline-controller.md) の「ソース列挙経路 > attachment の扱い」参照）
+
 ### source_id（ファイルパス）
 
-source_store 内の相対パスを使用する: `bluesky/{did}/{year}/{month}/{rkey}.json`
+独立ソース（親 JSON）の source_store 内の相対パス: `bluesky/{did}/{year}/{month}/{rkey}.json`
 
 - `did`: `post.author.did` から取得した DID（例: `did:plc:xxx`）。リポストの場合は元投稿者の DID。コロンは全角に置換
 - `rkey`: `post.uri` の末尾パス（`at://did:plc:xxx/app.bsky.feed.post/{rkey}` の `{rkey}` 部分）
+
+attachment（`media/{rkey}/` 配下の画像・動画）は独立ソースではないため source_id を持たない。
 
 AT URI は .meta の `at_uri` フィールドに格納する。AT URI を安定した識別子として .meta に保持する理由:
 
@@ -390,8 +413,8 @@ flowchart TD
 4. ts セグメントを DL し、バイナリ結合（単純連結）して保存する
 
 - Vision 解析用途のため、低画質（BANDWIDTH 最小）のバリアントで十分
-- 保存形式: ts セグメント結合のまま保存（mp4 変換は行わない）
-- ファイル名: `video_0.ts`
+- 保存形式: HLS の ts セグメント結合の場合は `.ts` のまま保存（mp4 変換は行わない）。将来、プレイリスト由来以外の動画形式に対応した場合は CDN レスポンスの Content-Type から決定される拡張子を用いる
+- ファイル名: `video_0.{ext}`, `video_1.{ext}`, ...（0-indexed、拡張子は保存形式に対応。現時点の実装では全動画が `.ts` 固定）
 - HLS 関連リクエスト（プレイリスト取得・セグメント DL）では CDN の 3xx リダイレクトに追従する。ただし SSRF 防止のため、リダイレクト先は元 URL と同一ベースドメイン（eTLD+1 相当）に限定し、異なるドメインへのリダイレクトは拒否する。リダイレクト追従の上限は 5 回
 
 #### メディア配置先
@@ -399,10 +422,12 @@ flowchart TD
 投稿 JSON と同階層の `media/{rkey}/` ディレクトリに配置する:
 
 ```
-{year}/{month}/media/{rkey}/image_0.webp
-{year}/{month}/media/{rkey}/image_1.webp
-{year}/{month}/media/{rkey}/video_0.ts
+{year}/{month}/media/{rkey}/image_0.{ext}
+{year}/{month}/media/{rkey}/image_1.{ext}
+{year}/{month}/media/{rkey}/video_0.{ext}
 ```
+
+画像の拡張子は CDN レスポンスの Content-Type で決定される（通常 `.webp`、他形式もあり得る）。動画の拡張子は現時点の実装で `.ts` 固定。
 
 #### recordWithMedia 時のメディア URL
 

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -169,8 +169,8 @@ BlueSky 投稿は親ファイル（投稿 JSON）と attachment（画像・動�
 拡張子の決定規則は「メディア DL と配置」セクションを参照（現時点の実装では動画は `.ts` 固定、画像は CDN レスポンスの Content-Type に基づく）。
 
 - **独立ソースは親 JSON のみ**: 変換・インデックスの単位は親 JSON。attachment は [source-store.md](../source-store.md) の `is_source_file` で除外され、独立変換・独立インデックスの対象にならない
-- **attachment → 親の逆引き**: `bluesky/{did}/{年}/{月}/media/{rkey}/...` のパスから親 JSON を計算する resolver を [source-store.md](../source-store.md) の `resolve_attachment_parent` に登録する。
-  親パスは `bluesky/{did}/{年}/{月}/{rkey}.json` となる
+- **attachment → 親の逆引き**: `bluesky/{did}/{年}/{月}/media/{rkey}/...` のパスから親 JSON を計算する resolver を [source-store.md](../source-store.md) の `resolve_attachment_parent` 実装内に**静的に組み込む**。
+  実行時の動的登録は行わない（詳細は [common.md](common.md) の「複合ソースの attachment 配置ルール」参照）。親パスは `bluesky/{did}/{年}/{月}/{rkey}.json` となる
 - **親の削除は attachment を伴う**: 親 JSON を削除する場合、対応する `media/{rkey}/` サブディレクトリも再帰削除する（[source-store.md](../source-store.md) のファイル削除仕様参照）
 - **attachment 変更は親の再変換トリガー**: attachment が追加・変更された場合、パイプライン制御が親 JSON を `modified` として処理対象に追加する（[pipeline-controller.md](../pipeline-controller.md) の「ソース列挙経路 > attachment の扱い」参照）
 
@@ -213,6 +213,9 @@ source_store/
             abc456/
               video_0.ts
 ```
+
+上記ツリーは**現行実装の具体例**（画像は CDN が webp を返した場合、動画は HLS ts 結合で保存される場合）である。
+一般形としての attachment ファイル名は `image_N.{ext}` / `video_N.{ext}` であり、拡張子の決定規則は「メディア DL と配置」セクションを参照。
 
 年月の導出: `post.record.createdAt`（投稿日時）から年（4桁）と月（2桁ゼロ埋め）を抽出する。
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -298,10 +298,13 @@ flowchart TB
 - **親ソースは独立ソースのパス規則に従って配置する**: 親ソースは各媒体の source_id 規則に従って配置し、`.meta` サイドカーを同階層に生成する
 - **attachment は親ソースと同じディレクトリ階層に attachment 専用サブディレクトリを作成して配置する**:
   パス規則は `<親ソースが配置されるディレクトリ>/<attachment 種別名>/<親識別子>/<attachment ファイル>`。
-  例（bluesky）: 親ソース `bluesky/{did}/{年}/{月}/{rkey}.json` に対する画像 attachment は `bluesky/{did}/{年}/{月}/media/{rkey}/image_0.webp`（親と同じ `{年}/{月}/` 配下に `media/{rkey}/` サブディレクトリを作成）
+  例（bluesky）: 親ソース `bluesky/{did}/{年}/{月}/{rkey}.json` に対する画像 attachment は `bluesky/{did}/{年}/{月}/media/{rkey}/image_0.{ext}`（親と同じ `{年}/{月}/` 配下に `media/{rkey}/` サブディレクトリを作成）。
+  拡張子は媒体ごとのルールで決定される（bluesky では CDN レスポンスに従い通常 `.webp`）
 - **attachment 自身の `.meta` は生成しない**: メタデータは親ソースの `.meta` に集約する
-- **attachment パスから親パスへの逆引きを実装する**: 各媒体のインジェスターは、attachment パスから親ソースパスを計算する resolver を [source-store.md](../source-store.md) の `resolve_attachment_parent` に登録する。
-  これにより パイプライン制御が attachment の変更を検出した際に、親ソースの再変換トリガーとして解釈できる
+- **attachment パスから親パスへの逆引きを実装する**: 各媒体は attachment パスから親ソースパスを計算する規則を定義し、source_store はその規則を `resolve_attachment_parent` に**静的に保持する**。
+  静的保持とは: プロセス起動時の初期化で一度だけ確定するか、`resolve_attachment_parent` の実装内に固定的に組み込む方式であり、実行時の動的登録・差し替えは行わない。
+  `resolve_attachment_parent` は attachment パスのみを入力として親ソースパスを返す純粋関数であり、入力以外の状態（グローバル変数・設定・登録済み resolver の動的変化など）に依存してはならない。
+  これにより パイプライン制御は attachment の変更検出時に、親ソースの再変換トリガーとして一意に解釈できる
 
 現時点で複合ソース構造を持つ媒体は BlueSky（投稿 JSON + `media/{rkey}/`）のみ。将来、他媒体で attachment 構造を追加する場合も本ルールに従う。
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -291,6 +291,20 @@ flowchart TB
 
 生成タイミング: データファイルの配置直後に同階層に .meta を生成する。正常時はデータファイルと .meta がペアで存在する。.meta の書き込みに失敗した場合は欠落し得る（フォールバック動作は [source-store.md](../source-store.md) のエッジケースに定義済み）。
 
+### 複合ソースの attachment 配置ルール
+
+複数のファイルを 1 つの論理ソースとして扱う媒体（複合ソース、[source-store.md](../source-store.md) の「用語定義」参照）では、親ソースと attachment を以下のルールで配置する。
+
+- **親ソースは独立ソースのパス規則に従って配置する**: 親ソースは各媒体の source_id 規則に従って配置し、`.meta` サイドカーを同階層に生成する
+- **attachment は親ソースと同じディレクトリ階層に attachment 専用サブディレクトリを作成して配置する**:
+  パス規則は `<親ソースが配置されるディレクトリ>/<attachment 種別名>/<親識別子>/<attachment ファイル>`。
+  例（bluesky）: 親ソース `bluesky/{did}/{年}/{月}/{rkey}.json` に対する画像 attachment は `bluesky/{did}/{年}/{月}/media/{rkey}/image_0.webp`（親と同じ `{年}/{月}/` 配下に `media/{rkey}/` サブディレクトリを作成）
+- **attachment 自身の `.meta` は生成しない**: メタデータは親ソースの `.meta` に集約する
+- **attachment パスから親パスへの逆引きを実装する**: 各媒体のインジェスターは、attachment パスから親ソースパスを計算する resolver を [source-store.md](../source-store.md) の `resolve_attachment_parent` に登録する。
+  これにより パイプライン制御が attachment の変更を検出した際に、親ソースの再変換トリガーとして解釈できる
+
+現時点で複合ソース構造を持つ媒体は BlueSky（投稿 JSON + `media/{rkey}/`）のみ。将来、他媒体で attachment 構造を追加する場合も本ルールに従う。
+
 ### 重複検出方式
 
 インジェスターは metadata.db に依存せず、ファイルシステムのみで重複を検出する。

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -280,9 +280,10 @@ sequenceDiagram
 いずれの経路も `is_source_file == False` のファイルを処理対象から除外する。除外対象には以下が含まれる:
 
 - `.meta` サイドカー（任意階層）
-- `/metadata.db*`・`.git/`・`/.gitignore`・`/.ingest.lock`・`/.rebuild.lock`（ルート直下のロック・管理ファイル）
+- `/metadata.db*`・`/.gitignore`・`/.ingest.lock`・`/.rebuild.lock`（ルート直下のロック・管理ファイル）
+- `.git/`（任意階層の `.git` ディレクトリ配下）
 - `/aozora/catalog.csv`・`/aozora/catalog.csv.meta`（aozora sidecar）
-- `.DS_Store`・`Thumbs.db`・`desktop.ini`（OS 生成ファイル）
+- `.DS_Store`・`Thumbs.db`・`desktop.ini`（OS 生成ファイル、任意階層）
 - 複合ソースの attachment（`resolve_attachment_parent` で親に解決されるパス）
 
 除外対象の全リストとパターン定義は [source-store.md](source-store.md) の「ソース判定 > 除外対象」を参照（SSoT）。

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -138,7 +138,9 @@ git diff から取得する変更ファイルリストの各エントリが持�
 3. `last_commit_id` が null commit hash（初回）の場合は全ファイルを対象とする。通常のコミット ID の場合は `git diff` で変更ファイルを取得する
 4. ネット差分で検出されない中間変更を補完する。`git log --name-only` で中間コミットの全触ファイルを取得し、ネット差分に含まれないが HEAD に存在するファイルを `modified` として追加する。HEAD に存在しないファイル（一時的に追加→削除）は除外する
 5. 変更ファイルがなければ終了する
-6. 変更ファイルを種別（追加・変更 / 削除）ごとに分類する。BlueSky の `bluesky/.../media/{rkey}/` 配下のファイルが追加・変更された場合、media 自身は独立 ChangeEntry として登録せず、対応する親ファイル（`{rkey}.json`）のみを `modified` として処理対象に追加する（詳細はエッジケース表を参照）
+6. 変更ファイルを種別（追加・変更 / 削除）ごとに分類する。
+   複合ソースの attachment（例: `bluesky/.../media/{rkey}/` 配下）が追加・変更された場合、attachment 自身は独立 ChangeEntry として登録しない。
+   [source-store.md](source-store.md) の `find_existing_parent` で親ソースを解決し、親ソースのみを `modified` として処理対象に追加する（詳細はエッジケース表を参照）
 7. 追加・変更ファイルはコンバーターで変換後、インデクサーでインデックスに追加・更新する
 8. 削除ファイルはインデクサーでインデックスから削除し、metadata.db で論理削除する
 9. `pipeline_history` に実行履歴を追加する
@@ -261,17 +263,41 @@ sequenceDiagram
 
 変換不要なファイル（md/txt/adoc）はコンバーターが source_store から converted_store にそのままコピーする。これによりインデクサーは常に converted_store のみを参照すればよく、フォールバックロジックは不要。
 
-### パイプライン処理対象外ファイル
+### ソース列挙経路
 
-source_store 内の以下のファイルは、git diff で検出されてもパイプライン処理をスキップする。
+パイプライン制御と CLI `rag_stats` は、4 つの実装と 1 つの再利用の計 5 経路で source_store 内のソースを列挙する。
+除外判定（sidecar、ロックファイル、OS 生成ファイル、複合ソースの attachment 等）はすべて [source-store.md](source-store.md) の `is_source_file` に一元化する（SSoT）。
+各経路は列挙元のファイル一覧を `is_source_file` でフィルタしてから後続処理に渡す。
 
-| ファイル | 理由 |
-|---------|------|
-| `.gitignore` | git メタデータ |
-| `.ingest.lock` | インジェスト排他制御用ロックファイル |
-| `.rebuild.lock` | 再構築排他制御用ロックファイル |
-| `aozora/catalog.csv` | 青空文庫カタログ（検索用、インデックス対象外） |
-| `aozora/catalog.csv.meta` | カタログのメタデータ |
+| # | 経路 | 使用箇所 | 列挙元 |
+|---|------|----------|--------|
+| 1 | `source_store.list_files()` | 全再構築 / コンバートのみ再実行 / インデックスのみ再構築 | ファイルシステム走査 |
+| 2 | `_scan_all_as_added()` | 差分更新の初回（`last_commit_id` が null commit hash） | `git ls-tree HEAD` |
+| 3 | `_classify_changes()` | 差分更新（`git diff`） | `git diff --name-status` |
+| 4 | `_supplement_hidden_changes()` | 差分更新の中間コミット補完 | `git log --name-only` |
+| 5 | `run_stats()` | CLI / MCP `rag_stats` | `source_store.list_files()`（経路 1 を再利用） |
+
+いずれの経路も `is_source_file == False` のファイルを処理対象から除外する。除外対象には以下が含まれる:
+
+- `.meta` サイドカー（任意階層）
+- `/metadata.db*`・`.git/`・`/.gitignore`・`/.ingest.lock`・`/.rebuild.lock`（ルート直下のロック・管理ファイル）
+- `/aozora/catalog.csv`・`/aozora/catalog.csv.meta`（aozora sidecar）
+- `.DS_Store`・`Thumbs.db`・`desktop.ini`（OS 生成ファイル）
+- 複合ソースの attachment（`resolve_attachment_parent` で親に解決されるパス）
+
+除外対象の全リストとパターン定義は [source-store.md](source-store.md) の「ソース判定 > 除外対象」を参照（SSoT）。
+
+#### attachment の扱い
+
+複合ソースの attachment（bluesky media 等）は `is_source_file` で除外されるが、attachment の追加・変更は親ソースの再変換トリガーとして扱う必要がある。
+経路 3（`_classify_changes`）では attachment 変更を検出した場合、`find_existing_parent` で親ソースを解決し、親ソースを `modified` の ChangeEntry として処理対象に追加する。
+この挙動は [source-store.md](source-store.md) の「複合ソースの構造」契約（attachment の変更は親の再変換を伴う）を実装する。
+
+#### invariant（呼び出し順序）
+
+`is_source_file == True` を通過したファイルのみを下流処理（`detect_source_type` / コンバーター / インデクサー）に渡す。
+この invariant により、下流処理は未知パスや attachment を考慮しなくてよい。
+違反時の挙動は [source-store.md](source-store.md) の「ソース判定 > invariant」を参照。
 
 ### 変更種別と処理の対応
 
@@ -313,7 +339,8 @@ source_store 内の以下のファイルは、git diff で検出されてもパ�
 | 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | エラーとして再構築を拒否する |
 | 差分更新時に source_store に未コミットの変更がある場合 | 自動コミットを実行してから差分更新を続行する |
 | 差分更新の自動コミット時に git commit が失敗した場合 | エラーとして差分更新を拒否する（コミット失敗の原因をエラーメッセージに含める） |
-| BlueSky `bluesky/.../media/{rkey}/` 配下のファイルが追加・変更された場合 | 対応する親 JSON（`{rkey}.json`）のみを `modified` として処理対象に追加する。media ファイル自体は独立 ChangeEntry として登録しない（媒体 JSON の変換時に参照される添付ファイルで、独立変換すると二重変換になるため。[source-store.md](source-store.md) のファイル一覧仕様と同じ方針）。親 JSON が source_store に存在しない孤児 media の場合は何も処理しない |
+| 複合ソースの attachment が追加・変更された場合 | [source-store.md](source-store.md) の `find_existing_parent` で親ソースを解決し、親ソースのみを `modified` として処理対象に追加する。attachment ファイル自体は独立 ChangeEntry として登録しない（変換時に親から参照される添付ファイルで、独立変換すると二重変換になるため）。親ソースが source_store に存在しない孤児 attachment の場合は何も処理しない |
+| 複合ソースの attachment のみが削除された場合（親ソースは残存） | `find_existing_parent` で親ソースを解決し、親ソースを `modified` として処理対象に追加する（attachment 追加・変更と対称）。これにより、削除後の attachment 構成に従って親ソースが再変換される（削除された attachment への参照は消える）。attachment 自体は独立 ChangeEntry として登録しない。親ソースが source_store に存在しない（親と attachment が同時削除された）場合は、親ソース自体の削除 ChangeEntry によりインデックスからも除去されるため、attachment 側は何も処理しない |
 
 ### 設定項目
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -199,10 +199,23 @@ CLI は `--output json` 指定時にこの callback 内で進捗 JSON を stdout
 
 | 項目 | 内容 |
 |------|------|
-| 総ファイル数 | source_store 内のデータファイル数（`.meta` ファイルを除く） |
-| 総サイズ | 全データファイルの合計サイズ |
-| 媒体別ファイル数 | `source_type` ごとのファイル数 |
+| 総ファイル数 | source_store 内の独立ソース数（[source-store.md](source-store.md) の `is_source_file` で `True` と判定されたファイルのみをカウント。`.meta` サイドカー・ロックファイル・OS 生成ファイル・複合ソースの attachment は除外される） |
+| 総サイズ | 全独立ソースの合計サイズ |
+| 媒体別ファイル数 | `source_type` ごとの独立ソース数 |
 | 媒体別サイズ | `source_type` ごとの合計サイズ |
+
+##### 件数の妥当性要件
+
+`rag_stats` が表示する件数は他のパイプライン経路（全再構築・差分更新等）と同じ除外判定を適用しなければならない。`rag_stats` の列挙経路（`run_stats`）は [pipeline-controller.md](pipeline-controller.md) の「ソース列挙経路」5 経路のうちの 1 つであり、他の経路と共通の `is_source_file` を使用する。
+
+以下は `source_type` フィルタを同条件で適用した場合に成立する件数一致である:
+
+- フィルタなしの `rag_stats` と `rag_rebuild --mode full`（`source_type` 指定なし）が対象とする総ファイル数は一致する
+- `source_type={T}` を指定した `rag_stats` の媒体別件数と、`rag_rebuild --mode full --source-type {T}` が対象とするファイル数は一致する
+- `rag_stats` が表示する媒体別件数は各 `source_type` ディレクトリ配下の独立ソース数と一致する（attachment・sidecar は含まない）
+- ロックファイル（`.ingest.lock`・`.rebuild.lock`）・`aozora/catalog.csv`・複合ソースの attachment は `rag_stats` に現れない
+
+5 経路の詳細・除外判定の SSoT は [pipeline-controller.md](pipeline-controller.md) の「ソース列挙経路」および [source-store.md](source-store.md) の「ソース判定」を参照。
 
 #### converted_store 統計
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -263,7 +263,8 @@ flowchart TD
   bluesky の統合方式（`<image:N>` / `<video:N>` タグ埋め込み）の詳細は [converter.md](converter.md) の「BlueSky 投稿のメディア解析」セクションを参照。メディア解析モジュール自体の仕様は [infrastructure/media-analysis.md](infrastructure/media-analysis.md) を参照
 - **親の削除は attachment を伴う**: 親ソースの削除時、関連する attachment ディレクトリも再帰削除される
 
-attachment を伴う媒体は `resolve_attachment_parent` に source_type ごとの resolver を登録する方式で拡張する。現時点で複合ソースを持つ媒体は bluesky のみ。将来 zenn/YouTube 等で attachment 構造が必要になった場合、対応する resolver を追加することで同じ契約を満たす。
+attachment を伴う媒体は `resolve_attachment_parent` の実装内に source_type ごとの resolver を**静的に組み込む**方式で拡張する（実行時の動的登録・差し替えは行わない。詳細は [ingesters/common.md](ingesters/common.md) の「複合ソースの attachment 配置ルール」参照）。
+現時点で複合ソースを持つ媒体は bluesky のみ。将来 zenn/YouTube 等で attachment 構造が必要になった場合、対応する resolver を実装内に追加することで同じ契約を満たす。
 
 ### converted_store のディレクトリ構成
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -13,6 +13,8 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 - metadata.db によるメタデータの索引
 - source_id の決定規則
 - URL とファイルパスの双方向変換
+- ソース判定述語（`is_source_file`）とソース種別判定（`detect_source_type`）の提供
+- 複合ソースの親・attachment 対応関係の解決（`resolve_attachment_parent` / `find_existing_parent`）
 - 削除（物理削除 + 論理削除）
 
 スコープ外:
@@ -20,6 +22,18 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 - converted_store の管理（コンバーター仕様の範疇）
 - git 操作の実行（パイプライン制御の範疇）
 - 検索インデックスの構築・更新（インデクサーの範疇）
+
+## 用語定義
+
+| 用語 | 意味 |
+|------|------|
+| 単純ソース | 1 ファイル = 1 独立ソースとして扱われる通常のファイル（local の Markdown、zenn の JSON 等） |
+| 複合ソース | 親ソースと attachment の集合からなる 1 論理ソース（例: bluesky 投稿 JSON + `media/{rkey}/` 配下の画像・動画） |
+| 親ソース | 複合ソースにおける独立ソースにあたるファイル。媒体により「親ファイル」「親 JSON」と呼ぶこともあるが、本仕様書では「親ソース」を正式名称とする |
+| attachment | 親ソースに付随し、単独では独立ソースとならないファイル（汎用語） |
+| media | bluesky の attachment 固有の呼称（画像・動画ファイル） |
+| 独立ソース | 変換・インデックスの単位として扱われるファイル。単純ソースおよび複合ソースの親ソースが該当する。attachment は独立ソースではない |
+| sidecar | 特定の独立ソースに付随するメタデータファイル（`.meta`）、または特定インジェスターの内部参照ファイル（例: `aozora/catalog.csv`）。独立ソースではない |
 
 ## 背景
 
@@ -72,15 +86,86 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 
 ## インターフェース
 
+### ソース判定
+
+source_store 層は「このファイルは独立ソースか？」「どの source_type に属するか？」「複合ソースの attachment なら親はどれか？」の判定をアプリケーション全体に提供する。これらの述語・関数は source_store を SSoT とし、パイプライン制御・CLI・コンバーター等の全呼び出し元がこの層を経由して判定する。
+
+| 関数 | 入力 | 出力 | 振る舞い |
+|------|------|------|---------|
+| `is_source_file` | 相対パス（source_store ルート基準） | `bool` | 相対パスが独立ソースに該当するかを判定する。除外対象（sidecar、ロックファイル、OS 生成ファイル、複合ソースの attachment 等）に該当する場合は `False`、独立ソースに該当する場合は `True` を返す |
+| `resolve_attachment_parent` | 相対パス | 親ソース相対パス / `None` | **純粋関数**。attachment 形式のパスから対応する親ソースの相対パスを計算する。attachment パターンに該当しない場合は `None` を返す。ファイル存在確認は行わない |
+| `find_existing_parent` | 相対パス | 親ソース相対パス / `None` | **IO 付き関数**。`resolve_attachment_parent` を呼び、親ソースが source_store 上に実在する場合のみパスを返す。親が存在しない（孤児 attachment）場合は `None` を返す。incremental diff の `_classify_changes` 等、親実在を前提に処理を振り分ける経路で使用する |
+| `detect_source_type` | 相対パス | `SourceType` | 相対パスの先頭ディレクトリから source_type を判定する。先頭ディレクトリが [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` 値のいずれにも一致しない場合は `ValueError` を送出する |
+
+#### invariant（不変条件）
+
+以下を invariant として宣言し、全呼び出し元はこの前提で動作する:
+
+> **`is_source_file(rel_path) == True` のとき、`detect_source_type(rel_path)` は必ず `SourceType` を返す（`ValueError` を送出しない）**
+
+この invariant により、`is_source_file` を通過したファイルのみを `detect_source_type` / コンバーター / インデクサーに渡す運用が安全となる。
+万一 invariant が破れた場合（`is_source_file` の除外漏れ等）、`ValueError` は上位に伝播し処理結果サマリの errors に計上される（契約違反のバグとして可視化）。
+下位層での `try/except ValueError` による無視は禁止する。
+
+#### 除外対象（`is_source_file` が `False` を返す対象）
+
+以下のパターンに該当するファイルを独立ソースから除外する。パターンは [pathspec](https://pypi.org/project/pathspec/) の gitignore 形式で表現する。
+
+```
+# .meta サイドカー
+*.meta
+
+# SQLite 管理ファイル
+/metadata.db*
+
+# Git・ロックファイル
+/.gitignore
+/.ingest.lock
+/.rebuild.lock
+.git/
+
+# 青空文庫カタログ（aozora インジェスターの内部参照ファイル。sidecar 扱い）
+/aozora/catalog.csv
+/aozora/catalog.csv.meta
+
+# OS 生成ファイル
+.DS_Store
+Thumbs.db
+desktop.ini
+```
+
+加えて、`resolve_attachment_parent(rel_path) is not None` のとき（すなわち attachment と判定される場合）も除外する。
+
+**パターンの意味**（pathspec anchoring）:
+
+- 先頭 `/` でルート直下限定にアンカリングする。
+  例: `/.gitignore` はルート直下の `.gitignore` のみを除外し、ユーザー文書内の同名ファイル（`local/myproject/.gitignore`）は独立ソースとして扱う。
+  上記パターンでは `/metadata.db*` / `/.gitignore` / `/.ingest.lock` / `/.rebuild.lock` / `/aozora/catalog.csv(.meta)` が該当
+- 末尾 `/` でディレクトリ配下を表現する（例: `.git/` は任意階層の `.git` ディレクトリ配下を除外）
+- アンカーなしパターンは任意階層でファイル名マッチする。上記パターンでは `*.meta` / `.DS_Store` / `Thumbs.db` / `desktop.ini` が該当
+
+**設計判断（採用しないアプローチ）**:
+
+- 「`.` 始まりの包括除外」は採用しない。実運用パスの多くで効果が薄く、`.upload/` のような意図した独立配置を誤除外するリスクがあるため
+
+#### 既知の制約
+
+以下のパスは `is_source_file` で除外されず、ユーザーが `.gitignore` 等の運用で排除する前提とする:
+
+- サポート外拡張子のファイル（例: `local/foo.pyc`、`local/node_modules/` 配下の JS ファイル等）
+- OS 隠しファイルの `.DS_Store` 以外の亜種（例: macOS の `._` 始まりファイル）
+
+これらは独立ソースとして列挙されるが、後続のコンバーターで「未対応拡張子」としてスキップされるか、あるいは誤って取り込まれる可能性がある。運用側で source_store に配置しないことで予防する。
+
 ### ストア操作
 
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
-| ファイル配置 | source_type、ファイルデータ、メタデータ | 配置先パス | source_type に応じたディレクトリにファイルを配置し、.meta を生成する（local 以外） |
+| ファイル配置 | source_type、ファイルデータ、メタデータ | 配置先パス | source_type に応じたディレクトリにファイルを配置し、.meta を生成する（local 以外）。独立ソースの配置のみを受け付け、`is_source_file` が `False` を返すパス（例: `.DS_Store`）は拒否する。複合ソースの attachment（例: bluesky の `media/{rkey}/` 配下）は本操作の対象外であり、各媒体のインジェスターが独自のパス規則で配置する |
 | .meta 読み取り | ファイルパス | メタデータ辞書 | 指定ファイルの .meta サイドカーを YAML として読み取る |
 | .meta 書き込み | ファイルパス、メタデータ辞書 | なし | 指定ファイルの .meta サイドカーを YAML として書き込む |
-| ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを列挙する。source_type 指定時はそのディレクトリのみ。`.meta`、`metadata.db`、`.git/`、`.gitignore`、ロックファイル（`.ingest.lock`、`.rebuild.lock`）は除外する。BlueSky の `media/` 配下（添付画像・動画）は親投稿の変換時に参照されるため、独立ソースとしては列挙しない |
-| ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。BlueSky 投稿の場合は対応する `media/{rkey}/` サブディレクトリも再帰削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
+| ファイル一覧 | source_type（任意） | ファイルパスのリスト | source_store 内のファイルを走査し、`is_source_file` で `True` と判定された独立ソースのみを列挙する。source_type 指定時はそのディレクトリのみ対象。除外されるファイル（sidecar、attachment、ロックファイル等）は「ソース判定 > 除外対象」を参照 |
+| ファイル削除 | source_id | なし | source_id に対応するファイルと .meta サイドカーをディスクから削除する。複合ソースの親（例: BlueSky 投稿 JSON）を削除する場合、対応する attachment ディレクトリ（例: `media/{rkey}/`）も再帰削除する。metadata.db の更新は行わない（パイプライン制御が git diff 経由で処理する）。呼び出し後にパイプライン制御の取り込み実行（[pipeline-controller.md](pipeline-controller.md) 参照）を実行することで、git commit → パイプラインによる論理削除・インデックス削除が行われる |
 | 論理削除 | source_id | なし | metadata.db のステータスを `deleted` に変更する。パイプライン制御の内部処理で使用 |
 | 論理削除解除 | source_id | なし | metadata.db のステータスを `active` に戻す |
 | ファイル取得 | source_id | ファイルデータ + メタデータ / `None` | source_id に対応するファイルと .meta を返す。物理削除済み（ファイル欠落）の場合は警告ログを出力して `None` を返す（復元が必要な場合は source_store の git リポジトリから `git checkout` で復元する） |
@@ -131,8 +216,12 @@ flowchart TD
     BS --> BS_DID["did：plc：xxx/"]
     BS_DID --> BS_YEAR["2026/"]
     BS_YEAR --> BS_MONTH["03/"]
-    BS_MONTH --> BS_POST["rkey.json"]
+    BS_MONTH --> BS_POST["rkey.json（親・独立ソース）"]
     BS_MONTH --> BS_POST_META["rkey.json.meta"]
+    BS_MONTH --> BS_MEDIA["media/"]
+    BS_MEDIA --> BS_MEDIA_RKEY["rkey/"]
+    BS_MEDIA_RKEY --> BS_IMG["image_0.webp（attachment・例）"]
+    BS_MEDIA_RKEY --> BS_VID["video_0.ts（attachment・例）"]
     ZENN --> Z_USER["username/"]
     Z_USER --> Z_ART["articles/"]
     Z_USER --> Z_SCR["scraps/"]
@@ -141,7 +230,7 @@ flowchart TD
     YT --> YT_CH["{channel_id}/"]
     YT_CH --> YT_VID["{video_id}.json"]
     YT_CH --> YT_VID_META["{video_id}.json.meta"]
-    AZ --> AZ_CAT["catalog.csv"]
+    AZ --> AZ_CAT["catalog.csv（sidecar）"]
     AZ --> AZ_CAT_META["catalog.csv.meta"]
     AZ --> AZ_PERSON["{person_id}/"]
     AZ_PERSON --> AZ_BOOK["{book_id}.html"]
@@ -156,11 +245,25 @@ flowchart TD
 - **.git/**: git リポジトリ管理ディレクトリ
 - **local/**: ユーザーが手動で自由にファイル・フォルダを配置する領域
 - **web/**: site_ingest が URL ベースのパス構成で自動配置
-- **bluesky/**: BlueSky インジェスターが DID + 年月で階層化して自動配置
+- **bluesky/**: BlueSky インジェスターが DID + 年月で階層化して自動配置。投稿 JSON が親ソース（独立）で、`media/{rkey}/` 配下の画像・動画が attachment（独立ソースではない）。両者を合わせて 1 つの複合ソースを構成する
 - **zenn/**: Zenn インジェスターがユーザー名 + コンテンツ種別（articles/scraps）で階層化して自動配置
 - **youtube/**: YouTube インジェスターがチャンネル ID で階層化して自動配置
-- **aozora/**: 青空文庫インジェスターがカタログ + 著者 ID で階層化して自動配置
+- **aozora/**: 青空文庫インジェスターが著者 ID で階層化して自動配置。`aozora/catalog.csv` は aozora インジェスター内部の参照ファイル（sidecar）であり、独立ソースではない
 - **journal/**: Journal インジェスターがリポジトリ名で階層化して自動配置
+
+### 複合ソースの構造
+
+複合ソースは「親ソース + 1 つ以上の attachment」からなる 1 論理ソースである。以下の契約を満たす:
+
+- **親のみが独立ソース**: 変換・インデックスの単位は親ソース。attachment は `is_source_file` で除外され、独立ソースとしては列挙されない
+- **attachment のパスから親を逆引き可能**: `resolve_attachment_parent` が純粋関数として attachment パス → 親ソースパスを計算する
+- **attachment の内容は親の変換時に参照され、親の変換結果に統合される**:
+  コンバーターは親ソースを変換する際、関連する attachment（画像・動画等）をメディア解析モジュール（LM Studio Vision）でテキスト化し、親ソースの変換結果に埋め込み統合する。
+  attachment 単体の変換結果は converted_store に独立出力されない（converted_store に現れるのは親ソース 1 ファイルの変換結果のみ）。
+  bluesky の統合方式（`<image:N>` / `<video:N>` タグ埋め込み）の詳細は [converter.md](converter.md) の「BlueSky 投稿のメディア解析」セクションを参照。メディア解析モジュール自体の仕様は [infrastructure/media-analysis.md](infrastructure/media-analysis.md) を参照
+- **親の削除は attachment を伴う**: 親ソースの削除時、関連する attachment ディレクトリも再帰削除される
+
+attachment を伴う媒体は `resolve_attachment_parent` に source_type ごとの resolver を登録する方式で拡張する。現時点で複合ソースを持つ媒体は bluesky のみ。将来 zenn/YouTube 等で attachment 構造が必要になった場合、対応する resolver を追加することで同じ契約を満たす。
 
 ### converted_store のディレクトリ構成
 
@@ -181,8 +284,12 @@ source_store 層では `file_path` として、metadata_db 以上の層では `s
 | bluesky | `bluesky/{escaped_did}/{年}/{月}/{rkey}.json` | `bluesky/did：plc：xxx/2026/03/rkey.json` |
 | zenn | `zenn/{username}/{articles\|scraps}/{slug}.json` | `zenn/alice/articles/sample-article.json` |
 | youtube | `youtube/{channel_id}/{video_id}.json` | `youtube/UCxxxxxxxx/xxxxxxxxxxx.json` |
-| aozora | `aozora/{person_id}/{book_id}.html` / `aozora/catalog.csv` | `aozora/000035/001567.html` |
+| aozora | `aozora/{person_id}/{book_id}.html` | `aozora/000035/001567.html` |
 | journal | `journal/{repository}/{entry_id}.md` | `journal/rag-knowledge/20260323-143000-session-summary.md` |
+
+`aozora/catalog.csv` は aozora インジェスター内部で参照される検索用カタログファイルであり、独立ソースではない（sidecar 扱い）。source_id テーブルに登場しないため、変換・インデックス対象にもならない。aozora インジェスターでの位置付けは [ingesters/aozora.md](ingesters/aozora.md) を参照。
+
+bluesky の attachment（`bluesky/{did}/{年}/{月}/media/{rkey}/` 配下）は独立ソースではないため source_id を持たない。attachment パスから親ソース（`{rkey}.json`）の source_id への逆引きは `resolve_attachment_parent` / `find_existing_parent`（「ソース判定」セクション参照）で行う。
 
 元 URL は .meta の `url` フィールド（web, zenn, youtube, aozora, bluesky）に保持される。bluesky は追加で `at_uri` フィールド（AT Protocol 識別子）も持つ。これらは検索インデックスでは `custom:url` / `custom:at_uri` のメタデータキーとして保持される。
 


### PR DESCRIPTION
## Change type

- [x] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）★

本 PR は Issue #601 の 2 フェーズ分割における**フェーズ 1（仕様書改訂）**。実装コードの変更は含まず、後続のフェーズ 2 PR で実装する。現在のコードとの不整合は意図的。

## Summary

Issue #597 / #598 / #599 で露呈した「ソース列挙が 5 経路に分散し除外ロジックが散在する構造問題」を解消するため、仕様書を先行改訂した。

- **source-store.md**: 用語定義（単純ソース / 複合ソース / 親ソース / attachment / media / 独立ソース / sidecar）、ソース判定インターフェース 4 関数（`is_source_file` / `resolve_attachment_parent` / `find_existing_parent` / `detect_source_type`）と invariant、pathspec 形式の除外対象定義、複合ソースの構造契約を追加。source_id テーブルから `aozora/catalog.csv` を削除し sidecar として再定義
- **pipeline-controller.md**: 5 経路 SSoT テーブル（`list_files` / `_scan_all_as_added` / `_classify_changes` / `_supplement_hidden_changes` / `run_stats`）を追加し、除外判定を `is_source_file` に一元化。attachment 削除時の挙動（親の `modified` トリガー化）を明記
- **ingesters/common.md**: 複合ソースの attachment 配置ルールを追加
- **ingesters/bluesky.md**: 複合ソース構造テーブル、media 動画拡張子を `video_N.{ext}` に抽象化
- **rebuild-stats.md**: stats 件数の妥当性要件を明記（`--source-type` フィルタ条件込み）

## Test plan

- [x] markdownlint 通過
- [x] md-mermaid-lint 通過
- [x] GitHub mermaid 互換チェック通過
- [x] doc-reviewer レビュー完了（要修正 6 件反映、要相談 3 件ユーザー確認済み）

## Related issues

フェーズ 1（本 PR）完了基準を満たす。Phase 2 実装 PR は後続で別途起票。

Refs #601（Close はフェーズ 2 PR で行う）