### PR TITLE
perf(bm25-scalability): BM25 インデックスの SQLite 外部化・トークンキャッシュ (#649, #650)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,38 +40,28 @@ MCP サーバープロセスを停止 → ChromaDB サーバーが起動して�
 
 worktree で CLI 操作・動作確認を行う場合、以下のセットアップを実施すること。
 
-1. メインリポジトリから `.env` をコピーする:
+1. メインリポジトリから `.env` をコピーする（ストレージパスは相対パスのため、worktree 内の `.tmp/` が自動的に使用される。書き換え不要）:
 
    ```bash
    cp .env <worktree-path>/.env
    ```
 
-2. worktree の `.env` でストレージパスを worktree 内の絶対パスに変更する（相対パスだとメインリポジトリのストレージを参照してしまう）:
-
-   ```
-   CHROMADB_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_chroma_db
-   BM25_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_bm25_index
-   SOURCE_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_source_store
-   CONVERTED_STORE_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_converted_store
-   CHROMADB_SERVER_PORT=8001
-   ```
-
-3. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する:
+2. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する:
 
    ```
    LMSTUDIO_BASE_URL=http://localhost:1234/v1
    ```
 
-4. `.tmp` ディレクトリを作成する:
+3. `.tmp` ディレクトリを作成する:
 
    ```bash
    mkdir -p <worktree-path>/.tmp
    ```
 
-5. ChromaDB サーバーを起動する（メインリポジトリの MCP サーバーが起動中の場合はポート 8000 が使用中のため、`.env` で `CHROMADB_SERVER_PORT` を変更すること）。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
+4. ChromaDB サーバーを起動する。ポート競合時（前セッションの停止漏れ等）は `.env` で `CHROMADB_SERVER_PORT` を変更すること。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
 
    ```bash
-   uv run chroma run --path <worktree-path>/.tmp/test_chroma_db --port <別ポート>
+   uv run chroma run --path <worktree-path>/.tmp/test_chroma_db
    ```
 
 ### CLI 動作確認の確認観点
@@ -100,23 +90,17 @@ uv run python -m rag.cli search --query "<クエリ>"
 
 worktree で開発中のコードを MCP サーバーとして動作確認する手順:
 
-1. worktree の `.env` でストレージパスを絶対パスに変更する（相対パスだとメインリポジトリのストレージを参照してしまう）:
-
-   ```
-   CHROMADB_PERSIST_DIR=D:/GitHub/becky3/rag-knowledge-wt-XXX/.tmp/test_chroma_db
-   ```
-
-2. worktree で MCP サーバーを HTTP モードで起動する:
+1. worktree で MCP サーバーを HTTP モードで起動する（ストレージパスは相対パスのため書き換え不要）:
 
    ```bash
    cd <worktree-path> && uv run python -m rag.server &
    ```
 
-3. `.mcp.json` の `url` は `http://localhost:<RAG_HTTP_PORT>/mcp` のまま変更不要（worktree のサーバーが同じポートで起動するため）。メインリポジトリの MCP サーバーが起動中の場合はポート競合するため、先に停止すること
+2. `.mcp.json` の `url` は `http://localhost:<RAG_HTTP_PORT>/mcp` のまま変更不要（worktree のサーバーが同じポートで起動するため）。ポート競合時（前セッションの停止漏れ等）は先に該当プロセスを停止すること
 
-4. `/mcp` で disabled の場合は enable、enabled の場合は reconnect（サーバー再接続）。`.mcp.json` を変更した場合はセッション再起動が必要
+3. `/mcp` で disabled の場合は enable、enabled の場合は reconnect（サーバー再接続）。`.mcp.json` を変更した場合はセッション再起動が必要
 
-5. 動作確認完了後、worktree のサーバープロセスを停止する
+4. 動作確認完了後、worktree のサーバープロセスを停止する
 
 ## Claude Code 拡張機能
 

--- a/docs/specs/infrastructure/bm25-scalability.md
+++ b/docs/specs/infrastructure/bm25-scalability.md
@@ -1,0 +1,173 @@
+# BM25 スケーラビリティ
+
+## 概要
+
+BM25 インデックスのメモリ消費・永続化・rebuild 性能を改善し、820k チャンク規模での安定運用を可能にする。
+
+スコープ:
+
+- 4 辞書（`_documents`, `_doc_source_map`, `_doc_source_type_map`, `_doc_metadata_map`）の SQLite 外部化
+- metadata.json 廃止と SQLite ベースの永続化への移行
+- トークン化結果のキャッシュによる rebuild 高速化
+
+スコープ外:
+
+- bm25s ライブラリの差分更新（API が存在しないため対象外）
+- BM25 の検索精度チューニング（既存仕様の範疇）
+- Embedding・ChromaDB 側のスケーラビリティ
+
+## 背景
+
+現在の BM25 インデックス実装は全チャンクのテキスト・メタデータを Python 辞書でオンメモリ保持し、永続化時に JSON 一括シリアライズする。133k チャンク（metadata.json 873KB）では問題ないが、820k チャンク規模では以下の問題が顕在化する。
+
+| 問題 | 現在（133k） | 見込み（820k） |
+|------|-------------|---------------|
+| metadata.json サイズ | 873 KB | 約 500 MB |
+| テキストメモリ | 約 25 MB | 約 150 MB |
+| 辞書オーバーヘッド含む合計 | 軽微 | 数百 MB |
+| `_save()` JSON シリアライズ | 瞬時 | OOM リスク |
+| `_rebuild_index()` トークン化 | 数秒 | 数時間 |
+
+MCP サーバー起動時に全データをメモリにロードするため、サーバー再起動失敗として顕在化するリスクがある。
+
+## 制約
+
+- **bm25s は差分更新不可**: `bm25s.BM25.index()` が唯一のインデックス構築メソッドであり、全コーパスのトークン列を受け取る。add/delete 後のインデックス再構築は全件 rebuild が必須
+- **rebuild 時のサービス中断なし**: rebuild 中も検索リクエストに応答する。旧インデックスを保持し、rebuild 完了後にアトミックスワップする既存方式を維持する
+- **既存データの移行**: `rebuild --mode full` で新フォーマットに移行する。旧 metadata.json からのマイグレーションパスは設けない
+- **BM25 の独立性**: BM25 インデックスは ChromaDB に依存しない。テキスト・メタデータの取得に ChromaDB へのアクセスを要求しない
+
+## インターフェース
+
+外部インターフェース（MCP ツール・CLI コマンド）の変更はない。BM25Index クラスの公開メソッドシグネチャも変更しない。
+
+内部的な変更:
+
+| 変更 | 内容 |
+|------|------|
+| 永続化形式 | metadata.json → SQLite（`bm25_store.db`）+ bm25s ネイティブファイル |
+| メモリモデル | 全データオンメモリ → SQLite に委譲、検索時に必要なデータのみ取得 |
+| rebuild | 全チャンクトークン化 → トークンキャッシュから読み出し、未キャッシュ分のみトークン化 |
+
+## コンポーネント構成
+
+### ストレージ構成
+
+BM25 永続化ディレクトリ（`BM25_PERSIST_DIR`）の構成を以下に変更する。
+
+変更前:
+
+```
+bm25_index/
+  metadata.json      # 全辞書の JSON ダンプ
+  bm25s/             # bm25s ネイティブファイル
+```
+
+変更後:
+
+```
+bm25_index/
+  bm25_store.db      # SQLite（チャンクデータ + トークンキャッシュ）
+  bm25s/             # bm25s ネイティブファイル
+```
+
+### SQLite スキーマ（`bm25_store.db`）
+
+2 テーブルで構成する。
+
+#### `chunks` テーブル
+
+旧 4 辞書の代替。チャンクのテキスト・メタデータを格納する。
+
+| カラム | 型 | 内容 |
+|--------|---|------|
+| `doc_id` | TEXT PRIMARY KEY | チャンク ID |
+| `text` | TEXT NOT NULL | チャンク本文（BM25 検索入力テキスト） |
+| `source_id` | TEXT NOT NULL | ソース識別子 |
+| `source_type` | TEXT NOT NULL | 媒体種別 |
+| `metadata` | TEXT NOT NULL DEFAULT '{}' | チャンクメタデータ（JSON） |
+
+インデックス: `source_id`, `source_type`
+
+#### `token_cache` テーブル
+
+トークン化結果のキャッシュ。rebuild 時にテキスト未変更のチャンクのトークン化をスキップする。
+
+| カラム | 型 | 内容 |
+|--------|---|------|
+| `doc_id` | TEXT PRIMARY KEY | チャンク ID |
+| `text_hash` | TEXT NOT NULL | テキストの SHA-256 ハッシュ（先頭 16 文字） |
+| `tokens` | TEXT NOT NULL | トークン化結果（JSON 配列） |
+
+### データフロー
+
+#### add_documents
+
+1. SQLite の `chunks` テーブルに INSERT OR REPLACE
+2. `_needs_rebuild = True` を設定
+3. 遅延 save モードでなければ rebuild + bm25s 永続化
+
+#### search
+
+1. `_needs_rebuild` なら rebuild を実行
+2. bm25s で検索し、doc_id リストを取得
+3. 検索結果の doc_id に対応する `text`・`source_type`・`metadata` を SQLite からバッチ取得
+4. source_type フィルタ・metadata フィルタはアプリケーション側で適用
+
+#### delete_by_source
+
+1. SQLite の `chunks` テーブルから `source_id` で DELETE
+2. SQLite の `token_cache` テーブルから `doc_id` で DELETE（chunks の doc_id と紐付け）
+3. `_needs_rebuild = True` を設定
+
+#### rebuild（_rebuild_index）
+
+1. SQLite の `chunks` テーブルから全 `doc_id` と `text` を取得
+2. 各チャンクのテキストハッシュを算出
+3. `token_cache` からハッシュが一致するトークンを取得（キャッシュヒット）
+4. キャッシュミスのチャンクのみ `tokenize_japanese()` を実行
+5. 新規トークン化結果を `token_cache` に INSERT OR REPLACE
+6. 全トークン列を `bm25s.BM25.index()` に渡してインデックス構築
+7. bm25s ネイティブファイルを永続化（アトミックスワップ）
+8. `_needs_rebuild = False`
+
+#### _save の廃止
+
+現行の `_save()` は metadata.json への JSON 一括ダンプと bm25s の保存を行う。SQLite 外部化後は:
+
+- チャンクデータの永続化: add/delete 時に SQLite へ即時書き込み（トランザクション制御）
+- bm25s の永続化: rebuild 完了時にアトミックスワップで保存
+- metadata.json の一括ダンプは廃止
+
+#### _load の廃止
+
+現行の `_load()` は metadata.json から全辞書をメモリに復元する。SQLite 外部化後は:
+
+- 起動時に SQLite の接続を確立するのみ（全データのメモリ読み込みは行わない）
+- bm25s モデルはネイティブファイルからロード（既存方式を維持）
+
+### メモリモデルの変化
+
+| データ | 変更前 | 変更後 |
+|--------|--------|--------|
+| チャンクテキスト（`_documents`） | 全件オンメモリ | SQLite に格納。検索結果分のみ取得 |
+| source_id マッピング（`_doc_source_map`） | 全件オンメモリ | SQLite `chunks.source_id` |
+| source_type マッピング（`_doc_source_type_map`） | 全件オンメモリ | SQLite `chunks.source_type` |
+| メタデータ（`_doc_metadata_map`） | 全件オンメモリ | SQLite `chunks.metadata` |
+| doc_id リスト（`_doc_ids`） | 全件オンメモリ | rebuild 時に SQLite から取得。bm25s のインデックス順序に対応するためオンメモリ保持を維持 |
+| bm25s モデル | オンメモリ | オンメモリ（変更なし。bm25s の内部構造は CSR スパース行列） |
+| トークンキャッシュ | なし | SQLite `token_cache` |
+
+## エッジケース
+
+- **bm25_store.db 破損時**: `rebuild --mode full` で復旧する。bm25_store.db を削除して rebuild すれば、converted_store から全データが再構築される
+- **トークンキャッシュの不整合**: `token_cache` のエントリが `chunks` に存在しない場合、rebuild 時に無視される。逆に `chunks` にあるが `token_cache` にない場合はキャッシュミスとしてトークン化を実行する。不整合が蓄積した場合は `token_cache` テーブルの全行削除で解消可能
+- **deferred_save モード**: SQLite への書き込みは即時コミットし、bm25s の rebuild + 永続化を flush() まで遅延する
+- **空インデックス**: チャンク 0 件の場合、bm25s ディレクトリを削除し bm25_store.db は空テーブルの状態を維持する
+
+## 関連ドキュメント
+
+- [インデクサー仕様](../indexer.md) — BM25 インデックスのデータ構造・変更種別ごとの処理
+- [再構築・統計・バックアップ](../rebuild-stats.md) — rebuild コマンドの仕様
+- [Issue #649](https://github.com/becky3/rag-knowledge/issues/649) — BM25 オンメモリ保持解消
+- [Issue #650](https://github.com/becky3/rag-knowledge/issues/650) — rebuild 全チャンク一括トークン化の改善

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -34,6 +34,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 24 | Upload HTTP API 認証 | API キー認証・バインドアドレス制約 | [infrastructure/upload-auth.md](infrastructure/upload-auth.md) |
 | 25 | 定期 index rebuild | 条件付き index rebuild の自動実行 | [infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) |
 | 26 | メディア解析 | 画像・動画の Vision モデルによるテキスト変換 | [infrastructure/media-analysis.md](infrastructure/media-analysis.md) |
+| 27 | BM25 スケーラビリティ | BM25 インデックスの SQLite 外部化・トークンキャッシュによる大規模対応 | [infrastructure/bm25-scalability.md](infrastructure/bm25-scalability.md) |
 
 ## 3. 技術スタック
 

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -1,15 +1,17 @@
 """BM25キーワード検索インデックスモジュール
 
-仕様: docs/specs/rag-knowledge.md
+仕様: docs/specs/infrastructure/bm25-scalability.md
 """
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import logging
 import re
 import shutil
+import sqlite3
 import tempfile
 from contextlib import redirect_stdout
 from dataclasses import dataclass
@@ -23,10 +25,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 永続化メタデータ
-METADATA_FILENAME = "metadata.json"
 BM25S_SUBDIR = "bm25s"
-METADATA_VERSION = 1
+STORE_DB_FILENAME = "bm25_store.db"
+_REBUILD_MEMORY_WARNING_BYTES = 256 * 1024 * 1024  # 256 MB
 
 # fugashiのインポートを遅延させる（オプショナル依存）
 _fugashi_available: bool | None = None
@@ -56,6 +57,31 @@ def _get_fugashi_tagger() -> "fugashi.Tagger | None":
         return None
 
 
+_STORE_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS chunks (
+    doc_id      TEXT PRIMARY KEY,
+    text        TEXT NOT NULL,
+    source_id   TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    metadata    TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_source_id ON chunks(source_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_source_type ON chunks(source_type);
+
+CREATE TABLE IF NOT EXISTS token_cache (
+    doc_id    TEXT PRIMARY KEY,
+    text_hash TEXT NOT NULL,
+    tokens    TEXT NOT NULL
+);
+"""
+
+
+def _text_hash(text: str) -> str:
+    """テキストの SHA-256 ハッシュ先頭 16 文字を返す."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
 @dataclass
 class BM25Result:
     """BM25検索結果."""
@@ -65,10 +91,272 @@ class BM25Result:
     text: str
 
 
+class _BM25Store:
+    """BM25 チャンクデータの SQLite ストア.
+
+    persist_dir が None の場合は :memory: で動作する。
+    """
+
+    def __init__(self, persist_dir: Path | None) -> None:
+        self._persist_dir = persist_dir
+        if persist_dir is not None:
+            persist_dir.mkdir(parents=True, exist_ok=True)
+            db_path = str(persist_dir / STORE_DB_FILENAME)
+        else:
+            db_path = ":memory:"
+
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(_STORE_SCHEMA_SQL)
+        except sqlite3.DatabaseError:
+            if conn is not None:
+                conn.close()
+            if persist_dir is not None:
+                corrupt_path = persist_dir / STORE_DB_FILENAME
+                if corrupt_path.exists():
+                    corrupt_path.unlink()
+                    logger.warning(
+                        "Corrupt BM25 store DB removed: %s", corrupt_path,
+                    )
+            conn = sqlite3.connect(db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(_STORE_SCHEMA_SQL)
+        self._conn = conn
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def upsert_chunks(
+        self,
+        documents: list[tuple[str, str, str, str]],
+        metadata_list: list[dict[str, str | int | float | bool]] | None,
+    ) -> tuple[int, int]:
+        """チャンクを INSERT OR REPLACE する.
+
+        Returns:
+            (added, updated) のタプル
+        """
+        existing: set[str] = set()
+        doc_ids = [d[0] for d in documents]
+        for batch_start in range(0, len(doc_ids), 900):
+            batch = doc_ids[batch_start:batch_start + 900]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                f"SELECT doc_id FROM chunks WHERE doc_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            existing.update(r[0] for r in rows)
+
+        added = 0
+        updated = 0
+        params = []
+        for i, (doc_id, text, source_id, source_type) in enumerate(documents):
+            meta_json = json.dumps(
+                metadata_list[i], ensure_ascii=False,
+            ) if metadata_list is not None else "{}"
+            params.append((doc_id, text, source_id, source_type, meta_json))
+            if doc_id in existing:
+                updated += 1
+            else:
+                added += 1
+
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO chunks (doc_id, text, source_id, source_type, metadata) "
+            "VALUES (?, ?, ?, ?, ?)",
+            params,
+        )
+        self._conn.commit()
+        return added, updated
+
+    def delete_by_source(self, source_id: str) -> list[str]:
+        """source_id で削除し、削除された doc_id リストを返す."""
+        rows = self._conn.execute(
+            "SELECT doc_id FROM chunks WHERE source_id = ?", (source_id,),
+        ).fetchall()
+        deleted_ids = [r[0] for r in rows]
+        if deleted_ids:
+            self._conn.execute(
+                "DELETE FROM chunks WHERE source_id = ?", (source_id,),
+            )
+            self._delete_token_cache(deleted_ids)
+            self._conn.commit()
+        return deleted_ids
+
+    def delete_by_source_type(self, source_type: str) -> list[str]:
+        """source_type で削除し、削除された doc_id リストを返す."""
+        rows = self._conn.execute(
+            "SELECT doc_id FROM chunks WHERE source_type = ?", (source_type,),
+        ).fetchall()
+        deleted_ids = [r[0] for r in rows]
+        if deleted_ids:
+            self._conn.execute(
+                "DELETE FROM chunks WHERE source_type = ?", (source_type,),
+            )
+            self._delete_token_cache(deleted_ids)
+            self._conn.commit()
+        return deleted_ids
+
+    def delete_stale(self, source_id: str, valid_ids: set[str]) -> list[str]:
+        """source_id のチャンクのうち valid_ids に含まれないものを削除する."""
+        rows = self._conn.execute(
+            "SELECT doc_id FROM chunks WHERE source_id = ?", (source_id,),
+        ).fetchall()
+        stale_ids = [r[0] for r in rows if r[0] not in valid_ids]
+        if stale_ids:
+            for batch_start in range(0, len(stale_ids), 900):
+                batch = stale_ids[batch_start:batch_start + 900]
+                placeholders = ",".join("?" * len(batch))
+                self._conn.execute(
+                    f"DELETE FROM chunks WHERE doc_id IN ({placeholders})", batch,
+                )
+            self._delete_token_cache(stale_ids)
+            self._conn.commit()
+        return stale_ids
+
+    def get_document_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()
+        return row[0] if row else 0
+
+    def get_source_url(self, doc_id: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT source_id FROM chunks WHERE doc_id = ?", (doc_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+    def get_source_type(self, doc_id: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT source_type FROM chunks WHERE doc_id = ?", (doc_id,),
+        ).fetchone()
+        return row[0] if row else None
+
+    def get_metadata(self, doc_id: str) -> dict[str, str | int | float | bool]:
+        row = self._conn.execute(
+            "SELECT metadata FROM chunks WHERE doc_id = ?", (doc_id,),
+        ).fetchone()
+        if row is None:
+            return {}
+        return json.loads(row[0])  # type: ignore[no-any-return]
+
+    def get_texts_by_ids(self, doc_ids: list[str]) -> dict[str, str]:
+        """doc_id リストに対応するテキストを取得する."""
+        result: dict[str, str] = {}
+        for batch_start in range(0, len(doc_ids), 900):
+            batch = doc_ids[batch_start:batch_start + 900]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                f"SELECT doc_id, text FROM chunks WHERE doc_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for r in rows:
+                result[r[0]] = r[1]
+        return result
+
+    def get_source_types_by_ids(self, doc_ids: list[str]) -> dict[str, str]:
+        """doc_id リストに対応する source_type を取得する."""
+        result: dict[str, str] = {}
+        for batch_start in range(0, len(doc_ids), 900):
+            batch = doc_ids[batch_start:batch_start + 900]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                f"SELECT doc_id, source_type FROM chunks WHERE doc_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for r in rows:
+                result[r[0]] = r[1]
+        return result
+
+    def get_metadatas_by_ids(
+        self, doc_ids: list[str],
+    ) -> dict[str, dict[str, str | int | float | bool]]:
+        """doc_id リストに対応するメタデータを取得する."""
+        result: dict[str, dict[str, str | int | float | bool]] = {}
+        for batch_start in range(0, len(doc_ids), 900):
+            batch = doc_ids[batch_start:batch_start + 900]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                f"SELECT doc_id, metadata FROM chunks WHERE doc_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for r in rows:
+                result[r[0]] = json.loads(r[1])
+        return result
+
+    def estimate_text_memory_bytes(self) -> tuple[int, int]:
+        """チャンク数とテキスト合計バイト数を返す（rebuild 前の見積もり用）."""
+        row = self._conn.execute(
+            "SELECT COUNT(*), COALESCE(SUM(LENGTH(text)), 0) FROM chunks",
+        ).fetchone()
+        return (row[0], row[1]) if row else (0, 0)
+
+    def get_all_for_rebuild(self) -> list[tuple[str, str]]:
+        """rebuild 用に全 (doc_id, text) を doc_id 順で返す."""
+        return self._conn.execute(
+            "SELECT doc_id, text FROM chunks ORDER BY doc_id",
+        ).fetchall()
+
+    def has_documents(self) -> bool:
+        row = self._conn.execute("SELECT 1 FROM chunks LIMIT 1").fetchone()
+        return row is not None
+
+    def clear(self) -> None:
+        self._conn.execute("DELETE FROM chunks")
+        self._conn.execute("DELETE FROM token_cache")
+        self._conn.commit()
+
+    # --- token cache ---
+
+    def get_cached_tokens(
+        self, doc_ids_with_hashes: list[tuple[str, str]],
+    ) -> dict[str, list[str]]:
+        """キャッシュヒットしたトークンを返す."""
+        result: dict[str, list[str]] = {}
+        for batch_start in range(0, len(doc_ids_with_hashes), 900):
+            batch = doc_ids_with_hashes[batch_start:batch_start + 900]
+            ids = [b[0] for b in batch]
+            placeholders = ",".join("?" * len(ids))
+            rows = self._conn.execute(
+                f"SELECT doc_id, text_hash, tokens FROM token_cache "
+                f"WHERE doc_id IN ({placeholders})",
+                ids,
+            ).fetchall()
+            hash_map = {b[0]: b[1] for b in batch}
+            for doc_id, cached_hash, tokens_json in rows:
+                if cached_hash == hash_map.get(doc_id):
+                    result[doc_id] = json.loads(tokens_json)
+        return result
+
+    def upsert_token_cache(
+        self, entries: list[tuple[str, str, list[str]]],
+    ) -> None:
+        """トークンキャッシュを一括更新する."""
+        if not entries:
+            return
+        params = [
+            (doc_id, text_hash, json.dumps(tokens, ensure_ascii=False))
+            for doc_id, text_hash, tokens in entries
+        ]
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO token_cache (doc_id, text_hash, tokens) "
+            "VALUES (?, ?, ?)",
+            params,
+        )
+        self._conn.commit()
+
+    def _delete_token_cache(self, doc_ids: list[str]) -> None:
+        for batch_start in range(0, len(doc_ids), 900):
+            batch = doc_ids[batch_start:batch_start + 900]
+            placeholders = ",".join("?" * len(batch))
+            self._conn.execute(
+                f"DELETE FROM token_cache WHERE doc_id IN ({placeholders})", batch,
+            )
+
+
 class BM25Index:
     """BM25ベースのキーワード検索インデックス.
 
-    仕様: docs/specs/rag-knowledge.md
+    仕様: docs/specs/infrastructure/bm25-scalability.md
     """
 
     def __init__(
@@ -88,25 +376,21 @@ class BM25Index:
         self._b = b
         self._persist_dir = Path(persist_dir) if persist_dir else None
 
-        # ドキュメントストレージ
-        self._documents: dict[str, str] = {}  # id -> text
-        self._doc_source_map: dict[str, str] = {}  # id -> source_url
-        self._doc_source_type_map: dict[str, str] = {}  # id -> source_type
-        self._doc_metadata_map: dict[str, dict[str, str | int | float | bool]] = {}  # id -> chunk metadata
+        self._store = _BM25Store(self._persist_dir)
 
         # BM25インデックス（遅延初期化）
         self._bm25: "bm25s.BM25 | None" = None
-        self._doc_ids: list[str] = []  # インデックス順序を保持
+        self._doc_ids: list[str] = []
 
         # 再構築フラグ
         self._needs_rebuild = True
 
-        # 遅延 save モード: バッチ処理中は save をスキップし flush() で一括実行
+        # 遅延 save モード
         self._deferred_save = False
 
-        # 永続化ディレクトリからロード
+        # 永続化ディレクトリからbm25sモデルをロード
         if self._persist_dir is not None:
-            self._load()
+            self._load_bm25s()
 
     def add_documents(
         self,
@@ -128,30 +412,15 @@ class BM25Index:
                 f"documents={len(documents)}, metadata_list={len(metadata_list)}"
             )
 
-        added = 0
-        updated = 0
-        for i, (doc_id, text, source_url, source_type) in enumerate(documents):
-            if doc_id in self._documents:
-                self._documents[doc_id] = text
-                self._doc_source_map[doc_id] = source_url
-                self._doc_source_type_map[doc_id] = source_type
-                updated += 1
-            else:
-                self._documents[doc_id] = text
-                self._doc_source_map[doc_id] = source_url
-                self._doc_source_type_map[doc_id] = source_type
-                added += 1
-            if metadata_list is not None:
-                self._doc_metadata_map[doc_id] = metadata_list[i]
+        added, updated = self._store.upsert_chunks(documents, metadata_list)
 
-        # 新規追加または更新があった場合はインデックス再構築が必要
         if added > 0 or updated > 0:
             self._needs_rebuild = True
             logger.debug(
-                "BM25 index: added %d, updated %d documents", added, updated
+                "BM25 index: added %d, updated %d documents", added, updated,
             )
             if not self._deferred_save:
-                self._save()
+                self._save_bm25s()
 
         return added
 
@@ -173,23 +442,19 @@ class BM25Index:
         Returns:
             BM25Resultのリスト（スコア降順）
         """
-        if not self._documents:
+        if not self._store.has_documents():
             return []
 
-        # 必要に応じてインデックスを再構築
         if self._needs_rebuild:
             self._rebuild_index()
 
         if self._bm25 is None:
             return []
 
-        # クエリをトークナイズ
         query_tokens = tokenize_japanese(query)
         if not query_tokens:
             return []
 
-        # BM25検索（k は corpus サイズ以下に制限）
-        # source_type / filters フィルタで除外される可能性を考慮し、3倍（最低20件）を取得
         fetch_count = n_results
         has_filter = source_type is not None or filters
         if has_filter:
@@ -199,29 +464,42 @@ class BM25Index:
             return []
 
         doc_indices, scores = self._bm25.retrieve(
-            [query_tokens], k=k, show_progress=False
+            [query_tokens], k=k, show_progress=False,
         )
 
-        # スコア > 0 の結果のみ抽出（source_type + filters フィルタ適用）
-        results: list[BM25Result] = []
+        hit_doc_ids: list[tuple[str, float]] = []
         for idx, score in zip(doc_indices[0], scores[0]):
             if score <= 0:
                 continue
-            doc_id = self._doc_ids[int(idx)]
+            hit_doc_ids.append((self._doc_ids[int(idx)], float(score)))
+
+        if not hit_doc_ids:
+            return []
+
+        all_hit_ids = [d[0] for d in hit_doc_ids]
+        texts = self._store.get_texts_by_ids(all_hit_ids)
+
+        if source_type is not None:
+            source_types = self._store.get_source_types_by_ids(all_hit_ids)
+        else:
+            source_types = {}
+
+        if filters:
+            metadatas = self._store.get_metadatas_by_ids(all_hit_ids)
+        else:
+            metadatas = {}
+
+        results: list[BM25Result] = []
+        for doc_id, score in hit_doc_ids:
             if source_type is not None:
-                if self._doc_source_type_map.get(doc_id) != source_type:
+                if source_types.get(doc_id) != source_type:
                     continue
             if filters:
-                doc_meta = self._doc_metadata_map.get(doc_id, {})
+                doc_meta = metadatas.get(doc_id, {})
                 if not self._matches_filters(doc_meta, filters):
                     continue
-            results.append(
-                BM25Result(
-                    doc_id=doc_id,
-                    score=float(score),
-                    text=self._documents[doc_id],
-                )
-            )
+            text = texts.get(doc_id, "")
+            results.append(BM25Result(doc_id=doc_id, score=score, text=text))
             if len(results) >= n_results:
                 break
 
@@ -232,11 +510,7 @@ class BM25Index:
         metadata: dict[str, str | int | float | bool],
         filters: dict[str, str],
     ) -> bool:
-        """メタデータがフィルタ条件に一致するか判定する.
-
-        フィルタ値（常に文字列）とメタデータ値を大文字変換して比較する。
-        これにより、メタデータの型（int/bool 等）や大文字小文字の違いを吸収する。
-        """
+        """メタデータがフィルタ条件に一致するか判定する."""
         for key, value in filters.items():
             meta_value = metadata.get(key)
             if meta_value is None:
@@ -254,29 +528,18 @@ class BM25Index:
         Returns:
             削除されたドキュメント数
         """
-        to_delete = [
-            doc_id
-            for doc_id, url in self._doc_source_map.items()
-            if url == source_url
-        ]
+        deleted_ids = self._store.delete_by_source(source_url)
 
-        for doc_id in to_delete:
-            del self._documents[doc_id]
-            del self._doc_source_map[doc_id]
-            self._doc_source_type_map.pop(doc_id, None)  # 旧データに source_type がない場合の互換性
-            self._doc_metadata_map.pop(doc_id, None)
-
-        if to_delete:
+        if deleted_ids:
             self._needs_rebuild = True
             logger.debug(
                 "Deleted %d documents from BM25 index (source: %s)",
-                len(to_delete),
-                source_url,
+                len(deleted_ids), source_url,
             )
             if not self._deferred_save:
-                self._save()
+                self._save_bm25s()
 
-        return len(to_delete)
+        return len(deleted_ids)
 
     def delete_by_source_type(self, source_type: str) -> int:
         """source_type 指定でドキュメントを一括削除する.
@@ -287,135 +550,71 @@ class BM25Index:
         Returns:
             削除されたドキュメント数
         """
-        to_delete = [
-            doc_id
-            for doc_id, st in self._doc_source_type_map.items()
-            if st == source_type
-        ]
+        deleted_ids = self._store.delete_by_source_type(source_type)
 
-        for doc_id in to_delete:
-            self._documents.pop(doc_id, None)
-            self._doc_source_map.pop(doc_id, None)
-            self._doc_source_type_map.pop(doc_id, None)
-            self._doc_metadata_map.pop(doc_id, None)
-
-        if to_delete:
+        if deleted_ids:
             self._needs_rebuild = True
             logger.debug(
                 "Deleted %d documents from BM25 index (source_type: %s)",
-                len(to_delete),
-                source_type,
+                len(deleted_ids), source_type,
             )
             if not self._deferred_save:
-                self._save()
+                self._save_bm25s()
 
-        return len(to_delete)
+        return len(deleted_ids)
+
+    def close(self) -> None:
+        """SQLite コネクションをクローズする."""
+        self._store.close()
 
     def get_document_count(self) -> int:
         """インデックス内のドキュメント数を返す."""
-        return len(self._documents)
+        return self._store.get_document_count()
 
     def get_source_url(self, doc_id: str) -> str | None:
-        """ドキュメントIDからソースURLを取得する.
-
-        Args:
-            doc_id: ドキュメントID
-
-        Returns:
-            ソースURL、見つからない場合はNone
-        """
-        return self._doc_source_map.get(doc_id)
+        """ドキュメントIDからソースURLを取得する."""
+        return self._store.get_source_url(doc_id)
 
     def get_source_type(self, doc_id: str) -> str | None:
-        """ドキュメントIDからソース種別を取得する.
-
-        Args:
-            doc_id: ドキュメントID
-
-        Returns:
-            ソース種別、見つからない場合はNone
-        """
-        return self._doc_source_type_map.get(doc_id)
+        """ドキュメントIDからソース種別を取得する."""
+        return self._store.get_source_type(doc_id)
 
     def get_metadata(self, doc_id: str) -> dict[str, str | int | float | bool]:
-        """ドキュメントIDからチャンクメタデータを取得する.
-
-        Args:
-            doc_id: ドキュメントID
-
-        Returns:
-            メタデータ辞書。見つからない場合は空辞書
-        """
-        return dict(self._doc_metadata_map.get(doc_id, {}))
+        """ドキュメントIDからチャンクメタデータを取得する."""
+        return self._store.get_metadata(doc_id)
 
     def delete_stale_docs(self, source_id: str, valid_ids: set[str]) -> int:
-        """ソースのドキュメントのうち、valid_ids に含まれないものを削除する.
-
-        Args:
-            source_id: ソース識別子
-            valid_ids: 保持する ID セット（これ以外を削除）
-
-        Returns:
-            削除件数
-        """
-        stale_ids = [
-            doc_id
-            for doc_id, src in self._doc_source_map.items()
-            if src == source_id and doc_id not in valid_ids
-        ]
-        for doc_id in stale_ids:
-            self._documents.pop(doc_id, None)
-            self._doc_source_map.pop(doc_id, None)
-            self._doc_source_type_map.pop(doc_id, None)
-            self._doc_metadata_map.pop(doc_id, None)
+        """ソースのドキュメントのうち、valid_ids に含まれないものを削除する."""
+        stale_ids = self._store.delete_stale(source_id, valid_ids)
 
         if stale_ids:
             self._needs_rebuild = True
             if not self._deferred_save:
-                self._save()
+                self._save_bm25s()
 
         return len(stale_ids)
 
     def clear(self) -> None:
         """全データをクリアして永続化する."""
-        self._documents.clear()
-        self._doc_source_map.clear()
-        self._doc_source_type_map.clear()
-        self._doc_metadata_map.clear()
+        self._store.clear()
         self._doc_ids.clear()
         self._bm25 = None
         self._needs_rebuild = True
-        self._save()
+        self._save_bm25s()
 
     def set_deferred_save(self, enabled: bool) -> None:
-        """遅延 save モードの有効/無効を切り替える.
-
-        有効にすると add/delete 操作で _save() を呼ばなくなる。
-        バッチ処理完了後に flush() で一括 rebuild + 永続化する。
-
-        Args:
-            enabled: True で遅延モード有効
-        """
+        """遅延 save モードの有効/無効を切り替える."""
         self._deferred_save = enabled
 
     def flush(self) -> None:
-        """未保存の変更を rebuild + 永続化する.
-
-        遅延 save モード中に蓄積された変更を一括で反映する。
-        _needs_rebuild が False（変更なし）の場合は何もしない。
-        """
+        """未保存の変更を rebuild + 永続化する."""
         if not self._needs_rebuild:
             return
-
-        if self._persist_dir is not None:
-            self._save()
-        else:
-            # インメモリモードでは _save() が早期リターンするため
-            # rebuild のみ実行して _needs_rebuild をリセットする
-            self._rebuild_index()
+        self._rebuild_index()
+        self._persist_bm25s()
 
     def _rebuild_index(self) -> None:
-        """BM25インデックスを再構築する."""
+        """BM25インデックスを再構築する（トークンキャッシュ使用）."""
         try:
             with redirect_stdout(io.StringIO()):
                 import bm25s
@@ -425,193 +624,149 @@ class BM25Index:
             self._needs_rebuild = False
             return
 
-        self._doc_ids = list(self._documents.keys())
-        tokenized_corpus = [
-            tokenize_japanese(self._documents[doc_id]) for doc_id in self._doc_ids
-        ]
+        chunk_count, text_bytes = self._store.estimate_text_memory_bytes()
+        if text_bytes > _REBUILD_MEMORY_WARNING_BYTES:
+            logger.warning(
+                "BM25 rebuild: text data is large (%d chunks, %d MB). "
+                "Peak memory usage will increase during rebuild.",
+                chunk_count, text_bytes // (1024 * 1024),
+            )
 
-        if tokenized_corpus:
-            self._bm25 = bm25s.BM25(k1=self._k1, b=self._b)
-            self._bm25.index(tokenized_corpus, show_progress=False)
-        else:
+        all_docs = self._store.get_all_for_rebuild()
+        if not all_docs:
             self._bm25 = None
-
-        self._needs_rebuild = False
-        logger.debug("Rebuilt BM25 index with %d documents", len(self._doc_ids))
-
-    def _save(self) -> None:
-        """インデックスをディスクに永続化する."""
-        if self._persist_dir is None:
-            return
-
-        if not self._documents:
-            # 空インデックスの場合、ディレクトリがあれば削除
-            if self._persist_dir.exists():
-                shutil.rmtree(self._persist_dir)
-                logger.debug("Removed empty BM25 persist dir: %s", self._persist_dir)
+            self._doc_ids = []
             self._needs_rebuild = False
             return
 
-        # インデックスが未構築なら構築
+        self._doc_ids = [doc_id for doc_id, _ in all_docs]
+        doc_hashes = [(doc_id, _text_hash(text)) for doc_id, text in all_docs]
+        text_map = {doc_id: text for doc_id, text in all_docs}
+
+        cached = self._store.get_cached_tokens(doc_hashes)
+
+        new_cache_entries: list[tuple[str, str, list[str]]] = []
+        tokenized_corpus: list[list[str]] = []
+        cache_hits = 0
+
+        for doc_id, text_h in doc_hashes:
+            if doc_id in cached:
+                tokenized_corpus.append(cached[doc_id])
+                cache_hits += 1
+            else:
+                tokens = tokenize_japanese(text_map[doc_id])
+                tokenized_corpus.append(tokens)
+                new_cache_entries.append((doc_id, text_h, tokens))
+
+        if new_cache_entries:
+            self._store.upsert_token_cache(new_cache_entries)
+
+        self._bm25 = bm25s.BM25(k1=self._k1, b=self._b)
+        self._bm25.index(tokenized_corpus, show_progress=False)
+        self._needs_rebuild = False
+
+        logger.debug(
+            "Rebuilt BM25 index with %d documents (cache hits: %d, misses: %d)",
+            len(self._doc_ids), cache_hits, len(new_cache_entries),
+        )
+
+    def _save_bm25s(self) -> None:
+        """rebuild + bm25s 永続化を実行する."""
+        if not self._store.has_documents():
+            if self._persist_dir is not None and self._persist_dir.exists():
+                bm25s_dir = self._persist_dir / BM25S_SUBDIR
+                if bm25s_dir.exists():
+                    shutil.rmtree(bm25s_dir)
+                logger.debug("Removed BM25S subdir (empty index): %s", self._persist_dir)
+            self._bm25 = None
+            self._doc_ids = []
+            self._needs_rebuild = False
+            return
+
         if self._needs_rebuild:
             self._rebuild_index()
 
-        if self._bm25 is None:
+        self._persist_bm25s()
+
+    def _persist_bm25s(self) -> None:
+        """bm25s モデルをディスクに保存する（アトミックスワップ）."""
+        if self._persist_dir is None or self._bm25 is None:
             return
 
         try:
-            self._persist_dir.parent.mkdir(parents=True, exist_ok=True)
+            bm25s_dir = self._persist_dir / BM25S_SUBDIR
+            old_dir = self._persist_dir / (BM25S_SUBDIR + "_old")
 
-            # アトミックスワップ用のディレクトリ名を事前定義
-            old_dir = self._persist_dir.with_name(
-                self._persist_dir.name + "_old"
-            )
-
-            # 一時ディレクトリに書き出し（アトミック書き込み）
             tmp_dir = Path(
                 tempfile.mkdtemp(
-                    dir=self._persist_dir.parent,
-                    prefix=f"{self._persist_dir.name}_tmp_",
-                )
+                    dir=self._persist_dir,
+                    prefix=f"{BM25S_SUBDIR}_tmp_",
+                ),
             )
             try:
-                # metadata.json
-                metadata = {
-                    "version": METADATA_VERSION,
-                    "doc_ids": self._doc_ids,
-                    "documents": self._documents,
-                    "doc_source_map": self._doc_source_map,
-                    "doc_source_type_map": self._doc_source_type_map,
-                    "doc_metadata_map": self._doc_metadata_map,
-                }
-                metadata_path = tmp_dir / METADATA_FILENAME
-                metadata_path.write_text(
-                    json.dumps(metadata, ensure_ascii=False), encoding="utf-8"
-                )
+                self._bm25.save(str(tmp_dir))
 
-                # bm25s ネイティブファイル
-                bm25s_dir = tmp_dir / BM25S_SUBDIR
-                bm25s_dir.mkdir()
-                self._bm25.save(str(bm25s_dir))
-
-                # アトミックスワップ: old → .old, tmp → 本体, .old 削除
                 if old_dir.exists():
                     shutil.rmtree(old_dir)
-
-                if self._persist_dir.exists():
-                    self._persist_dir.rename(old_dir)
-
-                tmp_dir.rename(self._persist_dir)
-
+                if bm25s_dir.exists():
+                    bm25s_dir.rename(old_dir)
+                tmp_dir.rename(bm25s_dir)
                 if old_dir.exists():
                     shutil.rmtree(old_dir)
 
                 logger.debug(
-                    "BM25 index saved to %s (%d documents)",
-                    self._persist_dir,
-                    len(self._doc_ids),
+                    "BM25 model saved to %s (%d documents)",
+                    bm25s_dir, len(self._doc_ids),
                 )
             except Exception:
-                # リカバリ: .old があれば復元
-                if old_dir.exists() and not self._persist_dir.exists():
-                    old_dir.rename(self._persist_dir)
+                if old_dir.exists() and not bm25s_dir.exists():
+                    old_dir.rename(bm25s_dir)
                 if tmp_dir.exists():
                     shutil.rmtree(tmp_dir)
                 raise
         except Exception:
-            logger.warning("Failed to save BM25 index", exc_info=True)
+            logger.warning("Failed to save BM25 model", exc_info=True)
 
-    def _load(self) -> None:
-        """ディスクからインデックスをロードする."""
+    def _load_bm25s(self) -> None:
+        """bm25s モデルをディスクからロードする."""
         if self._persist_dir is None:
             return
 
-        # クラッシュリカバリ: _old が残っていて本体がなければ復元
-        old_dir = self._persist_dir.with_name(self._persist_dir.name + "_old")
-        if old_dir.exists() and not self._persist_dir.exists():
-            old_dir.rename(self._persist_dir)
-            logger.warning("Recovered BM25 index from _old directory")
+        bm25s_dir = self._persist_dir / BM25S_SUBDIR
 
-        if not self._persist_dir.exists():
+        # クラッシュリカバリ
+        old_dir = self._persist_dir / (BM25S_SUBDIR + "_old")
+        if old_dir.exists() and not bm25s_dir.exists():
+            old_dir.rename(bm25s_dir)
+            logger.warning("Recovered BM25 model from _old directory")
+
+        if not bm25s_dir.exists():
             return
 
-        metadata_path = self._persist_dir / METADATA_FILENAME
-        if not metadata_path.exists():
-            logger.warning(
-                "BM25 metadata not found at %s, starting with empty index",
-                metadata_path,
-            )
+        if not self._store.has_documents():
             return
 
         try:
-            raw = metadata_path.read_text(encoding="utf-8")
-            metadata = json.loads(raw)
-
-            # バージョンチェック
-            version = metadata.get("version")
-            if version != METADATA_VERSION:
-                logger.warning(
-                    "BM25 metadata version mismatch (expected %d, got %s), "
-                    "starting with empty index",
-                    METADATA_VERSION,
-                    version,
-                )
-                return
-
-            # 必須キー検証
-            required_keys = ("doc_ids", "documents", "doc_source_map")
-            if not all(k in metadata for k in required_keys):
-                logger.warning(
-                    "BM25 metadata missing required keys at %s, "
-                    "starting with empty index",
-                    metadata_path,
-                )
-                return
-
-            # ドキュメントデータ復元
-            self._doc_ids = metadata["doc_ids"]
-            self._documents = metadata["documents"]
-            self._doc_source_map = metadata["doc_source_map"]
-            self._doc_source_type_map = metadata.get("doc_source_type_map", {})
-            self._doc_metadata_map = metadata["doc_metadata_map"]
-
-            # bm25s モデル復元
-            bm25s_dir = self._persist_dir / BM25S_SUBDIR
-            if not bm25s_dir.exists():
-                logger.warning(
-                    "BM25 model directory not found at %s, starting with empty index",
-                    bm25s_dir,
-                )
-                self._doc_ids = []
-                self._documents = {}
-                self._doc_source_map = {}
-                self._doc_source_type_map = {}
-                self._doc_metadata_map = {}
-                return
-
             with redirect_stdout(io.StringIO()):
                 import bm25s as bm25s_lib
 
             self._bm25 = bm25s_lib.BM25.load(str(bm25s_dir))
+
+            all_docs = self._store.get_all_for_rebuild()
+            self._doc_ids = [doc_id for doc_id, _ in all_docs]
             self._needs_rebuild = False
 
             logger.info(
                 "BM25 index loaded from %s (%d documents)",
-                self._persist_dir,
-                len(self._doc_ids),
+                self._persist_dir, len(self._doc_ids),
             )
         except Exception:
             logger.warning(
-                "Failed to load BM25 index from %s, starting with empty index",
-                self._persist_dir,
-                exc_info=True,
+                "Failed to load BM25 model from %s, will rebuild on next search",
+                bm25s_dir, exc_info=True,
             )
-            self._documents = {}
-            self._doc_source_map = {}
-            self._doc_source_type_map = {}
-            self._doc_metadata_map = {}
-            self._doc_ids = []
             self._bm25 = None
+            self._doc_ids = []
             self._needs_rebuild = True
 
 

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -151,22 +151,46 @@ class _BM25Store:
 
         added = 0
         updated = 0
-        params = []
-        for i, (doc_id, text, source_id, source_type) in enumerate(documents):
-            meta_json = json.dumps(
-                metadata_list[i], ensure_ascii=False,
-            ) if metadata_list is not None else "{}"
-            params.append((doc_id, text, source_id, source_type, meta_json))
-            if doc_id in existing:
-                updated += 1
-            else:
-                added += 1
 
-        self._conn.executemany(
-            "INSERT OR REPLACE INTO chunks (doc_id, text, source_id, source_type, metadata) "
-            "VALUES (?, ?, ?, ?, ?)",
-            params,
-        )
+        if metadata_list is not None:
+            params = []
+            for i, (doc_id, text, source_id, source_type) in enumerate(documents):
+                meta_json = json.dumps(metadata_list[i], ensure_ascii=False)
+                params.append((doc_id, text, source_id, source_type, meta_json))
+                if doc_id in existing:
+                    updated += 1
+                else:
+                    added += 1
+            self._conn.executemany(
+                "INSERT OR REPLACE INTO chunks "
+                "(doc_id, text, source_id, source_type, metadata) "
+                "VALUES (?, ?, ?, ?, ?)",
+                params,
+            )
+        else:
+            params_no_meta = []
+            for doc_id, text, source_id, source_type in documents:
+                params_no_meta.append((text, source_id, source_type, doc_id))
+                if doc_id in existing:
+                    updated += 1
+                else:
+                    added += 1
+            # 新規は metadata='{}' で INSERT、既存は metadata を保持して UPDATE
+            for doc_id, text, source_id, source_type in documents:
+                if doc_id in existing:
+                    self._conn.execute(
+                        "UPDATE chunks SET text=?, source_id=?, source_type=? "
+                        "WHERE doc_id=?",
+                        (text, source_id, source_type, doc_id),
+                    )
+                else:
+                    self._conn.execute(
+                        "INSERT INTO chunks "
+                        "(doc_id, text, source_id, source_type, metadata) "
+                        "VALUES (?, ?, ?, ?, '{}')",
+                        (doc_id, text, source_id, source_type),
+                    )
+
         self._conn.commit()
         return added, updated
 
@@ -286,7 +310,7 @@ class _BM25Store:
     def estimate_text_memory_bytes(self) -> tuple[int, int]:
         """チャンク数とテキスト合計バイト数を返す（rebuild 前の見積もり用）."""
         row = self._conn.execute(
-            "SELECT COUNT(*), COALESCE(SUM(LENGTH(text)), 0) FROM chunks",
+            "SELECT COUNT(*), COALESCE(SUM(LENGTH(CAST(text AS BLOB))), 0) FROM chunks",
         ).fetchone()
         return (row[0], row[1]) if row else (0, 0)
 
@@ -640,23 +664,24 @@ class BM25Index:
             return
 
         self._doc_ids = [doc_id for doc_id, _ in all_docs]
-        doc_hashes = [(doc_id, _text_hash(text)) for doc_id, text in all_docs]
-        text_map = {doc_id: text for doc_id, text in all_docs}
+        doc_hashes = [_text_hash(text) for _, text in all_docs]
 
-        cached = self._store.get_cached_tokens(doc_hashes)
+        cached = self._store.get_cached_tokens(
+            list(zip(self._doc_ids, doc_hashes)),
+        )
 
         new_cache_entries: list[tuple[str, str, list[str]]] = []
         tokenized_corpus: list[list[str]] = []
         cache_hits = 0
 
-        for doc_id, text_h in doc_hashes:
+        for i, (doc_id, text) in enumerate(all_docs):
             if doc_id in cached:
                 tokenized_corpus.append(cached[doc_id])
                 cache_hits += 1
             else:
-                tokens = tokenize_japanese(text_map[doc_id])
+                tokens = tokenize_japanese(text)
                 tokenized_corpus.append(tokens)
-                new_cache_entries.append((doc_id, text_h, tokens))
+                new_cache_entries.append((doc_id, doc_hashes[i], tokens))
 
         if new_cache_entries:
             self._store.upsert_token_cache(new_cache_entries)

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -1,14 +1,13 @@
 """BM25インデックスのテスト
 
-仕様: docs/specs/rag-knowledge.md
+仕様: docs/specs/infrastructure/bm25-scalability.md
 """
 
-import json
 from pathlib import Path
 
 import pytest
 
-from rag.bm25_index import METADATA_FILENAME, tokenize_japanese
+from rag.bm25_index import STORE_DB_FILENAME, tokenize_japanese
 
 from factories import make_bm25_index
 
@@ -226,7 +225,7 @@ class TestBM25Index:
 class TestBM25IndexPersistence:
     """BM25Index永続化のテスト.
 
-    仕様: docs/specs/rag-knowledge.md
+    仕様: docs/specs/infrastructure/bm25-scalability.md
     """
 
     @pytest.fixture()
@@ -307,34 +306,12 @@ class TestBM25IndexPersistence:
         assert index2.get_document_count() == 3
         assert index2.get_source_url("doc1") is None
 
-    def test_corrupt_metadata_starts_empty(self, persist_dir: str) -> None:
-        """AC81: 壊れたJSONメタデータ → 空インデックスで起動."""
-        # 永続化ディレクトリを手動作成して壊れたメタデータを配置
+    def test_corrupt_db_starts_empty(self, persist_dir: str) -> None:
+        """AC81: 壊れた SQLite DB → 空インデックスで起動."""
         persist_path = Path(persist_dir)
         persist_path.mkdir(parents=True)
-        (persist_path / METADATA_FILENAME).write_text(
-            "{ invalid json !!!", encoding="utf-8"
-        )
+        (persist_path / STORE_DB_FILENAME).write_bytes(b"corrupted data!!!")
 
-        # エラーなく起動、空インデックス
-        index = make_bm25_index(persist_dir=persist_dir)
-        assert index.get_document_count() == 0
-
-    def test_version_mismatch_starts_empty(self, persist_dir: str) -> None:
-        """AC81: 不明バージョン → 空インデックスで起動."""
-        persist_path = Path(persist_dir)
-        persist_path.mkdir(parents=True)
-        metadata = {
-            "version": 9999,
-            "doc_ids": ["doc1"],
-            "documents": {"doc1": "text"},
-            "doc_source_map": {"doc1": "source"},
-        }
-        (persist_path / METADATA_FILENAME).write_text(
-            json.dumps(metadata), encoding="utf-8"
-        )
-
-        # バージョン不一致で空インデックス
         index = make_bm25_index(persist_dir=persist_dir)
         assert index.get_document_count() == 0
 
@@ -348,9 +325,8 @@ class TestBM25IndexPersistence:
         index2 = make_bm25_index(persist_dir=persist_dir)
         assert index2.get_document_count() == 0
 
-    def test_corrupt_bm25s_model_starts_empty(self, persist_dir: str) -> None:
-        """AC81: 正常なメタデータだがbm25sモデルが壊れている場合."""
-        # 一度正常に保存
+    def test_corrupt_bm25s_model_rebuilds_on_search(self, persist_dir: str) -> None:
+        """AC81: bm25sモデルが壊れていてもデータは保持され、検索時に rebuild される."""
         index = make_bm25_index(persist_dir=persist_dir)
         index.add_documents(self._sample_docs())
         assert index.get_document_count() == 4
@@ -360,21 +336,25 @@ class TestBM25IndexPersistence:
         for f in bm25s_dir.iterdir():
             f.write_text("corrupted", encoding="utf-8")
 
-        # 空インデックスで起動
+        # データは SQLite に残っているため document_count は維持される
         index2 = make_bm25_index(persist_dir=persist_dir)
-        assert index2.get_document_count() == 0
+        assert index2.get_document_count() == 4
 
-    def test_delete_all_removes_persist_dir(self, persist_dir: str) -> None:
-        """AC79: 全ドキュメント削除後に永続化ディレクトリが削除される."""
+        # 検索時に rebuild が走り、正常に結果が返る
+        results = index2.search("adventure quest", n_results=3)
+        assert len(results) > 0
+
+    def test_delete_all_keeps_persist_dir_with_empty_db(self, persist_dir: str) -> None:
+        """AC79: 全ドキュメント削除後も persist_dir は存在し、DB は空."""
         index = make_bm25_index(persist_dir=persist_dir)
         index.add_documents(self._sample_docs())
         assert Path(persist_dir).exists()
 
-        # 全ソースを削除
         for src in ["source1", "source2", "source3", "source4"]:
             index.delete_by_source(src)
 
-        assert not Path(persist_dir).exists()
+        assert Path(persist_dir).exists()
+        assert index.get_document_count() == 0
 
         # 空状態で再ロードしてもエラーなし
         index2 = make_bm25_index(persist_dir=persist_dir)
@@ -438,7 +418,7 @@ class TestBM25DeferredSave:
         assert index._needs_rebuild is False
 
     def test_deferred_save_with_persistence(self, tmp_path: Path) -> None:
-        """遅延モードで永続化が flush まで遅延される (#548)."""
+        """遅延モードで bm25s 永続化が flush まで遅延される (#548)."""
         persist_dir = str(tmp_path / "bm25_deferred")
 
         index = make_bm25_index(persist_dir=persist_dir)
@@ -446,22 +426,18 @@ class TestBM25DeferredSave:
 
         index.add_documents(self._sample_docs())
 
-        # 遅延中は永続化されていない（ディレクトリが存在しない、または古い状態）
-        # flush 前の状態を記録
-        persist_path = Path(persist_dir)
-        existed_before_flush = persist_path.exists()
+        # 遅延中は bm25s ディレクトリが存在しない
+        bm25s_dir = Path(persist_dir) / "bm25s"
+        assert not bm25s_dir.exists()
 
         index.flush()
 
-        # flush 後は永続化される
-        assert persist_path.exists()
+        # flush 後は bm25s ディレクトリが永続化される
+        assert bm25s_dir.exists()
 
         # 新しいインスタンスで復元できる
         index2 = make_bm25_index(persist_dir=persist_dir)
         assert index2.get_document_count() == 3
-
-        # 初期状態では永続化ディレクトリがなかったことを確認
-        assert not existed_before_flush
 
     def test_deferred_delete_and_flush(self) -> None:
         """遅延モード中の delete も flush まで save されない."""

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -221,6 +221,19 @@ class TestBM25Index:
 
         assert index.get_metadata("doc1")["title"] == "Original"
 
+    def test_update_without_metadata_preserves_existing(self) -> None:
+        """metadata_list=None で更新しても既存メタデータが保持される."""
+        index = make_bm25_index()
+        docs = [("doc1", "sample text", "source1", "web")]
+        meta = [{"source_id": "source1", "title": "Original Title"}]
+        index.add_documents(docs, metadata_list=meta)
+
+        updated_docs = [("doc1", "updated text", "source1", "web")]
+        index.add_documents(updated_docs)
+
+        result = index.get_metadata("doc1")
+        assert result["title"] == "Original Title"
+
 
 class TestBM25IndexPersistence:
     """BM25Index永続化のテスト.

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -80,8 +80,8 @@ class TestBM25MetadataMap:
         ]
         added = index.add_documents(docs, metadata_list=metadata_list)
         assert added == 2
-        assert index._doc_metadata_map["doc1"]["custom:repository"] == "repo-a"
-        assert index._doc_metadata_map["doc2"]["custom:repository"] == "repo-b"
+        assert index.get_metadata("doc1")["custom:repository"] == "repo-a"
+        assert index.get_metadata("doc2")["custom:repository"] == "repo-b"
 
     def test_add_documents_without_metadata(self) -> None:
         """metadata_list なしでも従来通り動作する."""
@@ -91,7 +91,7 @@ class TestBM25MetadataMap:
         ]
         added = index.add_documents(docs)
         assert added == 1
-        assert "doc1" not in index._doc_metadata_map
+        assert index.get_metadata("doc1") == {}
 
     def test_update_document_metadata(self) -> None:
         """既存ドキュメントを更新するとメタデータも更新される."""
@@ -100,12 +100,11 @@ class TestBM25MetadataMap:
         meta = [{"custom:repository": "repo-a"}]
         index.add_documents(docs, metadata_list=meta)
 
-        # 更新
         docs2 = [("doc1", "テスト文書1更新版", "source1", "journal")]
         meta2 = [{"custom:repository": "repo-b"}]
         index.add_documents(docs2, metadata_list=meta2)
 
-        assert index._doc_metadata_map["doc1"]["custom:repository"] == "repo-b"
+        assert index.get_metadata("doc1")["custom:repository"] == "repo-b"
 
     def test_delete_by_source_cleans_metadata(self) -> None:
         """delete_by_source でメタデータも削除される."""
@@ -121,8 +120,8 @@ class TestBM25MetadataMap:
         index.add_documents(docs, metadata_list=meta)
 
         index.delete_by_source("source1")
-        assert "doc1" not in index._doc_metadata_map
-        assert "doc2" in index._doc_metadata_map
+        assert index.get_metadata("doc1") == {}
+        assert index.get_metadata("doc2")["custom:repository"] == "repo-b"
 
     def test_delete_stale_docs_cleans_metadata(self) -> None:
         """delete_stale_docs でメタデータも削除される."""
@@ -139,8 +138,8 @@ class TestBM25MetadataMap:
 
         deleted = index.delete_stale_docs("source1", valid_ids={"doc1"})
         assert deleted == 1
-        assert "doc1" in index._doc_metadata_map
-        assert "doc2" not in index._doc_metadata_map
+        assert index.get_metadata("doc1")["custom:repository"] == "repo-a"
+        assert index.get_metadata("doc2") == {}
 
     def test_clear_cleans_metadata(self) -> None:
         """clear でメタデータも全削除される."""
@@ -150,7 +149,7 @@ class TestBM25MetadataMap:
         index.add_documents(docs, metadata_list=meta)
 
         index.clear()
-        assert len(index._doc_metadata_map) == 0
+        assert index.get_metadata("doc1") == {}
 
 
 class TestBM25SearchWithFilters:
@@ -312,7 +311,7 @@ class TestBM25MetadataPersistence:
 
         # 新インスタンスで復元
         index2 = make_bm25_index(persist_dir=persist_dir)
-        assert index2._doc_metadata_map["doc1"]["custom:repository"] == "rag-knowledge"
+        assert index2.get_metadata("doc1")["custom:repository"] == "rag-knowledge"
 
     def test_filter_works_after_persistence(self, persist_dir: str) -> None:
         """永続化→復元後もフィルタ検索が動作する."""


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [ ] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- BM25 インデックスの 4 辞書（`_documents`, `_doc_source_map`, `_doc_source_type_map`, `_doc_metadata_map`）を SQLite (`bm25_store.db`) に外部化し、オンメモリ保持を解消
- `metadata.json` の JSON 一括ダンプを廃止し、OOM リスクを排除
- rebuild 時のトークン化結果を `token_cache` テーブルにキャッシュし、2回目以降の rebuild を高速化
- rebuild 前にテキスト合計サイズを見積もり、256MB 超過時に WARNING ログを出力
- 仕様書 `docs/specs/infrastructure/bm25-scalability.md` を新規作成
- CLAUDE.md の worktree セットアップ手順を簡素化（相対パスで十分なため絶対パスへの書き換え手順を削除）

## Test plan

- [x] pytest 1618 passed
- [x] ruff check: no violations
- [x] mypy: no errors
- [x] markdownlint: no violations
- [x] QA: CLI search / MCP search / rebuild / token cache / delete / memory warning

## Related issues

Closes #649
Closes #650