### PR TITLE
fix(bluesky,site-ingest): URL 自動取り込みでの二重 subprocess ロック競合を解消 (#686)

### DIFF
--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -65,8 +65,8 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 
 | 項目 | 内容 |
 |------|------|
-| 最悪ケースリクエスト数 | BlueSky API: ceil(投稿取得上限/ページサイズ) 回（ConstrainedClient バジェット消費）。URL 先取り込み: site_ingest（Scrapy subprocess）が独立して HTTP リクエストを管理するため、ConstrainedClient バジェットを消費しない |
-| 最悪ケース所要時間 | BlueSky API: リクエスト数 x リクエスト間隔（デフォルト・許容範囲は pydantic Field で定義）。URL 先取り込み: Scrapy subprocess の所要時間。直列実行のため合計時間 |
+| 最悪ケースリクエスト数 | BlueSky API: ceil(投稿取得上限/ページサイズ) 回（ConstrainedClient バジェット消費）。URL 先取り込み: site_ingest を同一プロセス内で呼び出し、site_ingest が内部で起動する Scrapy subprocess が独立して HTTP リクエストを管理するため、ConstrainedClient バジェットを消費しない |
+| 最悪ケース所要時間 | BlueSky API: リクエスト数 x リクエスト間隔（デフォルト・許容範囲は pydantic Field で定義）。URL 先取り込み: site_ingest 内部の Scrapy subprocess の所要時間。直列実行のため合計時間 |
 | 想定エラー率 | AT Protocol API 依存。リトライ機構なし。ConstrainedClient のサーキットブレーカー閾値で操作中断。中断時は取得済みデータを処理する |
 
 ### rag_add_bluesky（BlueSky 投稿ピンポイント取り込み）
@@ -75,8 +75,8 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 
 | 項目 | 内容 |
 |------|------|
-| 最悪ケースリクエスト数 | BlueSky API: `resolveHandle`（同一 handle 重複排除後の handle 数）+ `getPosts` N 回（ConstrainedClient バジェット消費）。URL 先取り込み: site_ingest（Scrapy subprocess）と YouTube インジェスター（`youtube-transcript-api` / `yt-dlp`）が独立して HTTP リクエストを管理するため、ConstrainedClient バジェットを消費しない |
-| 最悪ケース所要時間 | BlueSky API: 上記リクエスト数 × リクエスト間隔（pydantic Field 定義）。URL 先取り込み: Scrapy subprocess + YouTube `M_yt` 件分（URL 間に `rag_youtube_request_interval` 秒のスリープを挿入）の合計。直列実行のため合計時間 |
+| 最悪ケースリクエスト数 | BlueSky API: `resolveHandle`（同一 handle 重複排除後の handle 数）+ `getPosts` N 回（ConstrainedClient バジェット消費）。URL 先取り込み: site_ingest を同一プロセス内で呼び出し、site_ingest 内部の Scrapy subprocess と YouTube インジェスター（`youtube-transcript-api` / `yt-dlp`）が独立して HTTP リクエストを管理するため、ConstrainedClient バジェットを消費しない |
+| 最悪ケース所要時間 | BlueSky API: 上記リクエスト数 × リクエスト間隔（pydantic Field 定義）。URL 先取り込み: site_ingest 内部の Scrapy subprocess + YouTube `M_yt` 件分（URL 間に `rag_youtube_request_interval` 秒のスリープを挿入）の合計。直列実行のため合計時間 |
 | 想定エラー率 | AT Protocol API 依存。リトライ機構なし。ConstrainedClient のサーキットブレーカー閾値で操作中断。`getPosts` が空配列を返す（投稿削除済み）の場合は `errors` に計上し他 URL の処理は継続する |
 
 ピンポイント修復用途のため、典型的には `N` は 1〜数件、`M_yt`・`M_web` は投稿あたり数件以下の小規模な処理を想定している。タイムライン一括取り込み用途には `rag_crawl_bluesky` を使用する。
@@ -610,7 +610,11 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 1. 受け取った配置済み投稿の JSON から URL を一括抽出する
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）
 3. URL 種別を判定し、Web / YouTube / スキップに分類する
-4. Web URL を全てバッチ収集し、CLI の `site-ingest` コマンド（複数 URL モード）で 1 回の Scrapy subprocess として取り込む。`--download-only` と `--output json` を指定し、パイプライン処理は BlueSky 側で一括実行する。subprocess の JSON 出力から配置数を取得する
+4. Web URL を全てバッチ収集し、site-ingest（複数 URL モード）の Python API を直接呼び出して取り込む。
+   - 子 CLI subprocess として起動しない理由: BlueSky 取り込みの呼び出し元 CLI が既に source_store の write_lock を保持しており、子プロセス側での再取得がロック競合で失敗するため
+   - site-ingest 内部の Scrapy subprocess 起動は維持される（reactor 制約のため）
+   - bridge 結果の配置件数（新規配置と上書きの合算）とエラーを BlueSky 側の集計に反映する
+   - 後続のインデックス処理は BlueSky 側で一括実行する
 5. YouTube URL の取得対象判定:
    - 新規投稿由来の YouTube URL は常に取得する
    - 上書き投稿由来の YouTube URL は、呼び出し元から受け取った再取り込み許可フラグが `true` の場合のみ取得する
@@ -626,7 +630,7 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 
 #### 外部インジェスターとの連携
 
-- Web URL の取り込みは CLI の `site-ingest` コマンドを subprocess で呼び出す。Scrapy が独自に HTTP リクエストを管理するため、ConstrainedClient のバジェットは消費しない
+- Web URL の取り込みは site-ingest の Python API を同一プロセス内で直接呼び出す。site-ingest 内部で起動される Scrapy subprocess が独自に HTTP リクエストを管理するため、ConstrainedClient のバジェットは消費しない
 - BlueSky API 呼び出しのみ ConstrainedClient のバジェットを消費する
 - YouTube インジェスターは内部で `youtube-transcript-api` / `yt-dlp` を使用しており、ConstrainedClient は適用外
 - YouTube URL を複数処理する場合、URL 間に YouTube インジェスターの `request_interval`（デフォルト 5.0 秒）のスリープを挿入する。最後の URL の後はスリープしない。これはプレイリスト処理と同様のレート制御であり、連続リクエストによる IP ブロックを防止する
@@ -812,7 +816,8 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | YouTube URL の字幕取得に失敗 | YouTube インジェスターの既存のエラーハンドリングでスキップされる |
 | 投稿内の URL が「不正な YouTube 動画 URL」（パターン該当・video_id 形式不正） | 警告ログを出力し、いずれのインジェスターにも委譲しない。詳細は「URL 種別判定と委譲先」を参照 |
 | Web URL が 0 件の場合 | site_ingest 呼び出しをスキップする |
-| site_ingest subprocess が失敗 | エラーをログに記録し、`errors` に `delegation` カテゴリで計上する。BlueSky 投稿の取り込みには影響しない |
+| site_ingest 委譲が失敗（Scrapy subprocess の異常終了等） | エラーをログに記録し、`errors` に `delegation` カテゴリで計上する。BlueSky 投稿の取り込みには影響しない |
+| site_ingest 委譲中に bridge ステップで例外が発生（環境異常: ディスクフル・書き込み権限喪失等） | バッチ全 URL を `delegation` エラーとして計上する（Scrapy が完了していても source_store への配置が完了していないため）。Scrapy が出力した一時ディレクトリは cleanup されず残存し、次回起動時に再利用または手動削除が必要。BlueSky 投稿の取り込みには影響しない |
 | `--force` 時に上書き投稿の YouTube 再取り込みが `rag_bluesky_force_youtube_reingest` で抑制されている | 上書き投稿の YouTube URL をスキップし、Web URL とメディアのみ再取得する。新規投稿の YouTube URL は常に取り込む |
 | メディアが添付されていない投稿 | メディア DL フェーズをスキップし、JSON のみ配置する（既存動作と同じ） |
 | `rag_add_bluesky` に BlueSky 以外の URL が指定された | バリデーションエラーとして拒否する |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2551,6 +2551,8 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
                     youtube_ingester = _create_youtube_ingester_cli(controller.source_store, settings)
                     url_stats = await bluesky_ingester.follow_urls(
                         placed_items,
+                        source_store=controller.source_store,
+                        settings=settings,
                         youtube_ingester=youtube_ingester,
                         force_youtube_reingest=settings.rag_bluesky_force_youtube_reingest,
                         result=ingest_result,
@@ -2670,6 +2672,8 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
                     youtube_ingester = _create_youtube_ingester_cli(controller.source_store, settings)
                     url_stats = await bluesky_ingester.follow_urls(
                         placed_items,
+                        source_store=controller.source_store,
+                        settings=settings,
                         youtube_ingester=youtube_ingester,
                         result=ingest_result,
                     )
@@ -2925,8 +2929,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     import re
     import time as time_mod
 
-    from .scrapy.bridge import import_to_source_store
-    from .scrapy.runner import ScrapyRunner
+    from .pipeline.site_ingest_runner import execute_site_ingest
     from .utils.url import check_ssrf, validate_url
 
     json_out = _is_json_output(args)
@@ -2977,50 +2980,22 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 effective_max_pages = 1000
                 logger.warning("max_pages を 1000 にクランプしました")
 
-        # ドメイン導出
-        from urllib.parse import urlparse
-        if multi_url_mode:
-            # 複数 URL モード: 全ドメインの和集合
-            domains = []
-            for u in validated_urls:
-                hostname = urlparse(u).hostname
-                if hostname and hostname not in domains:
-                    domains.append(hostname)
-            allowed_domains = ",".join(domains)
-        else:
-            parsed = urlparse(validated_urls[0])
-            allowed_domains = parsed.hostname or ""
-
-        start_time = time_mod.monotonic()
-
-        # Scrapy Runner でクロール / 複数 URL 取得
-        runner = ScrapyRunner(
-            temp_dir=settings.site_ingest_temp_dir,
-            delay_sec=settings.site_ingest_delay_sec,
-            max_pages=effective_max_pages or settings.site_ingest_max_pages,
-            download_timeout=settings.site_ingest_download_timeout,
-            timeout_sec=settings.site_ingest_timeout_sec,
-            error_count=settings.site_ingest_error_count,
+        outer_start = time_mod.monotonic()
+        execution = await execute_site_ingest(
+            urls=validated_urls,
+            source_store=controller.source_store,
+            settings=settings,
+            url_pattern=args.url_pattern if not multi_url_mode else None,
+            max_pages=effective_max_pages,
+            force=args.force if not multi_url_mode else False,
         )
 
-        if multi_url_mode:
-            crawl_result = await runner.run(
-                start_urls=validated_urls,
-                allowed_domains=allowed_domains,
-            )
-        else:
-            crawl_result = await runner.run(
-                start_url=validated_urls[0],
-                allowed_domains=allowed_domains,
-                url_pattern=args.url_pattern,
-                max_pages=effective_max_pages,
-                force=args.force,
-            )
+        display_url = (
+            validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
+        )
 
-        display_url = validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
-
-        if not crawl_result.jsonl_path.exists():
-            elapsed = time_mod.monotonic() - start_time
+        if execution.no_output:
+            elapsed = time_mod.monotonic() - outer_start
             if json_out:
                 _output_result({
                     "placed": 0,
@@ -3028,22 +3003,18 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                     "skipped": 0,
                     "errors": 0,
                     "elapsed": round(elapsed, 1),
-                    "scrapy_exit_code": crawl_result.exit_code,
+                    "scrapy_exit_code": execution.scrapy_exit_code,
                     "no_output": True,
                 })
             else:
                 print(
                     f"クロールが完了しましたが、メタデータが出力されませんでした。"
-                    f" exit_code={crawl_result.exit_code}, 所要時間={elapsed:.1f}秒",
+                    f" exit_code={execution.scrapy_exit_code},"
+                    f" 所要時間={elapsed:.1f}秒",
                 )
             return
 
-        # Bridge: JSONL + HTML → source_store
-        bridge_result = import_to_source_store(
-            jsonl_path=crawl_result.jsonl_path,
-            html_dir=crawl_result.output_dir,
-            source_store=controller.source_store,
-        )
+        bridge_result = execution.bridge
 
         # パイプライン処理
         pipeline_summary = None
@@ -3052,24 +3023,26 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             pipeline_summary = await controller.ingest_and_index(
                 f"ingest(web): site-ingest {display_url}",
                 progress_callback=progress_cb,
-            concurrency=settings.rag_embedding_concurrency,
+                concurrency=settings.rag_embedding_concurrency,
             )
         elif has_changes and args.download_only:
             controller.commit(f"ingest(web): site-ingest {display_url} (download_only)")
 
         # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
-        if crawl_result.success:
-            crawl_result.cleanup()
+        if execution.scrapy_success and execution.crawl_result is not None:
+            execution.crawl_result.cleanup()
 
         # 操作全体の所要時間（クロール + Bridge + パイプライン）
-        elapsed = time_mod.monotonic() - start_time
+        elapsed = time_mod.monotonic() - outer_start
 
         if json_out:
-            data: dict[str, object] = _ingest_result_to_dict(bridge_result.ingest, pipeline_summary)
+            data: dict[str, object] = _ingest_result_to_dict(
+                bridge_result.ingest, pipeline_summary,
+            )
             data["elapsed"] = round(elapsed, 1)
             data["download_only"] = args.download_only
-            if not crawl_result.success:
-                data["scrapy_exit_code"] = crawl_result.exit_code
+            if not execution.scrapy_success:
+                data["scrapy_exit_code"] = execution.scrapy_exit_code
             _output_result(data)
         else:
             _print_ingest_result(
@@ -3081,8 +3054,10 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             print(f"所要時間: {elapsed:.1f}秒")
             if args.download_only:
                 print("パイプライン処理: スキップ（download_only）")
-            if not crawl_result.success:
-                print(f"Scrapy exit_code={crawl_result.exit_code}（部分的な結果）")
+            if not execution.scrapy_success:
+                print(
+                    f"Scrapy exit_code={execution.scrapy_exit_code}（部分的な結果）",
+                )
 
 
 async def run_update_aozora_catalog(args: argparse.Namespace) -> None:

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -1227,6 +1227,12 @@ class BlueskyIngester:
         プロセス内で site-ingest のコア処理を呼び出す（#686）。Scrapy 自体は
         site-ingest 内部で別 subprocess として起動される（reactor 制約のため）。
 
+        URL バリデーション (validate_url) と SSRF チェック (check_ssrf) を冒頭で
+        実施する。subprocess 経由から Python API 直呼出しに変更したことで、
+        従来 CLI ``site-ingest`` の入口で行われていた多層防御の初回チェック層が
+        欠落するため、bluesky 側で補完する（Scrapy Downloader Middleware の
+        per-request チェックは引き続き有効）。
+
         Args:
             urls: 取得対象の Web URL リスト
             source_store: 配置先の SourceStore
@@ -1234,39 +1240,80 @@ class BlueskyIngester:
 
         Returns:
             (配置されたファイル数の合計, エラー件数, errors の dict リスト)。
-            site-ingest 全体の失敗時は各 URL に category="delegation" の dict を
-            1 件ずつ生成する。
+            ``error_details`` の件数とエラー件数は常に一致する。
         """
+        from rag.utils.url import check_ssrf, validate_url
+
         logger.info("site-ingest（複数 URL モード）で %d 件の Web URL を取り込みます", len(urls))
+
+        validated_urls: list[str] = []
+        validation_errors: list[dict[str, Any]] = []
+        for url in urls:
+            try:
+                validated = validate_url(url)
+                check_ssrf(validated)
+            except ValueError as exc:
+                logger.warning("Web URL バリデーション失敗: %s (%s)", url, exc)
+                validation_errors.append(
+                    {
+                        "category": "delegation",
+                        "target": url,
+                        "url": url,
+                        "message": f"url validation failed: {exc}",
+                    },
+                )
+                continue
+            validated_urls.append(validated)
+
+        if not validated_urls:
+            return 0, len(validation_errors), validation_errors
 
         try:
             execution = await execute_site_ingest(
-                urls=urls,
+                urls=validated_urls,
                 source_store=source_store,
                 settings=settings,
             )
         except Exception as exc:
-            logger.exception("site-ingest 実行に失敗: %d 件", len(urls))
-            return 0, len(urls), [
+            logger.exception("site-ingest 実行に失敗: %d 件", len(validated_urls))
+            execute_errors = [
                 {
                     "category": "delegation",
                     "target": url,
                     "url": url,
                     "message": f"site-ingest failed: {exc}",
                 }
-                for url in urls
+                for url in validated_urls
             ]
+            all_errors = validation_errors + execute_errors
+            return 0, len(all_errors), all_errors
 
         bridge = execution.bridge
         placed = bridge.ingest.placed + bridge.ingest.overwritten
-        bridge_errors = bridge.ingest.errors + bridge.parse_errors
+        # bridge.ingest.errors は error_details に対応するエントリを持つ。
+        # bridge.parse_errors は JSONL 行単位のパースエラー件数で個別 detail を
+        # 持たないため、件数整合のため集約エントリを 1 件追加する。
+        error_details: list[dict[str, Any]] = list(bridge.ingest.error_details)
+        if bridge.parse_errors > 0:
+            error_details.append(
+                {
+                    "category": "delegation",
+                    "target": "site-ingest:jsonl",
+                    "message": (
+                        f"JSONL のパースに失敗した行が {bridge.parse_errors} 件"
+                        "あります（site-ingest 出力）"
+                    ),
+                },
+            )
+        all_error_details = validation_errors + error_details
+        total_errors = len(all_error_details)
         logger.info(
             "site-ingest 完了: 合計 %d 件配置, %d 件エラー",
-            placed, bridge_errors,
+            placed, total_errors,
         )
         # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）。
         # BlueSky 経由では bridge 完了後ただちに cleanup してよい
         # （後続のインデックス化は親 controller が一括で実行する）
         if execution.scrapy_success and execution.crawl_result is not None:
             execution.crawl_result.cleanup()
-        return placed, bridge_errors, list(bridge.ingest.error_details)
+        return placed, total_errors, all_error_details

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -12,7 +12,6 @@ import asyncio
 import json
 import logging
 import re
-import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -28,10 +27,12 @@ from rag.pipeline.ingesters._common import (
     now_iso,
 )
 from rag.pipeline.ingesters.youtube import classify_youtube_url
+from rag.pipeline.site_ingest_runner import execute_site_ingest
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from py_common_lib.httpx import ConstrainedClient
+    from rag.config import RAGSettings
     from rag.pipeline.ingesters.youtube import YoutubeIngester
     from rag.store.source_store import SourceStore
 
@@ -1063,6 +1064,8 @@ class BlueskyIngester:
         self,
         placed_items: list[dict[str, Any]],
         *,
+        source_store: SourceStore,
+        settings: RAGSettings,
         youtube_ingester: YoutubeIngester | None = None,
         force_youtube_reingest: bool = False,
         result: IngestResult | None = None,
@@ -1071,7 +1074,9 @@ class BlueskyIngester:
 
         仕様: docs/specs/ingesters/bluesky.md「投稿内 URL の自動取り込み」
 
-        Web URL は CLI の site-ingest コマンド（複数 URL モード）でバッチ取得する。
+        Web URL は site-ingest（複数 URL モード）の Python API を直接呼び出してバッチ
+        取得する。親 CLI が write_lock を保持した状態で動作させるため、subprocess
+        による二重ロック取得を避ける（#686）。
         YouTube URL は個別に YoutubeIngester で取り込む。
 
         各 placed_item の ``_suppress_youtube_reingest`` フラグにより YouTube 抑制対象
@@ -1081,6 +1086,8 @@ class BlueskyIngester:
         Args:
             placed_items: 配置済みフィードアイテムのリスト
                 （``_suppress_youtube_reingest`` フラグ付き）
+            source_store: site-ingest の配置先 SourceStore
+            settings: site-ingest のパラメータ参照用
             youtube_ingester: YoutubeIngester インスタンス
             force_youtube_reingest: 抑制対象の YouTube URL を強制的に取り込むか
             result: 委譲失敗の計上先 IngestResult。指定時は errors + category="delegation"
@@ -1141,10 +1148,10 @@ class BlueskyIngester:
 
         logger.info("投稿内から %d 件の URL を抽出しました", all_url_count)
 
-        # Web URL をバッチ取得（site-ingest 複数 URL モード、download_only）
+        # Web URL をバッチ取得（site-ingest 複数 URL モード、Python API 直呼出し）
         if web_urls:
             web_placed, web_errors, web_error_details = await self._fetch_web_urls(
-                web_urls,
+                web_urls, source_store=source_store, settings=settings,
             )
             stats["web_placed"] = web_placed
             stats["errors"] += web_errors
@@ -1207,89 +1214,59 @@ class BlueskyIngester:
         )
         return stats
 
-    # Windows コマンドライン長制限（約32K文字）を考慮したバッチサイズ
-    # URL あたり平均 ~80 文字 × 200 = ~16K文字で安全マージンを確保
-    _URL_BATCH_SIZE = 200
-
     async def _fetch_web_urls(
-        self, urls: list[str],
+        self,
+        urls: list[str],
+        *,
+        source_store: SourceStore,
+        settings: RAGSettings,
     ) -> tuple[int, int, list[dict[str, Any]]]:
-        """Web URL を site-ingest CLI subprocess（複数 URL モード）でバッチ取得する.
+        """Web URL を site-ingest（複数 URL モード）の Python API で取得する.
 
-        Windows のコマンドライン長制限を考慮し、URL リストが大きい場合は
-        バッチに分割して複数回の subprocess を実行する。
+        親プロセスが既に write_lock を保持している前提で、subprocess を介さず同一
+        プロセス内で site-ingest のコア処理を呼び出す（#686）。Scrapy 自体は
+        site-ingest 内部で別 subprocess として起動される（reactor 制約のため）。
 
         Args:
             urls: 取得対象の Web URL リスト
+            source_store: 配置先の SourceStore
+            settings: site-ingest 設定の参照元
 
         Returns:
             (配置されたファイル数の合計, エラー件数, errors の dict リスト)。
-            errors は各 URL に対し category="delegation" の dict を 1 件ずつ生成する。
+            site-ingest 全体の失敗時は各 URL に category="delegation" の dict を
+            1 件ずつ生成する。
         """
         logger.info("site-ingest（複数 URL モード）で %d 件の Web URL を取り込みます", len(urls))
 
-        total_placed = 0
-        total_errors = 0
-        error_details: list[dict[str, Any]] = []
-        for i in range(0, len(urls), self._URL_BATCH_SIZE):
-            batch = urls[i:i + self._URL_BATCH_SIZE]
-            try:
-                placed = await self._run_site_ingest_batch(batch)
-                total_placed += placed
-            except Exception as exc:
-                logger.exception(
-                    "site-ingest バッチ処理に失敗（スキップして続行）: batch_size=%d",
-                    len(batch),
-                )
-                total_errors += len(batch)
-                for url in batch:
-                    error_details.append(
-                        {
-                            "category": "delegation",
-                            "target": url,
-                            "url": url,
-                            "message": f"site-ingest batch failed: {exc}",
-                        },
-                    )
-
-        logger.info("site-ingest 完了: 合計 %d 件配置, %d 件エラー", total_placed, total_errors)
-        return total_placed, total_errors, error_details
-
-    async def _run_site_ingest_batch(
-        self, urls: list[str],
-    ) -> int:
-        """site-ingest CLI subprocess を 1 バッチ分実行する."""
-        cmd = [
-            sys.executable, "-m", "rag.cli",
-            "site-ingest", *urls, "--download-only", "--output", "json",
-        ]
-
-        process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await process.communicate()
-
-        if process.returncode != 0:
-            stderr_text = stderr.decode("utf-8", errors="replace")
-            logger.error(
-                "site-ingest subprocess が失敗: exit_code=%d, stderr=%s",
-                process.returncode, stderr_text[:500],
+        try:
+            execution = await execute_site_ingest(
+                urls=urls,
+                source_store=source_store,
+                settings=settings,
             )
-            raise RuntimeError(f"site-ingest failed with exit_code={process.returncode}")
+        except Exception as exc:
+            logger.exception("site-ingest 実行に失敗: %d 件", len(urls))
+            return 0, len(urls), [
+                {
+                    "category": "delegation",
+                    "target": url,
+                    "url": url,
+                    "message": f"site-ingest failed: {exc}",
+                }
+                for url in urls
+            ]
 
-        stdout_text = stdout.decode("utf-8", errors="replace")
-        for line in reversed(stdout_text.strip().splitlines()):
-            try:
-                data = json.loads(line)
-                if isinstance(data, dict) and data.get("type") == "result":
-                    return int(data.get("placed", 0))
-            except (json.JSONDecodeError, ValueError, TypeError):
-                continue
-
-        logger.warning(
-            "site-ingest の JSON 出力から result を取得できませんでした: %s",
-            stdout_text[:200],
+        bridge = execution.bridge
+        placed = bridge.ingest.placed + bridge.ingest.overwritten
+        bridge_errors = bridge.ingest.errors + bridge.parse_errors
+        logger.info(
+            "site-ingest 完了: 合計 %d 件配置, %d 件エラー",
+            placed, bridge_errors,
         )
-        return 0
+        # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）。
+        # BlueSky 経由では bridge 完了後ただちに cleanup してよい
+        # （後続のインデックス化は親 controller が一括で実行する）
+        if execution.scrapy_success and execution.crawl_result is not None:
+            execution.crawl_result.cleanup()
+        return placed, bridge_errors, list(bridge.ingest.error_details)

--- a/src/rag/pipeline/site_ingest_runner.py
+++ b/src/rag/pipeline/site_ingest_runner.py
@@ -1,0 +1,129 @@
+"""site-ingest 実行のコア処理（Python API）.
+
+仕様: docs/specs/site-ingest.md
+
+CLI コマンド ``site-ingest`` および BlueSky インジェスターの URL 自動取り込みから
+共通利用される。Scrapy subprocess 経由でクロール → source_store への配置までを
+実行し、git commit / インデックス化は呼び出し元の責務とする。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from ..scrapy.bridge import BridgeResult, import_to_source_store
+from ..scrapy.runner import CrawlResult, ScrapyRunner
+
+if TYPE_CHECKING:
+    from ..config import RAGSettings
+    from ..store.source_store import SourceStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SiteIngestExecution:
+    """site-ingest 実行結果.
+
+    ``crawl_result`` を保持するのは、呼び出し元がパイプライン処理の完了後に
+    ``crawl_result.cleanup()`` を呼び出せるようにするため。仕様書「処理フロー」の
+    順序（クロール → Bridge → パイプライン処理 → クリーンアップ）と整合させる。
+    所要時間は呼び出し元（CLI なら全体時間、bluesky なら集計対象外）が独自に
+    測るため、本クラスは経過時間を保持しない。
+    """
+
+    bridge: BridgeResult = field(default_factory=BridgeResult)
+    scrapy_exit_code: int = 0
+    scrapy_success: bool = True
+    no_output: bool = False
+    crawl_result: CrawlResult | None = None
+
+
+async def execute_site_ingest(
+    *,
+    urls: list[str],
+    source_store: SourceStore,
+    settings: RAGSettings,
+    url_pattern: str | None = None,
+    max_pages: int | None = None,
+    force: bool = False,
+) -> SiteIngestExecution:
+    """site-ingest のコア処理を実行する.
+
+    URL の値そのもののバリデーション（スキーム、SSRF 等）は呼び出し元で実施済み
+    である前提。本関数では空リストのみプログラミング契約として弾く。
+
+    Args:
+        urls: 取得対象 URL のリスト。**1 件以上必須**（空リストは不可）
+        source_store: 配置先の SourceStore
+        settings: 設定
+        url_pattern: URL フィルタ正規表現（クロールモードのみ有効）
+        max_pages: ページ数上限（クロールモードのみ有効）
+        force: クロールディレクトリを削除して再実行する
+
+    Returns:
+        実行結果。``bridge`` は配置結果、``scrapy_*`` は Scrapy の終了状態、
+        ``no_output`` は JSONL が出力されなかった場合に True。
+
+    Raises:
+        ValueError: ``urls`` が空リストの場合（呼び出し元の契約違反）
+    """
+    if not urls:
+        raise ValueError("urls must contain at least one URL")
+
+    multi_url_mode = len(urls) >= 2
+
+    if multi_url_mode:
+        domains: list[str] = []
+        for u in urls:
+            hostname = urlparse(u).hostname
+            if hostname and hostname not in domains:
+                domains.append(hostname)
+        allowed_domains = ",".join(domains)
+    else:
+        parsed = urlparse(urls[0])
+        allowed_domains = parsed.hostname or ""
+
+    runner = ScrapyRunner(
+        temp_dir=settings.site_ingest_temp_dir,
+        delay_sec=settings.site_ingest_delay_sec,
+        max_pages=max_pages or settings.site_ingest_max_pages,
+        download_timeout=settings.site_ingest_download_timeout,
+        timeout_sec=settings.site_ingest_timeout_sec,
+        error_count=settings.site_ingest_error_count,
+    )
+
+    if multi_url_mode:
+        crawl_result = await runner.run(
+            start_urls=urls,
+            allowed_domains=allowed_domains,
+        )
+    else:
+        crawl_result = await runner.run(
+            start_url=urls[0],
+            allowed_domains=allowed_domains,
+            url_pattern=url_pattern or "",
+            max_pages=max_pages,
+            force=force,
+        )
+
+    execution = SiteIngestExecution(
+        scrapy_exit_code=crawl_result.exit_code,
+        scrapy_success=crawl_result.success,
+        crawl_result=crawl_result,
+    )
+
+    if not crawl_result.jsonl_path.exists():
+        execution.no_output = True
+        return execution
+
+    execution.bridge = import_to_source_store(
+        jsonl_path=crawl_result.jsonl_path,
+        html_dir=crawl_result.output_dir,
+        source_store=source_store,
+    )
+
+    return execution

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -2203,7 +2203,12 @@ class TestFetchWebUrlsPythonApi:
         bridge_result.ingest.overwritten = 0
         bridge_result.ingest.errors = 1
         bridge_result.ingest.error_details = [
-            {"category": "placement", "url": "https://example.com/x", "message": "boom"},
+            {
+                "category": "placement",
+                "target": "web/https/example.com/x",
+                "url": "https://example.com/x",
+                "message": "boom",
+            },
         ]
         bridge_result.parse_errors = 0
         execution = MagicMock()
@@ -2225,8 +2230,52 @@ class TestFetchWebUrlsPythonApi:
         assert placed == 0
         assert errors == 1
         assert error_details == [
-            {"category": "placement", "url": "https://example.com/x", "message": "boom"},
+            {
+                "category": "placement",
+                "target": "web/https/example.com/x",
+                "url": "https://example.com/x",
+                "message": "boom",
+            },
         ]
+
+    async def test_parse_errors_aggregated_into_error_details(
+        self, source_store: SourceStore,
+    ) -> None:
+        """bridge.parse_errors が error_details の集約エントリ 1 件として計上され、件数整合が取れること."""
+        from rag.pipeline.ingesters._common import IngestResult
+
+        ingester = make_bluesky_ingester(source_store)
+        bridge_result = MagicMock()
+        bridge_result.ingest = IngestResult()
+        bridge_result.ingest.placed = 1
+        bridge_result.ingest.overwritten = 0
+        bridge_result.ingest.errors = 0
+        bridge_result.ingest.error_details = []
+        bridge_result.parse_errors = 3
+        execution = MagicMock()
+        execution.bridge = bridge_result
+        execution.scrapy_success = True
+        execution.crawl_result = MagicMock()
+
+        with patch(
+            "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+            new_callable=AsyncMock,
+            return_value=execution,
+        ):
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                ["https://example.com/x"],
+                source_store=source_store,
+                settings=MagicMock(),
+            )
+
+        assert placed == 1
+        # bridge_errors と error_details 件数が一致する（旧実装では parse_errors 分が
+        # error_details に出ず、呼び出し元の集計が乖離していた）
+        assert errors == len(error_details)
+        assert errors == 1
+        assert error_details[0]["category"] == "delegation"
+        assert "JSONL" in error_details[0]["message"]
+        assert "3" in error_details[0]["message"]
 
     async def test_records_delegation_failure_when_execute_raises(
         self, source_store: SourceStore,
@@ -2253,6 +2302,71 @@ class TestFetchWebUrlsPythonApi:
             assert detail["category"] == "delegation"
             assert detail["url"] == url
             assert "scrapy crashed" in detail["message"]
+
+    async def test_invalid_url_recorded_as_delegation_error_without_calling_execute(
+        self, source_store: SourceStore,
+    ) -> None:
+        """無効な URL（スキーム不正）は execute_site_ingest を呼ばず delegation エラーとして計上されること."""
+        ingester = make_bluesky_ingester(source_store)
+
+        with patch(
+            "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+            new_callable=AsyncMock,
+        ) as mock_execute:
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                ["ftp://example.com/x"],
+                source_store=source_store,
+                settings=MagicMock(),
+            )
+
+        # 全 URL が validate で弾かれた場合 execute_site_ingest は呼ばれない
+        mock_execute.assert_not_called()
+        assert placed == 0
+        assert errors == 1
+        assert error_details[0]["category"] == "delegation"
+        assert error_details[0]["url"] == "ftp://example.com/x"
+        assert "url validation failed" in error_details[0]["message"]
+
+    async def test_ssrf_url_recorded_as_delegation_error_and_valid_urls_proceed(
+        self, source_store: SourceStore,
+    ) -> None:
+        """SSRF 対象 URL は弾かれ、有効 URL のみ execute_site_ingest に渡ること."""
+        from rag.pipeline.ingesters._common import IngestResult
+
+        ingester = make_bluesky_ingester(source_store)
+        bridge_result = MagicMock()
+        bridge_result.ingest = IngestResult()
+        bridge_result.ingest.placed = 1
+        bridge_result.ingest.overwritten = 0
+        bridge_result.ingest.errors = 0
+        bridge_result.ingest.error_details = []
+        bridge_result.parse_errors = 0
+        execution = MagicMock()
+        execution.bridge = bridge_result
+        execution.scrapy_success = True
+        execution.crawl_result = MagicMock()
+
+        with patch(
+            "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+            new_callable=AsyncMock,
+            return_value=execution,
+        ) as mock_execute:
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                ["http://127.0.0.1/admin", "https://example.com/article"],
+                source_store=source_store,
+                settings=MagicMock(),
+            )
+
+        # 有効な URL のみ execute_site_ingest に渡る
+        mock_execute.assert_awaited_once()
+        called_urls = mock_execute.await_args.kwargs["urls"]
+        assert called_urls == ["https://example.com/article"]
+
+        assert placed == 1
+        assert errors == 1
+        assert error_details[0]["category"] == "delegation"
+        assert error_details[0]["url"] == "http://127.0.0.1/admin"
+        assert "url validation failed" in error_details[0]["message"]
 
 
 # ===========================================================================

--- a/tests/test_pipeline_ingesters_bluesky.py
+++ b/tests/test_pipeline_ingesters_bluesky.py
@@ -532,12 +532,19 @@ class TestFollowUrls:
         ]
 
         ingester = make_bluesky_ingester(source_store)
+        settings = MagicMock()
         with patch.object(ingester, "_fetch_web_urls", new_callable=AsyncMock, return_value=(1, 0, [])) as mock_fetch:
             stats = await ingester.follow_urls(
                 [item],
+                source_store=source_store,
+                settings=settings,
                 youtube_ingester=None,
             )
-            mock_fetch.assert_called_once_with(["https://example.com/article"])
+            mock_fetch.assert_called_once_with(
+                ["https://example.com/article"],
+                source_store=source_store,
+                settings=settings,
+            )
         assert stats["web_placed"] == 1
 
     async def test_youtube_url_delegated(self, source_store: SourceStore) -> None:
@@ -562,6 +569,8 @@ class TestFollowUrls:
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
         )
 
@@ -612,6 +621,8 @@ class TestFollowUrls:
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             stats = await ingester.follow_urls(
                 [item],
+                source_store=source_store,
+                settings=MagicMock(),
                 youtube_ingester=mock_yt,
             )
 
@@ -637,7 +648,10 @@ class TestFollowUrls:
 
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
-            [item], youtube_ingester=None,
+            [item],
+            source_store=source_store,
+            settings=MagicMock(),
+            youtube_ingester=None,
         )
 
         assert stats["skipped"] == 1
@@ -674,6 +688,8 @@ class TestFollowUrls:
         ):
             stats = await ingester.follow_urls(
                 [item],
+                source_store=source_store,
+                settings=MagicMock(),
                 youtube_ingester=None,
             )
 
@@ -694,20 +710,28 @@ class TestFollowUrls:
         item2["post"]["record"]["facets"] = [facet]
 
         ingester = make_bluesky_ingester(source_store)
+        settings = MagicMock()
         with patch.object(ingester, "_fetch_web_urls", new_callable=AsyncMock, return_value=(1, 0, [])) as mock_fetch:
             stats = await ingester.follow_urls(
                 [item1, item2],
+                source_store=source_store,
+                settings=settings,
                 youtube_ingester=None,
             )
             # URL は重複排除されるので 1 件のリストで呼ばれる
-            mock_fetch.assert_called_once_with([url])
+            mock_fetch.assert_called_once_with(
+                [url], source_store=source_store, settings=settings,
+            )
         assert stats["web_placed"] == 1
 
     async def test_empty_items(self, source_store: SourceStore) -> None:
         """配置済みアイテムが空の場合、何も実行されないこと."""
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
-            [], youtube_ingester=None,
+            [],
+            source_store=source_store,
+            settings=MagicMock(),
+            youtube_ingester=None,
         )
 
         assert stats["web_placed"] == 0
@@ -1114,6 +1138,8 @@ class TestFollowUrlsYoutubeOverwrite:
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             force_youtube_reingest=False,
         )
@@ -1149,6 +1175,8 @@ class TestFollowUrlsYoutubeOverwrite:
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             force_youtube_reingest=True,
         )
@@ -1181,6 +1209,8 @@ class TestFollowUrlsYoutubeOverwrite:
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             force_youtube_reingest=False,
         )
@@ -1228,6 +1258,8 @@ class TestFollowUrlsYoutubeOverwrite:
         ingester = make_bluesky_ingester(source_store)
         stats = await ingester.follow_urls(
             [new_item, overwrite_item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             force_youtube_reingest=False,
         )
@@ -1976,6 +2008,8 @@ class TestPartialFailureObservability:
         ):
             stats = await ingester.follow_urls(
                 [item],
+                source_store=source_store,
+                settings=MagicMock(),
                 youtube_ingester=None,
                 result=result,
             )
@@ -2009,6 +2043,8 @@ class TestPartialFailureObservability:
         result = IngestResult()
         await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             result=result,
         )
@@ -2048,6 +2084,8 @@ class TestPartialFailureObservability:
         result = IngestResult()
         stats = await ingester.follow_urls(
             [item],
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=mock_yt,
             result=result,
         )
@@ -2098,63 +2136,123 @@ class TestPartialFailureObservability:
 
 
 @pytest.mark.asyncio()
-class TestRunSiteIngestBatch:
-    """_run_site_ingest_batch の JSON パーステスト."""
+class TestFetchWebUrlsPythonApi:
+    """_fetch_web_urls が site-ingest の Python API を直接呼び出すこと.
 
-    async def test_parses_json_result(self, source_store: SourceStore) -> None:
-        """JSON Lines の result 行から placed を正しく抽出すること."""
+    仕様: docs/specs/ingesters/bluesky.md「投稿内 URL の自動取り込み」
+    背景: #686 — 二重 subprocess 構造によるロック競合を回避するため、
+    bluesky から site-ingest CLI subprocess を起動せず、Python API を直接呼ぶ。
+    """
+
+    async def test_invokes_execute_site_ingest_in_process(
+        self, source_store: SourceStore,
+    ) -> None:
+        """site-ingest が subprocess ではなく Python API として呼ばれ、配置数が返ること."""
+        from rag.pipeline.ingesters._common import IngestResult
+
         ingester = make_bluesky_ingester(source_store)
-        json_output = (
-            '{"type": "progress", "processed": 1, "total": 1, "current": "https://example.com"}\n'
-            '{"type": "result", "placed": 3, "overwritten": 0, "skipped": 1, "errors": 0, "elapsed": 1.5}\n'
+        settings = MagicMock()
+        bridge_result = MagicMock()
+        bridge_result.ingest = IngestResult()
+        bridge_result.ingest.placed = 2
+        bridge_result.ingest.overwritten = 1
+        bridge_result.parse_errors = 0
+        execution = MagicMock()
+        execution.bridge = bridge_result
+        execution.scrapy_success = True
+        execution.crawl_result = MagicMock()
+
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch(
+                "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+                new_callable=AsyncMock,
+                return_value=execution,
+            ) as mock_execute,
+        ):
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                ["https://example.com/a"],
+                source_store=source_store,
+                settings=settings,
+            )
+
+        # 重要: subprocess を起動していないこと（二重 subprocess 構造の解消）
+        mock_subprocess.assert_not_called()
+        mock_execute.assert_awaited_once_with(
+            urls=["https://example.com/a"],
+            source_store=source_store,
+            settings=settings,
         )
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
-        mock_proc.returncode = 0
+        # placed は ingest.placed + overwritten の合計
+        assert placed == 3
+        assert errors == 0
+        assert error_details == []
+        # 正常完了時は cleanup が呼ばれる
+        execution.crawl_result.cleanup.assert_called_once()
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await ingester._run_site_ingest_batch(["https://example.com"])
+    async def test_propagates_bridge_errors(
+        self, source_store: SourceStore,
+    ) -> None:
+        """bridge の行単位エラーが errors と error_details として返ること."""
+        from rag.pipeline.ingesters._common import IngestResult
 
-        assert result == 3
-
-    async def test_returns_zero_when_no_result_line(self, source_store: SourceStore) -> None:
-        """result 行がない場合 0 を返すこと."""
         ingester = make_bluesky_ingester(source_store)
-        json_output = '{"type": "progress", "processed": 1, "total": 1, "current": "x"}\n'
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
-        mock_proc.returncode = 0
+        bridge_result = MagicMock()
+        bridge_result.ingest = IngestResult()
+        bridge_result.ingest.placed = 0
+        bridge_result.ingest.overwritten = 0
+        bridge_result.ingest.errors = 1
+        bridge_result.ingest.error_details = [
+            {"category": "placement", "url": "https://example.com/x", "message": "boom"},
+        ]
+        bridge_result.parse_errors = 0
+        execution = MagicMock()
+        execution.bridge = bridge_result
+        execution.scrapy_success = True
+        execution.crawl_result = MagicMock()
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await ingester._run_site_ingest_batch(["https://example.com"])
+        with patch(
+            "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+            new_callable=AsyncMock,
+            return_value=execution,
+        ):
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                ["https://example.com/x"],
+                source_store=source_store,
+                settings=MagicMock(),
+            )
 
-        assert result == 0
+        assert placed == 0
+        assert errors == 1
+        assert error_details == [
+            {"category": "placement", "url": "https://example.com/x", "message": "boom"},
+        ]
 
-    async def test_raises_on_nonzero_exit(self, source_store: SourceStore) -> None:
-        """subprocess の exit code != 0 で RuntimeError を送出すること."""
+    async def test_records_delegation_failure_when_execute_raises(
+        self, source_store: SourceStore,
+    ) -> None:
+        """execute_site_ingest が例外送出時、各 URL を delegation エラーとして計上すること."""
         ingester = make_bluesky_ingester(source_store)
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"some error")
-        mock_proc.returncode = 1
+        urls = ["https://example.com/a", "https://example.com/b"]
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            with pytest.raises(RuntimeError, match="site-ingest failed"):
-                await ingester._run_site_ingest_batch(["https://example.com"])
+        with patch(
+            "rag.pipeline.ingesters.bluesky.execute_site_ingest",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("scrapy crashed"),
+        ):
+            placed, errors, error_details = await ingester._fetch_web_urls(
+                urls,
+                source_store=source_store,
+                settings=MagicMock(),
+            )
 
-    async def test_passes_output_json_flag(self, source_store: SourceStore) -> None:
-        """CLI コマンドに --output json フラグが含まれること."""
-        ingester = make_bluesky_ingester(source_store)
-        json_output = '{"type": "result", "placed": 0}\n'
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (json_output.encode("utf-8"), b"")
-        mock_proc.returncode = 0
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-            await ingester._run_site_ingest_batch(["https://example.com"])
-
-        cmd_args = mock_exec.call_args[0]
-        output_index = cmd_args.index("--output")
-        assert cmd_args[output_index + 1] == "json"
+        assert placed == 0
+        assert errors == 2
+        assert len(error_details) == 2
+        for detail, url in zip(error_details, urls, strict=True):
+            assert detail["category"] == "delegation"
+            assert detail["url"] == url
+            assert "scrapy crashed" in detail["message"]
 
 
 # ===========================================================================
@@ -2382,6 +2480,8 @@ class TestIngestPosts:
         # force_youtube_reingest=False でも、_suppress_youtube_reingest=False のため取り込まれる
         stats = await ingester.follow_urls(
             placed_items,
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=youtube_ingester,
             force_youtube_reingest=False,
         )
@@ -2439,15 +2539,22 @@ class TestIngestPosts:
         assert result.placed == 1
         assert len(placed_items) == 1
 
+        settings = MagicMock()
         with patch.object(
             ingester, "_fetch_web_urls",
             new=AsyncMock(return_value=(1, 0, [])),
         ) as mock_fetch:
-            stats = await ingester.follow_urls(placed_items)
+            stats = await ingester.follow_urls(
+                placed_items,
+                source_store=source_store,
+                settings=settings,
+            )
 
         assert stats["web_placed"] == 1
         assert stats["errors"] == 0
-        mock_fetch.assert_awaited_once_with([web_url])
+        mock_fetch.assert_awaited_once_with(
+            [web_url], source_store=source_store, settings=settings,
+        )
 
     @pytest.mark.asyncio
     async def test_ingest_post_overwrite_keeps_suppress_false(
@@ -2517,6 +2624,8 @@ class TestIngestPosts:
 
         stats = await ingester.follow_urls(
             placed_items,
+            source_store=source_store,
+            settings=MagicMock(),
             youtube_ingester=youtube_ingester,
             force_youtube_reingest=False,
         )

--- a/tests/test_pipeline_site_ingest_runner.py
+++ b/tests/test_pipeline_site_ingest_runner.py
@@ -1,0 +1,189 @@
+"""site_ingest_runner（site-ingest コア処理）のテスト.
+
+仕様: docs/specs/site-ingest.md
+
+テスト方針:
+- execute_site_ingest が ScrapyRunner と Bridge を正しく呼び出すこと
+- 単一 URL（クロールモード）と複数 URL（複数 URL モード）で正しい引数が渡ること
+- JSONL 未出力時の早期 return（no_output=True）
+- 空 URL リストの拒否
+- crawl_result が SiteIngestExecution に保持されること（cleanup 責務は呼び出し元）
+
+背景: #686 — site-ingest コア処理を Python API として切り出し、bluesky から
+subprocess を介さず直接呼び出せるようにした。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from settings_defaults import TEST_SETTINGS_DEFAULTS
+
+from rag.config import RAGSettings
+from rag.pipeline.ingesters._common import IngestResult
+from rag.pipeline.site_ingest_runner import execute_site_ingest
+from rag.scrapy.bridge import BridgeResult
+from rag.scrapy.runner import CrawlResult
+
+
+def _make_settings(**overrides: object) -> RAGSettings:
+    """site-ingest 関連設定を実 RAGSettings インスタンスとして返す.
+
+    pydantic Field の制約に追随させるため、共通の TEST_SETTINGS_DEFAULTS を
+    ベースに必要な site_ingest_* のみ上書きする。
+    """
+    return RAGSettings(**{**TEST_SETTINGS_DEFAULTS, **overrides})
+
+
+@pytest.mark.asyncio
+class TestExecuteSiteIngest:
+    async def test_empty_urls_raises(self) -> None:
+        """URL 0 件で ValueError を送出すること."""
+        with pytest.raises(ValueError, match="at least one URL"):
+            await execute_site_ingest(
+                urls=[],
+                source_store=MagicMock(),
+                settings=_make_settings(),
+            )
+
+    async def test_single_url_dispatches_crawl_mode(self) -> None:
+        """1 URL でクロールモード（start_url）として ScrapyRunner.run を呼ぶこと."""
+        crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/out"),
+            jsonl_path=Path("/tmp/out/nonexistent.jsonl"),
+            success=True,
+        )
+        with (
+            patch(
+                "rag.pipeline.site_ingest_runner.ScrapyRunner.run",
+                new_callable=AsyncMock,
+                return_value=crawl_result,
+            ) as mock_run,
+        ):
+            execution = await execute_site_ingest(
+                urls=["https://example.com/page"],
+                source_store=MagicMock(),
+                settings=_make_settings(),
+                url_pattern="^https://example\\.com/",
+                max_pages=10,
+                force=True,
+            )
+
+        kwargs = mock_run.await_args.kwargs
+        assert kwargs["start_url"] == "https://example.com/page"
+        assert kwargs["allowed_domains"] == "example.com"
+        assert kwargs["url_pattern"] == "^https://example\\.com/"
+        assert kwargs["max_pages"] == 10
+        assert kwargs["force"] is True
+        assert "start_urls" not in kwargs
+        assert execution.no_output is True
+        assert execution.crawl_result is crawl_result
+
+    async def test_multi_url_dispatches_multi_mode(self) -> None:
+        """2 URL 以上で複数 URL モード（start_urls）として呼ぶこと."""
+        crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/out"),
+            jsonl_path=Path("/tmp/out/nonexistent.jsonl"),
+            success=True,
+        )
+        with patch(
+            "rag.pipeline.site_ingest_runner.ScrapyRunner.run",
+            new_callable=AsyncMock,
+            return_value=crawl_result,
+        ) as mock_run:
+            execution = await execute_site_ingest(
+                urls=["https://a.example.com/x", "https://b.example.com/y"],
+                source_store=MagicMock(),
+                settings=_make_settings(),
+            )
+
+        kwargs = mock_run.await_args.kwargs
+        assert kwargs["start_urls"] == [
+            "https://a.example.com/x", "https://b.example.com/y",
+        ]
+        # ドメインの和集合
+        assert set(kwargs["allowed_domains"].split(",")) == {
+            "a.example.com", "b.example.com",
+        }
+        assert "start_url" not in kwargs
+        assert "url_pattern" not in kwargs
+        assert execution.no_output is True
+
+    async def test_invokes_bridge_when_jsonl_exists(self, tmp_path: Path) -> None:
+        """JSONL が存在する場合、Bridge を呼び出して bridge 結果を保持すること."""
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text("", encoding="utf-8")
+
+        crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+        )
+        bridge_result = BridgeResult(
+            ingest=IngestResult(placed=2, overwritten=1),
+            total_lines=3,
+            parse_errors=0,
+        )
+        source_store = MagicMock()
+
+        with (
+            patch(
+                "rag.pipeline.site_ingest_runner.ScrapyRunner.run",
+                new_callable=AsyncMock,
+                return_value=crawl_result,
+            ),
+            patch(
+                "rag.pipeline.site_ingest_runner.import_to_source_store",
+                return_value=bridge_result,
+            ) as mock_bridge,
+        ):
+            execution = await execute_site_ingest(
+                urls=["https://example.com/page"],
+                source_store=source_store,
+                settings=_make_settings(),
+            )
+
+        mock_bridge.assert_called_once_with(
+            jsonl_path=jsonl_path,
+            html_dir=tmp_path,
+            source_store=source_store,
+        )
+        assert execution.no_output is False
+        assert execution.bridge is bridge_result
+        assert execution.scrapy_success is True
+
+    async def test_does_not_cleanup_internally(self, tmp_path: Path) -> None:
+        """execute_site_ingest 自体は cleanup を呼ばない（呼び出し元の責務）."""
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text("", encoding="utf-8")
+        crawl_result = MagicMock(spec=CrawlResult)
+        crawl_result.exit_code = 0
+        crawl_result.output_dir = tmp_path
+        crawl_result.jsonl_path = jsonl_path
+        crawl_result.success = True
+
+        with (
+            patch(
+                "rag.pipeline.site_ingest_runner.ScrapyRunner.run",
+                new_callable=AsyncMock,
+                return_value=crawl_result,
+            ),
+            patch(
+                "rag.pipeline.site_ingest_runner.import_to_source_store",
+                return_value=BridgeResult(),
+            ),
+        ):
+            execution = await execute_site_ingest(
+                urls=["https://example.com/p"],
+                source_store=MagicMock(),
+                settings=_make_settings(),
+            )
+
+        crawl_result.cleanup.assert_not_called()
+        assert execution.crawl_result is crawl_result

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -474,7 +474,7 @@ class TestCliSiteIngestFlow:
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
-            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+            patch("rag.pipeline.site_ingest_runner.import_to_source_store", return_value=mock_bridge_result),
         ):
             from rag.cli import run_site_ingest
 
@@ -546,7 +546,7 @@ class TestCliSiteIngestFlow:
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
-            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+            patch("rag.pipeline.site_ingest_runner.import_to_source_store", return_value=mock_bridge_result),
         ):
             from rag.cli import run_site_ingest
 
@@ -603,7 +603,7 @@ class TestCliSiteIngestFlow:
         with (
             patch.object(ScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
-            patch("rag.scrapy.bridge.import_to_source_store", return_value=mock_bridge_result),
+            patch("rag.pipeline.site_ingest_runner.import_to_source_store", return_value=mock_bridge_result),
         ):
             from rag.cli import run_site_ingest
 


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正
- [x] refactor: リファクタリング（site-ingest コア処理を Python API として共通化）
- [x] docs: ドキュメント更新（bluesky.md）
- [x] test: テスト追加（site_ingest_runner / TestFetchWebUrlsPythonApi）

## Summary

- bluesky → site-ingest の二段目 CLI subprocess を廃止し、Python API 直呼出しに変更
- 親 CLI が保持する write_lock と子 site-ingest subprocess の write_lock 取得が競合し、`exit_code=1` で全件失敗していた問題を解消
- site-ingest コア処理（`ScrapyRunner.run` + `import_to_source_store`）を `src/rag/pipeline/site_ingest_runner.py:execute_site_ingest` として切り出し、CLI `run_site_ingest` と bluesky `_fetch_web_urls` の両方から共通利用
- site-ingest 内部で起動される Scrapy subprocess は維持（reactor 制約のため）
- 仕様書 `docs/specs/ingesters/bluesky.md` を新実装に追従させ、bridge 例外時のエッジケースを追加

## Test plan

- [x] pytest（256 件、`-n auto` 並列）全パス
- [x] ruff / mypy 全パス
- [x] code-reviewer / doc-reviewer による diff レビュー対応済み
- [x] Phase 3 QA 実施（同一セッション）:
  - MCP `rag_add_bluesky` 単発（Web URL 1 件付き投稿）→ `URL 自動取り込み: Web 1件` 確認 ✅
  - MCP `rag_add_bluesky` 上書き再実行 → `overwritten: 1` + `Web 1件` 再配置確認 ✅
  - CLI `ingest-bluesky` 同 URL 再実行 → `url_follow.web_placed=1` 確認 ✅
  - CLI `site-ingest` 単体（stat.go.jp、リファクタ回帰）→ 4 件配置・パイプライン処理完走確認 ✅
- [x] 回帰防止テスト追加: `tests/test_pipeline_ingesters_bluesky.py::TestFetchWebUrlsPythonApi::test_invokes_execute_site_ingest_in_process` で `mock_subprocess.assert_not_called()` を検証

## Related issues

Closes #686

関連:
- #685（同症状、duplicate として close 済み）
- #681（rag_add_bluesky の URL 自動取り込み有効化、本問題の発見契機）
- #692（MCP 取り込み系ツールの E2E mock 基盤整備、本 Issue 完了基準項目 3 から派生）

🤖 Generated with [Claude Code](https://claude.com/claude-code)