### PR TITLE
fix(rebuild-stats): rag_stats が大規模コレクションで失敗する問題を修正 (#639)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,10 +39,6 @@ rag_url_safety_check = true
 rag_url_safety_cache_ttl = 300
 rag_url_safety_timeout = 5.0
 
-# レスポンス制御
-# rag_max_response_chars = (未設定時は None)
-rag_stats_max_sources = 100
-
 # rag_list_recent / list-recent のデフォルト取得件数
 rag_list_recent_limit = 20
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -58,7 +58,7 @@ MCP サーバーとして独立動作し、18 個のツールを提供する。
 | ハイブリッド検索 | `rag_hybrid_search_enabled`, `rag_vector_weight`, `rag_bm25_k1`, `rag_bm25_b`, `rag_min_combined_score` |
 | ChromaDB | `chromadb_collection_name` |
 | URL 安全性 | `rag_url_safety_check`, `rag_url_safety_cache_ttl`, `rag_url_safety_timeout` |
-| レスポンス制御 | `rag_max_response_chars`（rag_get_document のトランケーション）, `rag_stats_max_sources`, `rag_list_recent_limit` |
+| レスポンス制御 | `rag_max_response_chars`（rag_get_document のトランケーション）, `rag_list_recent_limit` |
 | ログファイル出力 | `rag_log_file_max_bytes` |
 | Zenn インジェスター | `rag_zenn_max_articles`, `rag_zenn_request_timeout`, `rag_zenn_request_interval` |
 | BlueSky インジェスター | `rag_bluesky_appview_url`, `rag_bluesky_max_posts`, `rag_bluesky_request_timeout`, `rag_bluesky_request_interval`, `rag_bluesky_include_reposts` |
@@ -322,7 +322,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 
 #### rag_stats
 
-統計情報（総チャンク数、ソース URL 数）と蓄積データ概要（ドメイン別ソース URL 一覧・タイトル）を返す。表示件数上限は `rag_stats_max_sources` で制御する。引数なし。
+統計情報（総チャンク数、ソース数）を返す。詳細は [rebuild-stats.md](rebuild-stats.md) を参照。引数なし。
 
 ### 取り込みツールの出力形式
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -261,15 +261,14 @@ CLI は `--output json` 指定時にこの callback 内で進捗 JSON を stdout
 | 総ファイル数 | converted_store 内のファイル数 |
 | 総サイズ | 全ファイルの合計サイズ |
 
-#### インデックス統計（既存データ項目を維持）
+#### インデックス統計
 
 | 項目 | 内容 |
 |------|------|
-| 総チャンク数 | ChromaDB コレクション内のチャンク数 |
-| ソース数 | ユニークなソース数（source_id の種類数） |
-| ドメイン別ソース一覧 | ドメインごとのページ数・チャンク数（表示上限: `rag_stats_max_sources` 設定値） |
+| 総チャンク数 | ChromaDB コレクション内のチャンク数（`collection.count()`） |
+| ソース数 | metadata.db のアクティブソース数（`source_count(status="active")`） |
 
-既存の `rag_stats` が提供するデータ項目を維持する。出力テキストの形式は新セクション（source_store / converted_store / metadata.db）の追加に伴い統合フォーマットに変更する。
+総チャンク数は ChromaDB の軽量 API で取得する。ソース数は metadata.db が SSoT であり、ChromaDB のメタデータ走査は行わない。metadata.db が未設定・未初期化の場合、ソース数は 0 と表示する。
 
 #### metadata.db 統計
 
@@ -304,10 +303,6 @@ CLI は `--output json` 指定時にこの callback 内で進捗 JSON を stdout
 ■ インデックス
   総チャンク数: 1,234
   ソース数: 120
-  ドメイン別:
-    example.com: 5 pages (150 chunks)
-    ...
-  (以下省略、50件まで表示)
 
 ■ パイプライン
   最終処理: 2026-03-19T10:30:00+09:00

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1653,7 +1653,7 @@ def run_stats(args: argparse.Namespace) -> None:
     stats_data["converted_store"] = converted_store_data
 
     # インデックス
-    index_data: dict[str, object] = {}
+    index_data: dict[str, object] = {"source_count": 0}
     try:
         embedding_provider = get_embedding_provider(settings, settings.embedding_provider)
         with contextlib.redirect_stdout(io.StringIO()):

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -1668,7 +1668,6 @@ def run_stats(args: argparse.Namespace) -> None:
             )
         raw_stats = vector_store.get_stats()
         index_data["total_chunks"] = int(str(raw_stats.get("total_chunks", 0)))
-        index_data["source_count"] = int(str(raw_stats.get("source_count", 0)))
     except Exception:
         logger.exception("インデックス統計の取得に失敗")
         index_data["error"] = "統計の取得に失敗しました"
@@ -1690,6 +1689,8 @@ def run_stats(args: argparse.Namespace) -> None:
                 history = db.get_pipeline_history()
                 last_commit_id = db.get_last_commit_id()
                 deleted_count = db.source_count(status="deleted")
