### PR TITLE
fix(ingesters/bluesky): rag_add_bluesky で投稿内 URL の自動取り込みを実行 (#681)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -198,6 +198,7 @@ NG を検出した場合、Issue 起票を提案する。
 | C) SNS | BlueSky ハンドル | `rhythmcan.bsky.social` |
 | C) SNS | BlueSky --max-posts | `5`（メディア付き投稿を含むため増加） |
 | C) SNS | BlueSky --force | C-2 の後に `--max-posts 1 --force` で上書き再取得 |
+| C) SNS | BlueSky 単一投稿 URL（Web リンク付き） | `rhythmcan.bsky.social` の最近の投稿で外部リンク（リンクカードまたは facets）を含むものを 1 件選定する。実行時に `crawl-bluesky` 結果から `has_external_link: true` の投稿を確認 |
 | D) YouTube | 動画 URL | `https://www.youtube.com/watch?v=GuFBDpzH3ck` |
 | D) YouTube | プレイリスト URL | `https://www.youtube.com/playlist?list=PLaFZvPBpvhKKgHIDI16ja0jwEG_vIH55K`（`--max-videos 1`） |
 | E) Aozora | 著者検索キーワード | `太宰`（「太宰 治」にマッチ） |
@@ -264,10 +265,16 @@ MCP 対応: `rag_site_ingest`（`url` パラメータ / `urls` パラメータ�
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `crawl-zenn rhythmcan --max-articles 1` | Zenn 記事 1 件取り込み成功 | `ingest` |
-| 2 | `crawl-bluesky rhythmcan.bsky.social --max-posts 5` | BlueSky 投稿取り込み成功。メディア付き投稿がある場合、source_store の `bluesky/{did}/{year}/{month}/media/{rkey}/` にメディアファイル（`image_0.{ext}` / `video_0.ts`）が配置されていること | `ingest` |
+| 2 | `crawl-bluesky rhythmcan.bsky.social --max-posts 5` | BlueSky 投稿取り込み成功。メディア付き投稿がある場合、source_store の `bluesky/{did}/{year}/{month}/media/{rkey}/` にメディアファイル（`image_0.{ext}` / `video_0.ts`）が配置されていること。投稿内に外部リンクを含む投稿がある場合、site_ingest 経由で URL 先が取得され `URL 自動取り込み: Web N件` が表示されること | `ingest` |
 | 3 | `crawl-bluesky rhythmcan.bsky.social --max-posts 1 --force` | `--force` による上書き再取得成功。既存投稿が上書きされ、CLI に `完了: N件配置`（N > 0）と表示されること | `ingest` |
+| 4 | `ingest-bluesky <Web リンク付き投稿 URL>` | 投稿 1 件配置 + `URL 自動取り込み: Web N件` が表示される。site_ingest が呼ばれ、URL 先 Web ページが source_store に配置されること | `ingest` |
+| 5 | 同 URL で `ingest-bluesky <同じ Web リンク付き投稿 URL>` を再実行 | 投稿 1 件上書き（`overwritten=1`）。`URL 自動取り込み: Web N件` が再度表示され、site_ingest Bridge が URL 先 Web ページを上書き配置することを確認（ピンポイント修復シナリオ） | `ingest` |
 
-MCP 対応: `rag_crawl_zenn` / `rag_crawl_bluesky`（`force=True` で --force 相当）
+MCP 対応: `rag_crawl_zenn` / `rag_crawl_bluesky`（`force=True` で --force 相当） / `rag_add_bluesky`（C-4/C-5 用、`urls` パラメータに投稿 URL リストを渡す）
+
+**MCP テスト時の追加確認:**
+
+- C-4 / C-5: MCP 応答テキストに `URL 自動取り込み: Web N件` のフォーマット文字列が含まれること（`_format_ingest_response` の url_follow 反映を確認）
 
 ### D) YouTube
 

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -273,15 +273,21 @@ CLI / MCP 対応: `rag_site_ingest`（`url` パラメータ / `urls` パラメ�
 
 ### C) SNS
 
-目的: Zenn・BlueSky インジェスターの動作確認。BlueSky メディア DL と --force オプションの検証を含む。
+目的: Zenn・BlueSky インジェスターの動作確認。BlueSky メディア DL と --force オプション、および投稿内 URL 自動取り込み（`rag_crawl_bluesky` / `rag_add_bluesky` 経由）の検証を含む。
 
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
 | 1 | `crawl-zenn rhythmcan --max-articles 1` | Zenn 記事 1 件取り込み成功 | `ingest` |
-| 2 | `crawl-bluesky rhythmcan.bsky.social --max-posts 5` | BlueSky 投稿取り込み成功。メディア付き投稿がある場合、source_store の `bluesky/{did}/{year}/{month}/media/{rkey}/` にメディアファイル（`image_0.{ext}` / `video_0.ts`）が配置されていること | `ingest` |
+| 2 | `crawl-bluesky rhythmcan.bsky.social --max-posts 5` | BlueSky 投稿取り込み成功。メディア付き投稿がある場合、source_store の `bluesky/{did}/{year}/{month}/media/{rkey}/` にメディアファイル（`image_0.{ext}` / `video_0.ts`）が配置されていること。投稿内に外部リンクを含む投稿がある場合、site_ingest 経由で URL 先が取得され `URL 自動取り込み: Web N件` が表示されること | `ingest` |
 | 3 | `crawl-bluesky rhythmcan.bsky.social --max-posts 1 --force` | `--force` による上書き再取得成功。既存投稿が上書きされ、CLI に `完了: N件配置`（N > 0）と表示されること | `ingest` |
+| 4 | `ingest-bluesky <Web リンク付き投稿 URL>` | 投稿 1 件配置 + `URL 自動取り込み: Web N件` が表示される。site_ingest が呼ばれ URL 先 Web ページが source_store に配置されること（ピンポイント修復シナリオ） | `ingest` |
+| 5 | 同 URL で `ingest-bluesky` を再実行 | 投稿 1 件上書き（`overwritten=1`）。`URL 自動取り込み: Web N件` が再度表示され、site_ingest Bridge が URL 先 Web ページを上書き配置すること | `ingest` |
 
-CLI / MCP 対応: `rag_crawl_zenn` / `rag_crawl_bluesky`（`force=True` で --force 相当）
+CLI / MCP 対応: `rag_crawl_zenn` / `rag_crawl_bluesky`（`force=True` で --force 相当）/ `rag_add_bluesky`（C-4/C-5 用、`urls` パラメータに投稿 URL リストを渡す）
+
+**MCP テスト時の追加確認:**
+
+- C-4 / C-5: MCP 応答テキストに `URL 自動取り込み: Web N件` のフォーマット文字列が含まれること（`_format_ingest_response` の url_follow 反映を確認）
 
 ### D) YouTube
 

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -486,7 +486,10 @@ embed の `$type` が `app.bsky.embed.recordWithMedia` の場合、メディア�
 5. レスポンスの投稿オブジェクトをフィードアイテム形式（`{"post": ..., "reason": null}`）に変換する
 6. 既存の単一投稿保存ロジック（JSON 配置 + .meta 生成）で source_store に上書き配置する
 7. メディア（画像・動画）が添付されている場合、既存のメディア DL 処理で再 DL する
