### PR TITLE
ci: Quality Check reusable workflow の導入 (#632)

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,0 +1,25 @@
+# Quality Check — Caller
+#
+# PR マージ時の品質チェック（テスト・lint・型チェック・markdownlint）。
+# Reusable Workflow (shared-workflows) を呼び出す。
+# 設計書: shared-workflows/docs/specs/quality-check.md
+
+name: Quality Check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  quality:
+    uses: becky3/shared-workflows/.github/workflows/quality-check.yml@main
+    with:
+      python_version: "3.11"
+      install_command: "uv sync --no-group with-mineru"
+      test_command: "uv run pytest"
+      lint_command: "uv run ruff check src/ tests/"
+      typecheck_command: "uv run mypy src/"
+      markdownlint: true

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -1,6 +1,6 @@
 # Quality Check — Caller
 #
-# PR マージ時の品質チェック（テスト・lint・型チェック・markdownlint）。
+# PR 作成・更新時の品質チェック（テスト・lint・型チェック・markdownlint）。
 # Reusable Workflow (shared-workflows) を呼び出す。
 # 設計書: shared-workflows/docs/specs/quality-check.md
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ uv run mypy src
 
 ## CI/CD
 
-PR 作成時に GitHub Actions で品質チェックが自動実行される。全チェックの通過が develop / main へのマージ条件。
+PR 作成・更新時に GitHub Actions で品質チェックが自動実行される。全チェックの通過が develop / main へのマージ条件。
 
 | ワークフロー | トリガー | 概要 |
 |-------------|---------|------|
@@ -322,7 +322,7 @@ PR 作成時に GitHub Actions で品質チェックが自動実行される。�
 | Validate Enums | PR・push (develop, main) | enum スキーマの整合性検証 |
 | Raw HTTP Check | PR・push (develop, main) | Python ソース内の raw HTTP 使用検出 |
 | Copilot Auto Fix | PR | Copilot レビューコメントの自動修正 |
-| Claude Code | Issue comment・PR comment | メンション応答・自動実装 |
+| Claude Code | Issue 作成・ラベル付け・Issue comment・PR comment・PR review | メンション応答・自動実装 |
 | Late Review Scanner | スケジュール（毎時） | 24 時間以上レビュー待ちの PR を検出 |
 | Post Merge | PR close | マージ後の review-batch Issue 更新 |
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,22 @@ uv run ruff check .
 uv run mypy src
 ```
 
+## CI/CD
+
+PR 作成時に GitHub Actions で品質チェックが自動実行される。全チェックの通過が develop / main へのマージ条件。
+
+| ワークフロー | トリガー | 概要 |
+|-------------|---------|------|
+| Quality Check | PR (develop, main) | テスト・lint・型チェック・markdownlint |
+| Validate Enums | PR・push (develop, main) | enum スキーマの整合性検証 |
+| Raw HTTP Check | PR・push (develop, main) | Python ソース内の raw HTTP 使用検出 |
+| Copilot Auto Fix | PR | Copilot レビューコメントの自動修正 |
+| Claude Code | Issue comment・PR comment | メンション応答・自動実装 |
+| Late Review Scanner | スケジュール（毎時） | 24 時間以上レビュー待ちの PR を検出 |
+| Post Merge | PR close | マージ後の review-batch Issue 更新 |
+
+品質チェック（Quality Check）は [shared-workflows](https://github.com/becky3/shared-workflows) の reusable workflow を使用。
+
 ## プロジェクト構成
 
 プロジェクトのディレクトリ構成・モジュール責務・仕様書との対応は [ARCHITECTURE.md](ARCHITECTURE.md) を参照。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ follow_imports = "skip"
 module = ["youtube_transcript_api", "youtube_transcript_api.*", "yt_dlp", "yt_dlp.*", "faster_whisper", "faster_whisper.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = ["rag.infrastructure.file_lock"]
+warn_unused_ignores = false
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 addopts = "-n auto"

--- a/src/rag/infrastructure/file_lock.py
+++ b/src/rag/infrastructure/file_lock.py
@@ -114,7 +114,7 @@ class FileLock:
 
         assert self._fd is not None
         try:
-            msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
+            msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
         except OSError as e:
             if e.errno in (errno.EACCES, errno.EDEADLOCK):
                 raise LockAcquisitionError(
@@ -129,7 +129,7 @@ class FileLock:
         assert self._fd is not None
         # ファイルポインタを先頭に戻してから解放
         os.lseek(self._fd, 0, os.SEEK_SET)
-        msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+        msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
 
     def __enter__(self) -> FileLock:
         self.acquire()

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -212,6 +212,7 @@ class TestConfigureAndRun:
 
         with (
             patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod, "_check_api_key_registered", return_value=None),
             patch.object(mod.mcp, "run") as mock_run,
         ):
             _configure_and_run()
@@ -232,6 +233,7 @@ class TestConfigureAndRun:
 
         with (
             patch.object(mod, "get_settings", return_value=mock_settings),
+            patch.object(mod, "_check_api_key_registered", return_value=None),
             patch.object(
                 mod.mcp, "run", side_effect=KeyboardInterrupt
             ),

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import base64
+import sys
 
 import pytest
 
@@ -101,7 +102,8 @@ class TestSanitizeFilename:
         with pytest.raises(ValueError, match="filename"):
             sanitize_filename("/")
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows path semantics")
     def test_windows_drive_root_raises_value_error(self) -> None:
-        # "C:\" → Path("C:\\").name == "" → 拒否
+        # "C:\" → Path("C:\\").name == "" → 拒否 (Windows only)
         with pytest.raises(ValueError, match="filename"):
             sanitize_filename("C:\\")


### PR DESCRIPTION
## Change type

- [x] ci: CI/CD改善

## Summary

- shared-workflows の Quality Check reusable workflow を呼び出す caller workflow を配置
- install_command を `uv sync --no-group with-mineru` に調整（CI 環境は GPU なし）
- README.md に CI/CD セクションを新設し、全ワークフロー一覧を記載
- Branch protection rule で develop / main に必須チェック（Lint / Test / Type Check / Markdown Lint）を設定

## Test plan

- [x] markdownlint 通過
- [ ] PR 作成後に Quality Check ワークフローが自動実行されることを確認

## Related issues

Closes #632