+                active_count = db.source_count(status="active")
+                index_data["source_count"] = active_count
                 pipeline_data["last_processed_at"] = (
                     history[-1].processed_at if history else None
                 )

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -184,7 +184,6 @@ class RAGSettings(BaseModel):
     rag_max_response_chars: int | None = Field(default=None, ge=1)
 
     # MCP レスポンスの情報量を制御
-    rag_stats_max_sources: int = Field(ge=1)
     rag_list_recent_limit: int = Field(ge=1, le=100)
 
     # 単一ログファイルの肥大化を防ぎ、ツール側での読み込みコストを抑える

--- a/src/rag/rag_knowledge.py
+++ b/src/rag/rag_knowledge.py
@@ -776,12 +776,11 @@ class RAGKnowledgeService:
         return total_deleted
 
     async def get_stats(self) -> dict[str, object]:
-        """ナレッジベース統計とソース一覧.
+        """ナレッジベース統計（総チャンク数）.
 
         Returns:
-            統計情報の辞書（total_chunks, source_count, sources）
+            統計情報の辞書（total_chunks）
         """
-        # VectorStore.get_stats()は同期APIを呼ぶため、to_threadでラップ
         return await asyncio.to_thread(self._vector_store.get_stats)
 
 

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -9,8 +9,6 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from typing import cast
-from urllib.parse import urlparse
-
 import chromadb
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.api.types import Embeddings, Metadatas
@@ -503,62 +501,14 @@ class VectorStore:
         return len(stale_ids)
 
     def get_stats(self) -> dict[str, object]:
-        """ナレッジベース統計（総チャンク数等）とソース一覧を返す.
-
-        Note:
-            この関数は全チャンクのメタデータを走査するため O(N) のコストがかかる。
-            チャンク数が多い場合は頻繁な呼び出しを避けること。
+        """ナレッジベース統計（総チャンク数）を返す.
 
         Returns:
             統計情報の辞書。キー:
             - total_chunks: 総チャンク数
-            - source_count: ユニークソースURL数
-            - sources: ドメイン別ソース一覧
         """
-        count = self._collection.count()
-
-        # ユニークなソースURL数とソース詳細を取得
-        all_docs = self._collection.get(include=["metadatas"])
-        source_urls: set[str] = set()
-        # url -> {"title": str, "chunks": int}
-        source_details: dict[str, dict[str, str | int]] = {}
-        if all_docs["metadatas"]:
-            for meta in all_docs["metadatas"]:
-                if meta and "source_id" in meta:
-                    url = str(meta["source_id"])
-                    source_urls.add(url)
-                    if url not in source_details:
-                        source_details[url] = {
-                            "title": str(meta.get("title", "")),
-                            "chunks": 0,
-                        }
-                    source_details[url]["chunks"] = int(source_details[url]["chunks"]) + 1
-
-        # ドメイン別にグルーピング
-        domain_groups: dict[str, list[dict[str, str | int]]] = {}
-        for url, detail in source_details.items():
-            domain = urlparse(url).netloc or "unknown"
-            if domain not in domain_groups:
-                domain_groups[domain] = []
-            domain_groups[domain].append({
-                "url": url,
-                "title": detail["title"],
-                "chunks": detail["chunks"],
-            })
-
-        # ドメイン名でソート、各ドメイン内はタイトルでソート
-        sources: list[dict[str, object]] = []
-        for domain in sorted(domain_groups.keys()):
-            pages = sorted(domain_groups[domain], key=lambda p: str(p.get("title", "")))
-            sources.append({
-                "domain": domain,
-                "pages": pages,
-            })
-
         return {
-            "total_chunks": count,
-            "source_count": len(source_urls),
-            "sources": sources,
+            "total_chunks": self._collection.count(),
         }
 
     def close(self) -> None:

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -41,7 +41,6 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_url_safety_check": False,
     "rag_url_safety_cache_ttl": 300,
     "rag_url_safety_timeout": 5.0,
-    "rag_stats_max_sources": 100,
     "rag_list_recent_limit": 20,
     "rag_log_file_max_bytes": 10_485_760,
     "rag_zenn_max_articles": 50,

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -206,7 +206,6 @@ chromadb_collection_name = "knowledge"
 rag_url_safety_check = false
 rag_url_safety_cache_ttl = 300
 rag_url_safety_timeout = 5.0
-rag_stats_max_sources = 100
 rag_list_recent_limit = 20
 rag_log_file_max_bytes = 10485760
 rag_zenn_max_articles = 50

--- a/tests/test_rag_knowledge.py
+++ b/tests/test_rag_knowledge.py
@@ -46,8 +46,6 @@ def mock_vector_store(mock_embedding_provider: MagicMock) -> MagicMock:
     mock.get_metadata_by_ids = AsyncMock(return_value={})
     mock.get_stats = MagicMock(return_value={
         "total_chunks": 10,
-        "source_count": 2,
-        "sources": [],
     })
     return mock
 
@@ -152,15 +150,6 @@ class TestGetStats:
         # Arrange
         mock_vector_store.get_stats.return_value = {
             "total_chunks": 100,
-            "source_count": 10,
-            "sources": [
-                {
-                    "domain": "example.com",
-                    "pages": [
-                        {"url": "https://example.com/p1", "title": "Page 1", "chunks": 5},
-                    ],
-                },
-            ],
         }
 
         # Act
