### PR TITLE
fix(pipeline-controller,rebuild-stats,ingesters/common): PR #596 観測性機能を production 出力経路に届ける (#602)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -29,6 +29,7 @@ QA 検証グループ:
   F) Upload   — HTTP Upload API（HTTP モード固定）
   G) Eval     — init-test-db, evaluate（フィクスチャ必要）
   H) Core     — stats, list-recent, search, get-document, delete, rebuild
+  I) Obs      — 観測性（構造化エラー情報・exit code 体系の検証）
 
 どのグループを検証しますか？（例: A B D, all）
 ```
@@ -372,6 +373,26 @@ A〜G の取り込みデータを使ってパイプライン基盤を検証す�
 MCP 対応: `rag_stats` / `rag_list_recent` (+ filters) / `rag_search` / `rag_get_document` / `rag_delete` / `rag_rebuild`
 
 > MCP `rag_list_recent` の filters 確認: `rag_list_recent(source_type="journal", filters="repository=rag-knowledge")` で journal がリポジトリ名で絞り込まれること。
+
+### I) Obs（観測性）
+
+PR #596 の観測性機能（構造化エラー情報）が production 出力経路（CLI JSON / MCP レスポンス）に届いていることを検証する。
+仕様: [docs/specs/pipeline-controller.md](../../../docs/specs/pipeline-controller.md) の `PipelineSummary.errors`。
+
+> **TODO:#605** exit code 体系（`echo $?` での判定）および MCP 応答経路との整合は #605 で設計確定後に追加する。
+
+#### グループ準備
+
+1. 事前に何らかのインジェストを実行し、source_store を非空にしておく（グループ A や C の実行後を想定）
+2. 壊れた JSON を投入するための `source_store/zenn` ディレクトリが存在することを確認する
+
+| # | コマンド（CLI） | 期待結果 | 検証種別 |
+|---|----------------|---------|---------|
+| 1 | 壊れた JSON を `<SOURCE_STORE_DIR>/zenn/obs_test/articles/broken.json` に配置（`echo '<!DOCTYPE html>' > …`）し、source_store で `git add -A && git commit` | 壊れた JSON の配置・コミットが成功 | `none` |
+| 2 | `rebuild --mode incremental --output json` を実行し、最終 JSON 行を `tail -1 \| jq '.errors'` で確認 | JSON 出力の `errors` が構造化 dict のリストで、`path` / `size_bytes` / `message` / `phase` を含む | `none` |
+| 3 | 壊れた JSON を削除し source_store で `git add -A && git commit` | 片付け成功 | `none` |
+
+MCP 対応: ステップ 2 は `rag_rebuild(mode="incremental")` のレスポンステキストに `path`・`size_bytes`・`message`・`phase` が含まれることで確認する（CLI JSON → MCP テキスト変換経路の動作確認）。
 
 ### 7. クリーンアップ
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -150,6 +150,14 @@ ConstrainedClient はサーキットブレーカーの責務（HTTP レスポン
 
 **Why**: `error_details` は運用者の目視だけでなくスケジューラや再取り込みツールが機械的に処理できる形を要求されるため、構造化 dict としている。`category` を固定列挙にすることで、再取り込み方針（`media_download` は force 再取得で回復、`metadata_fetch` は原因調査が必要、等）の自動判定が可能になる。
 
+##### JSON シリアライズ
+
+CLI `--output json` および MCP レスポンスでは、`IngestResult` の観測性フィールドを欠落なく JSON に含めなければならない。
+スケジューラや再取り込みツールが親失敗・部分失敗・中断を独立して判定できるよう、
+`placed` / `skipped` / `overwritten` / `errors` / `error_details` /
+`partial_failures` / `partial_failure_details` / `aborted` / `abort_reason`
+の全項目をゼロ値・空リスト・`None` も省略せず常に出力する。
+
 #### 中断系エラーの扱い
 
 中断系エラー（回復不能な処理停止）は以下のように扱う:

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -61,10 +61,32 @@
 | `mode` | str | 実行モード（`incremental`, `convert`, `index`） |
 | `total_files` | int | 処理対象ファイル総数 |
 | `processed` | int | 正常処理されたファイル数 |
-| `errors` | list[str] | 予期しない例外が発生したファイルパスのリスト |
+| `errors` | list[dict] | 予期しない例外が発生したファイルの構造化詳細（スキーマは下記） |
 | `warnings` | list[str] | 非致命的スキップの詳細リスト（ファイルパス + 理由） |
 | `from_commit_id` | str | 処理開始時点のコミット ID |
 | `to_commit_id` | str | 処理終了時点のコミット ID |
+
+`errors` の各エントリは `PipelineErrorEntry` TypedDict で定義されたスキーマに従う。path 文字列のみを返す `failed_paths()` アクセサも併せて提供する。
+
+| フィールド | 型 | 必須 | 内容 |
+|---|---|:-:|---|
+| `path` | str | 必須 | エラー発生ファイルの rel_path |
+| `size_bytes` | int \| None | 必須 | ファイルサイズ（取得できない場合は `None`）。取得元は phase で切り替わる: convert / convert_and_index は source_store 側、index は converted_store 側 |
+| `message` | str | 必須 | 例外メッセージ（`str(exc)`） |
+| `phase` | str | 必須 | フェーズ識別子。`PipelinePhase` Enum の `error_key`（`"convert"` / `"index"` / `"convert_and_index"` / `"fetch"`） |
+
+`PipelineSummary.failed_paths()` は `errors` の各エントリから `path` を抽出した `set[str]` を返すアクセサ。集合演算（差分更新での convert 失敗分除外等）に使う consumer 側が dict 構造を意識しないようにするため。
+
+`PipelinePhase` は処理フェーズを表す Enum で、以下の 2 属性を持つ:
+
+- `display`: progress 通知用の人間向け表示名
+- `error_key`: `PipelineErrorEntry.phase` に記録される snake_case キー
+
+メンバーは `FETCH` / `CONVERT` / `INDEX` / `CONVERT_AND_INDEX`。未知フェーズは型で排除される（string literal ではなく Enum を使うため）。
+
+**Why（構造化スキーマ）**: 例外メッセージ・ファイルサイズ等の診断情報を保持し、壊れファイル検出（JSON パースエラー等）の原因追跡と再取り込み判断を production 出力経路（CLI JSON / MCP レスポンス）に届けるため。`ConvertBatchResult.error_files`（converter）と `IngestResult.error_details`（インジェスター）の構造化と同方針で揃える。
+
+**Why（`size_bytes` の phase 別取得）**: convert 側のエラー（JSON パース失敗等）では元データ（source_store）のサイズが原因追跡に有用。index 側のエラー（トークン超過等）では変換済みテキスト（converted_store）のサイズが診断に有用。phase ごとに「そのフェーズが扱っていたファイル」のサイズを返すことで、エラーの文脈に沿った診断情報を提供する。
 
 全操作は `progress_callback`（任意）を受け取り、ファイル処理完了ごとにコールバックを呼び出す。callback シグネチャ: `(processed: int, total: int, current: str) -> None`。未指定時は進捗通知なし。詳細は [rebuild-stats.md](rebuild-stats.md) の CLI サブプロセス進捗通知セクションを参照。
 
@@ -332,7 +354,7 @@ sequenceDiagram
 | ネット差分で検出されない中間変更（削除→同一内容再追加等） | `git log --name-only` で中間コミットの全触ファイルを取得し、ネット差分に含まれないが HEAD に存在するファイルを `modified` として追加する。HEAD に存在しないファイル（一時的に追加→削除）は除外する |
 | パイプライン処理中にエラーが発生した場合 | エラーが発生したファイルをスキップし、残りのファイルの処理を続行する。pipeline_history にレコードを追加しないことで `last_commit_id` が前回値のまま保持される（次回再実行で再処理される） |
 | コンバーターが変換スキップを返したファイル（空テキスト、0バイト、未対応拡張子等） | 該当ファイルをスキップし、処理結果サマリの `warnings` に記録する（`errors` ではない）。非致命的なスキップであり、パイプライン全体の成否には影響しない |
-| コンバーターが予期しない例外を発生させたファイル | 該当ファイルのインデックス追加をスキップし、処理結果サマリの `errors` に記録する |
+| コンバーターが予期しない例外を発生させたファイル | 該当ファイルのインデックス追加をスキップし、処理結果サマリの `errors` に `PipelineErrorEntry`（`{path, size_bytes, message, phase}`）として記録する。`ConversionFailedError`（JSON パースエラー等、ファイルが壊れている可能性がある失敗）は同じ `errors` 経路で捕捉するが、スタックトレース不要の想定される業務的失敗として `logger.error` で記録する（予期しない `Exception` は `logger.exception` でスタックトレース付き）。例外メッセージには `path` を含めず、`PipelineErrorEntry.path` フィールドと重複させない |
 | 大量のファイルが一度に変更された場合 | 全件を順次処理する。バッチサイズ制限は設けない |
 | source_store の git リポジトリが未初期化 | パイプライン初回実行時に `git init` を自動実行する |
 | .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータを更新する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -152,10 +152,15 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 | `type` 値 | 出力タイミング | フィールド |
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
-| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割） |
+| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割）。`errors` は [pipeline-controller.md](pipeline-controller.md) の `PipelineSummary.errors` スキーマに従う構造化 dict のリスト（`{path, size_bytes, message, phase?}`）を出力する。ingest 系コマンドでは `IngestResult` の全観測性フィールド（`partial_failures` / `aborted` 等）も併せて含める（[ingesters/common.md](ingesters/common.md) の「JSON シリアライズ」参照） |
 | `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`message`（str） |
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
+
+> **TODO:#605** CLI の exit code 体系（ingest/rebuild での errors/aborted の反映）
+> および MCP 応答経路との整合は本仕様書では未定義。#605 で設計確定後に追記する。
+> 現時点では「正常完走 → exit 0 / バリデーション失敗・例外 → exit 1」の 2 値のみ
+> （`errors > 0` や `aborted` は JSON 出力の構造化フィールドでのみ表現される）。
 
 #### サーバー側の処理
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -152,7 +152,7 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 | `type` 値 | 出力タイミング | フィールド |
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
-| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割）。`errors` は [pipeline-controller.md](pipeline-controller.md) の `PipelineSummary.errors` スキーマに従う構造化 dict のリスト（`{path, size_bytes, message, phase?}`）を出力する。ingest 系コマンドでは `IngestResult` の全観測性フィールド（`partial_failures` / `aborted` 等）も併せて含める（[ingesters/common.md](ingesters/common.md) の「JSON シリアライズ」参照） |
+| `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割）。`errors` は [pipeline-controller.md](pipeline-controller.md) の `PipelineSummary.errors` スキーマに従う構造化 dict のリスト（`{path, size_bytes, message, phase}`）を出力する。ingest 系コマンドでは `IngestResult` の全観測性フィールド（`partial_failures` / `aborted` 等）も併せて含める（[ingesters/common.md](ingesters/common.md) の「JSON シリアライズ」参照） |
 | `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`message`（str） |
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urldefrag
 
 from .filter_parser import parse_filters
