### PR TITLE
docs(qa-skill): CHROMADB_AUTO_START の記述を実運用に合わせる

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -55,7 +55,7 @@ QA 検証グループ:
    - 配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`
 3. メインリポジトリから `.env` をコピーする
 4. ストレージパスは相対パスのため worktree ディレクトリ基準で解決される（書き換え不要）。以下を確認・設定する:
-   - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
+   - `CHROMADB_AUTO_START` はデフォルト（`true`）のままでよい（`ChromaDBServerManager` は起動前に heartbeat チェックを行い、既存インスタンスが応答すれば起動をスキップするため競合しない）
    - ポート競合時（前セッションの停止漏れ等）は `CHROMADB_SERVER_PORT` を変更すること
 5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 6. `.tmp` ディレクトリを作成する

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -114,7 +114,7 @@ QA 検証グループ:
 2. worktree を作成する（配置: リポジトリの親ディレクトリ、命名: `<リポジトリ名>-wt-<Issue番号>`）
 3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する。以下も設定する:
    - `CHROMADB_SERVER_PORT=8001`（メインリポジトリの MCP サーバーとのポート競合回避）
-   - `CHROMADB_AUTO_START=false`（worktree では手動起動するため。`true` のままだと MCP サーバー起動時に競合する可能性がある）
+   - `CHROMADB_AUTO_START` はデフォルト（`true`）のままでよい（`ChromaDBServerManager` は起動前に heartbeat チェックを行い、既存インスタンスが応答すれば起動をスキップするため競合しない）
 4. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
 5. `.tmp` ディレクトリを作成する
 6. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新 ★

## Summary

- qa スキル仕様書 (`docs/specs/agentic/skills/qa-skill.md`) と SKILL.md (`.claude/skills/qa/SKILL.md`) の worktree セットアップ手順で `CHROMADB_AUTO_START=false` に変更する指示を削除
- デフォルト（`true`）のままでよい旨に変更。`ChromaDBServerManager` が起動前に heartbeat チェックを行い、既存インスタンスが応答すれば起動をスキップするため競合しない
- CLAUDE.md の worktree セットアップセクションには `CHROMADB_AUTO_START` の記載がなく、変更不要

## Test plan

- ドキュメントのみの変更のためテスト不要
- ドキュメントレビューで技術的正確性と 2 ファイル間の一貫性を確認済み

## Related issues

Closes #688

Generated with [Claude Code](https://claude.ai/code)