### PR TITLE
fix(bluesky,youtube): YouTube URL パターンの取りこぼし修正・SSoT 一元化 (#679)

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -536,9 +536,14 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 
 | URL パターン | 委譲先 | 備考 |
 |-------------|--------|------|
-| `youtube.com/watch?v=`, `youtu.be/`, `youtube.com/shorts/` | YoutubeIngester.ingest_video | YouTube 動画の字幕・文字起こしを取り込む |
+| YouTube 動画 URL（対応する具体パターンは [youtube.md](youtube.md) を参照） | YoutubeIngester.ingest_video | YouTube 動画の字幕・文字起こしを取り込む |
+| 不正な YouTube 動画 URL（パターンには該当するが video_id 形式が不正） | エラー扱いでスキップ | site_ingest に流すと無駄な HTTP アクセスが発生し、リスクもあるため取り込まない。`errors` カウンタを増やし、`error_details` に記録する |
 | `bsky.app/profile/` | スキップ | BlueSky 投稿は既にインジェスト対象 |
-| 上記以外の HTTP/HTTPS URL | site_ingest（複数 URL モード） | Web ページをバッチ取得する |
+| 上記以外の HTTP/HTTPS URL | site_ingest（複数 URL モード） | Web ページをバッチ取得する。YouTube チャンネル URL（`/@handle`, `/c/`, `/channel/`）・プレイリスト URL（`/playlist?list=`）はこの分類に含まれる |
+
+YouTube 動画 URL の判定は YouTube インジェスター側で SSoT として定義された判定関数を使用する。ここに URL パターンを直接列挙すると分類器（BlueSky 側）と抽出器（YouTube 側）で drift する恐れがあるため、参照リンクで一元化する。
+
+「不正な YouTube 動画 URL」とは、YouTube 動画 URL のホスト・パスパターンには該当するが video_id 形式が不正な URL を指す（具体パターンと video_id 形式は [youtube.md](youtube.md) 側を SSoT とする）。例: `https://www.youtube.com/watch?v=`, `https://youtu.be/short`。
 
 #### 処理フロー
 
@@ -741,6 +746,7 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | 同一 URL が複数投稿に出現 | URL 抽出時に重複排除し、1 回のみ取り込む |
 | URL 先が Safe Browsing で危険判定 | 複数 URL モードでは Safe Browsing チェックは実行されない（大量 URL への API 呼び出しは非現実的なため）。SSRF チェック（プライベート IP 拒否）のみ実行される |
 | YouTube URL の字幕取得に失敗 | YouTube インジェスターの既存のエラーハンドリングでスキップされる |
+| 投稿内の URL が「不正な YouTube 動画 URL」（パターン該当・video_id 形式不正） | 警告ログを出力し、いずれのインジェスターにも委譲しない。詳細は「URL 種別判定と委譲先」を参照 |
 | Web URL が 0 件の場合 | site_ingest 呼び出しをスキップする |
 | site_ingest subprocess が失敗 | エラーをログに記録し、`errors` に `delegation` カテゴリで計上する。BlueSky 投稿の取り込みには影響しない |
 | `--force` 時に上書き投稿の YouTube 再取り込みが `rag_bluesky_force_youtube_reingest` で抑制されている | 上書き投稿の YouTube URL をスキップし、Web URL とメディアのみ再取得する。新規投稿の YouTube URL は常に取り込む |

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -81,6 +81,27 @@ youtube-transcript-api は非公式 API を使用しており、短時間に多�
 - `--no-limit` 等の制約バイパス手段は一切設けない
 - `0 = 無制限` のセマンティクスを排除する
 
+### 対応 URL 形式
+
+YouTube インジェスターは以下の URL パターンを単一動画として認識する。判定ロジックは YouTube インジェスター内で一元定義し、BlueSky インジェスターから投稿内 URL の種別判定にも参照される（分類器と抽出器の drift 防止）。BlueSky 側の参照箇所は [bluesky.md](bluesky.md) を参照。
+
+| URL パターン | 用途 |
+|---|---|
+| `https://{host}/watch?v={video_id}` | 通常の動画ページ |
+| `https://youtu.be/{video_id}` | 短縮 URL |
+| `https://{host}/shorts/{video_id}` | Shorts |
+| `https://{host}/live/{video_id}` | ライブ配信 |
+| `https://{host}/embed/{video_id}` | 埋め込みプレイヤー |
+| `https://{host}/v/{video_id}` | レガシー埋め込み形式 |
+
+補足:
+
+- `{host}` は `www.youtube.com` / `youtube.com` / `m.youtube.com` のいずれか。ホストとパスは直交し、`m.youtube.com/shorts/{video_id}` 等の組み合わせも受理される
+- `{video_id}` は 11 文字固定の識別子。各文字は半角英大文字・半角英小文字・半角数字、またはアンダースコア（`_`）・ハイフン（`-`）のいずれか
+- `/watch?v={video_id}` の `v` 以外のクエリパラメータ（`t=30s`, `si=...` 等）と、短縮 URL・パスベース URL に付加されたクエリは判定で無視される
+- ホスト名・パスのプレフィックス比較は大文字小文字を区別しない。一方 `{video_id}` 部分は大文字小文字を保持して抽出する
+- プレイリスト URL（`/playlist?list=`）およびチャンネル URL（`/@handle`, `/c/`, `/channel/`）は本判定の対象外
+
 ### 重複検出
 
 [インジェスター共通仕様](common.md) のファイルシステムベース方式に従う。source_id（source_store 内の相対パス）で該当ファイルの存在有無を判定する。
@@ -118,7 +139,7 @@ youtube-transcript-api は非公式 API を使用しており、短時間に多�
 
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
-| `video_url` | 文字列 | はい | YouTube 動画 URL。対応形式: `youtube.com/watch?v={id}` および `youtu.be/{id}` |
+| `video_url` | 文字列 | はい | YouTube 動画 URL。対応形式は[対応 URL 形式](#対応-url-形式) を参照 |
 
 #### rag_crawl_youtube パラメータ
 

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -27,6 +27,7 @@ from rag.pipeline.ingesters._common import (
     fetch_get,
     now_iso,
 )
+from rag.pipeline.ingesters.youtube import classify_youtube_url
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -178,11 +179,6 @@ def _collect_media_from_embed(embed: dict[str, Any], image_urls: list[str]) -> N
                     image_urls.append(fullsize)
 
 
-# YouTube URL 判定パターン
-_YOUTUBE_URL_RE = re.compile(
-    r"^https?://(?:www\.)?(?:youtube\.com/(?:watch\?.*v=|shorts/)|youtu\.be/)",
-)
-
 # BlueSky URL 判定パターン（スキップ対象）
 _BSKY_URL_RE = re.compile(
     r"^https?://bsky\.app/profile/",
@@ -259,16 +255,26 @@ def extract_urls_from_item(item: dict[str, Any]) -> list[str]:
     return urls
 
 
-def classify_url(url: str) -> Literal["youtube", "web", "skip"]:
+def classify_url(url: str) -> Literal["youtube", "web", "skip", "invalid_youtube"]:
     """URL を種別判定する.
 
+    YouTube 動画 URL の判定は YouTube インジェスター側の SSoT を参照する
+    （対応パターンは docs/specs/ingesters/youtube.md「対応 URL 形式」）。
+
     Returns:
-        "youtube", "web", or "skip"
+        - "youtube": 認識可能な YouTube 動画 URL
+        - "invalid_youtube": YouTube 動画 URL のパターンに見えるが video_id 形式が不正。
+          site_ingest に流すと無駄な HTTP アクセスが発生するため、呼び出し側でエラーとして扱う
+        - "skip": BlueSky 投稿 URL 等の取り込み対象外
+        - "web": 上記以外（チャンネル URL・プレイリスト URL・一般 Web ページ等）
     """
     if _BSKY_URL_RE.match(url):
         return "skip"
-    if _YOUTUBE_URL_RE.match(url):
+    yt = classify_youtube_url(url)
+    if yt == "video":
         return "youtube"
+    if yt == "malformed":
+        return "invalid_youtube"
     return "web"
 
 
@@ -1086,10 +1092,25 @@ class BlueskyIngester:
                         web_urls.append(url)
                     elif url_type == "youtube":
                         youtube_urls.append(url)
+                    elif url_type == "invalid_youtube":
+                        logger.warning("不正な YouTube URL を検出したためスキップ: %s", url)
+                        stats["errors"] += 1
+                        if result is not None:
+                            result.errors += 1
+                            result.error_details.append(
+                                {
+                                    "category": "delegation",
+                                    "target": url,
+                                    "url": url,
+                                    "message": "invalid youtube url",
+                                },
+                            )
                     else:
                         stats["skipped"] += 1
 
-        all_url_count = len(web_urls) + len(youtube_urls) + stats["skipped"]
+        all_url_count = (
+            len(web_urls) + len(youtube_urls) + stats["skipped"] + stats["errors"]
+        )
         if all_url_count == 0:
             return stats
 

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -17,7 +17,7 @@ import shutil
 import tempfile
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, urlparse
 
 from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
@@ -37,33 +37,81 @@ CIRCUIT_BREAKER_THRESHOLD = 5
 # video_id の正規表現
 _VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
 
+# 仕様: docs/specs/ingesters/youtube.md「対応 URL 形式」が SSoT
+_YOUTUBE_HOSTS = ("www.youtube.com", "youtube.com", "m.youtube.com")
+_VIDEO_PATH_PREFIXES = ("/shorts/", "/live/", "/embed/", "/v/")
+
+
+def _extract_video_id_candidate(url: str) -> str | None:
+    """URL から video_id 候補を抽出する.
+
+    Returns:
+        - str (空文字の可能性あり): URL が動画 URL のパターンに該当する場合の video_id 候補。
+          形式（11 文字）の妥当性は呼び出し側で別途検証する。
+        - None: 動画 URL のパターンに該当しない場合（チャンネル URL、プレイリスト URL、別ホスト等）。
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    # host を lowercase 化している以上、一貫性のためパスのプレフィックス判定も
+    # 大文字小文字を区別せずに行う。video_id 部分は大文字小文字を保持するため、
+    # 抽出は parsed.path（元のパス）から行う
+    path_lower = parsed.path.lower()
+
+    if host == "youtu.be":
+        if not path_lower.lstrip("/"):
+            return None
+        return parsed.path.lstrip("/").split("/")[0]
+
+    if host in _YOUTUBE_HOSTS:
+        if path_lower in ("/watch", "/watch/"):
+            qs = parse_qs(parsed.query, keep_blank_values=True)
+            video_ids = qs.get("v")
+            if video_ids is not None:
+                return video_ids[0]
+        for prefix in _VIDEO_PATH_PREFIXES:
+            if path_lower.startswith(prefix):
+                return parsed.path[len(prefix) :].split("/")[0]
+
+    return None
+
+
+def is_youtube_video_url(url: str) -> bool:
+    """URL が有効な YouTube 動画 URL かを判定する.
+
+    仕様: docs/specs/ingesters/youtube.md「対応 URL 形式」
+    """
+    return classify_youtube_url(url) == "video"
+
+
+def classify_youtube_url(url: str) -> Literal["video", "malformed", "not_youtube"]:
+    """URL を YouTube 動画 URL の観点で分類する.
+
+    仕様: docs/specs/ingesters/youtube.md「対応 URL 形式」
+
+    Returns:
+        - "video": 動画 URL のパターンに該当し、video_id 形式（11 文字）も有効
+        - "malformed": 動画 URL のパターンに該当するが video_id 形式が不正
+        - "not_youtube": 動画 URL のパターンに該当しない
+    """
+    candidate = _extract_video_id_candidate(url)
+    if candidate is None:
+        return "not_youtube"
+    if _VIDEO_ID_RE.match(candidate):
+        return "video"
+    return "malformed"
+
 
 def extract_video_id(url: str) -> str:
     """YouTube URL から video_id を抽出する.
 
-    対応形式:
-    - https://www.youtube.com/watch?v={id}
-    - https://youtu.be/{id}
+    仕様: docs/specs/ingesters/youtube.md「対応 URL 形式」
 
     Raises:
         ValueError: 不正な URL 形式の場合
     """
-    parsed = urlparse(url)
-    host = parsed.hostname or ""
-
-    # youtube.com/watch?v=
-    if host in ("www.youtube.com", "youtube.com", "m.youtube.com"):
-        qs = parse_qs(parsed.query)
-        video_ids = qs.get("v")
-        if video_ids and _VIDEO_ID_RE.match(video_ids[0]):
-            return video_ids[0]
-
-    # youtu.be/{id}
-    if host == "youtu.be":
-        vid = parsed.path.lstrip("/").split("/")[0].split("?")[0]
-        if _VIDEO_ID_RE.match(vid):
-            return vid
-
+    candidate = _extract_video_id_candidate(url)
+    if candidate and _VIDEO_ID_RE.match(candidate):
+        return candidate
     raise ValueError(f"不正な YouTube URL です: {url}")
 
 
@@ -74,8 +122,8 @@ def extract_playlist_id(url: str) -> str:
         ValueError: 不正な URL 形式の場合
     """
     parsed = urlparse(url)
-    host = parsed.hostname or ""
-    if host not in ("www.youtube.com", "youtube.com", "m.youtube.com"):
+    host = (parsed.hostname or "").lower()
+    if host not in _YOUTUBE_HOSTS:
         raise ValueError(f"不正な YouTube プレイリスト URL です: {url}")
     qs = parse_qs(parsed.query)
     playlist_ids = qs.get("list")

--- a/tests/test_converter_youtube.py
+++ b/tests/test_converter_youtube.py
@@ -57,7 +57,7 @@ class TestConvertJsonYoutube:
         duration: int = 120,
     ) -> dict[str, Any]:
         return {
-            "video_id": "JV3KOJ_Z4Vs",
+            "video_id": "TestVideo01",
             "title": "Test Video",
             "uploader": "Test Channel",
             "upload_date": "20240901",
@@ -132,7 +132,7 @@ class TestConvertJsonYoutube:
         data = self._make_data()
         result = convert_json_youtube(data)
         assert result is not None
-        assert "https://www.youtube.com/watch?v=JV3KOJ_Z4Vs" in result
+        assert "https://www.youtube.com/watch?v=TestVideo01" in result
 
     def test_continuous_snippets_merged(self) -> None:
         """連続するスニペットが結合されることを検証する."""

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -442,15 +442,63 @@ class TestClassifyUrl:
 
     def test_youtube_watch(self) -> None:
         """YouTube watch URL が youtube に分類されること."""
-        assert classify_url("https://www.youtube.com/watch?v=abc123") == "youtube"
+        assert classify_url("https://www.youtube.com/watch?v=TestVideo01") == "youtube"
 
     def test_youtube_short(self) -> None:
         """youtu.be 短縮 URL が youtube に分類されること."""
-        assert classify_url("https://youtu.be/abc123") == "youtube"
+        assert classify_url("https://youtu.be/TestVideo01") == "youtube"
 
     def test_youtube_shorts(self) -> None:
         """YouTube Shorts URL が youtube に分類されること."""
-        assert classify_url("https://youtube.com/shorts/abc123") == "youtube"
+        assert classify_url("https://youtube.com/shorts/TestVideo01") == "youtube"
+
+    def test_youtube_live(self) -> None:
+        """YouTube ライブ配信 URL が youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/live/TestVideo01") == "youtube"
+
+    def test_youtube_live_with_query(self) -> None:
+        """クエリ付きの live URL も youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/live/TestVideo01?si=abc") == "youtube"
+
+    def test_youtube_embed(self) -> None:
+        """YouTube embed URL が youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/embed/TestVideo01") == "youtube"
+
+    def test_youtube_legacy_v(self) -> None:
+        """YouTube レガシー /v/ URL が youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/v/TestVideo01") == "youtube"
+
+    def test_youtube_mobile(self) -> None:
+        """m.youtube.com URL が youtube に分類されること."""
+        assert classify_url("https://m.youtube.com/watch?v=TestVideo01") == "youtube"
+
+    def test_youtube_channel_handle_classified_as_web(self) -> None:
+        """YouTube チャンネルハンドル URL は動画ではないため web に分類されること."""
+        assert classify_url("https://www.youtube.com/@SampleHandle") == "web"
+
+    def test_youtube_playlist_classified_as_web(self) -> None:
+        """YouTube プレイリスト URL は動画ではないため web に分類されること."""
+        assert classify_url("https://www.youtube.com/playlist?list=PLtest") == "web"
+
+    def test_invalid_video_id_in_watch_classified_as_invalid_youtube(self) -> None:
+        """video_id が 11 文字でない watch URL は invalid_youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/watch?v=short") == "invalid_youtube"
+
+    def test_invalid_video_id_in_shorts_classified_as_invalid_youtube(self) -> None:
+        """video_id が 11 文字でない shorts URL は invalid_youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/shorts/short") == "invalid_youtube"
+
+    def test_invalid_video_id_in_live_classified_as_invalid_youtube(self) -> None:
+        """video_id が 11 文字でない live URL は invalid_youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/live/short") == "invalid_youtube"
+
+    def test_invalid_video_id_in_youtu_be_classified_as_invalid_youtube(self) -> None:
+        """video_id が 11 文字でない youtu.be URL は invalid_youtube に分類されること."""
+        assert classify_url("https://youtu.be/short") == "invalid_youtube"
+
+    def test_watch_without_v_param_classified_as_invalid_youtube(self) -> None:
+        """v パラメータが空の watch URL は invalid_youtube に分類されること."""
+        assert classify_url("https://www.youtube.com/watch?v=") == "invalid_youtube"
 
     def test_bsky_url_skip(self) -> None:
         """BlueSky URL が skip に分類されること."""
@@ -500,7 +548,7 @@ class TestFollowUrls:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=test123",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA01",
                     }
                 ]
             }
@@ -518,7 +566,7 @@ class TestFollowUrls:
         )
 
         mock_yt.ingest_video.assert_called_once_with(
-            video_url="https://www.youtube.com/watch?v=test123"
+            video_url="https://www.youtube.com/watch?v=DummyVidA01"
         )
         assert stats["youtube_placed"] == 1
 
@@ -532,7 +580,7 @@ class TestFollowUrls:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=vid1",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA02",
                     }
                 ]
             },
@@ -540,7 +588,7 @@ class TestFollowUrls:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=vid2",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA03",
                     }
                 ]
             },
@@ -548,7 +596,7 @@ class TestFollowUrls:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=vid3",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA04",
                     }
                 ]
             },
@@ -1052,7 +1100,7 @@ class TestFollowUrlsYoutubeOverwrite:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=test123",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA01",
                     }
                 ]
             }
@@ -1086,7 +1134,7 @@ class TestFollowUrlsYoutubeOverwrite:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=test123",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA01",
                     }
                 ]
             }
@@ -1119,7 +1167,7 @@ class TestFollowUrlsYoutubeOverwrite:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=new123",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA05",
                     }
                 ]
             }
@@ -1153,7 +1201,7 @@ class TestFollowUrlsYoutubeOverwrite:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=new456",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA06",
                     }
                 ]
             }
@@ -1166,7 +1214,7 @@ class TestFollowUrlsYoutubeOverwrite:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=old789",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA07",
                     }
                 ]
             }
@@ -1186,7 +1234,7 @@ class TestFollowUrlsYoutubeOverwrite:
 
         # 新規の YouTube のみ取り込まれ、上書きはスキップ
         mock_yt.ingest_video.assert_called_once_with(
-            video_url="https://www.youtube.com/watch?v=new456"
+            video_url="https://www.youtube.com/watch?v=DummyVidA06"
         )
         assert stats["youtube_placed"] == 1
         assert stats["skipped"] == 1
@@ -1947,7 +1995,7 @@ class TestPartialFailureObservability:
                 "features": [
                     {
                         "$type": "app.bsky.richtext.facet#link",
-                        "uri": "https://www.youtube.com/watch?v=broken",
+                        "uri": "https://www.youtube.com/watch?v=DummyVidA08",
                     },
                 ],
             },
@@ -1968,8 +2016,50 @@ class TestPartialFailureObservability:
         assert result.errors == 1
         assert result.error_details[0]["category"] == "delegation"
         assert result.error_details[0]["url"] == (
-            "https://www.youtube.com/watch?v=broken"
+            "https://www.youtube.com/watch?v=DummyVidA08"
         )
+
+    @pytest.mark.asyncio()
+    async def test_invalid_youtube_url_recorded_as_errors(
+        self, source_store: SourceStore,
+    ) -> None:
+        """follow_urls 経由で不正な YouTube URL が errors + delegation に計上されること.
+
+        site_ingest にも YouTube インジェスターにも委譲されず、
+        warning ログ + errors カウンタ + error_details への記録のみ行われる。
+        """
+        item = _make_feed_item()
+        item["post"]["record"]["facets"] = [
+            {
+                "features": [
+                    {
+                        "$type": "app.bsky.richtext.facet#link",
+                        "uri": "https://www.youtube.com/watch?v=short",
+                    },
+                ],
+            },
+        ]
+
+        mock_yt = AsyncMock()
+        mock_yt.ingest_video = AsyncMock()
+        mock_yt.request_interval = 0
+
+        ingester = make_bluesky_ingester(source_store)
+        result = IngestResult()
+        stats = await ingester.follow_urls(
+            [item],
+            youtube_ingester=mock_yt,
+            result=result,
+        )
+
+        assert stats["errors"] == 1
+        assert stats["web_placed"] == 0
+        assert stats["youtube_placed"] == 0
+        assert result.errors == 1
+        assert result.error_details[0]["category"] == "delegation"
+        assert result.error_details[0]["message"] == "invalid youtube url"
+        assert result.error_details[0]["url"] == "https://www.youtube.com/watch?v=short"
+        mock_yt.ingest_video.assert_not_called()
 
     @pytest.mark.asyncio()
     async def test_placement_failure_uses_dict_error_detail(

--- a/tests/test_pipeline_ingesters_youtube.py
+++ b/tests/test_pipeline_ingesters_youtube.py
@@ -4,6 +4,7 @@
 
 テスト方針:
 - URL パース・バリデーション
+- URL 種別分類（video / malformed / not_youtube）
 - max_videos のバリデーション・クランプ
 - 字幕取得（モック）
 - Whisper フォールバック（モック）
@@ -25,8 +26,10 @@ from rag.pipeline.ingesters._common import IngestResult
 from rag.pipeline.ingesters.youtube import (
     MAX_VIDEOS_HARD_LIMIT,
     _validate_max_videos,
+    classify_youtube_url,
     extract_playlist_id,
     extract_video_id,
+    is_youtube_video_url,
 )
 
 from factories import make_youtube_ingester
@@ -37,16 +40,16 @@ from factories import make_youtube_ingester
 
 class TestExtractVideoId:
     def test_standard_url(self) -> None:
-        assert extract_video_id("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs") == "JV3KOJ_Z4Vs"
+        assert extract_video_id("https://www.youtube.com/watch?v=TestVideo01") == "TestVideo01"
 
     def test_short_url(self) -> None:
-        assert extract_video_id("https://youtu.be/JV3KOJ_Z4Vs") == "JV3KOJ_Z4Vs"
+        assert extract_video_id("https://youtu.be/TestVideo01") == "TestVideo01"
 
     def test_url_with_extra_params(self) -> None:
-        assert extract_video_id("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs&t=30s") == "JV3KOJ_Z4Vs"
+        assert extract_video_id("https://www.youtube.com/watch?v=TestVideo01&t=30s") == "TestVideo01"
 
     def test_mobile_url(self) -> None:
-        assert extract_video_id("https://m.youtube.com/watch?v=JV3KOJ_Z4Vs") == "JV3KOJ_Z4Vs"
+        assert extract_video_id("https://m.youtube.com/watch?v=TestVideo01") == "TestVideo01"
 
     def test_invalid_url_raises(self) -> None:
         with pytest.raises(ValueError, match="不正な YouTube URL"):
@@ -59,6 +62,140 @@ class TestExtractVideoId:
     def test_invalid_video_id_format_raises(self) -> None:
         with pytest.raises(ValueError, match="不正な YouTube URL"):
             extract_video_id("https://www.youtube.com/watch?v=short")
+
+    def test_shorts_url(self) -> None:
+        assert extract_video_id("https://www.youtube.com/shorts/TestVideo01") == "TestVideo01"
+
+    def test_live_url(self) -> None:
+        assert extract_video_id("https://www.youtube.com/live/TestVideo01") == "TestVideo01"
+
+    def test_live_url_with_query(self) -> None:
+        assert (
+            extract_video_id("https://www.youtube.com/live/TestVideo01?si=abc123")
+            == "TestVideo01"
+        )
+
+    def test_embed_url(self) -> None:
+        assert extract_video_id("https://www.youtube.com/embed/TestVideo01") == "TestVideo01"
+
+    def test_legacy_v_url(self) -> None:
+        assert extract_video_id("https://www.youtube.com/v/TestVideo01") == "TestVideo01"
+
+    def test_youtube_com_without_subdomain(self) -> None:
+        assert extract_video_id("https://youtube.com/watch?v=TestVideo01") == "TestVideo01"
+
+    def test_invalid_video_id_in_shorts_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="不正な YouTube URL"):
+            extract_video_id("https://www.youtube.com/shorts/short")
+
+    def test_playlist_url_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="不正な YouTube URL"):
+            extract_video_id("https://www.youtube.com/playlist?list=PLtest")
+
+    def test_channel_handle_url_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="不正な YouTube URL"):
+            extract_video_id("https://www.youtube.com/@SampleHandle")
+
+    def test_video_id_with_underscore(self) -> None:
+        """`_` を含む video_id (11 文字) が抽出できること."""
+        assert extract_video_id("https://www.youtube.com/watch?v=Test_Video1") == "Test_Video1"
+
+    def test_video_id_with_hyphen(self) -> None:
+        """`-` を含む video_id (11 文字) が抽出できること."""
+        assert extract_video_id("https://www.youtube.com/watch?v=Test-Video1") == "Test-Video1"
+
+    def test_video_id_with_underscore_in_shorts(self) -> None:
+        """`_` を含む video_id が shorts URL から抽出できること."""
+        assert (
+            extract_video_id("https://www.youtube.com/shorts/Test_Video1") == "Test_Video1"
+        )
+
+    def test_video_id_case_is_preserved(self) -> None:
+        """video_id の大文字小文字が保持されること（パス判定が大文字小文字無視でも）."""
+        assert (
+            extract_video_id("https://www.youtube.com/SHORTS/MixedCase11") == "MixedCase11"
+        )
+
+
+class TestIsYoutubeVideoUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.youtube.com/watch?v=TestVideo01",
+            "https://youtube.com/watch?v=TestVideo01",
+            "https://m.youtube.com/watch?v=TestVideo01",
+            "https://youtu.be/TestVideo01",
+            "https://www.youtube.com/shorts/TestVideo01",
+            "https://www.youtube.com/live/TestVideo01",
+            "https://www.youtube.com/live/TestVideo01?si=abc",
+            "https://www.youtube.com/embed/TestVideo01",
+            "https://www.youtube.com/v/TestVideo01",
+        ],
+    )
+    def test_video_urls_are_recognized(self, url: str) -> None:
+        assert is_youtube_video_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/watch?v=TestVideo01",
+            "https://www.youtube.com/playlist?list=PLtest",
+            "https://www.youtube.com/@SampleHandle",
+            "https://www.youtube.com/c/somechannel",
+            "https://www.youtube.com/channel/UCxxxx",
+            "https://www.youtube.com/watch?v=short",
+            "https://www.youtube.com/watch",
+        ],
+    )
+    def test_non_video_urls_are_rejected(self, url: str) -> None:
+        assert is_youtube_video_url(url) is False
+
+
+class TestClassifyYoutubeUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.youtube.com/watch?v=TestVideo01",
+            "https://youtu.be/TestVideo01",
+            "https://www.youtube.com/shorts/TestVideo01",
+            "https://www.youtube.com/live/TestVideo01",
+            "https://www.youtube.com/embed/TestVideo01",
+            "https://www.youtube.com/v/TestVideo01",
+            "https://m.youtube.com/watch?v=TestVideo01",
+        ],
+    )
+    def test_valid_video_urls(self, url: str) -> None:
+        assert classify_youtube_url(url) == "video"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.youtube.com/watch?v=short",
+            "https://www.youtube.com/watch?v=",
+            "https://www.youtube.com/shorts/short",
+            "https://www.youtube.com/live/short",
+            "https://www.youtube.com/embed/short",
+            "https://www.youtube.com/v/short",
+            "https://youtu.be/short",
+        ],
+    )
+    def test_malformed_video_urls(self, url: str) -> None:
+        assert classify_youtube_url(url) == "malformed"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/watch?v=TestVideo01",
+            "https://www.youtube.com/playlist?list=PLtest",
+            "https://www.youtube.com/@SampleHandle",
+            "https://www.youtube.com/c/somechannel",
+            "https://www.youtube.com/channel/UCxxxx",
+            "https://www.youtube.com/watch",
+            "https://youtu.be/",
+        ],
+    )
+    def test_not_youtube_video_urls(self, url: str) -> None:
+        assert classify_youtube_url(url) == "not_youtube"
 
 
 class TestExtractPlaylistId:
@@ -123,7 +260,7 @@ def source_store(tmp_path: Path) -> Any:
 def _make_metadata(*, channel_id: str = "UCtest123456789012345", duration: int = 120) -> dict[str, Any]:
     """テスト用メタデータを生成する."""
     return {
-        "id": "JV3KOJ_Z4Vs",
+        "id": "TestVideo01",
         "title": "Test Video Title",
         "channel_id": channel_id,
         "uploader": "Test Channel",
@@ -160,7 +297,7 @@ class TestIngestVideo:
                 return_value=(snippets, "subtitle", "ja"),
             ),
         ):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         assert result.errors == 0
@@ -169,18 +306,18 @@ class TestIngestVideo:
         source_store.place_file.assert_called_once()
         call_kwargs = source_store.place_file.call_args
         assert call_kwargs.kwargs["source_type"] == "youtube"
-        assert call_kwargs.kwargs["rel_path"] == "youtube/UCtest123456789012345/JV3KOJ_Z4Vs.json"
+        assert call_kwargs.kwargs["rel_path"] == "youtube/UCtest123456789012345/TestVideo01.json"
 
         # JSON データの検証
         data = json.loads(call_kwargs.kwargs["data"].decode("utf-8"))
-        assert data["video_id"] == "JV3KOJ_Z4Vs"
+        assert data["video_id"] == "TestVideo01"
         assert data["transcript_source"] == "subtitle"
         assert len(data["snippets"]) == 3
 
         # メタデータの検証
         meta = call_kwargs.kwargs["metadata"]
         assert meta["source_type"] == "youtube"
-        assert meta["video_id"] == "JV3KOJ_Z4Vs"
+        assert meta["video_id"] == "TestVideo01"
 
     @pytest.mark.asyncio()
     async def test_duration_exceeded_skipped(self, source_store: Any) -> None:
@@ -190,7 +327,7 @@ class TestIngestVideo:
         metadata = _make_metadata(duration=3600)
 
         with patch.object(ingester, "_fetch_metadata", new_callable=AsyncMock, return_value=metadata):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 0
         assert result.skipped == 1
@@ -206,12 +343,12 @@ class TestIngestVideo:
             new_callable=AsyncMock,
             side_effect=Exception("API error"),
         ):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.errors == 1
         detail = result.error_details[0]
         assert detail["category"] == "metadata_fetch"
-        assert detail["target"] == "JV3KOJ_Z4Vs"
+        assert detail["target"] == "TestVideo01"
         assert "メタデータ取得失敗" in detail["message"]
 
     @pytest.mark.asyncio()
@@ -223,13 +360,13 @@ class TestIngestVideo:
         metadata["channel_id"] = None
 
         with patch.object(ingester, "_fetch_metadata", new_callable=AsyncMock, return_value=metadata):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 0
         assert result.errors == 1
         detail = result.error_details[0]
         assert detail["category"] == "metadata_fetch"
-        assert detail["target"] == "JV3KOJ_Z4Vs"
+        assert detail["target"] == "TestVideo01"
         assert "channel_id" in detail["message"]
 
     @pytest.mark.asyncio()
@@ -249,7 +386,7 @@ class TestIngestVideo:
                 return_value=(snippets, "whisper", "ja"),
             ),
         ):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         call_kwargs = source_store.place_file.call_args
@@ -273,12 +410,12 @@ class TestIngestVideo:
             patch.object(ingester, "_fetch_metadata", new_callable=AsyncMock, return_value=metadata),
             patch.object(ingester, "_fetch_transcript", new_callable=AsyncMock, return_value=(snippets, "subtitle", "ja")),
         ):
-            result1 = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result1 = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
         assert result1.placed == 1
         assert result1.overwritten == 0
 
         # 2 回目: dest に実ファイルを作成して exists() が True になるようにする
-        dest = source_store.root_dir / "youtube" / "UCtest123456789012345" / "JV3KOJ_Z4Vs.json"
+        dest = source_store.root_dir / "youtube" / "UCtest123456789012345" / "TestVideo01.json"
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text("{}", encoding="utf-8")
 
@@ -286,7 +423,7 @@ class TestIngestVideo:
             patch.object(ingester, "_fetch_metadata", new_callable=AsyncMock, return_value=metadata),
             patch.object(ingester, "_fetch_transcript", new_callable=AsyncMock, return_value=(snippets, "subtitle", "ja")),
         ):
-            result2 = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result2 = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
         # 排他計上: 既存ファイル上書き時は placed=0, overwritten=1
         assert result2.placed == 0
         assert result2.overwritten == 1
@@ -311,10 +448,10 @@ class TestIngestVideo:
                 ingester,
                 "_fetch_subtitle",
                 new_callable=AsyncMock,
-                side_effect=RequestBlocked("JV3KOJ_Z4Vs"),
+                side_effect=RequestBlocked("TestVideo01"),
             ),
         ):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         # Whisper フォールバックされず、エラーとして処理される
         assert result.errors == 1
@@ -335,7 +472,7 @@ class TestIngestVideo:
                 ingester,
                 "_fetch_subtitle",
                 new_callable=AsyncMock,
-                side_effect=TranscriptsDisabled("JV3KOJ_Z4Vs"),
+                side_effect=TranscriptsDisabled("TestVideo01"),
             ),
             patch.object(
                 ingester,
@@ -344,7 +481,7 @@ class TestIngestVideo:
                 return_value=(snippets, "ja"),
             ),
         ):
-            result = await ingester.ingest_video("https://www.youtube.com/watch?v=JV3KOJ_Z4Vs")
+            result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         assert result.errors == 0


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- `/live/`, `/embed/`, `/v/`, `m.youtube.com` の認識を追加し、`/shorts/` の抽出 bug を修正
- `is_youtube_video_url` / `classify_youtube_url` を `youtube.py` に新設し、`bluesky.py` の `classify_url` から参照することで分類器・抽出器の drift を構造的に防止
- 不正な YouTube URL（パターン該当・video_id 形式不正）を `web` 委譲せず `invalid_youtube` 扱いとし、site_ingest への無駄な HTTP アクセスを抑止（ユーザー指示による Issue 本文外の挙動追加。詳細は Issue #679 完了コメント参照）
- `extract_playlist_id` の host チェックを `_YOUTUBE_HOSTS` 共有化
- 仕様書（bluesky.md, youtube.md）に対応 URL 形式と「不正な YouTube URL」エッジケースを追記

## Test plan

- [x] 単体テスト追加（URL パターン拡張・不正 URL 分類・video_id 境界条件）
- [x] 結合テスト追加（`follow_urls` 経由で `invalid_youtube` が `errors` に計上されることを検証）
- [x] pytest 1754 passed / ruff / mypy / markdownlint クリア
- [ ] YouTube 結合 QA は実 YouTube アクセスを避けるため、モック基盤整備とともに #683 に委譲

## Related issues

Closes #679

Related: #683 (YouTube mock 基盤整備), agent-commons #258 (doc-reviewer の §6.14 取りこぼし問題)