-8. 配置済み投稿から URL を抽出し、[投稿内 URL の自動取り込み](#投稿内-url-の自動取り込み) に従って site_ingest / YouTube インジェスターに委譲する。本ツールはピンポイント修復用途のため、配置済み投稿は **YouTube 抑制対象外** として渡される（投稿が新規/上書きいずれの場合も YouTube URL は常に取り込まれ、`rag_bluesky_force_youtube_reingest` 設定の影響を受けない）
+8. 配置済み投稿から URL を抽出し、[投稿内 URL の自動取り込み](#投稿内-url-の自動取り込み) に従って
+   site_ingest / YouTube インジェスターに委譲する。本ツールはピンポイント修復用途のため、
+   配置済み投稿は **YouTube 抑制対象外** として渡される（投稿が新規/上書きいずれの場合も YouTube URL は
+   常に取り込まれ、`rag_bluesky_force_youtube_reingest` 設定の影響を受けない）
 9. 全 URL の処理が完了したらパイプライン制御に取り込み完了を通知する
 
 ```mermaid
@@ -599,7 +602,10 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 
 #### 処理フロー
 
-呼び出し元（`rag_crawl_bluesky` または `rag_add_bluesky`）が配置済み投稿群と「上書き投稿の YouTube 再取り込み許可フラグ」を渡す。`rag_crawl_bluesky` は `--force` + `rag_bluesky_force_youtube_reingest` の組み合わせに従ってフラグを決め、`rag_add_bluesky` はピンポイント修復用途のため常にフラグを `true` 相当に設定する。
+呼び出し元（`rag_crawl_bluesky` または `rag_add_bluesky`）が配置済み投稿群と「上書き投稿の YouTube
+再取り込み許可フラグ」を渡す。`rag_crawl_bluesky` は `--force` + `rag_bluesky_force_youtube_reingest`
+の組み合わせに従ってフラグを決め、`rag_add_bluesky` はピンポイント修復用途のため常にフラグを `true`
+相当に設定する。
 
 1. 受け取った配置済み投稿の JSON から URL を一括抽出する
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -69,14 +69,26 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 | 最悪ケース所要時間 | BlueSky API: リクエスト数 x リクエスト間隔（デフォルト・許容範囲は pydantic Field で定義）。URL 先取り込み: Scrapy subprocess の所要時間。直列実行のため合計時間 |
 | 想定エラー率 | AT Protocol API 依存。リトライ機構なし。ConstrainedClient のサーキットブレーカー閾値で操作中断。中断時は取得済みデータを処理する |
 
+### rag_add_bluesky（BlueSky 投稿ピンポイント取り込み）
+
+入力 URL 数を `N`、URL 先取り込み対象数を `M_yt`（YouTube 動画）・`M_web`（Web ページ）とする。
+
+| 項目 | 内容 |
+|------|------|
+| 最悪ケースリクエスト数 | BlueSky API: `resolveHandle`（同一 handle 重複排除後の handle 数）+ `getPosts` N 回（ConstrainedClient バジェット消費）。URL 先取り込み: site_ingest（Scrapy subprocess）と YouTube インジェスター（`youtube-transcript-api` / `yt-dlp`）が独立して HTTP リクエストを管理するため、ConstrainedClient バジェットを消費しない |
+| 最悪ケース所要時間 | BlueSky API: 上記リクエスト数 × リクエスト間隔（pydantic Field 定義）。URL 先取り込み: Scrapy subprocess + YouTube `M_yt` 件分（URL 間に `rag_youtube_request_interval` 秒のスリープを挿入）の合計。直列実行のため合計時間 |
+| 想定エラー率 | AT Protocol API 依存。リトライ機構なし。ConstrainedClient のサーキットブレーカー閾値で操作中断。`getPosts` が空配列を返す（投稿削除済み）の場合は `errors` に計上し他 URL の処理は継続する |
+
+ピンポイント修復用途のため、典型的には `N` は 1〜数件、`M_yt`・`M_web` は投稿あたり数件以下の小規模な処理を想定している。タイムライン一括取り込み用途には `rag_crawl_bluesky` を使用する。
+
 ## インターフェース
 
 ### MCP ツール
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意）、force（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、source_store に JSON ファイルとして配置する。通常は既存ファイルと一致する投稿をスキップする。`force` 指定時は全データを上書き再取得する |
-| rag_add_bluesky | urls | 指定 URL の BlueSky 投稿を `getPosts` API 経由で取得し、source_store に配置する。既存ファイルは上書きする。メディア（画像・動画）も DL する。複数 URL を一括指定可能 |
+| rag_crawl_bluesky | handle、max_posts（任意）、include_reposts（任意）、force（任意） | 指定ユーザーの BlueSky 投稿を AT Protocol API 経由で取得し、source_store に JSON ファイルとして配置する。通常は既存ファイルと一致する投稿をスキップする。`force` 指定時は全データを上書き再取得する。投稿配置後に投稿内 URL の自動取り込み（YouTube/Web）を実行する |
+| rag_add_bluesky | urls | 指定 URL の BlueSky 投稿を `getPosts` API 経由で取得し、source_store に配置する。既存ファイルは上書きする。メディア（画像・動画）も DL する。複数 URL を一括指定可能。投稿配置後に投稿内 URL の自動取り込み（YouTube/Web）を実行する。詳細な振る舞いは [投稿取得フロー（rag_add_bluesky）](#投稿取得フローrag_add_bluesky) を参照 |
 
 ツール入力パラメータ:
 
@@ -100,7 +112,8 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 各 URL から `handle` と `rkey` をパースし、handle ごとに `resolveHandle` API で DID を解決した上で `getPosts` API で投稿データを取得する。
 同一 handle の投稿は DID 解決を 1 回にまとめる。
 常に上書き動作（`force=True` 相当）で source_store のファイルを更新する。メディア（画像・動画）も DL する。
-投稿内 URL の自動取り込みは実行しない（本ツールの目的は対象投稿自体の取得であり、URL 先の取り込みは `crawl_bluesky --force` の責務）。
+
+投稿配置完了後、投稿内 URL の自動取り込みを実行する。詳細な振る舞いは [投稿取得フロー（rag_add_bluesky）](#投稿取得フローrag_add_bluesky) を参照。
 
 各 URL は独立して処理し、1 件の失敗が他の URL の処理を妨げない。
 
@@ -473,7 +486,44 @@ embed の `$type` が `app.bsky.embed.recordWithMedia` の場合、メディア�
 5. レスポンスの投稿オブジェクトをフィードアイテム形式（`{"post": ..., "reason": null}`）に変換する
 6. 既存の単一投稿保存ロジック（JSON 配置 + .meta 生成）で source_store に上書き配置する
 7. メディア（画像・動画）が添付されている場合、既存のメディア DL 処理で再 DL する
-8. 全 URL の処理が完了したらパイプライン制御に取り込み完了を通知する
+8. 配置済み投稿から URL を抽出し、[投稿内 URL の自動取り込み](#投稿内-url-の自動取り込み) に従って site_ingest / YouTube インジェスターに委譲する。本ツールはピンポイント修復用途のため、配置済み投稿は **YouTube 抑制対象外** として渡される（投稿が新規/上書きいずれの場合も YouTube URL は常に取り込まれ、`rag_bluesky_force_youtube_reingest` 設定の影響を受けない）
+9. 全 URL の処理が完了したらパイプライン制御に取り込み完了を通知する
+
+```mermaid
+flowchart TD
+    START["rag_add_bluesky(urls)"]
+    PARSE["URL パース（handle, rkey 抽出）"]
+    PARSE_FAIL{"パース成功?"}
+    RESOLVE["handle 重複排除 → resolveHandle API で DID 解決"]
+    EACH_URL{"各 URL に未処理がある?"}
+    GET_POSTS["getPosts API で投稿データ取得"]
+    CHECK_POST{"投稿が存在する?"}
+    SAVE["JSON 配置 + .meta 生成（force=True 上書き）"]
+    MEDIA_CHECK{"メディア添付あり?"}
+    MEDIA_DL["メディア DL（画像/動画）"]
+    URL_FOLLOW["URL 自動取り込み委譲（YouTube 抑制対象外）"]
+    NOTIFY["パイプライン制御に完了通知"]
+    RESULT["結果サマリーを返却"]
+    ERR["errors に計上"]
+
+    START --> PARSE
+    PARSE --> PARSE_FAIL
+    PARSE_FAIL -->|"いいえ"| ERR
+    PARSE_FAIL -->|"はい"| RESOLVE
+    RESOLVE --> EACH_URL
+    EACH_URL -->|"はい"| GET_POSTS
+    EACH_URL -->|"いいえ（全件処理済み）"| URL_FOLLOW
+    GET_POSTS --> CHECK_POST
+    CHECK_POST -->|"いいえ（削除済み等）"| ERR
+    CHECK_POST -->|"はい"| SAVE
+    SAVE --> MEDIA_CHECK
+    MEDIA_CHECK -->|"はい"| MEDIA_DL
+    MEDIA_CHECK -->|"いいえ"| EACH_URL
+    MEDIA_DL --> EACH_URL
+    ERR --> EACH_URL
+    URL_FOLLOW --> NOTIFY
+    NOTIFY --> RESULT
+```
 
 ### --force オプション（上書き再取得）
 
@@ -513,7 +563,9 @@ BlueSky の投稿は最大 300 文字の短文であり、1 投稿が意味の�
 
 ### 投稿内 URL の自動取り込み
 
-BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて site_ingest / YouTube インジェスターに委譲して取り込む。この機能はデフォルトで有効であり、`crawl_bluesky` 実行時に常に動作する。
+BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて site_ingest / YouTube インジェスターに委譲して取り込む。この機能はデフォルトで有効であり、`rag_crawl_bluesky` および `rag_add_bluesky` の実行時に常に動作する。
+
+呼び出し元ごとの振る舞い差（YouTube 抑制の扱い等）は [投稿一括取り込みフロー](#投稿一括取り込みフロー) および [投稿取得フロー（rag_add_bluesky）](#投稿取得フローrag_add_bluesky) を参照。
 
 #### URL 抽出対象
 
@@ -547,12 +599,18 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 
 #### 処理フロー
 
-1. 全投稿の source_store への配置が完了した後、配置した投稿の JSON から URL を一括抽出する
+呼び出し元（`rag_crawl_bluesky` または `rag_add_bluesky`）が配置済み投稿群と「上書き投稿の YouTube 再取り込み許可フラグ」を渡す。`rag_crawl_bluesky` は `--force` + `rag_bluesky_force_youtube_reingest` の組み合わせに従ってフラグを決め、`rag_add_bluesky` はピンポイント修復用途のため常にフラグを `true` 相当に設定する。
+
+1. 受け取った配置済み投稿の JSON から URL を一括抽出する
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）
 3. URL 種別を判定し、Web / YouTube / スキップに分類する
 4. Web URL を全てバッチ収集し、CLI の `site-ingest` コマンド（複数 URL モード）で 1 回の Scrapy subprocess として取り込む。`--download-only` と `--output json` を指定し、パイプライン処理は BlueSky 側で一括実行する。subprocess の JSON 出力から配置数を取得する
-5. YouTube インジェスターで動画を取り込む（個別処理、URL 間に `rag_youtube_request_interval` に基づくスリープを挿入）
-6. 全 URL の処理が完了した後、パイプライン制御に取り込み完了を通知する
+5. YouTube URL の取得対象判定:
+   - 新規投稿由来の YouTube URL は常に取得する
+   - 上書き投稿由来の YouTube URL は、呼び出し元から受け取った再取り込み許可フラグが `true` の場合のみ取得する
+   - `rag_add_bluesky` 経由では全投稿が YouTube 抑制対象外として渡されるため、上記判定の結果として YouTube URL は常に取得対象となる
+6. YouTube インジェスターで動画を取り込む（個別処理、URL 間に `rag_youtube_request_interval` に基づくスリープを挿入）
+7. 全 URL の処理が完了した後、パイプライン制御に取り込み完了を通知する
 
 #### エラーハンドリング
 
@@ -755,6 +813,8 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | `rag_add_bluesky` に指定された URL の投稿が削除済み | `getPosts` が空の `posts` 配列を返す。エラーメッセージとして「投稿が見つかりません」を返す |
 | `rag_add_bluesky` に指定された URL の投稿が未取り込み | 新規配置として扱う（`placed` に計上） |
 | `rag_add_bluesky` で `resolveHandle` が失敗 | エラーメッセージを返す（DID 解決なしには `getPosts` を呼べない） |
+| `rag_add_bluesky` で対象投稿に YouTube URL が含まれる | YouTube インジェスターに委譲して再取得する（振る舞いの詳細は [投稿取得フロー（rag_add_bluesky）](#投稿取得フローrag_add_bluesky) のステップ 8 を参照） |
+| `rag_add_bluesky` で対象投稿に Web URL が含まれる | site_ingest（複数 URL モード）に委譲して取得する。site_ingest の Bridge は既存ファイルを上書きするため、URL 先データの修復経路として機能する |
 
 以下の `media_download` 系失敗はすべて `partial_failures` に計上する。投稿 JSON 自体の取り込みには影響しない（親成功）:
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2353,6 +2353,45 @@ def _print_ingest_result(
                 print(f"  - {_format_pipeline_error(entry)}")
 
 
+def _emit_bluesky_result(
+    *,
+    json_out: bool,
+    ingest_result: "IngestResult",
+    pipeline_summary: "PipelineSummary | None",
+    url_stats: dict[str, int],
+    context: str,
+) -> None:
+    """BlueSky 取り込み結果（パイプライン + URL 自動取り込み統計）を出力する.
+
+    run_crawl_bluesky / run_ingest_bluesky で共通利用する。
+    """
+    if json_out:
+        data = _ingest_result_to_dict(ingest_result, pipeline_summary)
+        if url_stats:
+            data["url_follow"] = {
+                "web_placed": url_stats.get("web_placed", 0),
+                "youtube_placed": url_stats.get("youtube_placed", 0),
+                "errors": url_stats.get("errors", 0),
+            }
+        _output_result(data)
+        return
+
+    _print_ingest_result(ingest_result, pipeline_summary, context=context)
+    if not url_stats:
+        return
+    if not any(url_stats.get(k, 0) > 0 for k in ("web_placed", "youtube_placed", "errors")):
+        return
+    parts = ["URL 自動取り込み:"]
+    web_n = url_stats.get("web_placed", 0)
+    yt_n = url_stats.get("youtube_placed", 0)
+    err_n = url_stats.get("errors", 0)
+    if web_n > 0 or yt_n > 0:
+        parts.append(f"Web {web_n}件, YouTube {yt_n}件")
+    if err_n > 0:
+        parts.append(f"エラー {err_n}件")
+    print(" ".join(parts))
+
+
 async def run_ingest_youtube(args: argparse.Namespace) -> None:
     """YouTube 単一動画取り込み."""
     from .pipeline.ingesters.youtube import YoutubeIngester
@@ -2527,27 +2566,13 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             progress_callback=progress_cb,
         concurrency=settings.rag_embedding_concurrency,
         )
-        if json_out:
-            data = _ingest_result_to_dict(ingest_result, pipeline_summary)
-            if url_stats:
-                data["url_follow"] = {
-                    "web_placed": url_stats.get("web_placed", 0),
-                    "youtube_placed": url_stats.get("youtube_placed", 0),
-                    "errors": url_stats.get("errors", 0),
-                }
-            _output_result(data)
-        else:
-            _print_ingest_result(ingest_result, pipeline_summary, context=f"ハンドル: {args.handle}")
-            if url_stats and any(url_stats.get(k, 0) > 0 for k in ("web_placed", "youtube_placed", "errors")):
-                parts = ["URL 自動取り込み:"]
-                web_n = url_stats.get("web_placed", 0)
-                yt_n = url_stats.get("youtube_placed", 0)
-                err_n = url_stats.get("errors", 0)
-                if web_n > 0 or yt_n > 0:
-                    parts.append(f"Web {web_n}件, YouTube {yt_n}件")
-                if err_n > 0:
-                    parts.append(f"エラー {err_n}件")
-                print(" ".join(parts))
+        _emit_bluesky_result(
+            json_out=json_out,
+            ingest_result=ingest_result,
+            pipeline_summary=pipeline_summary,
+            url_stats=url_stats,
+            context=f"ハンドル: {args.handle}",
+        )
 
 
 async def run_crawl_zenn(args: argparse.Namespace) -> None:
@@ -2627,15 +2652,27 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
+        url_stats: dict[str, int] = {}
         try:
             async with ConstrainedClient(
                 request_timeout=settings.rag_bluesky_request_timeout,
                 request_interval=settings.rag_bluesky_request_interval,
             ) as client:
-                ingest_result = await bluesky_ingester.ingest_posts(
+                ingest_result, placed_items = await bluesky_ingester.ingest_posts(
                     args.url,
                     client=client,
                 )
+
+                # 投稿内 URL の自動取り込み（仕様: 投稿取得フロー（rag_add_bluesky））。
+                # placed_items は _suppress_youtube_reingest=False で渡されるため、
+                # force_youtube_reingest 設定の値に関わらず YouTube/Web ともに取り込まれる
+                if placed_items:
+                    youtube_ingester = _create_youtube_ingester_cli(controller.source_store, settings)
+                    url_stats = await bluesky_ingester.follow_urls(
+                        placed_items,
+                        youtube_ingester=youtube_ingester,
+                        result=ingest_result,
+                    )
         except (ValueError, TypeError) as e:
             if json_out:
                 _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
@@ -2651,7 +2688,13 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
             progress_callback=_output_progress if json_out else None,
             concurrency=settings.rag_embedding_concurrency,
         )
-        _print_ingest_result(ingest_result, pipeline_summary, context="BlueSky ingest", json_output=json_out)
+        _emit_bluesky_result(
+            json_out=json_out,
+            ingest_result=ingest_result,
+            pipeline_summary=pipeline_summary,
+            url_stats=url_stats,
+            context="BlueSky ingest",
+        )
 
 
 async def run_ingest_zenn(args: argparse.Namespace) -> None:

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -406,23 +406,29 @@ class BlueskyIngester:
 
                 total_processed += 1
 
-                placed_ok = await self._place_single_post(
+                place_outcome = await self._place_single_post(
                     item,
                     is_repost=is_repost,
                     force=force,
                     client=client,
                     result=result,
                     seen_paths=seen_paths,
-                    placed_items=placed_items,
                 )
 
-                if progress_callback is not None and placed_ok is not None:
-                    post = item.get("post", {})
-                    author = post.get("author", {})
-                    post_uri = post.get("uri", "")
-                    rkey = post_uri.rsplit("/", 1)[-1] if "/" in post_uri else ""
-                    bsky_url = f"https://bsky.app/profile/{author.get('handle', '')}/post/{rkey}"
-                    progress_callback(total_processed, effective_max, bsky_url)
+                if place_outcome is not None:
+                    placed_ok, is_overwrite = place_outcome
+                    if placed_ok:
+                        # 上書き投稿の YouTube URL は force_youtube_reingest 設定で抑制可
+                        placed_items.append(
+                            {**item, "_suppress_youtube_reingest": is_overwrite},
+                        )
+                    if progress_callback is not None:
+                        post = item.get("post", {})
+                        author = post.get("author", {})
+                        post_uri = post.get("uri", "")
+                        rkey = post_uri.rsplit("/", 1)[-1] if "/" in post_uri else ""
+                        bsky_url = f"https://bsky.app/profile/{author.get('handle', '')}/post/{rkey}"
+                        progress_callback(total_processed, effective_max, bsky_url)
 
             # 次ページの確認
             cursor = data.get("cursor")
@@ -444,12 +450,18 @@ class BlueskyIngester:
         client: ConstrainedClient,
         result: IngestResult,
         seen_paths: set[str] | None = None,
-        placed_items: list[dict[str, Any]] | None = None,
-    ) -> bool | None:
+    ) -> tuple[bool, bool] | None:
         """単一投稿を source_store に配置する.
 
+        placed_items の組み立ては呼び出し側の責務とする。本関数は配置結果（成功可否と
+        既存ファイル上書きだったかの事実）のみを返す。呼び出し側は用途に応じて
+        ``_suppress_youtube_reingest`` 等のポリシーフラグを決定し、placed_items を
+        構築する。
+
         Returns:
-            True: 配置成功, False: 配置失敗, None: スキップ
+            (placed_ok, is_overwrite) のタプル、またはスキップ時は None。
+            placed_ok=True なら配置成功、False なら配置失敗。
+            is_overwrite はファイル配置の事実（既存ファイルを上書きしたか）。
         """
         post = item.get("post", {})
         post_uri = post.get("uri", "")
@@ -549,10 +561,6 @@ class BlueskyIngester:
                 result.overwritten += 1
             else:
                 result.placed += 1
-            if placed_items is not None:
-                placed_items.append(
-                    {**item, "_is_overwrite": is_overwrite},
-                )
         except Exception as exc:
             logger.exception("投稿の配置に失敗しました: %s", rel_path)
             result.errors += 1
@@ -563,7 +571,7 @@ class BlueskyIngester:
                     "message": str(exc),
                 },
             )
-            return False
+            return False, is_overwrite
 
         if has_images or has_video:
             media_dir = (
@@ -583,22 +591,32 @@ class BlueskyIngester:
                 rel_path=rel_path,
             )
 
-        return True
+        return True, is_overwrite
 
     async def ingest_posts(
         self,
         urls: list[str],
         *,
         client: ConstrainedClient,
-    ) -> IngestResult:
+    ) -> tuple[IngestResult, list[dict[str, Any]]]:
         """指定 URL の BlueSky 投稿を取得して source_store に配置する.
 
-        仕様: docs/specs/ingesters/bluesky.md
+        仕様: docs/specs/ingesters/bluesky.md「投稿取得フロー（rag_add_bluesky）」
+
+        投稿配置完了後、呼び出し側が `follow_urls` を実行することで投稿内 URL の
+        自動取り込みが走る。`rag_add_bluesky` はピンポイント修復用途のため、
+        placed_items の各 item には ``_suppress_youtube_reingest=False`` を付与する。
+        これにより follow_urls 側で常に取り込み対象となり、`force_youtube_reingest`
+        設定の値に関わらず YouTube URL を常に再取得する。
+
+        Returns:
+            (配置結果, 配置済みフィードアイテムのリスト)
         """
         result = IngestResult()
+        placed_items: list[dict[str, Any]] = []
 
         if not urls:
-            return result
+            return result, placed_items
 
         parsed: list[tuple[str, str]] = []
         for url in urls:
@@ -617,7 +635,7 @@ class BlueskyIngester:
             parsed.append(hr)
 
         if not parsed:
-            return result
+            return result, placed_items
 
         # handle → DID 解決（同一 handle はまとめる）
         handle_to_did: dict[str, str] = {}
@@ -691,19 +709,25 @@ class BlueskyIngester:
             post_obj = posts[0]
             item: dict[str, Any] = {"post": post_obj, "reason": None}
 
-            await self._place_single_post(
+            place_outcome = await self._place_single_post(
                 item,
                 is_repost=False,
                 force=True,
                 client=client,
                 result=result,
             )
+            if place_outcome is not None and place_outcome[0]:
+                # ピンポイント修復用途のため、新規/上書きいずれも抑制対象外として記録し、
+                # follow_urls 側で常に取り込み対象とする
+                placed_items.append(
+                    {**item, "_suppress_youtube_reingest": False},
+                )
 
         logger.info(
             "BlueSky ingest_posts completed: placed=%d, overwritten=%d, errors=%d",
             result.placed, result.overwritten, result.errors,
         )
-        return result
+        return result, placed_items
 
     async def _download_media(
         self,
@@ -1050,14 +1074,15 @@ class BlueskyIngester:
         Web URL は CLI の site-ingest コマンド（複数 URL モード）でバッチ取得する。
         YouTube URL は個別に YoutubeIngester で取り込む。
 
-        各 placed_item の ``_is_overwrite`` フラグにより新規/上書きを判定する。
-        上書き投稿の YouTube URL は ``force_youtube_reingest`` が True の場合のみ
-        再取得する。新規投稿の YouTube URL は常に取り込む。
+        各 placed_item の ``_suppress_youtube_reingest`` フラグにより YouTube 抑制対象
+        判定を行う。抑制対象（True）の URL は ``force_youtube_reingest`` が True の場合
+        のみ取り込む。抑制対象外（False）の URL は常に取り込む。
 
         Args:
-            placed_items: 配置済みフィードアイテムのリスト（``_is_overwrite`` フラグ付き）
+            placed_items: 配置済みフィードアイテムのリスト
+                （``_suppress_youtube_reingest`` フラグ付き）
             youtube_ingester: YoutubeIngester インスタンス
-            force_youtube_reingest: 上書き投稿の YouTube URL を再取得するか
+            force_youtube_reingest: 抑制対象の YouTube URL を強制的に取り込むか
             result: 委譲失敗の計上先 IngestResult。指定時は errors + category="delegation"
                 を追加する（従来の stats 返却は互換維持）
 
@@ -1072,19 +1097,19 @@ class BlueskyIngester:
         }
 
         # 全投稿から URL を一括抽出・重複排除・種別分類
-        # YouTube URL は投稿の is_overwrite 情報を保持する（新規投稿由来は常に取り込むため）
-        # 同一 URL が新規と上書き両方に存在する場合は安全側（新規=取り込む）に倒す
+        # YouTube URL は投稿の suppress 情報を保持する（抑制対象外なら常に取り込むため）
+        # 同一 URL が「抑制対象」と「抑制対象外」両方に存在する場合は安全側（取り込む）に倒す
         web_urls: list[str] = []
         youtube_urls: list[str] = []
         seen: set[str] = set()
-        youtube_url_overwrite: dict[str, bool] = {}
+        youtube_url_suppressed: dict[str, bool] = {}
         for item in placed_items:
-            item_is_overwrite = item.get("_is_overwrite", False)
+            item_suppressed = item.get("_suppress_youtube_reingest", False)
             for url in extract_urls_from_item(item):
                 url_type = classify_url(url)
                 if url_type == "youtube":
-                    youtube_url_overwrite[url] = (
-                        youtube_url_overwrite.get(url, True) and item_is_overwrite
+                    youtube_url_suppressed[url] = (
+                        youtube_url_suppressed.get(url, True) and item_suppressed
                     )
                 if url not in seen:
                     seen.add(url)
@@ -1128,22 +1153,22 @@ class BlueskyIngester:
                 result.error_details.extend(web_error_details)
 
         # YouTube URL を個別取り込み（URL 間にレート制限スリープを挿入）
-        # 上書き投稿の YouTube URL は force_youtube_reingest 設定に従う
-        # 新規投稿の YouTube URL は常に取り込む
+        # 抑制対象の YouTube URL は force_youtube_reingest 設定に従う
+        # 抑制対象外の YouTube URL は常に取り込む
         if not force_youtube_reingest:
-            new_youtube_urls = [
-                u for u in youtube_urls if not youtube_url_overwrite.get(u, False)
+            target_youtube_urls = [
+                u for u in youtube_urls if not youtube_url_suppressed.get(u, False)
             ]
-            skipped_count = len(youtube_urls) - len(new_youtube_urls)
+            skipped_count = len(youtube_urls) - len(target_youtube_urls)
             if skipped_count > 0:
                 logger.info(
-                    "上書き投稿の YouTube 再取り込みは無効です"
-                    "（%d 件スキップ、新規 %d 件は取り込み）",
+                    "抑制対象の YouTube 再取り込みは無効です"
+                    "（%d 件スキップ、抑制対象外 %d 件は取り込み）",
                     skipped_count,
-                    len(new_youtube_urls),
+                    len(target_youtube_urls),
                 )
                 stats["skipped"] += skipped_count
-            youtube_urls = new_youtube_urls
+            youtube_urls = target_youtube_urls
 
         if youtube_urls:
             for i, url in enumerate(youtube_urls):

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -120,6 +120,7 @@ def _format_ingest_response(
     pipeline_summary: PipelineSummary | None,
     *,
     context: str = "",
+    url_follow: dict[str, int] | None = None,
 ) -> str:
     """IngestResult + PipelineSummary を統合レスポンスに変換する."""
     parts = [ingest_result.summary(context=context)]
@@ -133,6 +134,15 @@ def _format_ingest_response(
                 _format_pipeline_error(e) for e in pipeline_summary.errors[:5]
             )
             parts.append(f"パイプラインエラー: {len(pipeline_summary.errors)}件 ({details})")
+    if url_follow:
+        web_n = url_follow.get("web_placed", 0)
+        yt_n = url_follow.get("youtube_placed", 0)
+        err_n = url_follow.get("errors", 0)
+        if web_n > 0 or yt_n > 0 or err_n > 0:
+            seg = [f"URL 自動取り込み: Web {web_n}件, YouTube {yt_n}件"]
+            if err_n > 0:
+                seg.append(f"エラー {err_n}件")
+            parts.append(" ".join(seg))
     return " / ".join(parts)
 
 
@@ -1316,7 +1326,18 @@ def _format_cli_ingest_result(
     pipeline_data = result.get("pipeline")
     pipeline_summary = _parse_pipeline_summary(pipeline_data) if pipeline_data else None
 
-    return _format_ingest_response(ingest_result, pipeline_summary, context=context)
+    url_follow_data = result.get("url_follow")
+    url_follow: dict[str, int] | None = None
+    if isinstance(url_follow_data, dict):
+        url_follow = {
+            "web_placed": int(url_follow_data.get("web_placed", 0)),
+            "youtube_placed": int(url_follow_data.get("youtube_placed", 0)),
+            "errors": int(url_follow_data.get("errors", 0)),
+        }
+
+    return _format_ingest_response(
+        ingest_result, pipeline_summary, context=context, url_follow=url_follow,
+    )
 
 
 def _parse_pipeline_summary(data: dict[str, Any]) -> PipelineSummary | None:

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -1094,7 +1094,7 @@ class TestFollowUrlsYoutubeOverwrite:
     ) -> None:
         """上書き投稿かつ force_youtube_reingest=False で YouTube がスキップされること."""
         item = _make_feed_item()
-        item["_is_overwrite"] = True
+        item["_suppress_youtube_reingest"] = True
         item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1128,7 +1128,7 @@ class TestFollowUrlsYoutubeOverwrite:
     ) -> None:
         """上書き投稿かつ force_youtube_reingest=True で YouTube が再取り込みされること."""
         item = _make_feed_item()
-        item["_is_overwrite"] = True
+        item["_suppress_youtube_reingest"] = True
         item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1161,7 +1161,7 @@ class TestFollowUrlsYoutubeOverwrite:
     ) -> None:
         """新規投稿の YouTube URL は force_youtube_reingest=False でも取り込まれること."""
         item = _make_feed_item()
-        item["_is_overwrite"] = False
+        item["_suppress_youtube_reingest"] = False
         item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1195,7 +1195,7 @@ class TestFollowUrlsYoutubeOverwrite:
     ) -> None:
         """新規と上書きが混在する場合、新規の YouTube のみ取り込まれること."""
         new_item = _make_feed_item()
-        new_item["_is_overwrite"] = False
+        new_item["_suppress_youtube_reingest"] = False
         new_item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -1208,7 +1208,7 @@ class TestFollowUrlsYoutubeOverwrite:
         ]
 
         overwrite_item = _make_feed_item()
-        overwrite_item["_is_overwrite"] = True
+        overwrite_item["_suppress_youtube_reingest"] = True
         overwrite_item["post"]["record"]["facets"] = [
             {
                 "features": [
@@ -2217,13 +2217,16 @@ class TestIngestPosts:
         client = AsyncMock()
         client.get = AsyncMock(side_effect=[resolve_resp, posts_resp])
 
-        result = await ingester.ingest_posts(
+        result, placed_items = await ingester.ingest_posts(
             ["https://bsky.app/profile/alice.bsky.social/post/xyz789"],
             client=client,
         )
 
         assert result.placed == 1
         assert result.errors == 0
+        assert len(placed_items) == 1
+        # ピンポイント修復用途のため新規扱いで記録される
+        assert placed_items[0]["_suppress_youtube_reingest"] is False
 
     @pytest.mark.asyncio
     async def test_ingest_invalid_url_reports_error(self, source_store: SourceStore) -> None:
@@ -2231,13 +2234,14 @@ class TestIngestPosts:
         ingester = make_bluesky_ingester(source_store)
         client = AsyncMock()
 
-        result = await ingester.ingest_posts(
+        result, placed_items = await ingester.ingest_posts(
             ["https://example.com/not-bluesky"],
             client=client,
         )
 
         assert result.errors == 1
         assert result.error_details[0]["category"] == "metadata_fetch"
+        assert placed_items == []
 
     @pytest.mark.asyncio
     async def test_ingest_deleted_post_reports_error(self, source_store: SourceStore) -> None:
@@ -2255,13 +2259,14 @@ class TestIngestPosts:
         client = AsyncMock()
         client.get = AsyncMock(side_effect=[resolve_resp, posts_resp])
 
-        result = await ingester.ingest_posts(
+        result, placed_items = await ingester.ingest_posts(
             ["https://bsky.app/profile/alice.bsky.social/post/deleted123"],
             client=client,
         )
 
         assert result.errors == 1
         assert "not found" in result.error_details[0]["message"].lower()
+        assert placed_items == []
 
     @pytest.mark.asyncio
     async def test_ingest_multiple_urls(self, source_store: SourceStore) -> None:
@@ -2290,7 +2295,7 @@ class TestIngestPosts:
         client = AsyncMock()
         client.get = AsyncMock(side_effect=[resolve_resp, posts_resp_ok, posts_resp_empty])
 
-        result = await ingester.ingest_posts(
+        result, placed_items = await ingester.ingest_posts(
             [
                 "https://bsky.app/profile/alice.bsky.social/post/ok1",
                 "https://bsky.app/profile/alice.bsky.social/post/deleted1",
@@ -2300,6 +2305,7 @@ class TestIngestPosts:
 
         assert result.placed == 1
         assert result.errors == 1
+        assert len(placed_items) == 1
 
     @pytest.mark.asyncio
     async def test_ingest_empty_urls_returns_empty_result(self, source_store: SourceStore) -> None:
@@ -2307,7 +2313,213 @@ class TestIngestPosts:
         ingester = make_bluesky_ingester(source_store)
         client = AsyncMock()
 
-        result = await ingester.ingest_posts([], client=client)
+        result, placed_items = await ingester.ingest_posts([], client=client)
 
         assert result.placed == 0
         assert result.errors == 0
+        assert placed_items == []
+
+    @pytest.mark.asyncio
+    async def test_ingest_post_with_youtube_url_is_followed_regardless_of_force_setting(
+        self, source_store: SourceStore,
+    ) -> None:
+        """ingest_posts 経由の YouTube URL は force_youtube_reingest=False でも常に取り込まれる.
+
+        仕様: docs/specs/ingesters/bluesky.md
+        投稿取得フロー（rag_add_bluesky）でピンポイント修復の意図を満たすため、
+        placed_items は _suppress_youtube_reingest=False で渡され、follow_urls 側で新規扱いとなる。
+        """
+        ingester = make_bluesky_ingester(source_store)
+
+        resolve_resp = MagicMock()
+        resolve_resp.json.return_value = {"did": "did:plc:abc123"}
+        resolve_resp.is_success = True
+
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        posts_resp = MagicMock()
+        posts_resp.json.return_value = {
+            "posts": [{
+                "uri": "at://did:plc:abc123/app.bsky.feed.post/withlink",
+                "cid": "cid-yt",
+                "author": {"did": "did:plc:abc123", "handle": "alice.bsky.social", "displayName": "Alice"},
+                "record": {
+                    "text": "Check this video!",
+                    "createdAt": "2026-01-15T09:00:00Z",
+                    "facets": [
+                        {
+                            "features": [
+                                {
+                                    "$type": "app.bsky.richtext.facet#link",
+                                    "uri": youtube_url,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }],
+        }
+        posts_resp.is_success = True
+
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=[resolve_resp, posts_resp])
+
+        result, placed_items = await ingester.ingest_posts(
+            ["https://bsky.app/profile/alice.bsky.social/post/withlink"],
+            client=client,
+        )
+
+        assert result.placed == 1
+        assert len(placed_items) == 1
+
+        # YouTube インジェスターのモック
+        youtube_ingester = MagicMock()
+        youtube_ingester.request_interval = 0.0
+        yt_result = MagicMock()
+        yt_result.placed = 1
+        yt_result.errors = 0
+        youtube_ingester.ingest_video = AsyncMock(return_value=yt_result)
+
+        # force_youtube_reingest=False でも、_suppress_youtube_reingest=False のため取り込まれる
+        stats = await ingester.follow_urls(
+            placed_items,
+            youtube_ingester=youtube_ingester,
+            force_youtube_reingest=False,
+        )
+
+        assert stats["youtube_placed"] == 1
+        assert stats["skipped"] == 0
+        youtube_ingester.ingest_video.assert_awaited_once_with(video_url=youtube_url)
+
+    @pytest.mark.asyncio
+    async def test_ingest_post_with_web_url_is_followed_via_site_ingest(
+        self, source_store: SourceStore,
+    ) -> None:
+        """ingest_posts 経由の Web URL は site_ingest（複数 URL モード）に委譲される.
+
+        Issue #681 のテスト方針:
+        rag_add_bluesky で Web URL を含む投稿を指定 → site_ingest 経由の取り込みが走ること
+        """
+        ingester = make_bluesky_ingester(source_store)
+
+        resolve_resp = MagicMock()
+        resolve_resp.json.return_value = {"did": "did:plc:abc123"}
+        resolve_resp.is_success = True
+
+        web_url = "https://example.com/article-to-repair"
+        posts_resp = MagicMock()
+        posts_resp.json.return_value = {
+            "posts": [{
+                "uri": "at://did:plc:abc123/app.bsky.feed.post/withweb",
+                "cid": "cid-web",
+                "author": {"did": "did:plc:abc123", "handle": "alice.bsky.social", "displayName": "Alice"},
+                "record": {
+                    "text": "Article link",
+                    "createdAt": "2026-01-15T09:00:00Z",
+                    "embed": {
+                        "$type": "app.bsky.embed.external",
+                        "external": {
+                            "uri": web_url,
+                            "title": "Sample Article",
+                            "description": "An article",
+                        },
+                    },
+                },
+            }],
+        }
+        posts_resp.is_success = True
+
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=[resolve_resp, posts_resp])
+
+        result, placed_items = await ingester.ingest_posts(
+            ["https://bsky.app/profile/alice.bsky.social/post/withweb"],
+            client=client,
+        )
+
+        assert result.placed == 1
+        assert len(placed_items) == 1
+
+        with patch.object(
+            ingester, "_fetch_web_urls",
+            new=AsyncMock(return_value=(1, 0, [])),
+        ) as mock_fetch:
+            stats = await ingester.follow_urls(placed_items)
+
+        assert stats["web_placed"] == 1
+        assert stats["errors"] == 0
+        mock_fetch.assert_awaited_once_with([web_url])
+
+    @pytest.mark.asyncio
+    async def test_ingest_post_overwrite_keeps_suppress_false(
+        self, source_store: SourceStore,
+    ) -> None:
+        """既存ファイルがある状態で ingest_posts を呼んでも _suppress_youtube_reingest=False が維持される.
+
+        ピンポイント修復用途の核心仕様: 上書きであっても YouTube URL を抑制しない。
+        """
+        ingester = make_bluesky_ingester(source_store)
+
+        # 事前に同じ rkey のファイルを配置（上書き対象を作る）
+        existing_dir = source_store.root_dir / "bluesky" / "did：plc：abc123" / "2026" / "01"
+        existing_dir.mkdir(parents=True, exist_ok=True)
+        (existing_dir / "overwrite1.json").write_text("{\"old\": true}", encoding="utf-8")
+
+        resolve_resp = MagicMock()
+        resolve_resp.json.return_value = {"did": "did:plc:abc123"}
+        resolve_resp.is_success = True
+
+        youtube_url = "https://www.youtube.com/watch?v=DummyVidA09"
+        posts_resp = MagicMock()
+        posts_resp.json.return_value = {
+            "posts": [{
+                "uri": "at://did:plc:abc123/app.bsky.feed.post/overwrite1",
+                "cid": "cid-ow",
+                "author": {"did": "did:plc:abc123", "handle": "alice.bsky.social", "displayName": "Alice"},
+                "record": {
+                    "text": "Updated post with YouTube link",
+                    "createdAt": "2026-01-15T09:00:00Z",
+                    "facets": [
+                        {
+                            "features": [
+                                {
+                                    "$type": "app.bsky.richtext.facet#link",
+                                    "uri": youtube_url,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }],
+        }
+        posts_resp.is_success = True
+
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=[resolve_resp, posts_resp])
+
+        result, placed_items = await ingester.ingest_posts(
+            ["https://bsky.app/profile/alice.bsky.social/post/overwrite1"],
+            client=client,
+        )
+
+        # 上書き動作になっている
+        assert result.overwritten == 1
+        assert result.placed == 0
+        # 上書きであっても抑制対象外として記録される（ピンポイント修復用途）
+        assert len(placed_items) == 1
+        assert placed_items[0]["_suppress_youtube_reingest"] is False
+
+        # follow_urls で YouTube が取り込まれる（force_youtube_reingest=False でも）
+        youtube_ingester = MagicMock()
+        youtube_ingester.request_interval = 0.0
+        youtube_ingester.ingest_video = AsyncMock(
+            return_value=MagicMock(placed=1, errors=0),
+        )
+
+        stats = await ingester.follow_urls(
+            placed_items,
+            youtube_ingester=youtube_ingester,
+            force_youtube_reingest=False,
+        )
+
+        assert stats["youtube_placed"] == 1
+        assert stats["skipped"] == 0

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -842,6 +842,43 @@ class TestFormatCliIngestResult:
         text = mod._format_cli_ingest_result(result)
         assert "1件配置" in text
 
+    def test_with_url_follow(self) -> None:
+        """url_follow キーがあれば Web/YouTube 件数が含まれること.
+
+        BlueSky 系（rag_crawl_bluesky / rag_add_bluesky）の CLI が出力する
+        url_follow 統計を MCP 応答に反映する。
+        """
+        mod = import_module("rag.server")
+        result = {
+            "placed": 1, "skipped": 0, "overwritten": 0,
+            "errors": 0, "error_details": [],
+            "url_follow": {
+                "web_placed": 3,
+                "youtube_placed": 2,
+                "errors": 1,
+            },
+        }
+        text = mod._format_cli_ingest_result(result)
+        assert "URL 自動取り込み" in text
+        assert "Web 3件" in text
+        assert "YouTube 2件" in text
+        assert "エラー 1件" in text
+
+    def test_with_empty_url_follow(self) -> None:
+        """url_follow が全て 0 の場合は URL セクションが出力されないこと."""
+        mod = import_module("rag.server")
+        result = {
+            "placed": 1, "skipped": 0, "overwritten": 0,
+            "errors": 0, "error_details": [],
+            "url_follow": {
+                "web_placed": 0,
+                "youtube_placed": 0,
+                "errors": 0,
+            },
+        }
+        text = mod._format_cli_ingest_result(result)
+        assert "URL 自動取り込み" not in text
+
 
 class TestRagDeleteTool:
     """rag_delete ツールのテスト（CLI サブプロセス移行後）."""


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

Issue #656 で要件定義された `rag_add_bluesky` の本来の振る舞いを実現するため、投稿配置完了後に投稿内 URL の自動取り込みフェーズを実行するよう修正。あわせて `_place_single_post` の責務縮小と placed_items キー名の意味分離リファクタを実施。

- `_place_single_post` 責務縮小: `(placed_ok, is_overwrite)` を返すのみに変更し、placed_items 組み立ては呼び出し側に移譲
- placed_items キー名を `_is_overwrite` から `_suppress_youtube_reingest` にリネーム（ファイル配置の事実と YouTube 抑制対象判定の意味を分離）
- `ingest_posts` 経由は `_suppress_youtube_reingest=False`（ピンポイント修復のため抑制対象外）で組み立てて follow_urls を呼び出し
- `run_ingest_bluesky` に follow_urls 呼び出しを追加し、`_emit_bluesky_result` ヘルパーで `run_crawl_bluesky` と出力ロジックを共通化
- MCP 応答に「URL 自動取り込み: Web N件, YouTube N件」フォーマットを反映 (`_format_ingest_response` の url_follow 引数追加)
- 仕様書から「投稿内 URL の自動取り込みは実行しない」制約を削除し、投稿取得フロー（rag_add_bluesky）に mermaid 図と想定プロファイルを追加。アンカーリンク化・ツール名表記統一も実施
- qa スキル C) SNS グループに ingest-bluesky テスト C-4/C-5 を追加

## Test plan

- [x] ruff / mypy 全件パス
- [x] pytest 1759 件パス（新規 5 件含む: ingest_posts URL follow / Web 委譲 / 上書きケース / MCP 応答 url_follow 表示 2 件）
- [x] Phase 3 QA: MCP rag_add_bluesky で BlueSky 投稿配置 + url_follow フォーマット表示を確認（OK）
- [ ] Phase 3 QA 残: site_ingest 委譲経路は別 Issue #686 で QA 検証を継続（subprocess ロック競合バグを発見し別 Issue 化）
- [ ] YouTube URL を含む投稿の検証は Issue #683 (YouTube mock 基盤) 整備後に実施

## Related issues

Closes #681

関連:
- #656 — 元の要件定義（本制約の記載なし）
- #657 — 制約が混入したコミット
- #686 — site-ingest subprocess 失敗（本 PR の Phase 3 QA で検出、QA 検証項目を持ち越し）
- #683 — YouTube mock 基盤（YouTube 検証を持ち越し）

🤖 Generated with [Claude Code](https://claude.com/claude-code)