### PR TITLE
docs(qa,handoff): worktree セットアップ手順簡素化・handoff プロセス停止手順追加 (#653, #654)

### DIFF
--- a/.claude/extra/handoff.md
+++ b/.claude/extra/handoff.md
@@ -1,0 +1,31 @@
+# rag-knowledge: handoff 追加手順
+
+worktree クリーンアップの前に、以下のプロセスを停止すること。停止しないとファイルロックにより worktree の削除に失敗する。
+
+## 実行タイミング
+
+handoff のステップ 1（本ファイル読み込み時）で即座に実行する。後続の `/merged` スキルによる worktree 削除時にファイルロックを回避するため、セッション終了前にプロセスを停止しておく。
+
+## 停止対象プロセス
+
+worktree パスを参照しているプロセスを特定し、停止する:
+
+```bash
+# worktree のプロセスを特定（Windows）
+wmic process where "CommandLine like '%<worktree-path>%'" get ProcessId,CommandLine
+
+# プロセスツリーごと停止（//T で子プロセスも含む）
+taskkill //PID <pid> //T //F
+```
+
+主な停止対象:
+
+- **ChromaDB サーバー**: worktree 内の `.tmp/` を参照して起動している場合
+- **MCP サーバー**: worktree で `uv run python -m rag.server` を起動している場合
+
+## 停止失敗時
+
+プロセスの停止に失敗した場合、ユーザーに以下を報告する:
+
+- 停止できなかったプロセスの PID とコマンドライン
+- worktree の手動削除が必要な旨

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -54,8 +54,8 @@ QA 検証グループ:
 2. worktree を作成する: `git worktree add -b qa/qa-skill-<Issue番号> <worktree-path> develop`
    - 配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`
 3. メインリポジトリから `.env` をコピーする
-4. `.env` のストレージパスを worktree 内の**絶対パス**に変更する（相対パスだとメインリポジトリのストレージを参照してしまう）。以下も設定する:
-   - `CHROMADB_SERVER_PORT=8001`（メインリポジトリの MCP サーバーとのポート競合回避）
+4. ストレージパスは相対パスのため書き換え不要（worktree 内の `.tmp/` が自動的に使用される）。以下を設定する:
+   - ポート競合時（前セッションの停止漏れ等）は `.env` で `CHROMADB_SERVER_PORT` を変更すること
    - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する
@@ -73,7 +73,6 @@ QA 検証グループ:
 - LM Studio の接続確認（Embedding API が必要なグループの場合）
 - LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）: `curl http://localhost:1234/v1/models` で Vision 対応モデルがロードされているか確認する
 - ffmpeg の確認（メディア解析の動画処理を検証する場合）: `ffmpeg -version` で利用可能か確認する
-- `.env` のストレージパスが worktree 内の絶対パスを指していることを確認
 - 問題があればユーザーに報告し、解決してから続行
 
 ### 5. グループ実行
@@ -428,7 +427,7 @@ MCP サーバーのログファイル出力（`SessionRotatingFileHandler`）が
 
 #### グループ準備
 
-1. `.env` の `RAG_LOG_DIR` を確認し、worktree 内の絶対パスを指していることを確認する（未設定の場合はデフォルトパスを使用）
+1. `.env` の `RAG_LOG_DIR` を確認する（未設定の場合はデフォルトパスを使用）
 2. MCP サーバーが HTTP モードで起動中であること（worktree セットアップで起動済み）
 
 | # | コマンド | 期待結果 | 検証種別 |

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -54,9 +54,9 @@ QA 検証グループ:
 2. worktree を作成する: `git worktree add -b qa/qa-skill-<Issue番号> <worktree-path> develop`
    - 配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`
 3. メインリポジトリから `.env` をコピーする
-4. ストレージパスは相対パスのため書き換え不要（worktree 内の `.tmp/` が自動的に使用される）。以下を設定する:
-   - ポート競合時（前セッションの停止漏れ等）は `.env` で `CHROMADB_SERVER_PORT` を変更すること
+4. ストレージパスは相対パスのため worktree ディレクトリ基準で解決される（書き換え不要）。以下を確認・設定する:
    - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
+   - ポート競合時（前セッションの停止漏れ等）は `CHROMADB_SERVER_PORT` を変更すること
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する
 7. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- QA スキルの worktree セットアップ手順を CLAUDE.md と整合させ、絶対パス書き換え手順を削除（#653）
- ポート競合の注意書きを「前セッション停止漏れ時」に限定（#653）
- `.claude/extra/handoff.md` を新規作成し、handoff 時の ChromaDB・MCP サーバー停止手順を記載（#654）

## Test plan

- [x] markdownlint 通過済み

## Related issues

Closes #653
Closes #654