### PR TITLE
refactor(tests): MCP ツール一覧テストの重複解消 (#658)

### DIFF
--- a/tests/expected_tools.py
+++ b/tests/expected_tools.py
@@ -1,0 +1,19 @@
+"""MCP ツール一覧の期待値定義（SSoT）.
+
+ツール追加・削除時はここだけを更新する。
+"""
+
+from __future__ import annotations
+
+EXPECTED_MCP_TOOL_NAMES: frozenset[str] = frozenset({
+    "rag_search", "rag_get_document",
+    "rag_crawl_zenn", "rag_add_zenn",
+    "rag_crawl_bluesky", "rag_add_bluesky",
+    "rag_add_youtube", "rag_crawl_youtube",
+    "rag_add_document", "rag_add_journal", "rag_crawl_documents",
+    "rag_site_ingest",
+    "rag_update_aozora_catalog", "rag_search_aozora",
+    "rag_add_aozora", "rag_crawl_aozora",
+    "rag_delete", "rag_rebuild", "rag_stats",
+    "rag_list_recent",
+})

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -2,13 +2,8 @@
 
 仕様: docs/specs/rag-knowledge.md, docs/specs/search-response.md, docs/specs/rebuild-stats.md,
       docs/specs/site-ingest.md
-18個のRAGツール（rag_search, rag_get_document,
-rag_crawl_zenn, rag_crawl_bluesky, rag_add_youtube, rag_crawl_youtube,
-rag_add_document, rag_crawl_documents, rag_add_journal,
-rag_site_ingest, rag_delete, rag_rebuild, rag_stats,
-rag_update_aozora_catalog, rag_search_aozora, rag_add_aozora, rag_crawl_aozora,
-rag_list_recent）が
-MCPサーバーとして公開されていることを検証する。
+MCP サーバーが公開するツール一覧（expected_tools.py の EXPECTED_MCP_TOOL_NAMES が SSoT）と
+各ツールの振る舞いを検証する。
 """
 
 from __future__ import annotations
@@ -21,6 +16,7 @@ import logging
 
 import pytest
 
+from expected_tools import EXPECTED_MCP_TOOL_NAMES
 from rag.server import _configure_and_run, _reset_safe_browsing_client
 
 
@@ -32,36 +28,26 @@ def _reset_rag_global_state() -> None:
 
 @pytest.mark.asyncio
 async def test_rag_server_exposes_tools() -> None:
-    """RAG MCPサーバーが20個のツールを公開すること."""
+    """RAG MCPサーバーが期待するツールを公開すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
     tool_names = {t.name for t in tools}
 
-    expected = {
-        "rag_search", "rag_get_document",
-        "rag_crawl_zenn", "rag_add_zenn",
-        "rag_crawl_bluesky", "rag_add_bluesky",
-        "rag_add_youtube", "rag_crawl_youtube",
-        "rag_add_document", "rag_add_journal", "rag_crawl_documents",
-        "rag_site_ingest",
-        "rag_update_aozora_catalog", "rag_search_aozora",
-        "rag_add_aozora", "rag_crawl_aozora",
-        "rag_delete", "rag_rebuild", "rag_stats",
-        "rag_list_recent",
-    }
-    assert tool_names == expected, f"Expected {expected}, got {tool_names}"
+    assert tool_names == EXPECTED_MCP_TOOL_NAMES, (
+        f"Expected {EXPECTED_MCP_TOOL_NAMES}, got {tool_names}"
+    )
 
 
 @pytest.mark.asyncio
 async def test_rag_server_tool_count() -> None:
-    """RAG MCPサーバーのツール数が exposes_tools の expected と一致すること."""
+    """RAG MCPサーバーのツール数が EXPECTED_MCP_TOOL_NAMES と一致すること."""
     mod = import_module("rag.server")
     server = mod.mcp
 
     tools = await server.list_tools()
-    expected_count = 20
+    expected_count = len(EXPECTED_MCP_TOOL_NAMES)
     assert len(tools) == expected_count, f"Expected {expected_count}, got {len(tools)}"
 
 

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -8,7 +8,6 @@ rag_rebuild MCP ツール・CLI、rag_stats 拡張の振る舞いを検証する
 from __future__ import annotations
 
 import json
-from importlib import import_module
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -497,33 +496,6 @@ class TestRagStats:
             result = await rag_stats()
 
         assert "エラー" in result
-
-
-# --- ツール数テスト ---
-
-
-@pytest.mark.asyncio
-async def test_rag_server_exposes_tools() -> None:
-    """RAG MCPサーバーが20個のツールを公開すること."""
-    mod = import_module("rag.server")
-    server = mod.mcp
-
-    tools = await server.list_tools()
-    tool_names = {t.name for t in tools}
-
-    expected = {
-        "rag_search", "rag_get_document",
-        "rag_crawl_zenn", "rag_add_zenn",
-        "rag_crawl_bluesky", "rag_add_bluesky",
-        "rag_add_youtube", "rag_crawl_youtube",
-        "rag_add_document", "rag_add_journal", "rag_crawl_documents",
-        "rag_site_ingest",
-        "rag_update_aozora_catalog", "rag_search_aozora",
-        "rag_add_aozora", "rag_crawl_aozora",
-        "rag_delete", "rag_rebuild", "rag_stats",
-        "rag_list_recent",
-    }
-    assert tool_names == expected, f"Expected {expected}, got {tool_names}"
 
 
 # --- _format_elapsed テスト ---


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング
- [x] test: テスト追加・修正

## Summary

- `tests/expected_tools.py` を新規作成し、`EXPECTED_MCP_TOOL_NAMES` を `frozenset` で SSoT 定義
- `tests/test_rag_mcp_server.py` の `test_rag_server_exposes_tools` / `test_rag_server_tool_count` を共有定数参照に変更
- `tests/test_rebuild_stats.py` の重複テスト `test_rag_server_exposes_tools` を削除（不要になった `import_module` も除去）
- ツール追加時に `tests/expected_tools.py` の 1 箇所のみ更新すれば済む

## Test plan

- [x] `uv run pytest tests/test_rag_mcp_server.py tests/test_rebuild_stats.py -n0 -v` — 28 tests passed
- [x] `uv run ruff check .` — lint OK
- [x] `uv run mypy src` — type check OK

## Related issues

Closes #658

Generated with [Claude Code](https://claude.ai/code)