### PR TITLE
feat(ingesters/bluesky,converter): リンクカード情報を .meta 構造化データに移行 (#661)

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -299,7 +299,7 @@ JSON パース自体に失敗した場合（構文エラー等、ファイル破
 AT Protocol の投稿 JSON（`getAuthorFeed` レスポンスのフィードアイテム）からテキストを抽出する。投稿は最大 300 文字の短文であり、Markdown 変換は不要。プレーンテキストとして抽出する。
 
 テキスト抽出は `post.record`（raw record）から行う。`post.record` の embed の `$type` に `#view` サフィックスは付かない。
-リンクカード情報（`embed.external` の `uri` / `title` / `description`）は変換テキストに含めず、`.meta` の `link_card` フィールドで管理する（[bluesky.md](ingesters/bluesky.md) 参照）。
+リンクカード情報（`embed.external` の `uri` / `title` / `description`）の詳細は変換テキストに含めず、`.meta` の `link_card` フィールドで管理する（[bluesky.md](ingesters/bluesky.md) 参照）。ただし、投稿テキストが空でリンクカードのみの場合に変換結果が欠落しないよう、リンクカードの URI のみを変換テキストに残す。
 
 **基本フィールド:**
 

--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -299,6 +299,7 @@ JSON パース自体に失敗した場合（構文エラー等、ファイル破
 AT Protocol の投稿 JSON（`getAuthorFeed` レスポンスのフィードアイテム）からテキストを抽出する。投稿は最大 300 文字の短文であり、Markdown 変換は不要。プレーンテキストとして抽出する。
 
 テキスト抽出は `post.record`（raw record）から行う。`post.record` の embed の `$type` に `#view` サフィックスは付かない。
+リンクカード情報（`embed.external` の `uri` / `title` / `description`）は変換テキストに含めず、`.meta` の `link_card` フィールドで管理する（[bluesky.md](ingesters/bluesky.md) 参照）。
 
 **基本フィールド:**
 
@@ -307,9 +308,6 @@ AT Protocol の投稿 JSON（`getAuthorFeed` レスポンスのフィードア�
 | 投稿テキスト | `post.record.text` | 投稿本文 |
 | 画像 ALT テキスト | `post.record.embed.images[].alt` | 画像の代替テキスト |
 | 動画 ALT テキスト | `post.record.embed.alt` | 動画の代替テキスト |
-| リンクカードタイトル | `post.record.embed.external.title` | 外部リンクのタイトル |
-| リンクカード URL | `post.record.embed.external.uri` | 外部リンクの URL |
-| リンクカード説明 | `post.record.embed.external.description` | 外部リンクの説明文 |
 
 **recordWithMedia 時のフィールド:**
 
@@ -319,9 +317,6 @@ embed の `$type` が `app.bsky.embed.recordWithMedia`（メディア + 引用�
 |-----------|--------------------------|------|
 | 画像 ALT テキスト | `post.record.embed.media.images[].alt` | recordWithMedia 時の画像 ALT |
 | 動画 ALT テキスト | `post.record.embed.media.alt` | recordWithMedia 時の動画 ALT |
-| リンクカードタイトル | `post.record.embed.media.external.title` | recordWithMedia 時のリンクタイトル |
-| リンクカード URL | `post.record.embed.media.external.uri` | recordWithMedia 時のリンク URL |
-| リンクカード説明 | `post.record.embed.media.external.description` | recordWithMedia 時のリンク説明 |
 
 **引用元投稿テキスト:**
 
@@ -358,11 +353,6 @@ embed の `$type` が `app.bsky.embed.recordWithMedia`（メディア + 引用�
 <video:1>
 メディア解析モジュールによる動画解析テキスト
 </video:1>
-
-[Link Card]
-Title: 外部リンクのタイトル
-URL: 外部リンクの URL
-Description: 外部リンクの説明文
 
 [Quote]
 引用元の投稿テキスト

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -309,6 +309,7 @@ source_store/
 | `has_images` | bool | 画像添付の有無 | `post.record.embed` に画像データが含まれるか |
 | `has_video` | bool | 動画添付の有無 | `post.record.embed` に動画データが含まれるか |
 | `has_external_link` | bool | 外部リンクの有無 | `post.record.embed` に外部リンクが含まれるか |
+| `link_card` | dict or null | リンクカード情報 | `post.record.embed.external`（recordWithMedia 時は `embed.media.external`）から `uri`, `title`, `description` を抽出。リンクカードがない場合は `null` |
 | `is_reply` | bool | リプライかどうか | `post.record.reply` が存在するか |
 | `is_repost` | bool | リポストかどうか | フィードアイテムの `reason.$type` が `app.bsky.feed.defs#reasonRepost` か |
 
@@ -327,6 +328,10 @@ created_at: "2026-01-15T09:00:00Z"
 has_images: false
 has_video: false
 has_external_link: true
+link_card:
+  uri: "https://example.com/article"
+  title: "Sample Article"
+  description: "An article about something"
 is_reply: false
 is_repost: false
 ```
@@ -498,7 +503,7 @@ BlueSky 上で削除された投稿は source_store に残り続ける。削除�
 
 BlueSky 投稿の JSON からのテキスト抽出仕様（フィールドパス、recordWithMedia 対応、引用元テキスト、テキスト構造）は [converter.md](../converter.md) の「JSON → テキスト抽出 > BlueSky 投稿」セクションで定義されている。converter.md が正本であり、本セクションでは概要のみ記載する。
 
-- 投稿テキスト、画像/動画 ALT、リンクカード、引用元テキストを構造化プレーンテキストとして抽出する
+- 投稿テキスト、画像/動画 ALT、引用元テキストを構造化プレーンテキストとして抽出する（リンクカード情報は `.meta` の `link_card` フィールドで管理）
 - Markdown 変換は不要（投稿は最大 300 文字の短文）
 - リポスト時は `[Repost: @handle]` ヘッダーを付与する
 

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -265,7 +265,6 @@ def _extract_text_from_post(value: dict[str, Any]) -> str:
     構造:
     1. 投稿テキスト（先頭）
     2. 画像/動画 ALT テキスト（[Image ALT] / [Video ALT] プレフィックス）
-    3. リンクカード（[Link Card] セクション）
 
     引用元テキストは呼び出し元で [Quote] セクションとして追加する。
 
@@ -282,7 +281,7 @@ def _extract_text_from_post(value: dict[str, Any]) -> str:
     if text:
         sections.append(text)
 
-    # 2-3. embed からメディア情報を抽出
+    # 2. embed からメディア情報を抽出
     embed = value.get("embed")
     if isinstance(embed, dict):
         media_sections = _extract_embed_sections(embed)
@@ -337,22 +336,6 @@ def _extract_media_sections(media: dict[str, Any]) -> list[str]:
     video_alt = media.get("alt", "")
     if video_alt:
         sections.append(f"[Video ALT] {video_alt}")
-
-    # リンクカード
-    external = media.get("external")
-    if isinstance(external, dict):
-        card_parts: list[str] = ["[Link Card]"]
-        ext_title = external.get("title", "")
-        if ext_title:
-            card_parts.append(f"Title: {ext_title}")
-        ext_uri = external.get("uri", "")
-        if ext_uri:
-            card_parts.append(f"URL: {ext_uri}")
-        ext_desc = external.get("description", "")
-        if ext_desc:
-            card_parts.append(f"Description: {ext_desc}")
-        if len(card_parts) > 1:
-            sections.append("\n".join(card_parts))
 
     return sections
 

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -337,6 +337,13 @@ def _extract_media_sections(media: dict[str, Any]) -> list[str]:
     if video_alt:
         sections.append(f"[Video ALT] {video_alt}")
 
+    # リンクカード URI（本文が空でも変換結果が欠落しないよう最低限の情報を残す）
+    external = media.get("external")
+    if isinstance(external, dict):
+        ext_uri = external.get("uri", "")
+        if ext_uri:
+            sections.append(ext_uri)
+
     return sections
 
 

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -52,6 +52,18 @@ def _escape_did(did: str) -> str:
     return did.replace(":", _COLON_FULLWIDTH)
 
 
+def _extract_link_card(external: object) -> dict[str, str] | None:
+    """embed.external オブジェクトからリンクカード情報を抽出する."""
+    if not isinstance(external, dict):
+        return None
+    card: dict[str, str] = {}
+    for key in ("uri", "title", "description"):
+        val = external.get(key, "")
+        if val:
+            card[key] = val
+    return card if card else None
+
+
 def _make_title(text: str) -> str:
     """投稿テキストからタイトルを生成する.
 
@@ -476,6 +488,7 @@ class BlueskyIngester:
         has_images = False
         has_video = False
         has_external_link = False
+        link_card: dict[str, str] | None = None
 
         if isinstance(embed, dict):
             embed_type = embed.get("$type", "")
@@ -485,6 +498,7 @@ class BlueskyIngester:
                 has_video = True
             if "external" in embed_type:
                 has_external_link = True
+                link_card = _extract_link_card(embed.get("external"))
             media = embed.get("media", {})
             if isinstance(media, dict):
                 media_type = media.get("$type", "")
@@ -494,6 +508,8 @@ class BlueskyIngester:
                     has_video = True
                 if "external" in media_type:
                     has_external_link = True
+                    if link_card is None:
+                        link_card = _extract_link_card(media.get("external"))
 
         is_reply = "reply" in record if isinstance(record, dict) else False
         bsky_url = f"https://bsky.app/profile/{handle_author}/post/{rkey}"
@@ -511,6 +527,7 @@ class BlueskyIngester:
             "has_images": has_images,
             "has_video": has_video,
             "has_external_link": has_external_link,
+            "link_card": link_card,
             "is_reply": is_reply,
             "is_repost": is_repost,
         }

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -59,8 +59,8 @@ def _extract_link_card(external: object) -> dict[str, str] | None:
     card: dict[str, str] = {}
     for key in ("uri", "title", "description"):
         val = external.get(key, "")
-        if val:
-            card[key] = val
+        if isinstance(val, str) and val.strip():
+            card[key] = val.strip()
     return card if card else None
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -744,6 +744,28 @@ class TestConvertJsonBluesky:
         assert "URL: https://example.com/article" not in result
         assert "Description: An article about something" not in result
 
+    def test_empty_text_with_link_card_returns_uri(self) -> None:
+        """本文が空でリンクカードのみの場合、URI が変換結果に残る."""
+        data = {
+            "post": {
+                "record": {
+                    "text": "",
+                    "embed": {
+                        "$type": "app.bsky.embed.external",
+                        "external": {
+                            "title": "Sample Article",
+                            "uri": "https://example.com/article",
+                            "description": "An article about something",
+                        },
+                    },
+                },
+            },
+        }
+        result = convert_json_bluesky(data)
+        assert result is not None
+        assert "https://example.com/article" in result
+        assert "[Link Card]" not in result
+
     def test_record_with_media(self) -> None:
         data = {
             "post": {

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -719,7 +719,8 @@ class TestConvertJsonBluesky:
         assert result is not None
         assert "[Video ALT] Video description" in result
 
-    def test_link_card(self) -> None:
+    def test_link_card_excluded_from_body(self) -> None:
+        """リンクカード情報は本文に含まれない（.meta で管理）."""
         data = {
             "post": {
                 "record": {
@@ -737,10 +738,11 @@ class TestConvertJsonBluesky:
         }
         result = convert_json_bluesky(data)
         assert result is not None
-        assert "[Link Card]" in result
-        assert "Title: Sample Article" in result
-        assert "URL: https://example.com/article" in result
-        assert "Description: An article about something" in result
+        assert "Check this out" in result
+        assert "[Link Card]" not in result
+        assert "Title: Sample Article" not in result
+        assert "URL: https://example.com/article" not in result
+        assert "Description: An article about something" not in result
 
     def test_record_with_media(self) -> None:
         data = {

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -27,6 +27,7 @@ from rag.pipeline.ingesters.bluesky import (
     BlueskyIngester,
     _escape_did,
     _ext_from_content_type,
+    _extract_link_card,
     _extract_media_urls,
     _make_title,
     _validate_max_posts,
@@ -313,6 +314,8 @@ class TestCrawlBluesky:
         assert meta["did"] == "did:plc:abc123"
         assert meta["rkey"] == "xyz789"
         assert meta["has_images"] is True
+        assert meta["has_external_link"] is False
+        assert meta["link_card"] is None
         assert meta["is_reply"] is True
         assert meta["is_repost"] is False
 
@@ -684,6 +687,37 @@ class TestExtFromContentType:
     def test_unknown_defaults_to_webp(self) -> None:
         """不明な Content-Type はデフォルト .webp."""
         assert _ext_from_content_type("application/octet-stream") == ".webp"
+
+
+class TestExtractLinkCard:
+    """_extract_link_card のテスト."""
+
+    def test_full_card(self) -> None:
+        """uri, title, description が全て含まれるリンクカード."""
+        result = _extract_link_card({
+            "uri": "https://example.com/article",
+            "title": "Sample Article",
+            "description": "An article about something",
+        })
+        assert result == {
+            "uri": "https://example.com/article",
+            "title": "Sample Article",
+            "description": "An article about something",
+        }
+
+    def test_uri_only(self) -> None:
+        """uri のみのリンクカード."""
+        result = _extract_link_card({"uri": "https://example.com"})
+        assert result == {"uri": "https://example.com"}
+
+    def test_empty_external(self) -> None:
+        """空の external オブジェクトは None を返す."""
+        assert _extract_link_card({}) is None
+
+    def test_non_dict(self) -> None:
+        """dict でない値は None を返す."""
+        assert _extract_link_card(None) is None
+        assert _extract_link_card("string") is None
 
 
 class TestExtractMediaUrls:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- BlueSky リンクカード（`embed.external`）の情報を変換テキスト本文から除去
- インジェスターで `.meta` の `link_card` フィールドに `uri` / `title` / `description` を構造化記録
- `recordWithMedia` 時の `embed.media.external` にも対応
- 検索時の無意味なトークンヒット（`URL:`, `Description:` 等）を削減
- 既存データは最終 full rebuild で反映

## Test plan

- [x] `TestExtractLinkCard` 4 テストメソッド追加（full/uri-only/empty/non-dict）
- [x] `test_link_card_excluded_from_body` でコンバーター出力にリンクカードが含まれないことを検証
- [x] `test_meta_fields` に `link_card: None` / `has_external_link` 検証を追加
- [x] pytest / ruff / mypy / markdownlint 通過

## Related issues

Closes #661