### PR TITLE
feat(source-store): docdata/ と xrefmap.yml を除外パターンに追加 (#670)

### DIFF
--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -122,6 +122,7 @@ source_store 層は「このファイルは独立ソースか？」「どの sou
 /.gitignore
 /.write.lock
 /.rebuild.lock
+/.ingest.lock
 .git/
 
 # 青空文庫カタログ（aozora インジェスターの内部参照ファイル。sidecar 扱い）
@@ -132,6 +133,10 @@ source_store 層は「このファイルは独立ソースか？」「どの sou
 .DS_Store
 Thumbs.db
 desktop.ini
+
+# ドキュメント生成ツールのインフラファイル（検索索引・TOC・xref 等）
+docdata/
+xrefmap.yml
 ```
 
 加えて、`resolve_attachment_parent(rel_path) is not None` のとき（すなわち attachment と判定される場合）も除外する。
@@ -140,9 +145,9 @@ desktop.ini
 
 - 先頭 `/` でルート直下限定にアンカリングする。
   例: `/.gitignore` はルート直下の `.gitignore` のみを除外し、ユーザー文書内の同名ファイル（`local/myproject/.gitignore`）は独立ソースとして扱う。
-  上記パターンでは `/metadata.db*` / `/.gitignore` / `/.write.lock` / `/.rebuild.lock` / `/aozora/catalog.csv(.meta)` が該当
-- 末尾 `/` でディレクトリ配下を表現する（例: `.git/` は任意階層の `.git` ディレクトリ配下を除外）
-- アンカーなしパターンは任意階層でファイル名マッチする。上記パターンでは `*.meta` / `.DS_Store` / `Thumbs.db` / `desktop.ini` が該当
+  上記パターンでは `/metadata.db*` / `/.gitignore` / `/.write.lock` / `/.rebuild.lock` / `/.ingest.lock` / `/aozora/catalog.csv(.meta)` が該当
+- 末尾 `/` でディレクトリ配下を表現する（例: `.git/` は任意階層の `.git` ディレクトリ配下を除外、`docdata/` は任意階層の `docdata` ディレクトリ配下を除外）
+- アンカーなしパターンは任意階層でファイル名マッチする。上記パターンでは `*.meta` / `.DS_Store` / `Thumbs.db` / `desktop.ini` / `xrefmap.yml` が該当
 
 **設計判断（採用しないアプローチ）**:
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -62,6 +62,9 @@ _EXCLUDE_PATTERNS: tuple[str, ...] = (
     ".DS_Store",
     "Thumbs.db",
     "desktop.ini",
+    # ドキュメント生成ツールのインフラファイル（検索索引・TOC・xref 等）
+    "docdata/",
+    "xrefmap.yml",
 )
 
 _EXCLUDE_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -624,6 +624,29 @@ class TestIsSourceFile:
         assert is_source_file("web/https/example.com/Thumbs.db") is False
         assert is_source_file("desktop.ini") is False
 
+    def test_docdata_directory_excluded_any_depth(self) -> None:
+        """docdata/ 配下はドキュメント生成ツールのインフラファイルとして除外される."""
+        from rag.store.source_store import is_source_file
+
+        assert is_source_file("local/Unity/Docs/Manual/docdata/index.js") is False
+        assert is_source_file("local/Unity/Docs/Manual/docdata/toc.js") is False
+        assert is_source_file("local/Unity/Docs/Manual/docdata/index.json") is False
+        assert is_source_file("local/Unity/Docs/Manual/docdata/toc.json") is False
+        assert is_source_file("local/other-docs/docdata/search.js") is False
+
+    def test_xrefmap_excluded_any_depth(self) -> None:
+        """xrefmap.yml はドキュメント生成ツールのインフラファイルとして除外される."""
+        from rag.store.source_store import is_source_file
+
+        assert is_source_file("local/Unity/Docs/Manual/xrefmap.yml") is False
+        assert is_source_file("local/other-docs/xrefmap.yml") is False
+
+    def test_docdata_name_in_non_directory_context_not_excluded(self) -> None:
+        """docdata がディレクトリではなくファイル名の一部の場合は除外しない."""
+        from rag.store.source_store import is_source_file
+
+        assert is_source_file("local/my-notes/docdata-notes.md") is True
+
     def test_bluesky_attachment_excluded(self) -> None:
         """BlueSky の attachment（media/ 配下）は除外される."""
         from rag.store.source_store import is_source_file


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- `_EXCLUDE_PATTERNS` に `docdata/` と `xrefmap.yml` を追加し、ドキュメント生成ツール（DocFX 等）のインフラファイルを `is_source_file` で除外
- rebuild 時の「Unsupported extension」「Empty conversion result」警告ノイズを削減
- 仕様書（source-store.md）の除外パターン一覧・anchoring 説明を更新
- 既存の仕様書とコードの不整合（`/.ingest.lock` 記載漏れ）も修正

## Test plan

- [x] `TestIsSourceFile` に 3 テストメソッド追加（docdata 除外・xrefmap 除外・非ディレクトリ文脈の非除外）
- [x] pytest / ruff / mypy / markdownlint 通過
- [ ] 実運用 rebuild で警告 0 件を確認（最終 full rebuild 時に検証予定）

## Related issues

Closes #670