### PR TITLE
fix(ingesters/bluesky): site-ingest subprocess の出力パースを regex から JSON Lines に移行 (#634)

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -511,7 +511,7 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 1. 全投稿の source_store への配置が完了した後、配置した投稿の JSON から URL を一括抽出する
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）
 3. URL 種別を判定し、Web / YouTube / スキップに分類する
-4. Web URL を全てバッチ収集し、CLI の `site-ingest` コマンド（複数 URL モード）で 1 回の Scrapy subprocess として取り込む。`--download-only` を指定し、パイプライン処理は BlueSky 側で一括実行する
+4. Web URL を全てバッチ収集し、CLI の `site-ingest` コマンド（複数 URL モード）で 1 回の Scrapy subprocess として取り込む。`--download-only` と `--output json` を指定し、パイプライン処理は BlueSky 側で一括実行する。subprocess の JSON 出力から配置数を取得する
 5. YouTube インジェスターで動画を取り込む（個別処理、URL 間に `rag_youtube_request_interval` に基づくスリープを挿入）
 6. 全 URL の処理が完了した後、パイプライン制御に取り込み完了を通知する
 

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -1038,7 +1038,7 @@ class BlueskyIngester:
         """site-ingest CLI subprocess を 1 バッチ分実行する."""
         cmd = [
             sys.executable, "-m", "rag.cli",
-            "site-ingest", *urls, "--download-only",
+            "site-ingest", *urls, "--download-only", "--output", "json",
         ]
 
         process = await asyncio.create_subprocess_exec(
@@ -1056,14 +1056,17 @@ class BlueskyIngester:
             )
             raise RuntimeError(f"site-ingest failed with exit_code={process.returncode}")
 
-        # stdout から配置数を抽出（"N件新規配置" パターン）
         stdout_text = stdout.decode("utf-8", errors="replace")
-        match = re.search(r"(\d+)件新規配置", stdout_text)
-        if match:
-            return int(match.group(1))
+        for line in reversed(stdout_text.strip().splitlines()):
+            try:
+                data = json.loads(line)
+                if isinstance(data, dict) and data.get("type") == "result":
+                    return int(data.get("placed", 0))
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
 
         logger.warning(
-            "site-ingest の出力から配置数を取得できませんでした: %s",
+            "site-ingest の JSON 出力から result を取得できませんでした: %s",
             stdout_text[:200],
         )
         return 0

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -313,7 +313,7 @@ class TestIngestResultToDict:
 
 
 class TestCommandsHaveOutputOption:
-    """12 対象コマンドに --output オプションが追加されていることを確認する.
+    """13 対象コマンドに --output オプションが追加されていることを確認する.
 
     cli.py のソースコードを解析して、対象コマンドの直後に
     _add_output_option() 呼び出しがあることを検証する。
@@ -332,19 +332,20 @@ class TestCommandsHaveOutputOption:
         "update-aozora-catalog",
         "delete",
         "rebuild",
+        "site-ingest",
     ]
 
-    def test_all_12_commands_have_output_option(self) -> None:
-        """cli.py のソースに 12 コマンド分の _add_output_option 呼び出しがある."""
+    def test_all_13_commands_have_output_option(self) -> None:
+        """cli.py のソースに 13 コマンド分の _add_output_option 呼び出しがある."""
         import inspect
         import rag.cli as cli_module
 
         source = inspect.getsource(cli_module)
         count = source.count("_add_output_option(")
         # ヘルパー関数の定義 (def _add_output_option) は除外して呼び出しだけ数える
