### PR TITLE
feat(rag-knowledge): CLI エラーコード taxonomy（enum ベース）の導入 (#607)

### DIFF
--- a/_schema/enums.yml
+++ b/_schema/enums.yml
@@ -30,3 +30,19 @@ pipeline_mode:
       description: 変換のみ（インデックス構築なし）
     - value: index
       description: インデックス構築のみ（変換なし）
+
+cli_error_code:
+  description: CLI JSON エラー出力のエラー種別コード
+  values:
+    - value: VALIDATION_ERROR
+      description: パラメータ検証失敗（argparse バリデーション、組合せ違反等）
+    - value: LOCK_CONFLICT
+      description: ロック競合（別プロセスが実行中）
+    - value: CONFIG_MISSING
+      description: 環境変数・設定不備
+    - value: DEPENDENCY_UNAVAILABLE
+      description: 外部依存エラー（LM Studio 接続失敗、ChromaDB 未起動等）
+    - value: NOT_FOUND
+      description: ソース・リソース不在
+    - value: INTERNAL_ERROR
+      description: 想定外例外（上記いずれにも該当しない）

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -187,6 +187,8 @@ CLI `--output json` 出力は MCP 応答経路および外部スケジューラ�
 
 **CLI exit code との関係**: `errors > 0` や `aborted = true` は CLI の exit code に反映されない（CLI exit code 体系の SSoT: [rebuild-stats.md](../rebuild-stats.md) の「CLI exit code 体系」）。
 
+**error 行のエラーコード**: `type: "error"` 行には `code` フィールド（[`_schema/enums.yml`](../../../_schema/enums.yml) の `cli_error_code` 参照）を含め、消費側が message 文字列のキーワードマッチに依存せずにエラー種別を判定できるようにする。詳細は [rebuild-stats.md](../rebuild-stats.md) の「CLI JSON 出力体系」を参照。
+
 **出力経路の区別**:
 
 | 出力経路 | 内容 | 欠落可否 |

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -156,7 +156,7 @@ CLI は `--output json` 指定時に JSON Lines 形式で stdout に出力する
 |-----------|-------------|-----------|
 | `progress` | ファイル処理完了ごと | `processed`（int）、`total`（int）、`current`（str: 処理済みファイルパス） |
 | `result` | 処理完了時（最終行） | コマンド固有のフィールド（`mode`, `total_files`, `processed`, `errors`, `warnings`, `elapsed` 等。`full` モードは `convert` / `index` オブジェクトに分割）。`errors` は [pipeline-controller.md](pipeline-controller.md) の `PipelineSummary.errors` スキーマに従う構造化 dict のリスト（`{path, size_bytes, message, phase}`）を出力する。ingest 系コマンドでは `IngestResult` の全観測性フィールド（`partial_failures` / `aborted` 等）も併せて含める（[ingesters/common.md](ingesters/common.md) の「JSON シリアライズ」参照） |
-| `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`message`（str） |
+| `error` | エラー時（最終行） | `error`（bool, 常に `true`）、`code`（str: エラー種別コード、[`_schema/enums.yml`](../../_schema/enums.yml) の `cli_error_code` 参照）、`message`（str）、`details`（dict, 任意: 種別固有の付加情報） |
 
 MCP サーバー（server.py）は stdout を行単位で読み取り、`progress` 行を MCP 通知に変換し、`result` / `error` 行で処理結果を確定する。
 
@@ -187,7 +187,7 @@ Python 標準の argparse はバリデーション失敗時に exit code 2 を�
 | 優先 | 検出対象 | 動作 |
 |------|----------|------|
 | 1 | `exit_code in _SEGFAULT_EXIT_CODES` | `CLISubprocessError("SEGFAULT, exit_code={code}")` を raise |
-| 2 | stdout に `type: "error"` 行 | `message` を取り出して `CLISubprocessError(message)` を raise（ロック競合判定は `_is_lock_conflict_error` が message 内のキーワード有無で実施。詳細は `src/rag/server.py`） |
+| 2 | stdout に `type: "error"` 行 | `message` と `code` を取り出して `CLISubprocessError(message, code=code)` を raise。ロック競合判定は `code == "LOCK_CONFLICT"` で実施（キーワードマッチは廃止） |
 | 3 | stdout に `type: "result"` 行 | JSON をパースして dict を返す（`errors>0` でも `aborted=true` でも返却） |
 | 4 | 出力なし | `CLISubprocessError("出力が空 (exit_code={code})")` を raise（stderr tail を付加） |
 

--- a/scripts/validate_enums.py
+++ b/scripts/validate_enums.py
@@ -101,6 +101,7 @@ def main() -> None:
     data = _load_enums_yml(enums_path)
 
     # Python 定義をインポート
+    from rag.errors import CliErrorCode  # type: ignore[import-untyped]
     from rag.pipeline.models import PipelineMode  # type: ignore[import-untyped]
     from rag.store.models import SourceType  # type: ignore[import-untyped]
 
@@ -116,6 +117,12 @@ def main() -> None:
     yml_pipeline_modes = _extract_yml_values(data, "pipeline_mode")
     python_pipeline_modes = _extract_enum_values(PipelineMode)
     if not _check_match("pipeline_mode (PipelineMode)", yml_pipeline_modes, python_pipeline_modes):
+        ok = False
+
+    # cli_error_code: Enum クラス
+    yml_error_codes = _extract_yml_values(data, "cli_error_code")
+    python_error_codes = _extract_enum_values(CliErrorCode)
+    if not _check_match("cli_error_code (CliErrorCode)", yml_error_codes, python_error_codes):
         ok = False
 
     if not ok:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urldefrag
 
+from .errors import CliErrorCode
 from .filter_parser import parse_filters
 from .pipeline.models import PipelinePhase, format_pipeline_error as _format_pipeline_error
 from .evaluation import (
@@ -145,9 +146,21 @@ def _wrap_progress(
     return wrapped
 
 
-def _output_error(message: str) -> None:
+def _output_error(
+    code: CliErrorCode,
+    message: str,
+    details: dict[str, object] | None = None,
+) -> None:
     """エラー JSON を出力し、exit code 1 で終了する."""
-    _output_json({"type": "error", "error": True, "message": message})
+    payload: dict[str, object] = {
+        "type": "error",
+        "error": True,
+        "code": code.value,
+        "message": message,
+    }
+    if details is not None:
+        payload["details"] = details
+    _output_json(payload)
     sys.exit(1)
 
 
@@ -167,7 +180,7 @@ class _JsonAwareArgumentParser(argparse.ArgumentParser):
 
     def error(self, message: str) -> None:  # type: ignore[override]
         if self._output_json_requested():
-            _output_error(f"{self.prog}: {message}")
+            _output_error(CliErrorCode.VALIDATION_ERROR, f"{self.prog}: {message}")
         # text モード: argparse 標準の usage + エラーメッセージを stderr に出す
         self.print_usage(sys.stderr)
         self.exit(1, f"{self.prog}: error: {message}\n")
@@ -1248,7 +1261,7 @@ def run_get_document(args: argparse.Namespace) -> None:
 
     if result.error:
         if json_out:
-            _output_error(result.error)
+            _output_error(CliErrorCode.NOT_FOUND, result.error)
         else:
             print(f"エラー: {result.error}", file=sys.stderr)
             sys.exit(1)
@@ -1337,7 +1350,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
     # incremental + source_type のバリデーション
     if mode == "incremental" and source_type is not None:
         if json_out:
-            _output_error("incremental モードでは source_type を指定できません")
+            _output_error(CliErrorCode.VALIDATION_ERROR, "incremental モードでは source_type を指定できません")
         logger.error(
             "incremental モードでは source_type を指定できません"
         )
@@ -1347,7 +1360,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
     if if_needed and mode not in ("index", "full"):
         msg = "--if-needed は --mode index または --mode full でのみ使用できます"
         if json_out:
-            _output_error(msg)
+            _output_error(CliErrorCode.VALIDATION_ERROR, msg)
         logger.error(msg)
         sys.exit(1)
 
@@ -1355,12 +1368,12 @@ async def run_rebuild(args: argparse.Namespace) -> None:
 
     if not settings.source_store_dir:
         if json_out:
-            _output_error("SOURCE_STORE_DIR が設定されていません")
+            _output_error(CliErrorCode.CONFIG_MISSING, "SOURCE_STORE_DIR が設定されていません")
         logger.error("SOURCE_STORE_DIR が設定されていません")
         sys.exit(1)
     if not settings.converted_store_dir:
         if json_out:
-            _output_error("CONVERTED_STORE_DIR が設定されていません")
+            _output_error(CliErrorCode.CONFIG_MISSING, "CONVERTED_STORE_DIR が設定されていません")
         logger.error("CONVERTED_STORE_DIR が設定されていません")
         sys.exit(1)
 
@@ -1368,7 +1381,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
     if not source_store_dir.exists():
         msg = f"source_store ディレクトリが存在しません: {source_store_dir}"
         if json_out:
-            _output_error(msg)
+            _output_error(CliErrorCode.CONFIG_MISSING, msg)
         logger.error(
             "source_store ディレクトリが存在しません: %s", source_store_dir,
         )
@@ -1399,7 +1412,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
     except LockAcquisitionError:
         msg = "別の再構築が実行中です（ロック競合）"
         if json_out:
-            _output_error(msg)
+            _output_error(CliErrorCode.LOCK_CONFLICT, msg)
         print(f"エラー: {msg}", file=sys.stderr)
         if if_needed:
             _show_error_dialog(msg)
@@ -1432,7 +1445,7 @@ async def run_rebuild(args: argparse.Namespace) -> None:
         if args.concurrency is not None and args.concurrency < 1:
             msg = "--concurrency は 1 以上を指定してください"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             logger.error(msg)
             sys.exit(1)
 
@@ -1763,7 +1776,7 @@ def run_list_recent(args: argparse.Namespace) -> None:
             parsed_filters = parse_filters(args.filters)
         except ValueError as e:
             if json_out:
-                _output_error(str(e))
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
             else:
                 logger.error("エラー: %s", e)
                 sys.exit(1)
@@ -1798,7 +1811,7 @@ def run_list_recent(args: argparse.Namespace) -> None:
                 sources = db.list_sources(source_type=st, limit=limit, ascending=ascending, filters=parsed_filters)
                 total = db.count_sources_by_type(source_type=st, filters=parsed_filters)
             except ValueError as e:
-                _output_error(str(e))
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
                 return
         finally:
             db.close()
@@ -1885,7 +1898,7 @@ def run_search(args: argparse.Namespace) -> None:
             parsed_filters = parse_filters(args.filters)
         except ValueError as e:
             if json_out:
-                _output_error(str(e))  # sys.exit(1) で終了
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
             else:
                 logger.error("エラー: %s", e)
                 sys.exit(1)
@@ -1940,7 +1953,7 @@ async def run_delete(args: argparse.Namespace) -> None:
     except Exception:
         logger.exception("削除パイプライン実行に失敗: %s", source_id)
         if json_out:
-            _output_error(f"削除に失敗しました: {source_id}")
+            _output_error(CliErrorCode.INTERNAL_ERROR, f"削除に失敗しました: {source_id}")
         print(
             f"エラー: 削除に失敗しました: {source_id}",
             file=sys.stderr,
@@ -1984,14 +1997,14 @@ async def run_add_journal(args: argparse.Namespace) -> None:
         body = sys.stdin.read()
         if not body:
             if json_out:
-                _output_error("stdin からの入力が空です")
+                _output_error(CliErrorCode.VALIDATION_ERROR, "stdin からの入力が空です")
             print("エラー: stdin からの入力が空です", file=sys.stderr)
             raise SystemExit(1)
     else:
         file_path = Path(args.file)
         if not file_path.is_file():
             if json_out:
-                _output_error(f"ファイルが見つかりません: {file_path}")
+                _output_error(CliErrorCode.NOT_FOUND, f"ファイルが見つかりません: {file_path}")
             print(f"エラー: ファイルが見つかりません: {file_path}", file=sys.stderr)
             raise SystemExit(1)
         body = file_path.read_text(encoding="utf-8")
@@ -2003,7 +2016,7 @@ async def run_add_journal(args: argparse.Namespace) -> None:
     except LockAcquisitionError:
         msg = "別のインジェストが実行中です（ロック競合）"
         if json_out:
-            _output_error(msg)
+            _output_error(CliErrorCode.LOCK_CONFLICT, msg)
         print(f"エラー: {msg}", file=sys.stderr)
         raise SystemExit(1)
 
@@ -2020,7 +2033,7 @@ async def run_add_journal(args: argparse.Namespace) -> None:
         if ingest_result.errors > 0:
             first_detail = _error_detail_message(ingest_result.error_details[0])
             if json_out:
-                _output_error(first_detail)
+                _output_error(CliErrorCode.INTERNAL_ERROR, first_detail)
             print(f"エラー: {first_detail}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2317,7 +2330,7 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
         ingest_result = await youtube_ingester.ingest_video(args.video_url)
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2363,7 +2376,7 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
         )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2447,7 +2460,7 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
                 )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2512,7 +2525,7 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
             )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2555,7 +2568,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         if not filename:
             msg = "--stdin 使用時は --filename が必須です"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             print(f"エラー: {msg}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2563,7 +2576,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         if not raw_input:
             msg = "stdin からの入力が空です"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             print(f"エラー: {msg}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2573,7 +2586,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
             data = decode_upload_content(raw_input, encoding)
         except ValueError as e:
             if json_out:
-                _output_error(str(e))
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
             print(f"エラー: {e}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2582,7 +2595,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         if ext not in supported_extensions:
             msg = f"対応していないファイル形式です: {ext!r}（対応: {', '.join(supported_extensions)}）"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             print(f"エラー: {msg}", file=sys.stderr)
             raise SystemExit(1)
         display_name = filename
@@ -2591,18 +2604,18 @@ async def run_add_document(args: argparse.Namespace) -> None:
         file_path_str = args.file_path
         if not file_path_str or not file_path_str.strip():
             if json_out:
-                _output_error("file_path が空です")
+                _output_error(CliErrorCode.VALIDATION_ERROR, "file_path が空です")
             print("エラー: file_path が空です", file=sys.stderr)
             raise SystemExit(1)
         resolved = Path(file_path_str.strip()).resolve()
         if not resolved.exists():
             if json_out:
-                _output_error(f"ファイルが見つかりません: {resolved}")
+                _output_error(CliErrorCode.NOT_FOUND, f"ファイルが見つかりません: {resolved}")
             print(f"エラー: ファイルが見つかりません: {resolved}", file=sys.stderr)
             raise SystemExit(1)
         if resolved.is_dir():
             if json_out:
-                _output_error(f"パスはファイルではなくディレクトリです: {resolved}")
+                _output_error(CliErrorCode.VALIDATION_ERROR, f"パスはファイルではなくディレクトリです: {resolved}")
             print(f"エラー: パスはファイルではなくディレクトリです: {resolved}", file=sys.stderr)
             raise SystemExit(1)
         data = resolved.read_bytes()
@@ -2612,7 +2625,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         if ext not in supported_extensions:
             msg = f"対応していないファイル形式です: {ext!r}（対応: {', '.join(supported_extensions)}）"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             print(f"エラー: {msg}", file=sys.stderr)
             raise SystemExit(1)
         display_name = file_path_str
@@ -2624,7 +2637,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
     except LockAcquisitionError:
         msg = "別のインジェストが実行中です（ロック競合）"
         if json_out:
-            _output_error(msg)
+            _output_error(CliErrorCode.LOCK_CONFLICT, msg)
         print(f"エラー: {msg}", file=sys.stderr)
         raise SystemExit(1)
 
@@ -2643,7 +2656,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         except FileExistsError as e:
             msg = f"同名ファイルが既に存在します: {filename} ({e})"
             if json_out:
-                _output_error(msg)
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
             print(f"エラー: {msg}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2655,7 +2668,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         if ingest_result.errors > 0:
             first_detail = _error_detail_message(ingest_result.error_details[0])
             if json_out:
-                _output_error(first_detail)
+                _output_error(CliErrorCode.INTERNAL_ERROR, first_detail)
             print(f"エラー: {first_detail}", file=sys.stderr)
             raise SystemExit(1)
 
@@ -2705,7 +2718,7 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
         # 早期終了: エラー詳細を先頭 1 件だけ表示してから exit
         first_detail = _error_detail_message(ingest_result.error_details[0])
         if json_out:
-            _output_error(first_detail)
+            _output_error(CliErrorCode.INTERNAL_ERROR, first_detail)
         print(f"エラー: {first_detail}", file=sys.stderr)
         raise SystemExit(1)
 
@@ -2740,7 +2753,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             validated_urls.append(validated)
         except ValueError as e:
             if json_out:
-                _output_error(str(e))
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
             logger.error("エラー: %s", e)
             sys.exit(1)
 
@@ -2750,7 +2763,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             re.compile(args.url_pattern)
         except re.error as e:
             if json_out:
-                _output_error(f"無効な正規表現パターン: {e}")
+                _output_error(CliErrorCode.VALIDATION_ERROR, f"無効な正規表現パターン: {e}")
             logger.error("無効な正規表現パターン: %s", e)
             sys.exit(1)
 
@@ -2900,7 +2913,7 @@ async def run_update_aozora_catalog(args: argparse.Namespace) -> None:
             result_text = await aozora_ingester.update_catalog(client=client)
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2934,7 +2947,7 @@ def run_search_aozora(args: argparse.Namespace) -> None:
         )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -2992,7 +3005,7 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
             )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 
@@ -3035,7 +3048,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
             )
     except (ValueError, TypeError) as e:
         if json_out:
-            _output_error(str(e))
+            _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
         logger.error("エラー: %s", e)
         sys.exit(1)
 

--- a/src/rag/errors.py
+++ b/src/rag/errors.py
@@ -1,0 +1,19 @@
+"""CLI エラーコード定義."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CliErrorCode(str, Enum):
+    """CLI JSON エラー出力のエラー種別コード.
+
+    SSoT: _schema/enums.yml の cli_error_code
+    """
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    LOCK_CONFLICT = "LOCK_CONFLICT"
+    CONFIG_MISSING = "CONFIG_MISSING"
+    DEPENDENCY_UNAVAILABLE = "DEPENDENCY_UNAVAILABLE"
+    NOT_FOUND = "NOT_FOUND"
+    INTERNAL_ERROR = "INTERNAL_ERROR"

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -198,7 +198,7 @@ async def rag_search(
         result = await _run_cli_subprocess("search", args)
         return _format_cli_search_result(result)
     except CLISubprocessError as e:
-        return f"エラー: 検索に失敗しました ({e})"
+        return e.format_mcp_error("検索に失敗しました")
 
 
 _VALID_DOCUMENT_FORMATS: frozenset[str] = frozenset({"text", "original"})
@@ -236,7 +236,7 @@ async def rag_get_document(
         result = await _run_cli_subprocess("get-document", args)
         return _format_cli_document_result(result)
     except CLISubprocessError as e:
-        return f"エラー: ドキュメント取得に失敗しました ({e})"
+        return e.format_mcp_error("ドキュメント取得に失敗しました")
 
 
 _VALID_ZENN_CONTENT_TYPES: frozenset[str] = frozenset({"articles", "scraps", "all"})
@@ -277,9 +277,7 @@ async def rag_crawl_zenn(
         result = await _run_cli_subprocess("crawl-zenn", args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"ユーザー: {username}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: Zenn 記事の取り込みに失敗しました（ユーザー: {username}） ({e})"
+        return e.format_mcp_error(f"Zenn 記事の取り込みに失敗しました（ユーザー: {username}）")
     except Exception:
         logger.exception("Failed to crawl Zenn articles for user: %s", username)
         return f"エラー: Zenn 記事の取り込みに失敗しました（ユーザー: {username}）"
@@ -320,9 +318,7 @@ async def rag_crawl_bluesky(
         result = await _run_cli_subprocess("crawl-bluesky", args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"ハンドル: {handle}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: BlueSky 投稿の取り込みに失敗しました（ハンドル: {handle}） ({e})"
+        return e.format_mcp_error(f"BlueSky 投稿の取り込みに失敗しました（ハンドル: {handle}）")
     except Exception:
         logger.exception(
             "Failed to crawl BlueSky posts for handle: %s", handle
@@ -350,9 +346,7 @@ async def rag_add_youtube(
         result = await _run_cli_subprocess("ingest-youtube", [video_url], ctx=ctx)
         return _format_cli_ingest_result(result, context=f"動画: {video_url}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: YouTube 動画の取り込みに失敗しました: {video_url} ({e})"
+        return e.format_mcp_error(f"YouTube 動画の取り込みに失敗しました: {video_url}")
     except Exception:
         logger.exception(
             "Failed to ingest YouTube video: %s", video_url
@@ -386,9 +380,7 @@ async def rag_crawl_youtube(
         result = await _run_cli_subprocess("ingest-youtube-playlist", args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"プレイリスト: {playlist_url}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: YouTube プレイリストの取り込みに失敗しました: {playlist_url} ({e})"
+        return e.format_mcp_error(f"YouTube プレイリストの取り込みに失敗しました: {playlist_url}")
     except Exception:
         logger.exception(
             "Failed to crawl YouTube playlist: %s", playlist_url
@@ -448,9 +440,7 @@ async def rag_add_document(
         )
         return _format_cli_ingest_result(result, context=sanitized_filename)
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: ファイルの取り込みに失敗しました: {sanitized_filename} ({e})"
+        return e.format_mcp_error(f"ファイルの取り込みに失敗しました: {sanitized_filename}")
     except Exception:
         logger.exception("Failed to add document: %s", sanitized_filename)
         return f"エラー: ファイルの取り込みに失敗しました: {sanitized_filename}"
@@ -501,9 +491,7 @@ async def rag_add_journal(
             result, context=f"journal: {repository}/{entry_id or title}",
         )
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: ジャーナルエントリの登録に失敗しました: {title} ({e})"
+        return e.format_mcp_error(f"ジャーナルエントリの登録に失敗しました: {title}")
     except Exception:
         logger.exception("Failed to add journal entry: %s/%s", repository, title)
         return f"エラー: ジャーナルエントリの登録に失敗しました: {title}"
@@ -545,9 +533,7 @@ async def rag_crawl_documents(
         result = await _run_cli_subprocess("crawl-documents", args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"ディレクトリ: {dir_path}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: ドキュメントの取り込みに失敗しました（ディレクトリ: {dir_path}） ({e})"
+        return e.format_mcp_error(f"ドキュメントの取り込みに失敗しました（ディレクトリ: {dir_path}）")
     except Exception:
         logger.exception("Failed to crawl documents: %s", dir_path)
         return f"エラー: ドキュメントの取り込みに失敗しました（ディレクトリ: {dir_path}）"
@@ -649,9 +635,7 @@ async def rag_site_ingest(
         result = await _run_cli_subprocess("site-ingest", cli_args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"サイト: {display_url}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: サイト取り込みに失敗しました（{display_url}） ({e})"
+        return e.format_mcp_error(f"サイト取り込みに失敗しました（{display_url}）")
     except Exception:
         logger.exception("Failed to site-ingest: %s", display_url)
         return f"エラー: サイト取り込みに失敗しました（{display_url}）"
@@ -674,9 +658,7 @@ async def rag_update_aozora_catalog(
         result = await _run_cli_subprocess("update-aozora-catalog", ctx=ctx)
         return str(result.get("message", "カタログ更新完了"))
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: 青空文庫カタログの更新に失敗しました ({e})"
+        return e.format_mcp_error("青空文庫カタログの更新に失敗しました")
     except Exception:
         logger.exception("Failed to update Aozora catalog")
         return "エラー: 青空文庫カタログの更新に失敗しました"
@@ -713,7 +695,7 @@ async def rag_search_aozora(
         result = await _run_cli_subprocess("search-aozora", args)
         return _format_cli_search_aozora_result(result)
     except CLISubprocessError as e:
-        return f"エラー: 青空文庫カタログ検索に失敗しました ({e})"
+        return e.format_mcp_error("青空文庫カタログ検索に失敗しました")
 
 
 @mcp.tool()
@@ -736,9 +718,7 @@ async def rag_add_aozora(
         result = await _run_cli_subprocess("ingest-aozora", [book_id], ctx=ctx)
         return _format_cli_ingest_result(result, context=f"作品ID: {book_id}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: 青空文庫作品の取り込みに失敗しました（作品ID: {book_id}） ({e})"
+        return e.format_mcp_error(f"青空文庫作品の取り込みに失敗しました（作品ID: {book_id}）")
     except Exception:
         logger.exception("Failed to add Aozora work: %s", book_id)
         return f"エラー: 青空文庫作品の取り込みに失敗しました（作品ID: {book_id}）"
@@ -770,9 +750,7 @@ async def rag_crawl_aozora(
         result = await _run_cli_subprocess("ingest-aozora-author", args, ctx=ctx)
         return _format_cli_ingest_result(result, context=f"人物ID: {person_id}")
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別のインジェストが実行中です。しばらく待ってから再試行してください"
-        return f"エラー: 青空文庫作品の取り込みに失敗しました（人物ID: {person_id}） ({e})"
+        return e.format_mcp_error(f"青空文庫作品の取り込みに失敗しました（人物ID: {person_id}）")
     except Exception:
         logger.exception(
             "Failed to crawl Aozora works for person_id: %s", person_id
@@ -811,9 +789,7 @@ async def rag_delete(source_id: str, ctx: MCPContext | None = None) -> str:
                 return f"削除しましたが、パイプラインでエラーが発生しました: {source_id} ({errors_text})"
         return f"削除しました: {source_id}"
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別の操作が実行中です。しばらく待ってから再試行してください"
-        return f"エラー: 削除に失敗しました。source_id: {source_id} ({e})"
+        return e.format_mcp_error(f"削除に失敗しました。source_id: {source_id}")
     except Exception:
         logger.exception("Failed to delete: %s", source_id)
         return f"エラー: 削除に失敗しました。source_id: {source_id}"
@@ -964,34 +940,41 @@ async def rag_rebuild(
             return _format_rebuild_summary(summary, elapsed)
         return "再構築完了（結果の解析に失敗）"
     except CLISubprocessError as e:
-        if e.lock_conflict:
-            return "エラー: 別の再構築が実行中です"
-        return f"エラー: 再構築中にエラーが発生しました ({e})"
+        return e.format_mcp_error("再構築中にエラーが発生しました")
     except Exception:
         logger.exception("再構築中にエラーが発生しました")
         return "エラー: 再構築中にエラーが発生しました"
 
 
-# --- ロック競合判定キーワード ---
-_LOCK_CONFLICT_KEYWORDS: frozenset[str] = frozenset({
-    "ロック競合",
-    "lock conflict",
-    "already locked",
-})
-
-
-def _is_lock_conflict_error(message: str) -> bool:
-    """エラーメッセージがロック競合を示すかを判定する."""
-    lower = message.lower()
-    return any(kw in lower for kw in _LOCK_CONFLICT_KEYWORDS)
-
-
 class CLISubprocessError(Exception):
     """CLI サブプロセスの実行エラー."""
 
-    def __init__(self, message: str, *, lock_conflict: bool = False) -> None:
+    _LOCK_CONFLICT_MESSAGE = (
+        "エラー: 別のプロセスがロックを保持しています。"
+        "しばらく待ってから再試行してください"
+    )
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+    ) -> None:
         super().__init__(message)
-        self.lock_conflict = lock_conflict
+        self.code = code
+
+    @property
+    def lock_conflict(self) -> bool:
+        """ロック競合エラーであるかを判定する."""
+        return self.code == "LOCK_CONFLICT"
+
+    def format_mcp_error(self, context: str = "") -> str:
+        """MCP ツール用のエラーメッセージを生成する."""
+        if self.lock_conflict:
+            return self._LOCK_CONFLICT_MESSAGE
+        if context:
+            return f"エラー: {context} ({self})"
+        return f"エラー: {self}"
 
 
 def _sanitize_log_value(value: str, *, max_length: int = 200) -> str:
@@ -1025,7 +1008,7 @@ async def _run_cli_subprocess(
 
     Raises:
         CLISubprocessError: サブプロセスの異常終了・クラッシュ・結果パース失敗時。
-            lock_conflict=True の場合はロック競合エラー。
+            code 属性に CLI エラーコード（CliErrorCode の値）を保持する。
     """
     cmd = [
         sys.executable, "-m", "rag.cli",
@@ -1143,9 +1126,10 @@ async def _run_cli_subprocess(
                 f"CLI サブプロセスのエラー行パースに失敗: {error_line}"
             ) from exc
         error_msg = error_data.get("message", "不明なエラー")
+        error_code = error_data.get("code")
         raise CLISubprocessError(
             error_msg,
-            lock_conflict=_is_lock_conflict_error(error_msg),
+            code=error_code,
         )
 
     if not result_line:
@@ -1451,7 +1435,7 @@ async def rag_list_recent(
         result = await _run_cli_subprocess("list-recent", args)
         return _format_cli_list_recent_result(result)
     except CLISubprocessError as e:
-        return f"エラー: ソース一覧の取得に失敗しました ({e})"
+        return e.format_mcp_error("ソース一覧の取得に失敗しました")
 
 
 @mcp.tool()
@@ -1471,7 +1455,7 @@ async def rag_stats() -> str:
         result = await _run_cli_subprocess("stats")
         return _format_cli_stats_result(result)
     except CLISubprocessError as e:
-        return f"エラー: 統計情報の取得に失敗しました ({e})"
+        return e.format_mcp_error("統計情報の取得に失敗しました")
 
 
 # --- Upload HTTP API ---

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -22,6 +22,7 @@ from rag.cli import (
     _output_progress,
     _output_result,
 )
+from rag.errors import CliErrorCode
 
 
 class TestJsonHelpers:
@@ -51,15 +52,36 @@ class TestJsonHelpers:
 
     def test_output_error_exits_with_code_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as exc_info:
-            _output_error("something went wrong")
+            _output_error(CliErrorCode.INTERNAL_ERROR, "something went wrong")
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         parsed = json.loads(captured.out.strip())
         assert parsed == {
             "type": "error",
             "error": True,
+            "code": "INTERNAL_ERROR",
             "message": "something went wrong",
         }
+
+    def test_output_error_with_details(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _output_error(
+                CliErrorCode.VALIDATION_ERROR,
+                "invalid value",
+                details={"field": "mode", "value": "invalid"},
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out.strip())
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert parsed["details"] == {"field": "mode", "value": "invalid"}
+
+    def test_output_error_without_details_omits_key(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            _output_error(CliErrorCode.LOCK_CONFLICT, "locked")
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out.strip())
+        assert "details" not in parsed
 
     def test_output_result_format(self, capsys: pytest.CaptureFixture[str]) -> None:
         _output_result({"placed": 1, "skipped": 0})
@@ -109,6 +131,7 @@ class TestJsonAwareArgumentParser:
         parsed = json.loads(captured.out.strip())
         assert parsed["type"] == "error"
         assert parsed["error"] is True
+        assert parsed["code"] == "VALIDATION_ERROR"
         assert "invalid choice" in parsed["message"]
 
     def test_json_equals_form_exits_with_1(
@@ -341,13 +364,14 @@ class TestJsonOutputProtocolCompatibility:
         assert parsed["type"] == "progress"
 
     def test_error_has_required_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """error メッセージが worker.py と同じフィールドを持つ."""
+        """error メッセージが必須フィールド（type, error, code, message）を持つ."""
         with pytest.raises(SystemExit):
-            _output_error("test error")
+            _output_error(CliErrorCode.INTERNAL_ERROR, "test error")
         captured = capsys.readouterr()
         parsed = json.loads(captured.out.strip())
         assert parsed["type"] == "error"
         assert parsed["error"] is True
+        assert parsed["code"] == "INTERNAL_ERROR"
         assert "message" in parsed
 
     def test_result_has_type_field(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -581,11 +581,11 @@ class TestRagCrawlZennTool:
 
         with patch.object(
             mod, "_run_cli_subprocess", new_callable=AsyncMock,
-            side_effect=mod.CLISubprocessError("ロック取得失敗", lock_conflict=True),
+            side_effect=mod.CLISubprocessError("ロック取得失敗", code="LOCK_CONFLICT"),
         ):
             result = await mod.rag_crawl_zenn("testuser")
 
-        assert "別のインジェストが実行中" in result
+        assert "ロックを保持しています" in result
 
     @pytest.mark.asyncio
     async def test_crawl_zenn_cli_error(self) -> None:
@@ -605,56 +605,53 @@ class TestRagCrawlZennTool:
 # --- CLI サブプロセス基盤テスト（#409） ---
 
 
-class TestIsLockConflictError:
-    """_is_lock_conflict_error のテスト."""
-
-    def test_detects_lock_conflict_english(self) -> None:
-        """'lock conflict' を含むメッセージでTrue."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("lock conflict detected") is True
-
-    def test_detects_already_locked(self) -> None:
-        """'already locked' を含むメッセージでTrue."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("file is already locked") is True
-
-    def test_detects_japanese_lock_conflict(self) -> None:
-        """'ロック競合' を含むメッセージでTrue."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("別のインジェストが実行中です（ロック競合）") is True
-
-    def test_case_insensitive(self) -> None:
-        """大文字小文字を区別しないこと."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("LOCK CONFLICT detected") is True
-
-    def test_no_false_positive_on_lock_alone(self) -> None:
-        """'lock' 単独では誤判定しないこと."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("unlock failed") is False
-        assert mod._is_lock_conflict_error("file lock acquisition failed") is False
-
-    def test_no_match(self) -> None:
-        """ロック関連キーワードを含まないメッセージでFalse."""
-        mod = import_module("rag.server")
-        assert mod._is_lock_conflict_error("general error occurred") is False
-
-
 class TestCLISubprocessError:
     """CLISubprocessError のテスト."""
 
-    def test_default_lock_conflict_false(self) -> None:
-        """lock_conflict のデフォルトが False."""
+    def test_default_code_none(self) -> None:
+        """code のデフォルトが None で lock_conflict が False."""
         mod = import_module("rag.server")
         err = mod.CLISubprocessError("test error")
+        assert err.code is None
         assert err.lock_conflict is False
         assert str(err) == "test error"
 
-    def test_lock_conflict_true(self) -> None:
-        """lock_conflict=True が設定されること."""
+    def test_lock_conflict_from_code(self) -> None:
+        """code=LOCK_CONFLICT のとき lock_conflict が True."""
         mod = import_module("rag.server")
-        err = mod.CLISubprocessError("lock failed", lock_conflict=True)
+        err = mod.CLISubprocessError("lock failed", code="LOCK_CONFLICT")
+        assert err.code == "LOCK_CONFLICT"
         assert err.lock_conflict is True
+
+    def test_non_lock_conflict_code(self) -> None:
+        """LOCK_CONFLICT 以外の code では lock_conflict が False."""
+        mod = import_module("rag.server")
+        err = mod.CLISubprocessError("validation error", code="VALIDATION_ERROR")
+        assert err.code == "VALIDATION_ERROR"
+        assert err.lock_conflict is False
+
+    def test_format_mcp_error_lock_conflict(self) -> None:
+        """lock_conflict 時は統一メッセージを返す."""
+        mod = import_module("rag.server")
+        err = mod.CLISubprocessError("raw msg", code="LOCK_CONFLICT")
+        result = err.format_mcp_error("取り込みに失敗しました")
+        assert "ロックを保持しています" in result
+        assert "取り込み" not in result
+
+    def test_format_mcp_error_with_context(self) -> None:
+        """一般エラー時はコンテキスト付きメッセージを返す."""
+        mod = import_module("rag.server")
+        err = mod.CLISubprocessError("詳細メッセージ")
+        result = err.format_mcp_error("Zenn 記事の取り込みに失敗しました")
+        assert "Zenn 記事の取り込みに失敗しました" in result
+        assert "詳細メッセージ" in result
+
+    def test_format_mcp_error_without_context(self) -> None:
+        """コンテキストなしの場合はエラーメッセージのみ."""
+        mod = import_module("rag.server")
+        err = mod.CLISubprocessError("something failed")
+        result = err.format_mcp_error()
+        assert result == "エラー: something failed"
 
 
 class TestRunCliSubprocess:
@@ -724,7 +721,7 @@ class TestRunCliSubprocess:
     async def test_error_line_raises_cli_subprocess_error(self) -> None:
         """type: error 行がある場合は CLISubprocessError を raise する."""
         mod = import_module("rag.server")
-        error_payload = '{"type": "error", "message": "バリデーション失敗"}'
+        error_payload = '{"type": "error", "code": "VALIDATION_ERROR", "message": "バリデーション失敗"}'
         mock_process = self._make_mock_process([error_payload], exit_code=1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
@@ -732,6 +729,7 @@ class TestRunCliSubprocess:
                 await mod._run_cli_subprocess("rebuild")
 
         assert "バリデーション失敗" in str(exc_info.value)
+        assert exc_info.value.code == "VALIDATION_ERROR"
         assert exc_info.value.lock_conflict is False
 
     @pytest.mark.asyncio
@@ -740,7 +738,7 @@ class TestRunCliSubprocess:
         mod = import_module("rag.server")
         stdout_lines = [
             '{"type": "result", "placed": 1}',
-            '{"type": "error", "message": "後から発生したエラー"}',
+            '{"type": "error", "code": "INTERNAL_ERROR", "message": "後から発生したエラー"}',
         ]
         mock_process = self._make_mock_process(stdout_lines, exit_code=0)
 
@@ -780,15 +778,16 @@ class TestRunCliSubprocess:
 
     @pytest.mark.asyncio
     async def test_lock_conflict_detected_from_error_line(self) -> None:
-        """ロック競合エラーの場合 lock_conflict=True が設定される."""
+        """ロック競合エラーの場合 code="LOCK_CONFLICT" が設定される."""
         mod = import_module("rag.server")
-        error_payload = '{"type": "error", "message": "lock conflict: already held"}'
+        error_payload = '{"type": "error", "code": "LOCK_CONFLICT", "message": "別の再構築が実行中です（ロック競合）"}'
         mock_process = self._make_mock_process([error_payload], exit_code=1)
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             with pytest.raises(mod.CLISubprocessError) as exc_info:
                 await mod._run_cli_subprocess("rebuild")
 
+        assert exc_info.value.code == "LOCK_CONFLICT"
         assert exc_info.value.lock_conflict is True
 
 
@@ -888,11 +887,11 @@ class TestRagDeleteTool:
         mod = import_module("rag.server")
         with patch.object(
             mod, "_run_cli_subprocess", new_callable=AsyncMock,
-            side_effect=mod.CLISubprocessError("排他制御エラー", lock_conflict=True),
+            side_effect=mod.CLISubprocessError("排他制御エラー", code="LOCK_CONFLICT"),
         ):
             result = await mod.rag_delete("https://example.com/page")
 
-        assert "別の操作が実行中" in result
+        assert "ロックを保持しています" in result
 
 
 class TestRagRebuildTool:
@@ -948,11 +947,11 @@ class TestRagRebuildTool:
         mod = import_module("rag.server")
         with patch.object(
             mod, "_run_cli_subprocess", new_callable=AsyncMock,
-            side_effect=mod.CLISubprocessError("lock conflict", lock_conflict=True),
+            side_effect=mod.CLISubprocessError("lock conflict", code="LOCK_CONFLICT"),
         ):
             result = await mod.rag_rebuild("full")
 
-        assert "別の再構築が実行中" in result
+        assert "ロックを保持しています" in result
 
     @pytest.mark.asyncio
     async def test_cli_error(self) -> None:

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -315,11 +315,11 @@ class TestRagRebuild:
         with patch(
             "rag.server._run_cli_subprocess",
             new_callable=AsyncMock,
-            side_effect=CLISubprocessError("ロック競合", lock_conflict=True),
+            side_effect=CLISubprocessError("ロック競合", code="LOCK_CONFLICT"),
         ):
             result = await rag_rebuild(mode="full")
 
-        assert "別の再構築が実行中" in result
+        assert "ロックを保持しています" in result
 
     @pytest.mark.asyncio
     async def test_cli_error_returns_error(self) -> None:

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -227,7 +227,7 @@ class TestMcpSiteIngestCliDelegation:
         mod = import_module("rag.server")
         with (
             patch.object(mod, "_get_safe_browsing_client", return_value=None),
-            patch.object(mod, "_run_cli_subprocess", new_callable=AsyncMock, side_effect=CLISubprocessError("lock", lock_conflict=True)),
+            patch.object(mod, "_run_cli_subprocess", new_callable=AsyncMock, side_effect=CLISubprocessError("lock", code="LOCK_CONFLICT")),
         ):
             result = await mod.rag_site_ingest(
                 url="https://example.com",
@@ -235,7 +235,7 @@ class TestMcpSiteIngestCliDelegation:
                 force=False,
             )
             assert "エラー" in result
-            assert "実行中" in result
+            assert "ロックを保持しています" in result
 
 
 # --- CLI コマンド site-ingest テスト ---

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -334,7 +334,7 @@ class TestIngestLockConflict:
         with patch(
             "rag.server._run_cli_subprocess",
             new_callable=AsyncMock,
-            side_effect=CLISubprocessError("ロック競合", lock_conflict=True),
+            side_effect=CLISubprocessError("ロック競合", code="LOCK_CONFLICT"),
         ):
             resp = await client.post(
                 "/upload/document",
@@ -350,7 +350,7 @@ class TestIngestLockConflict:
         with patch(
             "rag.server._run_cli_subprocess",
             new_callable=AsyncMock,
-            side_effect=CLISubprocessError("ロック競合", lock_conflict=True),
+            side_effect=CLISubprocessError("ロック競合", code="LOCK_CONFLICT"),
         ):
             resp = await client.post(
                 "/upload/journal",
@@ -407,7 +407,7 @@ class TestMCPToolIngestLock:
         with patch(
             "rag.server._run_cli_subprocess",
             new_callable=AsyncMock,
-            side_effect=CLISubprocessError("ロック競合", lock_conflict=True),
+            side_effect=CLISubprocessError("ロック競合", code="LOCK_CONFLICT"),
         ):
             result = await rag_add_document(
                 content="test",
@@ -416,7 +416,7 @@ class TestMCPToolIngestLock:
                 upload_mode="fail",
             )
 
-        assert "別のインジェスト" in result
+        assert "ロックを保持しています" in result
 
     @pytest.mark.asyncio
     async def test_rag_add_journal_lock_conflict(self) -> None:
@@ -426,7 +426,7 @@ class TestMCPToolIngestLock:
         with patch(
             "rag.server._run_cli_subprocess",
             new_callable=AsyncMock,
-            side_effect=CLISubprocessError("ロック競合", lock_conflict=True),
+            side_effect=CLISubprocessError("ロック競合", code="LOCK_CONFLICT"),
         ):
             result = await rag_add_journal(
                 title="Test",
@@ -435,7 +435,7 @@ class TestMCPToolIngestLock:
                 repository="test-repo",
             )
 
-        assert "別のインジェスト" in result
+        assert "ロックを保持しています" in result
 
 
 # --- レスポンス形式テスト ---


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- `_schema/enums.yml` に `cli_error_code` enum を追加（6 コード: VALIDATION_ERROR, LOCK_CONFLICT, CONFIG_MISSING, DEPENDENCY_UNAVAILABLE, NOT_FOUND, INTERNAL_ERROR）
- `src/rag/errors.py` に `CliErrorCode` enum を新規作成し、`scripts/validate_enums.py` で CI 同期検証を追加
- `src/rag/cli.py` の `_output_error` シグネチャを `(code: CliErrorCode, message: str, details: dict | None)` に変更し、全呼び出し箇所（約40箇所）に適切なエラーコードを割り当て
- `src/rag/server.py` の `CLISubprocessError` に `code` 属性を追加、`_is_lock_conflict_error` キーワードマッチを廃止し `code == "LOCK_CONFLICT"` で判定
- `CLISubprocessError.format_mcp_error(context)` メソッドを追加し、MCP ツール 18 箇所の catch ブロックを統一・簡略化
- 仕様書（rebuild-stats.md / ingesters/common.md）にエラーコード仕様を反映

## Test plan

- [x] 90 テスト PASSED（test_cli_json_output.py + test_rag_mcp_server.py）
- [x] ruff / mypy クリア
- [x] validate_enums.py PASSED（enums.yml ↔ CliErrorCode 同期確認）
- [x] QA: CLI で `code: "VALIDATION_ERROR"` + exit code 1 を確認
- [x] QA: MCP で `format_mcp_error` 経由のエラー伝播を確認
- [x] QA: MCP で lock_conflict 統一メッセージを確認

## Related issues

Closes #607