### PR TITLE
fix(rag-knowledge): BM25 検索品質改善 — section_path 分離・メタデータ補完・フォーマット改善 (#624)

### DIFF
--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -101,7 +101,7 @@ MCP クライアントからの rag_search ツール呼び出し。
 | Section | 見出し階層（`section_path`） | 値がある場合のみ | `Section: 第1章 > 1.1 前処理` |
 | Collected | 取り込み日時 | 値がある場合のみ | `Collected: 2025-01-15T10:30:00Z` |
 
-メタデータの後に空行を挟み、チャンクテキストを出力する。
+メタデータの後に `<<content>>` / `<</content>>` タグでチャンクテキストを囲む。タグによりメタデータと本文の境界を明確にし、本文中に Markdown 見出し（`###` 等）が含まれる場合でも Result ヘッダーとの混同を防ぐ。
 
 レスポンスの Source 値は、[source-store.md](source-store.md) で定義された `source_id`（= source_store 内の相対パス）を使用する。この値をそのまま rag_get_document の `source_id` パラメータとして使用できる。元 URL がある場合は URL 行に表示される。
 
@@ -118,8 +118,9 @@ Chunk: 3/15
 Type: web
 Section: 第1章 導入 > 1.1 セットアップ
 Collected: 2025-01-15T10:30:00Z
-
+<<content>>
 チャンクテキストがここに入る...
+<</content>>
 
 ### Result 2 [distance=0.456]
 Source: bluesky/did：plc：abc123/2026/01/xyz789.json
@@ -128,8 +129,9 @@ Title: Sample post
 Chunk: 1/1
 Type: bluesky
 Collected: 2025-01-20T14:00:00Z
-
+<<content>>
 チャンクテキストがここに入る...
+<</content>>
 
 ## BM25 検索結果 (キーワード一致)
 
@@ -140,8 +142,9 @@ Title: サンプル記事
 Chunk: 5/20
 Type: zenn
 Collected: 2025-01-18T08:00:00Z
-
+<<content>>
 チャンクテキストがここに入る...
+<</content>>
 ```
 
 **チャンク位置情報の取得:**

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -337,6 +337,17 @@ class BM25Index:
         """
         return self._doc_source_type_map.get(doc_id)
 
+    def get_metadata(self, doc_id: str) -> dict[str, str | int | float | bool]:
+        """ドキュメントIDからチャンクメタデータを取得する.
+
+        Args:
+            doc_id: ドキュメントID
+
+        Returns:
+            メタデータ辞書。見つからない場合は空辞書
+        """
+        return dict(self._doc_metadata_map.get(doc_id, {}))
+
     def delete_stale_docs(self, source_id: str, valid_ids: set[str]) -> int:
         """ソースのドキュメントのうち、valid_ids に含まれないものを削除する.
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -843,11 +843,7 @@ def _build_bm25_index_from_fixture(
         normalized_url, _ = urldefrag(source_url)
         url_hash = hashlib.sha256(normalized_url.encode()).hexdigest()[:16]
         for i, (chunk_text, section_path) in enumerate(chunks):
-            # BM25 には section_path + 本文を結合したテキストを登録
-            bm25_text = (
-                f"{section_path}\n{chunk_text}" if section_path else chunk_text
-            )
-            documents.append((f"{url_hash}_{i}", bm25_text, normalized_url, "web"))
+            documents.append((f"{url_hash}_{i}", chunk_text, normalized_url, "web"))
 
     added = bm25_index.add_documents(documents)
     logger.info("BM25 index built with %d chunks from fixture", added)

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -842,7 +842,7 @@ def _build_bm25_index_from_fixture(
         chunks = smart_chunk(content, chunk_size, chunk_overlap)
         normalized_url, _ = urldefrag(source_url)
         url_hash = hashlib.sha256(normalized_url.encode()).hexdigest()[:16]
-        for i, (chunk_text, section_path) in enumerate(chunks):
+        for i, (chunk_text, _section_path) in enumerate(chunks):
             documents.append((f"{url_hash}_{i}", chunk_text, normalized_url, "web"))
 
     added = bm25_index.add_documents(documents)

--- a/src/rag/hybrid_search.py
+++ b/src/rag/hybrid_search.py
@@ -5,25 +5,17 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from .indexer.chunk_id import generate_chunk_id
 
 if TYPE_CHECKING:
     from .bm25_index import BM25Index, BM25Result
     from .vector_store import RetrievalResult, VectorStore
 
 logger = logging.getLogger(__name__)
-
-
-def _generate_doc_id(source_url: str, chunk_index: int) -> str:
-    """ドキュメントIDを生成する.
-
-    VectorStoreと同じ形式（url_hash + "_" + chunk_index）で生成する。
-    """
-    url_hash = hashlib.sha256(source_url.encode()).hexdigest()[:16]
-    return f"{url_hash}_{chunk_index}"
 
 
 def min_max_normalize(scores: list[float]) -> list[float]:
@@ -200,9 +192,9 @@ class HybridSearchEngine:
         vector_doc_data: dict[str, tuple[float, str, dict[str, str | int | float | bool], float]] = {}
 
         for i, vr in enumerate(vector_results):
-            source_url = str(vr.metadata.get("source_id", ""))
+            source_id = str(vr.metadata.get("source_id", ""))
             chunk_index = int(vr.metadata.get("chunk_index", i))
-            doc_id = _generate_doc_id(source_url, chunk_index)
+            doc_id = generate_chunk_id(source_id, chunk_index)
 
             similarity = 1.0 - vr.distance
 
@@ -230,10 +222,11 @@ class HybridSearchEngine:
         bm25_doc_data: dict[str, tuple[float, str, dict[str, str | int | float | bool]]] = {}
 
         for br in bm25_results:
-            bm25_source_url = self._bm25_index.get_source_url(br.doc_id)
-            bm25_metadata: dict[str, str | int | float | bool] = {}
-            if bm25_source_url:
-                bm25_metadata["source_id"] = bm25_source_url
+            bm25_metadata = dict(self._bm25_index.get_metadata(br.doc_id))
+            if not bm25_metadata:
+                bm25_source_url = self._bm25_index.get_source_url(br.doc_id)
+                if bm25_source_url:
+                    bm25_metadata["source_id"] = bm25_source_url
             bm25_doc_data[br.doc_id] = (br.score, br.text, bm25_metadata)
 
         # BM25 スコアの min-max 正規化

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -339,12 +339,9 @@ class Indexer:
                 metadata=meta,
             ))
 
-            # BM25: section_path + 本文を結合（見出しキーワードでもヒットさせる）
-            bm25_text = (
-                f"{section_path}\n{content}" if section_path else content
-            )
+            # BM25: 本文のみ（section_path はメタデータで保持）
             bm25_docs.append((
-                chunk_id, bm25_text, source_id, metadata.source_type,
+                chunk_id, content, source_id, metadata.source_type,
             ))
             bm25_metadata_list.append(meta)
 

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -241,8 +241,9 @@ def format_raw_search_results(raw: RawSearchResults) -> str:
                 parts.append(f"Section: {item.section_path}")
             if item.collected_at:
                 parts.append(f"Collected: {item.collected_at}")
-            parts.append("")
+            parts.append("<<content>>")
             parts.append(item.text)
+            parts.append("<</content>>")
             parts.append("")
 
     return "\n".join(parts).rstrip()
@@ -384,9 +385,7 @@ class RAGKnowledgeService:
         if self._bm25_index is not None:
             bm25_docs = []
             for chunk in document_chunks:
-                sp = str(chunk.metadata.get("section_path", ""))
-                bm25_text = f"{sp}\n{chunk.text}" if sp else chunk.text
-                bm25_docs.append((chunk.id, bm25_text, normalized_url, "web"))
+                bm25_docs.append((chunk.id, chunk.text, normalized_url, "web"))
             try:
                 self._bm25_index.add_documents(bm25_docs)
                 logger.debug("Added %d documents to BM25 index", len(bm25_docs))

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -384,10 +384,12 @@ class RAGKnowledgeService:
         # 注: BM25は補助的機能のため、失敗してもVectorStoreの結果は維持する
         if self._bm25_index is not None:
             bm25_docs = []
+            bm25_metadata_list = []
             for chunk in document_chunks:
                 bm25_docs.append((chunk.id, chunk.text, normalized_url, "web"))
+                bm25_metadata_list.append(chunk.metadata)
             try:
-                self._bm25_index.add_documents(bm25_docs)
+                self._bm25_index.add_documents(bm25_docs, metadata_list=bm25_metadata_list)
                 logger.debug("Added %d documents to BM25 index", len(bm25_docs))
             except Exception:
                 logger.warning(

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -1241,8 +1241,9 @@ def _format_cli_search_result(result: dict[str, Any]) -> str:
             collected_at = item.get("collected_at", "")
             if collected_at:
                 parts.append(f"Collected: {collected_at}")
-            parts.append("")
+            parts.append("<<content>>")
             parts.append(item.get("text", ""))
+            parts.append("<</content>>")
             parts.append("")
 
     return "\n".join(parts).rstrip()

--- a/tests/indexer/test_indexer.py
+++ b/tests/indexer/test_indexer.py
@@ -245,19 +245,23 @@ class TestAdd:
             assert "[" not in doc  # 旧形式の breadcrumb
             assert "# " not in doc  # 旧形式の見出しプレフィックス
 
-    async def test_bm25_receives_section_path_plus_content(
+    async def test_bm25_receives_content_without_section_path(
         self, indexer: Indexer, bm25_index: BM25Index, tmp_path: Path,
     ) -> None:
-        """BM25 には section_path + 本文が渡されること."""
-        text = "# MyHeading\n\nBody text for BM25."
+        """BM25 には本文のみが渡され section_path は含まれないこと."""
+        text = "# UniqueHeading\n\nBody text for BM25 verification."
         path = _write_text_file(tmp_path, "heading.txt", text)
         meta = _make_metadata(source_id="src-bm25-sp")
 
         await indexer.add("src-bm25-sp", path, meta)
 
-        # BM25 で見出しキーワードで検索できる
-        results = bm25_index.search("MyHeading", n_results=5)
+        # BM25 で本文キーワードで検索できる
+        results = bm25_index.search("verification", n_results=5)
         assert len(results) > 0
+
+        # BM25 テキストに section_path が混入していないこと
+        for r in results:
+            assert not r.text.startswith("UniqueHeading")
 
     async def test_table_text_uses_table_chunker(
         self, indexer: Indexer, vector_store: VectorStore, tmp_path: Path,

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -193,6 +193,35 @@ class TestBM25Index:
         assert index._k1 == 2.0
         assert index._b == 0.5
 
+    def test_get_metadata_returns_stored_metadata(self) -> None:
+        """metadata_list 付きで追加したメタデータを get_metadata で取得できる."""
+        index = make_bm25_index()
+        docs = [("doc1", "sample text", "source1", "web")]
+        meta = [{"source_id": "source1", "chunk_index": 0, "title": "Test Title"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        result = index.get_metadata("doc1")
+        assert result["source_id"] == "source1"
+        assert result["chunk_index"] == 0
+        assert result["title"] == "Test Title"
+
+    def test_get_metadata_returns_empty_for_unknown_doc(self) -> None:
+        """存在しない doc_id に対して空辞書を返す."""
+        index = make_bm25_index()
+        assert index.get_metadata("nonexistent") == {}
+
+    def test_get_metadata_returns_defensive_copy(self) -> None:
+        """get_metadata は防御コピーを返し、内部状態を変更しない."""
+        index = make_bm25_index()
+        docs = [("doc1", "sample text", "source1", "web")]
+        meta = [{"source_id": "source1", "title": "Original"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        result = index.get_metadata("doc1")
+        result["title"] = "Modified"
+
+        assert index.get_metadata("doc1")["title"] == "Original"
+
 
 class TestBM25IndexPersistence:
     """BM25Index永続化のテスト.
@@ -237,6 +266,22 @@ class TestBM25IndexPersistence:
         # ソースURLも復元
         assert index2.get_source_url("doc1") == "source1"
         assert index2.get_source_url("doc4") == "source4"
+
+    def test_metadata_survives_save_and_load(self, persist_dir: str) -> None:
+        """metadata_list 付きで追加したメタデータが永続化後も復元される."""
+        index = make_bm25_index(persist_dir=persist_dir)
+        meta = [
+            {"source_id": "source1", "chunk_index": 0, "title": "Doc 1"},
+            {"source_id": "source2", "chunk_index": 0, "title": "Doc 2"},
+            {"source_id": "source3", "chunk_index": 0, "title": "Doc 3"},
+            {"source_id": "source4", "chunk_index": 0, "title": "Doc 4"},
+        ]
+        index.add_documents(self._sample_docs(), metadata_list=meta)
+
+        index2 = make_bm25_index(persist_dir=persist_dir)
+        result = index2.get_metadata("doc1")
+        assert result["title"] == "Doc 1"
+        assert result["chunk_index"] == 0
 
     def test_none_dir_means_in_memory(self) -> None:
         """AC80: persist_dir=Noneで従来のインメモリ動作."""


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正
- [x] docs: ドキュメント更新

## Summary

- BM25 テキストから section_path を分離し content のみ格納（スコア膨張解消）
- BM25 のみヒット時のメタデータ欠落を補完（`BM25Index.get_metadata()` メソッド追加）
- 検索結果フォーマットに `<<content>>` / `<</content>>` タグ追加（メタデータと本文の境界明確化）
- doc_id 生成を `chunk_id.py` の `generate_chunk_id()` に統一（`hybrid_search.py` の重複 `_generate_doc_id` を削除）
- 仕様書（search-response.md）のレスポンス形式例をタグ形式に更新

## Test plan

- [x] 全 1594 テスト通過
- [x] ruff / mypy クリーン
- [x] CLI で Zenn 10 件取り込み → 検索出力確認（section_path 二重表示解消、スコア適正化、メタデータ完備、タグ区切り）

## Related issues

Closes #624