@@ -168,9 +157,8 @@ class TestGetStats:
 
         # Assert
         assert result["total_chunks"] == 100
-        assert result["source_count"] == 10
-        assert isinstance(result["sources"], list)
-        assert len(result["sources"]) == 1
+        assert "source_count" not in result
+        assert "sources" not in result
 
 
 class TestConfiguration:

--- a/tests/test_rag_knowledge_hybrid.py
+++ b/tests/test_rag_knowledge_hybrid.py
@@ -32,7 +32,7 @@ def mock_vector_store(mock_embedding_provider: MagicMock) -> MagicMock:
     mock.search = AsyncMock(return_value=[])
     mock.delete_by_source = AsyncMock(return_value=0)
     mock.delete_stale_chunks = AsyncMock(return_value=0)
-    mock.get_stats = MagicMock(return_value={"total_chunks": 10, "source_count": 2})
+    mock.get_stats = MagicMock(return_value={"total_chunks": 10})
     return mock
 
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -273,14 +273,14 @@ class TestDeleteBySourceType:
 
 
 class TestAC11GetStats:
-    """AC11: VectorStore.get_stats() でナレッジベースの統計情報を取得できること."""
+    """AC11: VectorStore.get_stats() で総チャンク数を取得できること."""
 
     def test_get_stats_empty_store(self, ephemeral_store: VectorStore) -> None:
         """空のストアの統計."""
         stats = ephemeral_store.get_stats()
         assert stats["total_chunks"] == 0
-        assert stats["source_count"] == 0
-        assert stats["sources"] == []
+        assert "source_count" not in stats
+        assert "sources" not in stats
 
     @pytest.mark.asyncio
     async def test_get_stats_with_documents(self, ephemeral_store: VectorStore) -> None:
@@ -318,71 +318,6 @@ class TestAC11GetStats:
 
         stats = ephemeral_store.get_stats()
         assert stats["total_chunks"] == 3
-        assert stats["source_count"] == 2
-
-    @pytest.mark.asyncio
-    async def test_get_stats_returns_sources_with_domain_grouping(
-        self,
-        ephemeral_store: VectorStore,
-    ) -> None:
-        """ソース一覧がドメイン別にグルーピングされて返ること."""
-        chunks = [
-            DocumentChunk(
-                id="a_0",
-                text="テキスト1",
-                metadata={
-                    "source_id": "https://example.com/page1",
-                    "title": "ページA",
-                    "chunk_index": 0,
-                },
-            ),
-            DocumentChunk(
-                id="a_1",
-                text="テキスト2",
-                metadata={
-                    "source_id": "https://example.com/page1",
-                    "title": "ページA",
-                    "chunk_index": 1,
-                },
-            ),
-            DocumentChunk(
-                id="b_0",
-                text="テキスト3",
-                metadata={
-                    "source_id": "https://other.com/doc",
-                    "title": "ドキュメントB",
-                    "chunk_index": 0,
-                },
-            ),
-        ]
-        await ephemeral_store.add_documents(chunks)
-
-        stats = ephemeral_store.get_stats()
-        sources = stats["sources"]
-        assert isinstance(sources, list)
-        assert len(sources) == 2
-
-        # ドメイン名でソートされている
-        domains = [g["domain"] for g in sources]
-        assert domains == ["example.com", "other.com"]
-
-        # example.com のページ情報
-        example_group = sources[0]
-        assert example_group["domain"] == "example.com"
-        pages = example_group["pages"]
-        assert len(pages) == 1  # 1つのユニークURL
-        assert pages[0]["url"] == "https://example.com/page1"
-        assert pages[0]["title"] == "ページA"
-        assert pages[0]["chunks"] == 2
-
-        # other.com のページ情報
-        other_group = sources[1]
-        assert other_group["domain"] == "other.com"
-        pages = other_group["pages"]
-        assert len(pages) == 1
-        assert pages[0]["url"] == "https://other.com/doc"
-        assert pages[0]["title"] == "ドキュメントB"
-        assert pages[0]["chunks"] == 1
 
 
 class TestVectorStoreDataClasses:


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- `VectorStore.get_stats()` の全メタデータ一括取得（`collection.get(include=["metadatas"])`）を廃止し、`collection.count()` のみの軽量実装に変更
- `source_count` を metadata.db の `source_count(status="active")` から取得するように CLI を変更（metadata.db が SSoT）
- デッドコード削除: `sources`（ドメイン別一覧）フィールド、`rag_stats_max_sources` 設定値、`urlparse` import
- 仕様書（rebuild-stats.md, rag-knowledge.md）を更新

## Test plan

- [x] pytest 103件通過（test_vector_store, test_rag_knowledge, test_rag_knowledge_hybrid, test_rag_config）
- [x] ruff lint 違反なし
- [x] mypy 型エラーなし
- [x] markdownlint 違反なし
- [ ] 本番環境（133k+ チャンク）で `stats` がエラーなく動作すること（マージ後に QA 実施予定）

## Related issues

Closes #639