### PR TITLE
refactor(cli,server,rebuild-stats): CLI exit code 2 値契約と stdout-first MCP 応答契約の本実装 (#605)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -376,10 +376,12 @@ MCP 対応: `rag_stats` / `rag_list_recent` (+ filters) / `rag_search` / `rag_ge
 
 ### I) Obs（観測性）
 
-PR #596 の観測性機能（構造化エラー情報）が production 出力経路（CLI JSON / MCP レスポンス）に届いていることを検証する。
-仕様: [docs/specs/pipeline-controller.md](../../../docs/specs/pipeline-controller.md) の `PipelineSummary.errors`。
+PR #596 の観測性機能（構造化エラー情報）が production 出力経路（CLI JSON / MCP レスポンス）に届いていること、および #605 で確定した CLI exit code 体系（2 値）・MCP 応答契約（result line 優先）が正しく動作することを検証する。
 
-> **TODO:#605** exit code 体系（`echo $?` での判定）および MCP 応答経路との整合は #605 で設計確定後に追加する。
+仕様:
+
+- [docs/specs/pipeline-controller.md](../../../docs/specs/pipeline-controller.md) の `PipelineSummary.errors`
+- [docs/specs/rebuild-stats.md](../../../docs/specs/rebuild-stats.md) の「CLI exit code 体系」「MCP 応答契約」
 
 #### グループ準備
 
@@ -390,9 +392,18 @@ PR #596 の観測性機能（構造化エラー情報）が production 出力経
 |---|----------------|---------|---------|
 | 1 | 壊れた JSON を `<SOURCE_STORE_DIR>/zenn/obs_test/articles/broken.json` に配置（`echo '<!DOCTYPE html>' > …`）し、source_store で `git add -A && git commit` | 壊れた JSON の配置・コミットが成功 | `none` |
 | 2 | `rebuild --mode incremental --output json` を実行し、最終 JSON 行を `tail -1 \| jq '.errors'` で確認 | JSON 出力の `errors` が構造化 dict のリストで、`path` / `size_bytes` / `message` / `phase` を含む | `none` |
-| 3 | 壊れた JSON を削除し source_store で `git add -A && git commit` | 片付け成功 | `none` |
+| 3 | 直前コマンドの `echo $?` を実行 | **exit code = 0**（workload で `errors > 0` であっても CLI は完走扱い。2 値契約に従う） | `none` |
+| 4 | 壊れた JSON を削除し source_store で `git add -A && git commit` | 片付け成功 | `none` |
+| 5 | バリデーション失敗コマンドを実行: `rebuild --mode incremental --source-type web --output json`（`_output_error` 経路を通る組合せ違反） | stdout に `{"type": "error", "message": "incremental モードでは source_type を指定できません"}` が出力される | `none` |
+| 6 | 直前コマンドの `echo $?` を実行 | **exit code = 1**（2 値契約に従う。argparse バリデーション失敗も `_JsonAwareArgumentParser` で exit 1 に統一される） | `none` |
 
-MCP 対応: ステップ 2 は `rag_rebuild(mode="incremental")` のレスポンステキストに `path`・`size_bytes`・`message`・`phase` が含まれることで確認する（CLI JSON → MCP テキスト変換経路の動作確認）。
+MCP 対応:
+
+MCP 経路では `echo $?` を直接検証できないため、代替として以下を確認する:
+
+- ステップ 2: `rag_rebuild(mode="incremental")` のレスポンステキストに `path`・`size_bytes`・`message`・`phase` が含まれることで確認する（CLI JSON → MCP テキスト変換経路の動作確認）
+- ステップ 3 の代替: MCP 経路では `_run_cli_subprocess` が result 行を優先してパースするため、workload の `errors > 0` でも MCP クライアントは構造化サマリを受け取る（例外として失敗しない）。ステップ 2 でサマリが正しく返れば exit code 契約の動作も保証される
+- ステップ 5 の代替: `rag_rebuild(mode="incremental", source_type="web")` が `CLISubprocessError` として伝播し、エラーメッセージが MCP レスポンスに含まれる
 
 ### 7. クリーンアップ
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -152,11 +152,20 @@ ConstrainedClient はサーキットブレーカーの責務（HTTP レスポン
 
 ##### JSON シリアライズ
 
-CLI `--output json` および MCP レスポンスでは、`IngestResult` の観測性フィールドを欠落なく JSON に含めなければならない。
-スケジューラや再取り込みツールが親失敗・部分失敗・中断を独立して判定できるよう、
-`placed` / `skipped` / `overwritten` / `errors` / `error_details` /
-`partial_failures` / `partial_failure_details` / `aborted` / `abort_reason`
-の全項目をゼロ値・空リスト・`None` も省略せず常に出力する。
+CLI `--output json` 出力は MCP 応答経路および外部スケジューラが解釈する workload 結果の SSoT である。
+`IngestResult` の観測性フィールド
+（`placed` / `skipped` / `overwritten` / `errors` / `error_details` /
+`partial_failures` / `partial_failure_details` / `aborted` / `abort_reason`）
+を欠落なく含め、スケジューラや再取り込みツールが親失敗・部分失敗・中断を独立して判定できるようにする。
+
+**CLI exit code との関係**: `errors > 0` や `aborted = true` は CLI の exit code に反映されない（CLI exit code 体系の SSoT: [rebuild-stats.md](../rebuild-stats.md) の「CLI exit code 体系」）。
+
+**出力経路の区別**:
+
+| 出力経路 | 内容 | 欠落可否 |
+|---|------|---------|
+| CLI `--output json`（SSoT） | `IngestResult` の全観測性フィールドを構造化 JSON で出力 | 欠落禁止。ゼロ値・空リスト・`None` も省略しない |
+| MCP テキスト応答（表示層） | 構造化 JSON を表示用テキストへ変換（`src/rag/server.py` の表示変換関数が担当） | 表示層の省略は許容（ゼロ件の内訳行を非表示にする等）。ただし表示対象から除外した情報も元 JSON には含まれる |
 
 #### 中断系エラーの扱い
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -128,7 +128,10 @@ flowchart TD
     CRASH --> ERROR_CRASH["エラー返却（サーバー生存）"]
 ```
 
-MCP 経由の場合、パイプライン処理（再構築・取り込み後のインデックス構築・削除）は CLI を別プロセスとして実行する（MCP 薄層アダプターパターン、詳細は [rag-knowledge.md](rag-knowledge.md) を参照）。C 拡張の SEGFAULT が発生してもサーバープロセスは生存し、exit code からエラーメッセージを返却する。CLI 直接実行は独立プロセスのためサブプロセス化は不要。
+MCP 経由の場合、パイプライン処理（再構築・取り込み後のインデックス構築・削除）は CLI を別プロセスとして実行する
+（MCP 薄層アダプターパターン、詳細は [rag-knowledge.md](rag-knowledge.md) を参照）。
+C 拡張の SEGFAULT が発生してもサーバープロセスは生存し、SEGFAULT 検出時は専用のエラーメッセージを返却する
+（判定ロジックは後述「MCP 応答契約」参照）。CLI 直接実行は独立プロセスのためサブプロセス化は不要。
 
 ### CLI サブプロセス進捗通知
 
@@ -157,10 +160,38 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
 
-> **TODO:#605** CLI の exit code 体系（ingest/rebuild での errors/aborted の反映）
-> および MCP 応答経路との整合は本仕様書では未定義。#605 で設計確定後に追記する。
-> 現時点では「正常完走 → exit 0 / バリデーション失敗・例外 → exit 1」の 2 値のみ
-> （`errors > 0` や `aborted` は JSON 出力の構造化フィールドでのみ表現される）。
+#### CLI exit code 体系（2 値）
+
+CLI の exit code は「CLI プロセスが最終 JSON 行（`type: "result"` または `type: "error"`）を出力して正常終了したか」を示す 2 値であり、workload の結果（`errors` / `aborted`）は JSON 出力の構造化フィールドで表現する。
+
+| exit code | 意味 | 発生条件 |
+|-----------|------|---------|
+| `0` | CLI プロセスが最終 JSON 行を出力して正常終了した | workload の errors 有無は問わない（`errors>0` でも `0`、`aborted=true` でも `0`） |
+| `1` | CLI プロセスが致命的に失敗した | パラメータ・設定不備による進行不能、プログラミングエラー、未捕捉例外。`type: "error"` JSON 行を出力するか、または出力前にクラッシュする |
+
+**設計意図 (Why)**: MCP 経路は CLI の stdout を構造化 JSON として解釈する。workload の errors を exit code に反映すると「非ゼロ exit → 例外化」のガード経路と衝突し、構造化サマリが MCP クライアントに届かなくなる。CLI 側は「完走したか」のみを exit code で表現し、workload の結果は JSON 経路に単一責任を持たせる。
+
+**argparse バリデーション失敗の扱い**:
+Python 標準の argparse はバリデーション失敗時に exit code 2 を返す（POSIX usage-error 慣習）。
+本プロジェクトでは 2 値契約との一貫性を優先し、`_JsonAwareArgumentParser`（`src/rag/cli.py`）で exit code を 1 に統一する。
+`--output json` 指定時は `_output_error` 経由で構造化エラー行を出力する。
+
+**SEGFAULT の扱い**: C 拡張のクラッシュにより `_SEGFAULT_EXIT_CODES`（`src/rag/server.py` で定義）に含まれる exit code が返る場合、2 値契約の範囲外として MCP 応答契約で個別検出する（後述の優先度 1 参照）。
+
+**スケジューラ運用**: 致命的失敗の検知は exit code（`cmd && ...`）、workload の errors/aborted の判定は JSON parse（`jq '.errors | length > 0'` / `jq '.aborted'`）で行う。
+
+#### MCP 応答契約（stdout 判定ロジック）
+
+`src/rag/server.py::_run_cli_subprocess` は CLI の stdout を以下の優先順位で判定する。SEGFAULT 検出を除き、exit code は判定に使わず debug ログ出力および「出力なし」エラーメッセージでの参照のみに用いる。
+
+| 優先 | 検出対象 | 動作 |
+|------|----------|------|
+| 1 | `exit_code in _SEGFAULT_EXIT_CODES` | `CLISubprocessError("SEGFAULT, exit_code={code}")` を raise |
+| 2 | stdout に `type: "error"` 行 | `message` を取り出して `CLISubprocessError(message)` を raise（ロック競合判定は `_is_lock_conflict_error` が message 内のキーワード有無で実施。詳細は `src/rag/server.py`） |
+| 3 | stdout に `type: "result"` 行 | JSON をパースして dict を返す（`errors>0` でも `aborted=true` でも返却） |
+| 4 | 出力なし | `CLISubprocessError("出力が空 (exit_code={code})")` を raise（stderr tail を付加） |
+
+**設計意図 (Why)**: `errors>0` を含む result 行は MCP クライアントが期待する構造化サマリであり、exit code の値で破棄してはならない。error 行が明示的に出ている場合のみ失敗として扱う。
 
 #### サーバー側の処理
 
@@ -170,9 +201,10 @@ MCP サーバー（server.py）は stdout を行単位で読み取り、`progres
 2. stdout を行単位で非同期に読み取る（`readline()` ループ）
 3. 各行を JSON パースし:
    - `type: "progress"` → `ctx.report_progress(processed, total, message=current)` で進捗通知
-   - `type: "result"` → 結果として返却
-   - `type: "error"` → エラーとして処理
-4. stderr はプロセス終了後に読み取る
+   - `type: "result"` → 最終結果候補として保持
+   - `type: "error"` → エラー候補として保持
+4. stderr はプロセス終了後に読み取る（ログ転送のみ）
+5. 上記「MCP 応答契約」の優先順位に従って判定する
 
 #### PipelineController の変更
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -159,9 +159,8 @@ class _JsonAwareArgumentParser(argparse.ArgumentParser):
     docs/specs/rebuild-stats.md）と矛盾する。
     本プロジェクトでは以下を優先して慣習より契約の一貫性を取る:
 
-    - `--output json` / `-o json`: `_output_error` 経由で stdout に
-      `type:"error"` JSON 行を出力してから `sys.exit(1)`（MCP 応答経路が
-      構造化エラーを受け取れる）
+    - `--output json`: `_output_error` 経由で stdout に `type:"error"` JSON 行を
+      出力してから `sys.exit(1)`（MCP 応答経路が構造化エラーを受け取れる）
     - 上記以外（text モード）: argparse 標準のメッセージを stderr に書いてから
       `sys.exit(1)`（exit code のみ統一、メッセージ形式は argparse 既定）
     """
@@ -176,10 +175,10 @@ class _JsonAwareArgumentParser(argparse.ArgumentParser):
     @staticmethod
     def _output_json_requested() -> bool:
         argv = sys.argv[1:]
-        if "--output=json" in argv or "-o=json" in argv:
+        if "--output=json" in argv:
             return True
         for i, arg in enumerate(argv):
-            if arg in ("--output", "-o") and i + 1 < len(argv) and argv[i + 1] == "json":
+            if arg == "--output" and i + 1 < len(argv) and argv[i + 1] == "json":
                 return True
         return False
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -151,6 +151,39 @@ def _output_error(message: str) -> None:
     sys.exit(1)
 
 
+class _JsonAwareArgumentParser(argparse.ArgumentParser):
+    """argparse のバリデーションエラーを CLI 2 値契約（0/1）に統一する.
+
+    標準の argparse はバリデーション失敗で exit code 2（POSIX usage error 慣習）を
+    返すが、これは CLI exit code の 2 値契約（0=完走 / 1=致命、仕様:
+    docs/specs/rebuild-stats.md）と矛盾する。
+    本プロジェクトでは以下を優先して慣習より契約の一貫性を取る:
+
+    - `--output json` / `-o json`: `_output_error` 経由で stdout に
+      `type:"error"` JSON 行を出力してから `sys.exit(1)`（MCP 応答経路が
+      構造化エラーを受け取れる）
+    - 上記以外（text モード）: argparse 標準のメッセージを stderr に書いてから
+      `sys.exit(1)`（exit code のみ統一、メッセージ形式は argparse 既定）
+    """
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        if self._output_json_requested():
+            _output_error(f"{self.prog}: {message}")
+        # text モード: argparse 標準の usage + エラーメッセージを stderr に出す
+        self.print_usage(sys.stderr)
+        self.exit(1, f"{self.prog}: error: {message}\n")
+
+    @staticmethod
+    def _output_json_requested() -> bool:
+        argv = sys.argv[1:]
+        if "--output=json" in argv or "-o=json" in argv:
+            return True
+        for i, arg in enumerate(argv):
+            if arg in ("--output", "-o") and i + 1 < len(argv) and argv[i + 1] == "json":
+                return True
+        return False
+
+
 def _error_detail_message(detail: dict[str, object]) -> str:
     """error_details の dict から表示用メッセージを抽出する."""
     message = detail.get("message")
@@ -269,8 +302,12 @@ def _validate_bm25_b(value: str) -> float:
 
 def main() -> None:
     """CLIエントリポイント."""
-    parser = argparse.ArgumentParser(description="RAG Knowledge CLI")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser = _JsonAwareArgumentParser(description="RAG Knowledge CLI")
+    # サブパーサーにも _JsonAwareArgumentParser を使わせる。
+    # argparse のデフォルトは ArgumentParser 固定で、親クラスを継承しない。
+    subparsers = parser.add_subparsers(
+        dest="command", required=True, parser_class=_JsonAwareArgumentParser,
+    )
 
     # evaluate サブコマンド
     eval_parser = subparsers.add_parser("evaluate", help="RAG検索精度を評価")

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1058,9 +1058,10 @@ async def _run_cli_subprocess(
             process.stdin.close()
             await process.stdin.wait_closed()
 
-    async def _read_stdout() -> str:
-        """stdout を行単位で読み、progress 通知を処理し、最終 result/error 行を返す."""
+    async def _read_stdout() -> tuple[str, str]:
+        """stdout を行単位で読み、progress を処理し、最終 result 行・error 行を返す."""
         _result_line = ""
+        _error_line = ""
         assert process.stdout is not None  # noqa: S101
         while True:
             raw = await process.stdout.readline()
@@ -1070,7 +1071,6 @@ async def _run_cli_subprocess(
             if not line:
                 continue
 
-            # JSON パースを試みて type フィールドで分岐
             try:
                 data = json.loads(line)
                 if isinstance(data, dict):
@@ -1085,13 +1085,13 @@ async def _run_cli_subprocess(
                                 message=current,
                             )
                         continue
-                    # result/error のみ最終結果として保持
-                    if msg_type in {"result", "error"}:
+                    if msg_type == "error":
+                        _error_line = line
+                    elif msg_type == "result":
                         _result_line = line
             except json.JSONDecodeError:
-                # 非 JSON 行（ログ等）は result_line を上書きしない
                 pass
-        return _result_line
+        return _result_line, _error_line
 
     async def _drain_stderr() -> bytes:
         """stderr を並行に drain する（パイプバッファ溢れ防止）."""
@@ -1101,7 +1101,7 @@ async def _run_cli_subprocess(
 
     # stdout と stderr を並行に読み取る（パイプバッファのデッドロック防止）
     try:
-        result_line, stderr_bytes = await asyncio.gather(
+        (result_line, error_line), stderr_bytes = await asyncio.gather(
             _read_stdout(),
             _drain_stderr(),
         )
@@ -1122,37 +1122,36 @@ async def _run_cli_subprocess(
     stderr_lines = stderr_text.rstrip().splitlines()
     stderr_tail = "\n".join(stderr_lines[-10:])
 
-    # SEGFAULT 検出
+    if stderr_text:
+        for line in stderr_lines:
+            logger.debug("[CLI] %s", line)
+    logger.debug("CLI subprocess %s exit_code=%d", command, exit_code)
+
+    # 判定は優先順位「SEGFAULT > error line > result line > 出力なし」。
+    # exit_code は判定に使わない（CLI の 2 値契約: 0=完走 / 1=致命、
+    # workload の errors/aborted は result JSON で表現する）。
     if exit_code in _SEGFAULT_EXIT_CODES:
         raise CLISubprocessError(
             f"CLI サブプロセスがクラッシュしました (SEGFAULT, exit_code={exit_code})"
         )
 
-    # エラー処理
-    if exit_code != 0:
-        if result_line:
-            try:
-                error_data = json.loads(result_line)
-                if error_data.get("error") or error_data.get("type") == "error":
-                    error_msg = error_data.get("message", "不明なエラー")
-                    raise CLISubprocessError(
-                        error_msg,
-                        lock_conflict=_is_lock_conflict_error(error_msg),
-                    )
-            except json.JSONDecodeError:
-                pass
+    if error_line:
+        try:
+            error_data = json.loads(error_line)
+        except json.JSONDecodeError as exc:
+            raise CLISubprocessError(
+                f"CLI サブプロセスのエラー行パースに失敗: {error_line}"
+            ) from exc
+        error_msg = error_data.get("message", "不明なエラー")
         raise CLISubprocessError(
-            f"CLI サブプロセスが異常終了しました (exit_code={exit_code})\n{stderr_tail}"
+            error_msg,
+            lock_conflict=_is_lock_conflict_error(error_msg),
         )
 
-    # 正常終了時の stderr をログに転送（警告やデバッグ情報の保全）
-    if stderr_text:
-        for line in stderr_lines:
-            logger.debug("[CLI] %s", line)
-
-    # 結果パース
     if not result_line:
-        raise CLISubprocessError("CLI サブプロセスの出力が空です")
+        raise CLISubprocessError(
+            f"CLI サブプロセスの出力が空です (exit_code={exit_code})\n{stderr_tail}"
+        )
 
     try:
         result: dict[str, Any] = json.loads(result_line)
@@ -1161,7 +1160,7 @@ async def _run_cli_subprocess(
             f"CLI サブプロセスの結果パースに失敗: {result_line}"
         ) from exc
 
-    logger.info("CLI subprocess completed: %s (exit_code=0)", command)
+    logger.info("CLI subprocess completed: %s (exit_code=%d)", command, exit_code)
     return result
 
 

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -16,6 +16,7 @@ from rag.cli import (
     _add_output_option,
     _ingest_result_to_dict,
     _is_json_output,
+    _JsonAwareArgumentParser,
     _output_error,
     _output_json,
     _output_progress,
@@ -81,6 +82,67 @@ class TestIsJsonOutput:
     def test_returns_false_when_attr_missing(self) -> None:
         args = argparse.Namespace()
         assert _is_json_output(args) is False
+
+
+class TestJsonAwareArgumentParser:
+    """_JsonAwareArgumentParser のバリデーションエラー挙動."""
+
+    @pytest.fixture
+    def parser(self) -> _JsonAwareArgumentParser:
+        parser = _JsonAwareArgumentParser(prog="testcli")
+        parser.add_argument("--mode", choices=["a", "b"], required=True)
+        parser.add_argument("--output", choices=["text", "json"], default="text")
+        return parser
+
+    def test_json_mode_exits_with_1_and_json_error(
+        self,
+        parser: _JsonAwareArgumentParser,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--output json 指定時はバリデーション失敗で exit 1 + JSON error を出す."""
+        monkeypatch.setattr("sys.argv", ["testcli", "--mode", "invalid", "--output", "json"])
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--mode", "invalid", "--output", "json"])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out.strip())
+        assert parsed["type"] == "error"
+        assert parsed["error"] is True
+        assert "invalid choice" in parsed["message"]
+
+    def test_json_equals_form_exits_with_1(
+        self,
+        parser: _JsonAwareArgumentParser,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--output=json 形式も検出される."""
+        monkeypatch.setattr("sys.argv", ["testcli", "--mode", "invalid", "--output=json"])
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--mode", "invalid", "--output=json"])
+        assert exc_info.value.code == 1
+
+    def test_text_mode_exits_with_1_and_stderr_message(
+        self,
+        parser: _JsonAwareArgumentParser,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """text モードでも exit 1 に統一し、メッセージは stderr に出す（2 値契約）.
+
+        argparse 標準の exit 2 は CLI 2 値契約（0/1）と矛盾するため、
+        本プロジェクトでは text モードでも exit 1 に統一する。
+        POSIX の usage-error 慣習より契約の一貫性を優先する。
+        """
+        monkeypatch.setattr("sys.argv", ["testcli", "--mode", "invalid"])
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--mode", "invalid"])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        # text モードでは stderr にエラー、stdout は空
+        assert captured.out == ""
+        assert "invalid choice" in captured.err
 
 
 class TestAddOutputOption:

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -122,6 +122,9 @@ class TestJsonAwareArgumentParser:
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--mode", "invalid", "--output=json"])
         assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out.strip())
+        assert parsed["type"] == "error"
 
     def test_text_mode_exits_with_1_and_stderr_message(
         self,

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -657,6 +657,141 @@ class TestCLISubprocessError:
         assert err.lock_conflict is True
 
 
+class TestRunCliSubprocess:
+    """_run_cli_subprocess の判定ロジック（result line 優先、exit code は判定に使わない）."""
+
+    @staticmethod
+    def _make_mock_process(
+        stdout_lines: list[str],
+        *,
+        exit_code: int = 0,
+        stderr: str = "",
+    ) -> AsyncMock:
+        """stdout/stderr を非同期 readline で返すモックプロセスを作成する."""
+        mock_process = AsyncMock()
+        mock_process.returncode = exit_code
+        mock_process.wait = AsyncMock(return_value=exit_code)
+
+        lines_iter = iter([line.encode("utf-8") + b"\n" for line in stdout_lines] + [b""])
+        stdout = AsyncMock()
+
+        async def _readline() -> bytes:
+            return next(lines_iter, b"")
+
+        stdout.readline = _readline
+        mock_process.stdout = stdout
+
+        stderr_mock = AsyncMock()
+        stderr_mock.read = AsyncMock(return_value=stderr.encode("utf-8"))
+        mock_process.stderr = stderr_mock
+        return mock_process
+
+    @pytest.mark.asyncio
+    async def test_result_line_returns_parsed_result(self) -> None:
+        """type: result 行がある場合、exit code 0 でパース済み結果を返す."""
+        mod = import_module("rag.server")
+        result_payload = '{"type": "result", "placed": 3, "errors": 0}'
+        mock_process = self._make_mock_process([result_payload], exit_code=0)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await mod._run_cli_subprocess("rebuild")
+
+        assert result["type"] == "result"
+        assert result["placed"] == 3
+        assert result["errors"] == 0
+
+    @pytest.mark.asyncio
+    async def test_result_line_with_nonzero_exit_returns_result(self) -> None:
+        """非ゼロ exit でも type: result 行があればパース成功を返す.
+
+        これが本 Issue の核となる変更: exit code は判定に使わず、
+        workload の errors/aborted は result JSON で表現する。
+        """
+        mod = import_module("rag.server")
+        result_payload = (
+            '{"type": "result", "placed": 0, "errors": 2, '
+            '"error_details": [{"path": "a.md", "message": "x"}]}'
+        )
+        mock_process = self._make_mock_process([result_payload], exit_code=2)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await mod._run_cli_subprocess("rebuild")
+
+        assert result["errors"] == 2
+        assert result["error_details"][0]["path"] == "a.md"
+
+    @pytest.mark.asyncio
+    async def test_error_line_raises_cli_subprocess_error(self) -> None:
+        """type: error 行がある場合は CLISubprocessError を raise する."""
+        mod = import_module("rag.server")
+        error_payload = '{"type": "error", "message": "バリデーション失敗"}'
+        mock_process = self._make_mock_process([error_payload], exit_code=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            with pytest.raises(mod.CLISubprocessError) as exc_info:
+                await mod._run_cli_subprocess("rebuild")
+
+        assert "バリデーション失敗" in str(exc_info.value)
+        assert exc_info.value.lock_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_error_line_priority_over_result_line(self) -> None:
+        """error 行と result 行が両方ある場合、error 行が優先される."""
+        mod = import_module("rag.server")
+        stdout_lines = [
+            '{"type": "result", "placed": 1}',
+            '{"type": "error", "message": "後から発生したエラー"}',
+        ]
+        mock_process = self._make_mock_process(stdout_lines, exit_code=0)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            with pytest.raises(mod.CLISubprocessError) as exc_info:
+                await mod._run_cli_subprocess("rebuild")
+
+        assert "後から発生したエラー" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_no_output_raises_with_exit_code(self) -> None:
+        """出力が空の場合、exit_code を含む CLISubprocessError を raise する."""
+        mod = import_module("rag.server")
+        mock_process = self._make_mock_process([], exit_code=1, stderr="fatal error")
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            with pytest.raises(mod.CLISubprocessError) as exc_info:
+                await mod._run_cli_subprocess("rebuild")
+
+        msg = str(exc_info.value)
+        assert "出力が空" in msg
+        assert "exit_code=1" in msg
+
+    @pytest.mark.asyncio
+    async def test_segfault_exit_code_raises_segfault_error(self) -> None:
+        """SEGFAULT 扱いの exit_code では result 行の有無にかかわらず raise する."""
+        mod = import_module("rag.server")
+        segfault_code = next(iter(mod._SEGFAULT_EXIT_CODES))
+        result_payload = '{"type": "result", "placed": 1}'
+        mock_process = self._make_mock_process([result_payload], exit_code=segfault_code)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            with pytest.raises(mod.CLISubprocessError) as exc_info:
+                await mod._run_cli_subprocess("rebuild")
+
+        assert "SEGFAULT" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_lock_conflict_detected_from_error_line(self) -> None:
+        """ロック競合エラーの場合 lock_conflict=True が設定される."""
+        mod = import_module("rag.server")
+        error_payload = '{"type": "error", "message": "lock conflict: already held"}'
+        mock_process = self._make_mock_process([error_payload], exit_code=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            with pytest.raises(mod.CLISubprocessError) as exc_info:
+                await mod._run_cli_subprocess("rebuild")
+
+        assert exc_info.value.lock_conflict is True
+
+
 class TestFormatCliIngestResult:
     """_format_cli_ingest_result のテスト."""
 

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -7,6 +7,7 @@ rag_rebuild MCP ツール・CLI、rag_stats 拡張の振る舞いを検証する
 
 from __future__ import annotations
 
+import json
 from importlib import import_module
 from unittest.mock import AsyncMock, patch
 
@@ -251,6 +252,60 @@ class TestRagRebuild:
         assert "zenn/user/articles/broken.json" in result
         assert "15 bytes" in result
         assert "JSON parse error" in result
+
+    @pytest.mark.asyncio
+    async def test_structured_errors_with_nonzero_exit_reach_mcp_response(self) -> None:
+        """非ゼロ exit_code でも result 行があれば構造化サマリが MCP に届くこと.
+
+        本テストは #605 の核となる契約を subprocess レベルでカバーする:
+        workload の errors>0 により CLI が将来的に非ゼロで終了しても、
+        stdout に result 行がある限り MCP クライアントはサマリを受け取る。
+        仕様: docs/specs/rebuild-stats.md「MCP 応答契約」。
+        """
+        from rag.server import rag_rebuild
+
+        result_payload = json.dumps({
+            "type": "result",
+            "mode": "incremental",
+            "total_files": 2,
+            "processed": 1,
+            "errors": [
+                {
+                    "path": "zenn/user/articles/broken.json",
+                    "size_bytes": 15,
+                    "message": "JSON parse error",
+                    "phase": "convert_and_index",
+                },
+            ],
+            "warnings": [],
+            "elapsed": 0.4,
+        })
+
+        mock_process = AsyncMock()
+        # 将来 CLI が errors>0 で非ゼロ exit を返したとしても result 行が優先される
+        mock_process.returncode = 2
+        mock_process.wait = AsyncMock(return_value=2)
+
+        lines_iter = iter([result_payload.encode("utf-8") + b"\n", b""])
+        stdout = AsyncMock()
+
+        async def _readline() -> bytes:
+            return next(lines_iter, b"")
+
+        stdout.readline = _readline
+        mock_process.stdout = stdout
+
+        stderr_mock = AsyncMock()
+        stderr_mock.read = AsyncMock(return_value=b"")
+        mock_process.stderr = stderr_mock
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            response = await rag_rebuild(mode="incremental")
+
+        # exit_code=2 にもかかわらず構造化サマリが MCP レスポンスに含まれる
+        assert "zenn/user/articles/broken.json" in response
+        assert "15 bytes" in response
+        assert "JSON parse error" in response
 
     @pytest.mark.asyncio
     async def test_lock_conflict_returns_error(self) -> None:


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング ★
- [x] test: テスト追加・修正
- [x] docs: ドキュメント更新

## Summary

PR #606（Issue #602 暫定対応）で導入された 3 値 exit code を撤回し、Issue #605 で確定した 2 値 exit code 契約（0=完走 / 1=致命）と stdout-first MCP 応答契約を本実装する。トリアージで判明した argparse exit 2 との乖離も根本対応し、真の 2 値契約を成立させる。

- `src/rag/server.py::_run_cli_subprocess`: 判定ロジックを stdout-first に変更（優先順位: SEGFAULT > error line > result line > 出力なし）。exit code は SEGFAULT 検出とログのみに使用
- `src/rag/cli.py`: `_JsonAwareArgumentParser` を追加し argparse バリデーション失敗を exit 1 に統一（POSIX exit 2 慣習より契約の一貫性を優先）。`--output json` 指定時は `_output_error` 経由で構造化エラー JSON を出力
- `docs/specs/rebuild-stats.md`: 「CLI exit code 体系（2 値）」「MCP 応答契約」セクションを追加、TODO:#605 削除
- `docs/specs/ingesters/common.md`: JSON シリアライズの SSoT 位置付けと出力経路区別（CLI JSON=SSoT / MCP テキスト=表示層）を整理
- `.claude/skills/qa/SKILL.md`: I) Obs グループを正式化（`echo $?` 検証ステップ追加）、TODO:#605 削除

**スコープ外（別 Issue）**: エラーコード taxonomy の導入は #607 に切り出し。現状の message 文字列のキーワードマッチ（`_is_lock_conflict_error`）は本 PR では維持する。

## Test plan

- [x] `_run_cli_subprocess` 単体テスト 7 ケース（`tests/test_rag_mcp_server.py::TestRunCliSubprocess`）
- [x] `_JsonAwareArgumentParser` 単体テスト 3 ケース（`tests/test_cli_json_output.py::TestJsonAwareArgumentParser`）
- [x] 非ゼロ exit でも MCP が構造化サマリを返すことの統合テスト（`tests/test_rebuild_stats.py::test_structured_errors_with_nonzero_exit_reach_mcp_response`）
- [x] pytest 全通過、ruff / mypy / markdownlint 違反なし
- [x] QA グループ I) Obs（CLI 経路）: 壊れ JSON 投入で構造化エラー確認、`echo \$?` が 0（workload errors>0）/ 1（バリデーション失敗）で正しく分離されることを実証

## Related issues

Closes #605