-from .pipeline.models import PHASE_FETCH
+from .pipeline.models import PipelinePhase, format_pipeline_error as _format_pipeline_error
 from .evaluation import (
     EvaluationReport,
     FailureTag,
@@ -176,13 +176,20 @@ def _ingest_result_to_dict(
     ingest_result: "IngestResult",
     pipeline_summary: "PipelineSummary | None",
 ) -> dict[str, object]:
-    """IngestResult + PipelineSummary を JSON 出力用 dict に変換する."""
+    """IngestResult + PipelineSummary を JSON 出力用 dict に変換する.
+
+    仕様: docs/specs/ingesters/common.md「JSON シリアライズ」
+    """
     data: dict[str, object] = {
         "placed": ingest_result.placed,
         "skipped": ingest_result.skipped,
         "overwritten": ingest_result.overwritten,
         "errors": ingest_result.errors,
         "error_details": ingest_result.error_details,
+        "partial_failures": ingest_result.partial_failures,
+        "partial_failure_details": ingest_result.partial_failure_details,
+        "aborted": ingest_result.aborted,
+        "abort_reason": ingest_result.abort_reason,
     }
     if pipeline_summary is not None:
         data["pipeline"] = {
@@ -217,8 +224,8 @@ def _log_phase_summary(phase: str, summary: "PipelineSummary") -> None:
     )
     for warn in summary.warnings:
         logger.warning("  [%s] 警告: %s", phase, warn)
-    for err_file in summary.errors:
-        logger.error("  [%s] エラーファイル: %s", phase, err_file)
+    for entry in summary.errors:
+        logger.error("  [%s] エラー: %s", phase, _format_pipeline_error(entry))
 
 
 def _add_output_option(parser: argparse.ArgumentParser) -> None:
@@ -1429,7 +1436,9 @@ async def run_rebuild(args: argparse.Namespace) -> None:
                 if all_errors:
                     has_error = True
                     if if_needed:
-                        error_files = ", ".join(all_errors)
+                        error_files = ", ".join(
+                            _format_pipeline_error(e) for e in all_errors
+                        )
                         _show_error_dialog(
                             f"rebuild --mode {mode} でエラーが発生しました。\n"
                             f"エラーファイル: {error_files}"
@@ -1449,7 +1458,9 @@ async def run_rebuild(args: argparse.Namespace) -> None:
                 if summary.errors:
                     has_error = True
                     if if_needed:
-                        error_files = ", ".join(summary.errors)
+                        error_files = ", ".join(
+                            _format_pipeline_error(e) for e in summary.errors
+                        )
                         _show_error_dialog(
                             f"rebuild --mode {mode} でエラーが発生しました。\n"
                             f"エラーファイル: {error_files}"
@@ -1468,8 +1479,8 @@ async def run_rebuild(args: argparse.Namespace) -> None:
                     logger.warning("  警告: %s", warn)
             if summary.errors:
                 has_error = True
-                for err_file in summary.errors:
-                    logger.error("  エラーファイル: %s", err_file)
+                for entry in summary.errors:
+                    logger.error("  エラー: %s", _format_pipeline_error(entry))
     except Exception as e:
         has_error = True
         if if_needed:
@@ -1483,7 +1494,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
                 if mode == "full"
                 else summary.errors
             )
-            error_files = ", ".join(all_err)
+            error_files = ", ".join(_format_pipeline_error(e) for e in all_err)
             _show_error_dialog(
                 f"rebuild --mode {mode} でエラーが発生しました。\n"
                 f"エラーファイル: {error_files}"
@@ -1913,8 +1924,8 @@ async def run_delete(args: argparse.Namespace) -> None:
             print(f"  - {warn}")
     if summary.errors:
         print(f"パイプラインエラー: {len(summary.errors)}件")
-        for err in summary.errors:
-            print(f"  - {err}")
+        for entry in summary.errors:
+            print(f"  - {_format_pipeline_error(entry)}")
     print(f"削除しました: {source_id}")
 
 
@@ -2242,8 +2253,8 @@ def _print_ingest_result(
                 print(f"  - {warn}")
         if pipeline_summary.errors:
             print(f"パイプラインエラー: {len(pipeline_summary.errors)}件")
-            for err in pipeline_summary.errors:
-                print(f"  - {err}")
+            for entry in pipeline_summary.errors:
+                print(f"  - {_format_pipeline_error(entry)}")
 
 
 async def run_ingest_youtube(args: argparse.Namespace) -> None:
@@ -2312,7 +2323,7 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
         ingest_result = await youtube_ingester.crawl_playlist(
             args.playlist_url,
             max_videos=max_videos,
-            progress_callback=_wrap_progress(progress_cb, PHASE_FETCH),
+            progress_callback=_wrap_progress(progress_cb, PipelinePhase.FETCH.display),
         )
     except (ValueError, TypeError) as e:
         if json_out:
@@ -2385,7 +2396,7 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
                 include_reposts=include_reposts,
                 force=force,
                 client=client,
-                progress_callback=_wrap_progress(progress_cb, PHASE_FETCH),
+                progress_callback=_wrap_progress(progress_cb, PipelinePhase.FETCH.display),
             )
 
             # 投稿内 URL の自動取り込み
@@ -2461,7 +2472,7 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 content_type=args.content_type,
                 force=args.force,
                 client=client,
-                progress_callback=_wrap_progress(progress_cb, PHASE_FETCH),
+                progress_callback=_wrap_progress(progress_cb, PipelinePhase.FETCH.display),
             )
     except (ValueError, TypeError) as e:
         if json_out:
@@ -2470,13 +2481,11 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     if ingest_result.placed == 0 and ingest_result.errors == 0:
-        if json_out:
-            _output_result(_ingest_result_to_dict(ingest_result, None))
-            return
-        if ingest_result.skipped > 0:
-            print(f"全 {ingest_result.skipped} 件のコンテンツがスキップされました（ユーザー: {args.username}）。上書きするには --force を指定してください")
-        else:
-            print(f"コンテンツが見つかりませんでした（ユーザー: {args.username}）")
+        _print_ingest_result(
+            ingest_result, None, context=f"ユーザー: {args.username}", json_output=json_out,
+        )
+        if not json_out and ingest_result.skipped > 0:
+            print("（上書きするには --force を指定してください）")
         return
 
     pipeline_summary = await controller.ingest_and_index(
@@ -2603,10 +2612,9 @@ async def run_add_document(args: argparse.Namespace) -> None:
             raise SystemExit(1)
 
         if ingest_result.placed == 0 and ingest_result.errors == 0:
-            if json_out:
-                _output_result(_ingest_result_to_dict(ingest_result, None))
-                return
-            print(f"取り込み対象がありませんでした: {display_name}")
+            _print_ingest_result(
+                ingest_result, None, context=display_name, json_output=json_out,
+            )
             return
         if ingest_result.errors > 0:
             first_detail = _error_detail_message(ingest_result.error_details[0])
@@ -2648,16 +2656,17 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
 
     ingest_result = local_ingester.crawl_documents(
         args.dir_path, args.pattern, upload_mode=args.upload_mode,
-        progress_callback=_wrap_progress(progress_cb, PHASE_FETCH),
+        progress_callback=_wrap_progress(progress_cb, PipelinePhase.FETCH.display),
     )
 
     if ingest_result.placed == 0 and ingest_result.errors == 0:
-        if json_out:
-            _output_result(_ingest_result_to_dict(ingest_result, None))
-            return
-        print(f"対象ファイルが見つかりませんでした: {args.dir_path}")
+        _print_ingest_result(
+            ingest_result, None, context=f"ディレクトリ: {args.dir_path}",
+            json_output=json_out,
+        )
         return
     if ingest_result.errors > 0 and ingest_result.placed == 0:
+        # 早期終了: エラー詳細を先頭 1 件だけ表示してから exit
         first_detail = _error_detail_message(ingest_result.error_details[0])
         if json_out:
             _output_error(first_detail)
@@ -2819,20 +2828,15 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             data["scrapy_exit_code"] = crawl_result.exit_code
         _output_result(data)
     else:
-        # text 出力
-        print(
-            f"サイト取り込み完了: {bridge_result.ingest.placed}件新規配置"
-            f", {bridge_result.ingest.overwritten}件上書き"
-            f", {bridge_result.ingest.skipped}件スキップ"
-            f", {bridge_result.ingest.errors}件エラー"
+        _print_ingest_result(
+            bridge_result.ingest,
+            pipeline_summary,
+            context=f"サイト: {display_url}",
+            json_output=False,
         )
         print(f"所要時間: {elapsed:.1f}秒")
         if args.download_only:
             print("パイプライン処理: スキップ（download_only）")
-        elif pipeline_summary is not None:
-            print(f"パイプライン: {pipeline_summary.processed}件処理")
-            if pipeline_summary.errors:
-                print(f"パイプラインエラー: {len(pipeline_summary.errors)}件")
         if not crawl_result.success:
             print(f"Scrapy exit_code={crawl_result.exit_code}（部分的な結果）")
 
@@ -2991,7 +2995,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
                 args.person_id,
                 max_works=max_works,
                 client=client,
-                progress_callback=_wrap_progress(progress_cb, PHASE_FETCH),
+                progress_callback=_wrap_progress(progress_cb, PipelinePhase.FETCH.display),
             )
     except (ValueError, TypeError) as e:
         if json_out:

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -450,16 +450,14 @@ class Converter:
         try:
             raw = source_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
-            raise ConversionFailedError(
-                f"JSON read error: {file_path}",
-            ) from exc
+            # path は PipelineErrorEntry.path で提供されるためメッセージには含めない
+            raise ConversionFailedError("JSON read error") from exc
 
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise ConversionFailedError(
-                f"JSON parse error: {file_path}",
-            ) from exc
+            # path は PipelineErrorEntry.path で提供されるためメッセージには含めない
+            raise ConversionFailedError("JSON parse error") from exc
 
         if not isinstance(parsed, dict):
             logger.warning(

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -20,16 +20,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeVar
 
-from rag.converter.converter import ConversionSkippedError, get_converted_rel_path
+from rag.converter.converter import (
+    ConversionFailedError,
+    ConversionSkippedError,
+    get_converted_rel_path,
+)
 from rag.pipeline.git_ops import GitOperations
 from rag.pipeline.models import (
-    PHASE_CONVERT,
-    PHASE_CONVERT_AND_INDEX,
-    PHASE_INDEX,
     ChangeEntry,
     ChangeStatus,
     FullRebuildResult,
+    PipelineErrorEntry,
     PipelineMode,
+    PipelinePhase,
     PipelineSummary,
 )
 from rag.pipeline.protocols import ConverterProtocol, IndexerProtocol
@@ -292,7 +295,7 @@ class PipelineController:
             records,
             process_fn=_convert_single,
             get_file_path=lambda r: r.source_id,
-            phase=PHASE_CONVERT,
+            phase=PipelinePhase.CONVERT,
             mode=PipelineMode.CONVERT_ONLY,
             log_prefix="全再構築(Convert)中に",
             progress_callback=progress_callback,
@@ -307,7 +310,7 @@ class PipelineController:
         # --- Phase 2: Index (convert 成功分のみ) ---
         await self._indexer.clear(source_type)
 
-        convert_failed = set(convert_summary.errors)
+        convert_failed = convert_summary.failed_paths()
         convert_warned: set[str] = set()
         for w in convert_summary.warnings:
             source_id, sep, _reason = w.partition(": ")
@@ -354,7 +357,7 @@ class PipelineController:
                 index_records,
                 process_fn=_index_single,
                 get_file_path=lambda r: r.source_id,
-                phase=PHASE_INDEX,
+                phase=PipelinePhase.INDEX,
                 mode=PipelineMode.INDEX_ONLY,
                 log_prefix="全再構築(Index)中に",
                 progress_callback=progress_callback,
@@ -466,7 +469,7 @@ class PipelineController:
             records,
             process_fn=_convert_single,
             get_file_path=lambda r: r.source_id,
-            phase=PHASE_CONVERT,
+            phase=PipelinePhase.CONVERT,
             mode=PipelineMode.CONVERT_ONLY,
             log_prefix="コンバート再実行中に",
             progress_callback=progress_callback,
@@ -543,7 +546,7 @@ class PipelineController:
                 records,
                 process_fn=_index_single,
                 get_file_path=lambda r: r.source_id,
-                phase=PHASE_INDEX,
+                phase=PipelinePhase.INDEX,
                 mode=PipelineMode.INDEX_ONLY,
                 log_prefix="インデックス再構築中に",
                 progress_callback=progress_callback,
@@ -720,7 +723,7 @@ class PipelineController:
         *,
         process_fn: Callable[[_T], Awaitable[None]] | Callable[[_T], None],
         get_file_path: Callable[[_T], str],
-        phase: str,
+        phase: PipelinePhase,
         mode: PipelineMode,
         log_prefix: str,
         progress_callback: ProgressCallback | None = None,
@@ -745,7 +748,7 @@ class PipelineController:
 
         sem = asyncio.Semaphore(concurrency)
         processed = 0
-        errors: list[str] = []
+        errors: list[PipelineErrorEntry] = []
         warnings: list[str] = []
         lock = asyncio.Lock()
 
@@ -767,19 +770,31 @@ class PipelineController:
                     )
                     async with lock:
                         warnings.append(f"{file_path}: {e}")
-                except Exception:
+                except ConversionFailedError as e:
+                    logger.error(
+                        "%s変換失敗: %s (%s)", log_prefix, file_path, e,
+                    )
+                    entry = self._build_error_entry(
+                        file_path, str(e), phase,
+                    )
+                    async with lock:
+                        errors.append(entry)
+                except Exception as e:
                     logger.exception(
                         "%sエラー: %s", log_prefix, file_path,
                     )
+                    entry = self._build_error_entry(
+                        file_path, str(e), phase,
+                    )
                     async with lock:
-                        errors.append(file_path)
+                        errors.append(entry)
                 if progress_callback is not None:
                     async with lock:
                         completed = processed + len(errors) + len(warnings)
                     try:
                         progress_callback(
                             completed, len(items),
-                            f"[{phase}] {file_path}",
+                            f"[{phase.display}] {file_path}",
                         )
                     except Exception:
                         logger.debug(
@@ -799,6 +814,41 @@ class PipelineController:
             to_commit_id=to_commit_id,
         )
 
+    def _build_error_entry(
+        self,
+        file_path: str,
+        message: str,
+        phase: PipelinePhase,
+    ) -> PipelineErrorEntry:
+        """PipelineSummary.errors に追加する構造化エントリを生成する.
+
+        仕様: docs/specs/pipeline-controller.md の `PipelineSummary.errors`
+
+        size_bytes の取得元は phase に応じて切り替える:
+        - CONVERT / CONVERT_AND_INDEX: source_store 側のファイルサイズ
+          （壊れファイル検出時に元データのサイズを残す）
+        - INDEX: converted_store 側のファイルサイズ
+          （index 失敗時は変換済みテキストのサイズが診断に有用）
+        - FETCH / その他: source_store 側（デフォルト）
+
+        取得失敗時（権限エラー・未配置等）は `size_bytes=None` とする。
+        """
+        if phase is PipelinePhase.INDEX:
+            converted_rel = get_converted_rel_path(file_path)
+            target_path = self._converted_store_dir / converted_rel
+        else:
+            target_path = self._source_store.root_dir / file_path
+        try:
+            size_bytes: int | None = target_path.stat().st_size
+        except OSError:
+            size_bytes = None
+        return PipelineErrorEntry(
+            path=file_path,
+            size_bytes=size_bytes,
+            message=message,
+            phase=phase.error_key,
+        )
+
     # --- 変更処理 ---
 
     async def _process_changes(
@@ -815,7 +865,7 @@ class PipelineController:
                 changes,
                 process_fn=self._process_single_change,
                 get_file_path=lambda e: e.file_path,
-                phase=PHASE_CONVERT_AND_INDEX,
+                phase=PipelinePhase.CONVERT_AND_INDEX,
                 mode=mode,
                 log_prefix="パイプライン処理中に",
                 progress_callback=progress_callback,

--- a/src/rag/pipeline/ingesters/_common.py
+++ b/src/rag/pipeline/ingesters/_common.py
@@ -49,6 +49,8 @@ class IngestResult:
     def summary(self, *, context: str = "") -> str:
         """結果サマリーテキストを生成する."""
         parts = [f"完了: {self.placed}件配置"]
+        if self.overwritten > 0:
+            parts.append(f"上書き: {self.overwritten}件")
         if self.skipped > 0:
             parts.append(f"スキップ: {self.skipped}件")
         if self.errors > 0:

--- a/src/rag/pipeline/models.py
+++ b/src/rag/pipeline/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import NotRequired, TypedDict
+from typing import TypedDict
 
 
 class ChangeStatus(Enum):
@@ -71,7 +71,7 @@ class PipelineErrorEntry(TypedDict):
     """
 
     path: str
-    size_bytes: NotRequired[int | None]
+    size_bytes: int | None
     message: str
     phase: str
 
@@ -81,15 +81,15 @@ def format_pipeline_error(entry: PipelineErrorEntry) -> str:
 
     MCP レスポンス・CLI テキスト出力の両方で使用する共通フォーマッタ。
     `{path (size_bytes bytes) [phase]: message}` のフォーマットで返す。
-    size_bytes が None または未設定の場合はバイト数表示を省略する。
-    phase が空文字の場合は phase 表示を省略する。
+    size_bytes が None の場合はバイト数表示を省略する。
+    phase が空文字の場合は phase 表示を省略する（通常は常にセットされる）。
     """
-    path = entry.get("path", "")
-    message = entry.get("message", "")
-    phase = entry.get("phase", "")
-    size_bytes = entry.get("size_bytes")
+    path = entry["path"]
+    message = entry["message"]
+    phase = entry["phase"]
+    size_bytes = entry["size_bytes"]
 
-    size_part = f" ({size_bytes} bytes)" if isinstance(size_bytes, int) else ""
+    size_part = f" ({size_bytes} bytes)" if size_bytes is not None else ""
     phase_part = f" [{phase}]" if phase else ""
     return f"{path}{size_part}{phase_part}: {message}"
 

--- a/src/rag/pipeline/models.py
+++ b/src/rag/pipeline/models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import NotRequired, TypedDict
 
 
 class ChangeStatus(Enum):
@@ -36,17 +37,87 @@ class PipelineMode(Enum):
     INDEX_ONLY = "index"
 
 
+class PipelinePhase(Enum):
+    """パイプライン処理のフェーズ.
+
+    display は progress 通知のプレフィックス（人間向け表示）、
+    error_key は `PipelineErrorEntry.phase` に記録される列挙値。
+    """
+
+    FETCH = ("Fetch", "fetch")
+    CONVERT = ("Convert", "convert")
+    INDEX = ("Index", "index")
+    CONVERT_AND_INDEX = ("Convert & Index", "convert_and_index")
+
+    def __init__(self, display: str, error_key: str) -> None:
+        self._display = display
+        self._error_key = error_key
+
+    @property
+    def display(self) -> str:
+        """progress 表示・ログ出力用のフェーズ名."""
+        return self._display
+
+    @property
+    def error_key(self) -> str:
+        """PipelineErrorEntry.phase に記録される snake_case キー."""
+        return self._error_key
+
+
+class PipelineErrorEntry(TypedDict):
+    """PipelineSummary.errors の各エントリのスキーマ.
+
+    仕様: docs/specs/pipeline-controller.md の `PipelineSummary.errors`
+    """
+
+    path: str
+    size_bytes: NotRequired[int | None]
+    message: str
+    phase: str
+
+
+def format_pipeline_error(entry: PipelineErrorEntry) -> str:
+    """PipelineErrorEntry を表示用文字列に整形する.
+
+    MCP レスポンス・CLI テキスト出力の両方で使用する共通フォーマッタ。
+    `{path (size_bytes bytes) [phase]: message}` のフォーマットで返す。
+    size_bytes が None または未設定の場合はバイト数表示を省略する。
+    phase が空文字の場合は phase 表示を省略する。
+    """
+    path = entry.get("path", "")
+    message = entry.get("message", "")
+    phase = entry.get("phase", "")
+    size_bytes = entry.get("size_bytes")
+
+    size_part = f" ({size_bytes} bytes)" if isinstance(size_bytes, int) else ""
+    phase_part = f" [{phase}]" if phase else ""
+    return f"{path}{size_part}{phase_part}: {message}"
+
+
 @dataclass
 class PipelineSummary:
-    """パイプライン実行結果サマリ."""
+    """パイプライン実行結果サマリ.
+
+    `errors` の各エントリは `PipelineErrorEntry` TypedDict で定義されたスキーマ
+    （仕様: docs/specs/pipeline-controller.md の `PipelineSummary.errors`）。
+    path 文字列のみが必要な consumer は `failed_paths()` を使う。
+    """
 
     mode: PipelineMode
     total_files: int
     processed: int
-    errors: list[str] = field(default_factory=list)
+    errors: list[PipelineErrorEntry] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     from_commit_id: str = ""
     to_commit_id: str = ""
+
+    def failed_paths(self) -> set[str]:
+        """errors の各 dict から path を抽出した set を返すアクセサ.
+
+        集合演算（convert 失敗分の index 除外等）で使う consumer 側が
+        dict 構造を意識しないようにするため。
+        """
+        return {e["path"] for e in self.errors}
 
 
 @dataclass
@@ -58,10 +129,3 @@ class FullRebuildResult:
 
     convert: PipelineSummary
     index: PipelineSummary
-
-
-# プログレス通知のフェーズ名
-PHASE_FETCH = "Fetch"
-PHASE_CONVERT = "Convert"
-PHASE_INDEX = "Index"
-PHASE_CONVERT_AND_INDEX = "Convert & Index"

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -55,7 +55,7 @@ with contextlib.redirect_stdout(io.StringIO()):
     from .upload import sanitize_filename as sanitize_upload_filename
     from .pipeline.ingesters.local import _UPLOAD_DIR as _LOCAL_UPLOAD_DIR
 
-    from .pipeline.models import PipelineMode, PipelineSummary
+    from .pipeline.models import PipelineMode, PipelineSummary, format_pipeline_error as _format_pipeline_error
 from .safe_browsing import (
     SafeBrowsingClient,
     SafeBrowsingConfigError,
@@ -127,7 +127,9 @@ def _format_ingest_response(
             details = "; ".join(pipeline_summary.warnings[:5])
             parts.append(f"パイプライン警告: {len(pipeline_summary.warnings)}件 ({details})")
         if pipeline_summary.errors:
-            details = "; ".join(pipeline_summary.errors[:5])
+            details = "; ".join(
+                _format_pipeline_error(e) for e in pipeline_summary.errors[:5]
+            )
             parts.append(f"パイプラインエラー: {len(pipeline_summary.errors)}件 ({details})")
     return " / ".join(parts)
 
@@ -803,7 +805,9 @@ async def rag_delete(source_id: str, ctx: MCPContext | None = None) -> str:
         if pipeline_data:
             pipeline_summary = _parse_pipeline_summary(pipeline_data)
             if pipeline_summary and pipeline_summary.errors:
-                errors_text = "; ".join(pipeline_summary.errors)
+                errors_text = "; ".join(
+                    _format_pipeline_error(e) for e in pipeline_summary.errors
+                )
                 return f"削除しましたが、パイプラインでエラーが発生しました: {source_id} ({errors_text})"
         return f"削除しました: {source_id}"
     except CLISubprocessError as e:
@@ -840,9 +844,9 @@ def _format_phase_summary(phase: str, summary: PipelineSummary) -> list[str]:
         if len(summary.warnings) > 10:
             parts.append(f"      ... 他 {len(summary.warnings) - 10} 件")
     if summary.errors:
-        parts.append("    エラーファイル:")
-        for err_file in summary.errors[:10]:
-            parts.append(f"      - {err_file}")
+        parts.append("    エラー:")
+        for entry in summary.errors[:10]:
+            parts.append(f"      - {_format_pipeline_error(entry)}")
         if len(summary.errors) > 10:
             parts.append(f"      ... 他 {len(summary.errors) - 10} 件")
     return parts
@@ -871,9 +875,9 @@ def _format_rebuild_summary(summary: PipelineSummary, elapsed: float) -> str:
         if len(summary.warnings) > 10:
             parts.append(f"    ... 他 {len(summary.warnings) - 10} 件")
     if summary.errors:
-        parts.append("  エラーファイル:")
-        for err_file in summary.errors[:10]:
-            parts.append(f"    - {err_file}")
+        parts.append("  エラー:")
+        for entry in summary.errors[:10]:
+            parts.append(f"    - {_format_pipeline_error(entry)}")
         if len(summary.errors) > 10:
             parts.append(f"    ... 他 {len(summary.errors) - 10} 件")
 
@@ -1170,6 +1174,10 @@ def _format_cli_ingest_result(
 
     _run_cli_subprocess の戻り値（IngestResult + PipelineSummary の dict 表現）を
     既存の _format_ingest_response と同等のフォーマットに変換する。
+
+    IngestResult の全観測性フィールド（partial_failures / aborted 等）は
+    CLI が JSON に含める契約（仕様: docs/specs/ingesters/common.md）に従い、
+    ここでは常にキーが存在する前提で再構築する。
     """
     ingest_result = IngestResult(
         placed=result.get("placed", 0),
@@ -1177,6 +1185,10 @@ def _format_cli_ingest_result(
         overwritten=result.get("overwritten", 0),
         errors=result.get("errors", 0),
         error_details=result.get("error_details", []),
+        partial_failures=result.get("partial_failures", 0),
+        partial_failure_details=result.get("partial_failure_details", []),
+        aborted=result.get("aborted", False),
+        abort_reason=result.get("abort_reason"),
     )
 
     pipeline_data = result.get("pipeline")
@@ -1188,6 +1200,8 @@ def _format_cli_ingest_result(
 def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
     """JSON dict から PipelineSummary を復元する.
 
+    `errors` は `{path, size_bytes, message, phase?}` スキーマを持つ dict の
+    リストとして渡される前提（仕様: docs/specs/pipeline-controller.md）。
     パース失敗時は None を返す。
     """
     try:

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1200,7 +1200,7 @@ def _format_cli_ingest_result(
 def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:
     """JSON dict から PipelineSummary を復元する.
 
-    `errors` は `{path, size_bytes, message, phase?}` スキーマを持つ dict の
+    `errors` は `{path, size_bytes, message, phase}` スキーマを持つ dict の
     リストとして渡される前提（仕様: docs/specs/pipeline-controller.md）。
     パース失敗時は None を返す。
     """

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -102,13 +102,34 @@ class TestAddOutputOption:
 class TestIngestResultToDict:
     """_ingest_result_to_dict のテスト."""
 
+    @staticmethod
+    def _make_ingest_result(
+        *,
+        placed: int = 0,
+        skipped: int = 0,
+        overwritten: int = 0,
+        errors: int = 0,
+        error_details: list[dict[str, object]] | None = None,
+        partial_failures: int = 0,
+        partial_failure_details: list[dict[str, object]] | None = None,
+        aborted: bool = False,
+        abort_reason: str | None = None,
+    ) -> MagicMock:
+        """IngestResult のモックを生成する."""
+        mock = MagicMock()
+        mock.placed = placed
+        mock.skipped = skipped
+        mock.overwritten = overwritten
+        mock.errors = errors
+        mock.error_details = error_details or []
+        mock.partial_failures = partial_failures
+        mock.partial_failure_details = partial_failure_details or []
+        mock.aborted = aborted
+        mock.abort_reason = abort_reason
+        return mock
+
     def test_without_pipeline_summary(self) -> None:
-        ingest_result = MagicMock()
-        ingest_result.placed = 2
-        ingest_result.skipped = 1
-        ingest_result.overwritten = 0
-        ingest_result.errors = 0
-        ingest_result.error_details = []
+        ingest_result = self._make_ingest_result(placed=2, skipped=1)
 
         result = _ingest_result_to_dict(ingest_result, None)
         assert result == {
@@ -117,15 +138,14 @@ class TestIngestResultToDict:
             "overwritten": 0,
             "errors": 0,
             "error_details": [],
+            "partial_failures": 0,
+            "partial_failure_details": [],
+            "aborted": False,
+            "abort_reason": None,
         }
 
     def test_with_pipeline_summary(self) -> None:
-        ingest_result = MagicMock()
-        ingest_result.placed = 1
-        ingest_result.skipped = 0
-        ingest_result.overwritten = 0
-        ingest_result.errors = 0
-        ingest_result.error_details = []
+        ingest_result = self._make_ingest_result(placed=1)
 
         pipeline_summary = MagicMock()
         pipeline_summary.mode.value = "incremental"
@@ -140,6 +160,43 @@ class TestIngestResultToDict:
         assert result["pipeline"]["mode"] == "incremental"
         assert result["pipeline"]["processed"] == 3
         assert "skipped" not in result["pipeline"]
+
+    def test_includes_observability_fields_with_values(self) -> None:
+        """partial_failures / aborted 等がゼロ値でない場合も正しくシリアライズされる.
+
+        失敗の観測性（仕様: docs/specs/ingesters/common.md）を production 出力に
+        届けるため、IngestResult の全観測性フィールドを JSON に含めなければならない。
+        """
+        partial_details = [{"target": "a.png", "category": "media_download"}]
+        ingest_result = self._make_ingest_result(
+            placed=10,
+            partial_failures=2,
+            partial_failure_details=partial_details,
+            aborted=True,
+            abort_reason="circuit breaker open",
+        )
+
+        result = _ingest_result_to_dict(ingest_result, None)
+        assert result["partial_failures"] == 2
+        assert result["partial_failure_details"] == partial_details
+        assert result["aborted"] is True
+        assert result["abort_reason"] == "circuit breaker open"
+
+    def test_aborted_false_is_preserved(self) -> None:
+        """aborted が False でも省略されず False として出力される.
+
+        スケジューラが `.get("aborted", False)` で補完に依存せず、
+        常にキーが存在する前提で判定できるようにする。
+        """
+        ingest_result = self._make_ingest_result()
+
+        result = _ingest_result_to_dict(ingest_result, None)
+        assert "aborted" in result
+        assert result["aborted"] is False
+        assert "abort_reason" in result
+        assert result["abort_reason"] is None
+        assert "partial_failures" in result
+        assert "partial_failure_details" in result
 
 
 class TestCommandsHaveOutputOption:

--- a/tests/test_cli_stdin.py
+++ b/tests/test_cli_stdin.py
@@ -366,6 +366,12 @@ class TestAddDocumentFilenamePriority:
         mock.overwritten = 0
         mock.errors = 0
         mock.error_details = []
+        # 観測性フィールド（JSON 出力に含めるため明示的に値を設定。
+        # MagicMock の自動属性生成に任せると JSON シリアライズ時にエラーになる）
+        mock.partial_failures = 0
+        mock.partial_failure_details = []
+        mock.aborted = False
+        mock.abort_reason = None
         return mock
 
     @staticmethod

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -39,6 +39,8 @@ class StubConverter:
         self.deleted: list[str] = []
         self.cleared: list[SourceType | None] = []
         self.fail_on: set[str] = set()
+        # ConversionFailedError を送出させたいパス（convert 系のエラー経路検証用）
+        self.fail_on_with_failed_error: set[str] = set()
 
     def convert(
         self,
@@ -46,6 +48,10 @@ class StubConverter:
         source_store_dir: Path,
         converted_store_dir: Path,
     ) -> Path:
+        if file_path in self.fail_on_with_failed_error:
+            from rag.converter.converter import ConversionFailedError
+
+            raise ConversionFailedError("stub conversion failure")
         if file_path in self.fail_on:
             msg = f"converter error: {file_path}"
             raise RuntimeError(msg)
@@ -199,6 +205,33 @@ def _place_web_file(
 
 
 # --- テスト ---
+
+
+class TestPipelineSummaryFailedPaths:
+    """PipelineSummary.failed_paths() アクセサのテスト."""
+
+    def test_returns_empty_when_no_errors(self) -> None:
+        from rag.pipeline.models import PipelineMode, PipelineSummary
+
+        summary = PipelineSummary(
+            mode=PipelineMode.INCREMENTAL, total_files=0, processed=0,
+        )
+        assert summary.failed_paths() == set()
+
+    def test_extracts_paths_from_error_dicts(self) -> None:
+        """errors の dict から path のみを抽出する."""
+        from rag.pipeline.models import PipelineMode, PipelineSummary
+
+        summary = PipelineSummary(
+            mode=PipelineMode.CONVERT_ONLY,
+            total_files=3,
+            processed=1,
+            errors=[
+                {"path": "a.txt", "size_bytes": 10, "message": "x", "phase": "convert"},
+                {"path": "b.txt", "size_bytes": None, "message": "y", "phase": "convert"},
+            ],
+        )
+        assert summary.failed_paths() == {"a.txt", "b.txt"}
 
 
 class TestCommit:
@@ -418,9 +451,41 @@ class TestRunIncremental:
         assert summary.processed == 1
         assert len(summary.errors) == 1
 
+        # 構造化エラー情報が保持されていること（仕様: pipeline-controller.md）
+        entry = summary.errors[0]
+        assert entry["path"] == "local/bad.txt"
+        assert entry["size_bytes"] is not None and entry["size_bytes"] > 0
+        assert "converter error" in entry["message"]
+        assert entry["phase"] == "convert_and_index"
+
+        # failed_paths() アクセサが path 集合を返すこと
+        assert summary.failed_paths() == {"local/bad.txt"}
+
         # pipeline_history は記録されない
         history = ctrl.db.get_pipeline_history()
         assert len(history) == 0
+
+    async def test_conversion_failed_preserves_message(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """ConversionFailedError のメッセージが errors に保持されること.
+
+        PR #596 の観測性強化の目的（壊れファイル検出時の原因追跡）を
+        production 出力経路（PipelineSummary.errors）に届けるための要件。
+        """
+        ctrl, converter, _ = controller
+        _place_local_file(workspace["source"], "local/corrupt.txt")
+        ctrl.commit("first")
+
+        converter.fail_on_with_failed_error.add("local/corrupt.txt")
+
+        summary = await ctrl.run_incremental()
+        assert len(summary.errors) == 1
+        entry = summary.errors[0]
+        assert entry["path"] == "local/corrupt.txt"
+        assert "stub conversion failure" in entry["message"]
 
     async def test_invalid_last_commit_processes_all(
         self,
@@ -905,7 +970,7 @@ class TestRunFullRebuild:
         # convert: 1 成功, 1 エラー
         assert result.convert.processed == 1
         assert len(result.convert.errors) == 1
-        assert "local/bad.txt" in result.convert.errors
+        assert "local/bad.txt" in result.convert.failed_paths()
 
         # index: convert 成功分のみ
         assert result.index.total_files == 1

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -69,13 +69,19 @@ class TestFormatRebuildSummary:
             mode=PipelineMode.INDEX_ONLY,
             total_files=5,
             processed=3,
-            errors=["file1.txt", "file2.txt"],
+            errors=[
+                {"path": "file1.txt", "size_bytes": 100, "message": "parse error", "phase": "convert"},
+                {"path": "file2.txt", "size_bytes": None, "message": "read error", "phase": "convert"},
+            ],
         )
         result = _format_rebuild_summary(summary, 5.0)
         assert "インデックスのみ再構築" in result
         assert "エラー: 2" in result
         assert "file1.txt" in result
         assert "file2.txt" in result
+        # 構造化詳細（size_bytes / message）も出力されること
+        assert "parse error" in result
+        assert "read error" in result
 
     def test_all_non_full_modes(self) -> None:
         mode_labels = {
@@ -95,7 +101,7 @@ class TestFormatRebuildSummary:
             mode=PipelineMode.CONVERT_ONLY,
             total_files=10,
             processed=8,
-            errors=["bad.txt"],
+            errors=[{"path": "bad.txt", "size_bytes": 50, "message": "boom", "phase": "convert"}],
             warnings=["warn.txt: skipped"],
         )
         index = PipelineSummary(
@@ -206,6 +212,45 @@ class TestRagRebuild:
         mock_subprocess.assert_called_once_with(
             "rebuild", ["--mode", "incremental"], ctx=None,
         )
+
+    @pytest.mark.asyncio
+    async def test_structured_errors_reach_mcp_response(self) -> None:
+        """構造化エラー情報が CLI JSON → MCP レスポンスへ透過すること.
+
+        PR #596 の観測性強化（壊れファイル検出時の size_bytes / message）を
+        production 出力経路に届けるための要件（Issue #602 問題 3+4）。
+        仕様: docs/specs/pipeline-controller.md
+        """
+        from rag.server import rag_rebuild
+
+        mock_cli_result: dict[str, object] = {
+            "type": "result",
+            "mode": "incremental",
+            "total_files": 2,
+            "processed": 1,
+            "errors": [
+                {
+                    "path": "zenn/user/articles/broken.json",
+                    "size_bytes": 15,
+                    "message": "JSON parse error: zenn/user/articles/broken.json",
+                    "phase": "convert_and_index",
+                },
+            ],
+            "warnings": [],
+            "elapsed": 0.4,
+        }
+
+        with patch(
+            "rag.server._run_cli_subprocess",
+            new_callable=AsyncMock,
+            return_value=mock_cli_result,
+        ):
+            result = await rag_rebuild(mode="incremental")
+
+        # path / size_bytes / message がすべて MCP レスポンスに含まれること
+        assert "zenn/user/articles/broken.json" in result
+        assert "15 bytes" in result
+        assert "JSON parse error" in result
 
     @pytest.mark.asyncio
     async def test_lock_conflict_returns_error(self) -> None:

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -434,6 +434,79 @@ class TestCliSiteIngestFlow:
         mock_pipeline_summary = MagicMock()
         mock_pipeline_summary.processed = 5
         mock_pipeline_summary.errors = []
+        mock_pipeline_summary.warnings = []
+
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
+
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
+
+        with (
+            patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
+            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            from rag.cli import run_site_ingest
+
+            # exit code は 2 値（0=成功 / 1=致命的失敗）のため errors>0 でも exit 0
+            # 3 値 exit code 化（aborted/errors を exit に反映）は Issue #605 で実装
+            await run_site_ingest(args)
+            captured = capsys.readouterr()
+            # site-ingest の text 出力は IngestResult.summary() 経由で統一される
+            # (仕様: docs/specs/ingesters/common.md)
+            assert "完了: 5件配置" in captured.out
+            assert "上書き: 3件" in captured.out
+            assert "スキップ: 2件" in captured.out
+            assert "エラー: 1件" in captured.out
+            assert "パイプライン: 5件処理" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_text_output_uses_ingest_result_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """site-ingest の text 出力が IngestResult.summary() を経由すること.
+
+        他 ingest コマンドと同じく _print_ingest_result 経由で出力される
+        ことにより、partial_failures / aborted 等の観測性フィールドが
+        欠落なく表示される。
+        """
+        import json
+
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, ScrapyRunner
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+        )
+
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(
+                placed=2,
+                skipped=0,
+                partial_failures=1,
+                partial_failure_details=[
+                    {"target": "https://example.com/img.png", "category": "media_download"},
+                ],
+            ),
+            total_lines=2,
+            parse_errors=0,
+        )
+
+        mock_pipeline_summary = MagicMock()
+        mock_pipeline_summary.processed = 2
+        mock_pipeline_summary.errors = []
+        mock_pipeline_summary.warnings = []
 
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
@@ -450,11 +523,10 @@ class TestCliSiteIngestFlow:
 
             await run_site_ingest(args)
             captured = capsys.readouterr()
-            assert "5件新規配置" in captured.out
-            assert "3件上書き" in captured.out
-            assert "2件スキップ" in captured.out
-            assert "1件エラー" in captured.out
-            assert "パイプライン: 5件処理" in captured.out
+            # summary() の特徴的な出力（partial_failures が IngestResult.summary で可視化される）
+            assert "部分失敗: 1件" in captured.out
+            # context（サイト: ...）が summary に含まれる
+            assert "サイト:" in captured.out
 
     @pytest.mark.asyncio
     async def test_cleanup_on_success(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] refactor: リファクタリング（PipelinePhase Enum 化 / PipelineErrorEntry TypedDict 化）

## Summary

PR #596 で追加された観測性機能（`errors>0` 時のエラー詳細、`partial_failures` / `aborted` 等）を、production 出力経路（CLI JSON / MCP レスポンス）に届ける。

### 問題 1: `_ingest_result_to_dict` が JSON 出力で 4 フィールドを欠落

- `partial_failures` / `partial_failure_details` / `aborted` / `abort_reason` を JSON 出力に含める
- スケジューラが親失敗・部分失敗・中断を独立判定できるよう、ゼロ値・空リスト・None も省略せず常に出力
- `src/rag/cli.py::_ingest_result_to_dict`、`src/rag/server.py::_format_cli_ingest_result`

### 問題 3+4: `PipelineSummary.errors` を構造化型に変更

- `list[str]` → `list[PipelineErrorEntry]`（TypedDict）に型変更
- スキーマ: `{path: str, size_bytes: int | None, message: str, phase: str}`
- `failed_paths()` アクセサを追加（consumer が dict 構造を意識せず path 集合を取得可能）
- `_run_processing_loop` で `ConversionFailedError` を専用捕捉しスタックトレース抑制
- `_build_error_entry` で phase に応じて size_bytes の取得元を切り替え（convert → source_store / index → converted_store）
- MCP 経路（`_format_cli_ingest_result` / `_parse_pipeline_summary` / `_format_phase_summary` / `_format_rebuild_summary` / `rag_delete`）を新しい型に追従

### 問題 5: `run_site_ingest` の text 出力を `_print_ingest_result` 経由に統一

- 他 ingest コマンドと同じ `IngestResult.summary()` 経由で出力される
- `IngestResult.summary()` に `overwritten` 行を追加し、site-ingest 含む全インジェスターで上書き件数を可視化

### 品質改善（code-reviewer / doc-reviewer の triage 結果）

- **PipelinePhase Enum 導入**: `PHASE_FETCH` / `PHASE_CONVERT` 等の文字列定数と `_phase_to_error_phase` 変換 fallback を廃止。型で存在保証し未知フェーズは型エラーで検出
- **`_format_pipeline_error` を `models.py` に集約**: `cli.py` / `server.py` の重複実装を解消
- **empty-result 分岐を `_print_ingest_result` 経由に統一**: `zenn` / `add-document` / `crawl-documents` の「取り込み対象がありませんでした」分岐で aborted が text モードでも表示されるように（`IngestResult.summary()` の【処理中断】前置が自動適用）
- **`ConversionFailedError` メッセージから `file_path` 除去**: `PipelineErrorEntry.path` と重複しないように

### Issue #605 に繰越（問題 2 の根本対応）

- 問題 2（`errors`/`aborted` を exit code に反映する 3 値化）は、MCP 応答経路との矛盾があり設計見直しが必要と判明
- 2 値設計（0=成功 / 1=致命的失敗）での再設計方針を #605 で確定済み
- 本 PR では 3 値 exit code 関連の変更は全面撤回し、QA も #605 で実施する

## Test plan

- [x] ruff / mypy / doc-lint 通過
- [x] pytest 1581 passed（diff モード・全件）
- [x] 壊れ JSON 注入 + rebuild で構造化エラー情報が MCP レスポンスに含まれる（`test_rebuild_stats.py::test_structured_errors_reach_mcp_response`）
- [x] `ConversionFailedError` のメッセージ保持（`test_pipeline_controller.py::test_conversion_failed_preserves_message`）
- [x] `PipelineSummary.failed_paths()` アクセサ（`test_pipeline_controller.py::TestPipelineSummaryFailedPaths`）
- [x] `_ingest_result_to_dict` の 4 フィールド検証（`test_cli_json_output.py::TestIngestResultToDict`）
- [x] site-ingest text 出力で `IngestResult.summary()` 経由 + `overwritten` 表示（`test_scrapy_site_ingest.py`）
- [ ] QA 実施 — Issue #605 の根本対応後にまとめて実施（exit code 挙動・MCP 応答経路の設計変更を伴うため）

## Related issues

Closes #602

関連:

- #605: exit code 体系と MCP 応答経路の責務分離（問題 2 の根本対応、本 PR で暫定対応とした範囲）
- becky3/agent-commons#221: 緩い型（`str` 定数 / `dict[str, Any]` / `int` フラグ）の代替として構造化型（Enum / TypedDict / dataclass）を標準化