-        # 定義は 1 つ、呼び出しが 12 個で合計 13 回出現
-        assert count >= 12 + 1, (
-            f"_add_output_option の出現回数が {count} 回（期待: 定義1 + 呼び出し12 = 13）"
+        # 定義は 1 つ、呼び出しが 13 個で合計 14 回出現
+        assert count >= 13 + 1, (
+            f"_add_output_option の出現回数が {count} 回（期待: 定義1 + 呼び出し13 = 14）"
         )
 
     @pytest.mark.parametrize("command", TARGET_COMMANDS)
@@ -367,6 +368,7 @@ class TestCommandsHaveOutputOption:
             "update-aozora-catalog": "run_update_aozora_catalog",
             "delete": "run_delete",
             "rebuild": "run_rebuild",
+            "site-ingest": "run_site_ingest",
         }
 
         func_name = func_names[command]

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -1970,3 +1970,63 @@ class TestPartialFailureObservability:
         assert result.errors == 1
         assert result.error_details[0]["category"] == "placement"
         assert result.error_details[0]["message"] == "disk full"
+
+
+@pytest.mark.asyncio()
+class TestRunSiteIngestBatch:
+    """_run_site_ingest_batch の JSON パーステスト."""
+
+    async def test_parses_json_result(self, source_store: SourceStore) -> None:
+        """JSON Lines の result 行から placed を正しく抽出すること."""
+        ingester = make_bluesky_ingester(source_store)
+        json_output = (
+            '{"type": "progress", "processed": 1, "total": 1, "current": "https://example.com"}\n'
+            '{"type": "result", "placed": 3, "overwritten": 0, "skipped": 1, "errors": 0, "elapsed": 1.5}\n'
+        )
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await ingester._run_site_ingest_batch(["https://example.com"])
+
+        assert result == 3
+
+    async def test_returns_zero_when_no_result_line(self, source_store: SourceStore) -> None:
+        """result 行がない場合 0 を返すこと."""
+        ingester = make_bluesky_ingester(source_store)
+        json_output = '{"type": "progress", "processed": 1, "total": 1, "current": "x"}\n'
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await ingester._run_site_ingest_batch(["https://example.com"])
+
+        assert result == 0
+
+    async def test_raises_on_nonzero_exit(self, source_store: SourceStore) -> None:
+        """subprocess の exit code != 0 で RuntimeError を送出すること."""
+        ingester = make_bluesky_ingester(source_store)
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"some error")
+        mock_proc.returncode = 1
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            with pytest.raises(RuntimeError, match="site-ingest failed"):
+                await ingester._run_site_ingest_batch(["https://example.com"])
+
+    async def test_passes_output_json_flag(self, source_store: SourceStore) -> None:
+        """CLI コマンドに --output json フラグが含まれること."""
+        ingester = make_bluesky_ingester(source_store)
+        json_output = '{"type": "result", "placed": 0}\n'
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await ingester._run_site_ingest_batch(["https://example.com"])
+
+        cmd_args = mock_exec.call_args[0]
+        assert "--output" in cmd_args
+        assert "json" in cmd_args

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -2028,5 +2028,5 @@ class TestRunSiteIngestBatch:
             await ingester._run_site_ingest_batch(["https://example.com"])
 
         cmd_args = mock_exec.call_args[0]
-        assert "--output" in cmd_args
-        assert "json" in cmd_args
+        output_index = cmd_args.index("--output")
+        assert cmd_args[output_index + 1] == "json"


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正
- [x] docs: ドキュメント更新

## Summary

- `_run_site_ingest_batch` の出力パースを regex (`(\d+)件新規配置`) から `--output json` + JSON Lines パースに移行
- `test_cli_json_output.py` の `TARGET_COMMANDS` に `site-ingest` を追加（テストカバレッジの穴を修正）
- `_run_site_ingest_batch` の JSON パーステスト 4 件を追加
- 仕様書 `docs/specs/ingesters/bluesky.md` のステップ 4 に `--output json` を追記

## Test plan

- [x] pytest 133 passed
- [x] ruff: 違反なし
- [x] mypy: 型エラーなし
- [x] markdownlint: 違反なし
- [x] QA: MCP 経由で BlueSky 取り込み（C-2, C-3）を実行し、site-ingest JSON パースの正常動作を確認

## Related issues

Closes #634