### PR TITLE
feat(converter): HTML変換時のclass除去を完全トークン一致に変更しconfig.tomlでパラメータ化 (#660)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,6 +61,20 @@ rag_document_allowed_dirs = ""
 # Upload HTTP API の最大ファイルサイズ（MB）
 rag_upload_max_file_size_mb = 500
 
+# HTML → Markdown 変換時に除去する class トークン（完全一致、大文字小文字無視）
+rag_html_remove_class_tokens = [
+    "breadcrumb",   # パンくずリスト
+    "breadcrumbs",  # パンくずリスト（複数形: Foundation, Docusaurus 等）
+    "topic-path",   # パンくずリスト（日本語サイト）
+    "nextprev",     # ページ送りナビゲーション
+    "pagination",   # ページネーション
+    "toolbar",      # ツールバー
+    "footer-wrapper", # サイトフッター（ラッパー要素）
+    "footer",       # サイトフッター
+    "scrollToFeedback", # フィードバックリンク
+    "suggest",      # 変更提案フォーム
+]
+
 # PDF バックエンド (auto / mineru / pymupdf4llm)
 rag_pdf_backend = "auto"
 rag_pdf_mineru_mfd_conf_thres = 0.6

--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -232,15 +232,9 @@ class パターン一覧（試行順）:
 | `<noscript>` | JavaScript 無効時の代替コンテンツ |
 | `<form>` | 検索フォーム等の入力要素 |
 
-class パターンベースの除去（部分一致、大文字小文字を区別しない）:
+class トークン完全一致の除去（大文字小文字を区別しない）:
 
-| パターン | 理由 |
-|---------|------|
-| `breadcrumb` | パンくずリスト |
-| `topic-path` | パンくずリスト（Nintendo 等の命名） |
-| `nextprev` | ページ送りナビゲーション |
-| `pagination` | ページネーション |
-| `toolbar` | ツールバー |
+除去対象の class トークンは `config.toml` の `rag_html_remove_class_tokens` で設定する。BS4 は各クラストークンに対して `regex.search()` を実行するため、`^(?:トークン1|トークン2|...)$` の正規表現で完全トークン一致を実現する。部分一致（`suggest` が `suggested-reading` にマッチする等）による誤除去を防ぐ。
 
 `<nav>`, `<header>`, `<footer>`, `<aside>` タグはコンテンツ領域の特定により自動的に除外されるケースが多いため、コンテンツ領域内では一律除去しない。これにより、コンテンツ領域内の `<header>` タグ（インタビュータイトル等）が誤って除去される問題を回避する。
 
@@ -481,6 +475,7 @@ source_type が `local` のメディアファイル（画像・動画）は、�
 | `rag_pdf_quality_sample_pages` | 共通設定値 | 品質サンプリングページ数。判定の精度とコストのバランス |
 | `rag_youtube_merge_gap_sec` | 共通設定値 | YouTube スニペット結合の間隔閾値。段落分割の粒度を制御する |
 | `rag_youtube_merge_max_chars` | 共通設定値 | YouTube スニペット結合の最大文字数。段落サイズの上限 |
+| `rag_html_remove_class_tokens` | 共通設定値 | HTML 変換時のボイラープレート除去。完全トークン一致でサイト UI 要素を除外する |
 
 `CONVERTED_STORE_DIR` は [pipeline-controller.md](pipeline-controller.md) の設定項目で定義済み。
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2293,6 +2293,7 @@ def _build_cli_pipeline_controller() -> tuple[
         youtube_merge_gap_sec=settings.rag_youtube_merge_gap_sec,
         youtube_merge_max_chars=settings.rag_youtube_merge_max_chars,
         media_analyzer=media_analyzer,
+        html_remove_class_tokens=settings.rag_html_remove_class_tokens,
     )
 
     embedding_provider = get_embedding_provider(settings, settings.embedding_provider)

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -23,7 +23,7 @@ import io
 import sys
 import tomllib
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -194,6 +194,11 @@ class RAGSettings(BaseModel):
     rag_zenn_max_articles: int = Field(ge=1, le=100)
     rag_zenn_request_timeout: int = Field(ge=1, le=120)
     rag_zenn_request_interval: float = Field(ge=0.1, le=60.0)
+
+    # HTML → Markdown 変換時に除去する class トークン（完全一致）
+    rag_html_remove_class_tokens: list[Annotated[str, Field(min_length=1)]] = Field(
+        min_length=1,
+    )
 
     # ドキュメントインジェスター
     rag_document_supported_extensions: str

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from rag.media.analyzer import MediaAnalyzer
 
 from rag.converter.handlers import (
+    compile_remove_class_re,
     convert_html,
     convert_json_bluesky,
     convert_json_youtube,
@@ -105,6 +106,7 @@ class Converter:
         youtube_merge_gap_sec: float,
         youtube_merge_max_chars: int,
         media_analyzer: MediaAnalyzer | None,
+        html_remove_class_tokens: list[str],
     ) -> None:
         """Converter を初期化する.
 
@@ -114,12 +116,14 @@ class Converter:
             youtube_merge_gap_sec: YouTube スニペット結合の間隔閾値（秒）
             youtube_merge_max_chars: YouTube スニペット結合の最大文字数
             media_analyzer: メディア解析モジュール（None の場合メディア解析スキップ）
+            html_remove_class_tokens: HTML 変換時に除去する class トークン
         """
         self._regen_option = regen_option
         self._pdf_config = pdf_config
         self._youtube_merge_gap_sec = youtube_merge_gap_sec
         self._youtube_merge_max_chars = youtube_merge_max_chars
         self._media_analyzer = media_analyzer
+        self._html_remove_class_re = compile_remove_class_re(html_remove_class_tokens)
 
     # --- ConverterProtocol 実装 ---
 
@@ -378,7 +382,7 @@ class Converter:
             変換後テキスト、または失敗時は None
         """
         if ext in (".html", ".htm"):
-            return convert_html(source_path)
+            return convert_html(source_path, self._html_remove_class_re)
 
         if ext == ".pdf":
             return extract_pdf(source_path, self._pdf_config)

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -104,7 +104,7 @@ def compile_remove_class_re(tokens: list[str]) -> re.Pattern[str]:
     BS4 は各クラストークンに regex.search() するため ^...$ で完全一致にする。
     空文字列トークンは除外される。
     """
-    valid = [t for t in tokens if t.strip()]
+    valid = [t.strip() for t in tokens if t.strip()]
     if not valid:
         msg = "rag_html_remove_class_tokens に有効なトークンがありません"
         raise ValueError(msg)

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -84,15 +84,6 @@ _CONTENT_CLASS_PATTERNS = (
 # タグ名ベースの除去
 _REMOVE_TAGS = ("script", "style", "noscript", "form")
 
-# class パターンベースの除去（部分一致）
-_REMOVE_CLASS_PATTERNS = (
-    "breadcrumb",
-    "topic-path",
-    "nextprev",
-    "pagination",
-    "toolbar",
-)
-
 # テキスト密度フォールバックで除外するタグ
 _TEXT_DENSITY_SKIP_TAGS = frozenset(
     ("script", "style", "nav", "noscript", "link"),
@@ -105,9 +96,22 @@ _COMPILED_ID_PATTERNS = tuple(
 _COMPILED_CLASS_PATTERNS = tuple(
     re.compile(re.escape(p), re.IGNORECASE) for p in _CONTENT_CLASS_PATTERNS
 )
-_COMPILED_REMOVE_CLASS_RE = re.compile(
-    "|".join(re.escape(p) for p in _REMOVE_CLASS_PATTERNS), re.IGNORECASE
-)
+
+
+def compile_remove_class_re(tokens: list[str]) -> re.Pattern[str]:
+    """class トークン除去用の正規表現をコンパイルする.
+
+    BS4 は各クラストークンに regex.search() するため ^...$ で完全一致にする。
+    空文字列トークンは除外される。
+    """
+    valid = [t for t in tokens if t.strip()]
+    if not valid:
+        msg = "rag_html_remove_class_tokens に有効なトークンがありません"
+        raise ValueError(msg)
+    return re.compile(
+        "^(?:" + "|".join(re.escape(t) for t in valid) + ")$",
+        re.IGNORECASE,
+    )
 
 
 def _create_md_converter() -> RagMarkdownConverter:
@@ -183,7 +187,10 @@ def _find_content_area(soup: BeautifulSoup) -> Tag | BeautifulSoup:
     return soup
 
 
-def _clean_content_area(content: Tag | BeautifulSoup) -> None:
+def _clean_content_area(
+    content: Tag | BeautifulSoup,
+    remove_class_re: re.Pattern[str],
+) -> None:
     """コンテンツ領域内の非コンテンツ要素を除去する.
 
     仕様: docs/specs/converter.md「コンテンツ領域内の非コンテンツ除去」
@@ -193,23 +200,22 @@ def _clean_content_area(content: Tag | BeautifulSoup) -> None:
         for tag in content.find_all(tag_name):
             tag.decompose()
 
-    # class パターンベースの除去（1つの結合済み正規表現で1パス走査）
-    for tag in content.find_all(class_=_COMPILED_REMOVE_CLASS_RE):
+    # class トークン完全一致の除去（1つの結合済み正規表現で1パス走査）
+    for tag in content.find_all(class_=remove_class_re):
         tag.decompose()
 
 
-def convert_html(source_path: Path) -> str | None:
+def convert_html(
+    source_path: Path,
+    remove_class_re: re.Pattern[str],
+) -> str | None:
     """HTML ファイルを Markdown に変換する.
 
     仕様: docs/specs/converter.md「HTML → Markdown 変換」
 
-    - コンテンツ領域の特定（article/main → role="main" → id/class パターン → テキスト密度 → body）
-    - コンテンツ領域内の非コンテンツ除去
-    - markdownify ベースの変換（ATX見出し、テーブル保持、リンクURL除去）
-    - 非 UTF-8 エンコーディング自動推定（charset_normalizer）
-
     Args:
         source_path: HTML ファイルの絶対パス
+        remove_class_re: 除去対象 class トークンのコンパイル済み正規表現
 
     Returns:
         Markdown テキスト、または変換失敗時は None
@@ -236,7 +242,7 @@ def convert_html(source_path: Path) -> str | None:
     content_area = _find_content_area(soup)
 
     # コンテンツ領域内の非コンテンツ除去
-    _clean_content_area(content_area)
+    _clean_content_area(content_area, remove_class_re)
 
     # HTML → Markdown 変換
     md_converter = _create_md_converter()

--- a/src/rag/pipeline/factory.py
+++ b/src/rag/pipeline/factory.py
@@ -65,6 +65,7 @@ def build_pipeline_controller(
         youtube_merge_gap_sec=settings.rag_youtube_merge_gap_sec,
         youtube_merge_max_chars=settings.rag_youtube_merge_max_chars,
         media_analyzer=media_analyzer,
+        html_remove_class_tokens=settings.rag_html_remove_class_tokens,
     )
 
     embedding_provider = get_embedding_provider(settings, settings.embedding_provider)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -234,6 +234,10 @@ def make_converter_args(**overrides: Any) -> dict[str, Any]:
         "youtube_merge_gap_sec": 2.0,
         "youtube_merge_max_chars": 300,
         "media_analyzer": None,
+        "html_remove_class_tokens": [
+            "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
+            "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
+        ],
     }
     defaults.update(overrides)
     return defaults

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -46,6 +46,10 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_zenn_max_articles": 50,
     "rag_zenn_request_timeout": 30,
     "rag_zenn_request_interval": 1.0,
+    "rag_html_remove_class_tokens": [
+        "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
+        "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
+    ],
     "rag_document_supported_extensions": ".md,.txt,.pdf,.adoc,.jpg,.jpeg,.png,.webp,.mp4,.ts",
     "rag_document_http_mode_enabled": False,
     "rag_document_allowed_dirs": "",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -24,6 +24,7 @@ from rag.converter.converter import (
 )
 from rag.converter.handlers import (
     _fix_void_elements,
+    compile_remove_class_re,
     convert_html,
     convert_json_bluesky,
     convert_json_zenn_article,
@@ -31,6 +32,11 @@ from rag.converter.handlers import (
     passthrough_copy,
 )
 from rag.converter.normalize import normalize_text
+
+_TEST_REMOVE_CLASS_RE = compile_remove_class_re([
+    "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
+    "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
+])
 
 
 # ============================================================
@@ -81,7 +87,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Title" in result
         assert "Content here." in result
@@ -97,7 +103,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Article body." in result
         assert "Navigation" not in result
@@ -113,7 +119,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Main body." in result
         assert "Navigation" not in result
@@ -134,7 +140,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Content" in result
         assert "alert" not in result
@@ -155,7 +161,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Main body." in result
         assert "Header Noise" not in result
@@ -173,7 +179,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Content body." in result
         assert "Sidebar" not in result
@@ -190,7 +196,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Main body." in result
         assert "Sidebar Noise" not in result
@@ -210,7 +216,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Interview Title" in result
         assert "Interview body." in result
@@ -227,7 +233,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Main content." in result
         assert "Nav" not in result
@@ -245,7 +251,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Article Title" in result
         assert "Article body." in result
@@ -266,7 +272,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Long content paragraph" in result
         assert "Nav Link" not in result
@@ -285,10 +291,124 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Content here." in result
         assert "Home > Page" not in result
+
+    def test_footer_wrapper_class_removed(self, tmp_path: Path) -> None:
+        """コンテンツ領域内の footer-wrapper class が除去される."""
+        html = (
+            "<html><body>"
+            "<div id='content-wrap'>"
+            "<p>Main content.</p>"
+            "<div class='footer-wrapper'><div class='footer clear'>"
+            "<div class='copy'>Copyright 2026 Example.</div>"
+            "<div class='menu'><a>Terms</a><a>Privacy</a></div>"
+            "</div></div>"
+            "</div>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "Main content." in result
+        assert "Copyright" not in result
+        assert "Terms" not in result
+
+    def test_scrolltofeedback_class_removed(self, tmp_path: Path) -> None:
+        """コンテンツ領域内の scrollToFeedback class が除去される."""
+        html = (
+            "<html><body>"
+            "<div id='main'>"
+            "<p>API description.</p>"
+            "<div class='scrollToFeedback'>"
+            "<a>Leave feedback</a>"
+            "</div>"
+            "</div>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "API description." in result
+        assert "Leave feedback" not in result
+
+    def test_footer_class_removed(self, tmp_path: Path) -> None:
+        """コンテンツ領域内の footer class（完全トークン一致）が除去される."""
+        html = (
+            "<html><body>"
+            "<div id='main'>"
+            "<p>Main content.</p>"
+            "<div class='footer'>"
+            "<p>Copyright 2026.</p>"
+            "</div>"
+            "</div>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "Main content." in result
+        assert "Copyright" not in result
+
+    def test_exact_match_does_not_remove_partial(self, tmp_path: Path) -> None:
+        """完全トークン一致のため、部分一致するクラスは除去されない."""
+        html = (
+            "<html><body>"
+            "<div id='main'>"
+            "<div class='suggested-reading'>"
+            "<p>Recommended articles.</p>"
+            "</div>"
+            "<div class='user-feedback-section'>"
+            "<p>User reviews here.</p>"
+            "</div>"
+            "</div>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "Recommended articles." in result
+        assert "User reviews here." in result
+
+    def test_suggest_class_removed(self, tmp_path: Path) -> None:
+        """コンテンツ領域内の suggest class が除去される."""
+        html = (
+            "<html><body>"
+            "<div id='main'>"
+            "<h1>AnimationClip</h1>"
+            "<div class='suggest'>"
+            "<a>Suggest a change</a>"
+            "<div class='suggest-wrap'>"
+            "<div class='suggest-success'><h2>Success!</h2>"
+            "<p>Thank you for helping us improve.</p></div>"
+            "<div class='suggest-form'>"
+            "<label>Your name</label><input type='text'>"
+            "</div></div></div>"
+            "<h3>Description</h3>"
+            "<p>Provides an asset.</p>"
+            "</div>"
+            "</body></html>"
+        )
+        html_file = tmp_path / "test.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "AnimationClip" in result
+        assert "Provides an asset." in result
+        assert "Suggest a change" not in result
+        assert "Success!" not in result
+        assert "Your name" not in result
 
     def test_details_summary_preserved(self, tmp_path: Path) -> None:
         """<details>/<summary> タグ内のコンテンツが保持される."""
@@ -304,7 +424,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "FAQ Question" in result
         assert "FAQ Answer" in result
@@ -320,7 +440,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Article content." in result
         assert "Main div content." not in result
@@ -330,7 +450,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "# H1" in result
         assert "## H2" in result
@@ -341,7 +461,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Link Text" in result
         assert "https://example.com" not in result
@@ -351,7 +471,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Photo description" in result
         assert "img.png" not in result
@@ -361,7 +481,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_bytes(html.encode("shift_jis"))
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "日本語テスト" in result
 
@@ -375,7 +495,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Name" in result
         assert "Value" in result
@@ -406,7 +526,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "First paragraph" in result
         assert "Second paragraph" in result
@@ -423,7 +543,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Before break." in result
         assert "After break." in result
@@ -439,7 +559,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "Content after self-closed img." in result
 
@@ -453,7 +573,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "吾輩" in result
         assert "(わがはい)" in result
@@ -469,7 +589,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "漢字" in result
         assert "(かんじ)" in result
@@ -487,7 +607,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file)
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "青空" in result
         assert "文庫" in result

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -211,6 +211,7 @@ rag_log_file_max_bytes = 10485760
 rag_zenn_max_articles = 50
 rag_zenn_request_timeout = 30
 rag_zenn_request_interval = 1.0
+rag_html_remove_class_tokens = ["breadcrumb", "toolbar"]
 rag_document_supported_extensions = ".md,.txt,.pdf,.adoc,.jpg,.jpeg,.png,.webp,.mp4,.ts"
 rag_document_http_mode_enabled = false
 rag_document_allowed_dirs = ""

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -488,11 +488,17 @@ class TestAC38SimilarityThreshold:
         ]
         await ephemeral_store.add_documents(chunks)
 
-        # Act
-        with caplog.at_level(logging.DEBUG, logger="rag.vector_store"):
-            await ephemeral_store.search(
-                "テキスト", n_results=5, similarity_threshold=0.0001
-            )
+        # Act — server.py が rag ロガーの propagate を False にするため明示的に復元
+        rag_logger = logging.getLogger("rag")
+        original_propagate = rag_logger.propagate
+        rag_logger.propagate = True
+        try:
+            with caplog.at_level(logging.DEBUG, logger="rag.vector_store"):
+                await ephemeral_store.search(
+                    "テキスト", n_results=5, similarity_threshold=0.0001
+                )
+        finally:
+            rag_logger.propagate = original_propagate
 
         # Assert: 厳しい閾値により除外が発生し、デバッグログが出力される
         threshold_logs = [


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- HTML → Markdown 変換時の class 除去を部分一致から完全トークン一致（`^(?:...)$`）に変更し、`suggested-reading` 等の誤除去を防止
- 除去対象 class トークンをハードコードから `config.toml`（`rag_html_remove_class_tokens`）でのパラメータ管理に移行
- Unity Docs 向けの新トークン追加: `breadcrumbs`, `footer-wrapper`, `footer`, `scrollToFeedback`, `suggest`
- 既存 flaky test 修正: `server.py` が `rag` ロガーの `propagate` を `False` にする影響で `caplog` にログが届かない問題を解消

## Test plan

- [x] pytest 201 passed（converter + config + vector_store）
- [x] ruff check — 違反なし
- [x] mypy — 型エラーなし
- [x] markdownlint — 違反なし
- [x] QA: Unity ScriptReference/Manual 30 ファイルでボイラープレート全除去確認
- [x] QA: 部分一致クラス（`suggested-reading` 等 6 パターン）の誤除去なし確認

## Related issues

Closes #660