### PR TITLE
feat(rebuild-stats,pipeline-controller): rebuild にパス prefix フィルタを追加 (#678)

### DIFF
--- a/docs/specs/infrastructure/scheduled-rebuild.md
+++ b/docs/specs/infrastructure/scheduled-rebuild.md
@@ -28,7 +28,12 @@ HNSW グラフの劣化はインデックス側の問題であり、ソースフ
 ## 制約
 
 - **index モード限定**: 定期バッチで実行するのは `rebuild --mode index` のみ。full rebuild は手動実行とする
-- **更新判定の基準**: `pipeline_history` を参照し、最後の **未フィルタの** `index` または `full` モードの実行（`filter_source_type = ''` かつ `filter_path = ''`）以降に新しい `pipeline_history` レコード（`incremental` や filter 付き rebuild 等）が存在するかで判定する。filter 付き rebuild は subset しか触っていないため判定基準には含めない（filter 付きを「全体 rebuild 完了」と誤認するとスキップ漏れが発生する）
+- **更新判定の基準**: `pipeline_history` を参照し、最後の **未フィルタの**
+  `index` または `full` モードの実行（`filter_source_type = ''` かつ
+  `filter_path = ''`）以降に新しい `pipeline_history` レコード
+  （`incremental` や filter 付き rebuild 等）が存在するかで判定する。
+  filter 付き rebuild は subset しか触っていないため判定基準には含めない
+  （filter 付きを「全体 rebuild 完了」と誤認するとスキップ漏れが発生する）
 - **スキップ時の挙動**: 更新がない場合は rebuild を実行せず、正常終了する（exit code 0）
 - **排他制御**: 既存の rebuild ロック機構を使用する。ロック取得失敗時はエラーとする
 - **実行環境**: Windows 11 の開発マシンを前提とする
@@ -56,7 +61,14 @@ uv run python -m rag.cli rebuild --mode index --if-needed
 
 `--if-needed` は `--mode` が `index` または `full` の場合のみ有効。それ以外のモードで指定された場合はパラメータ検証エラーとする。
 
-`--if-needed` と filter（`--source-type` / `--path`）の併用はパラメータ検証エラーとする。Why: filter 付き rebuild は `pipeline_history` の filter 列に記録され、`needs_index_rebuild()` の判定対象から除外される。filter 付きで `--if-needed` を実行すると「filter スコープが古ければ rebuild される」と誤期待されやすく、実際は「未フィルタの index/full」が古ければ filter スコープで rebuild が走るという挙動の乖離が起きる。スケジューラ運用では未フィルタの `--if-needed` 実行と、アドホックな filter 付き手動 rebuild を分離して運用する。
+`--if-needed` と filter（`--source-type` / `--path`）の併用はパラメータ検証エラーとする。
+
+Why: filter 付き rebuild は `pipeline_history` の filter 列に記録され、
+`needs_index_rebuild()` の判定対象から除外される。filter 付きで `--if-needed`
+を実行すると「filter スコープが古ければ rebuild される」と誤期待されやすく、
+実際は「未フィルタの index/full」が古ければ filter スコープで rebuild が走る
+という挙動の乖離が起きる。スケジューラ運用では未フィルタの `--if-needed`
+実行と、アドホックな filter 付き手動 rebuild を分離して運用する。
 
 ### 所要時間の表示形式
 

--- a/docs/specs/infrastructure/scheduled-rebuild.md
+++ b/docs/specs/infrastructure/scheduled-rebuild.md
@@ -7,7 +7,7 @@ HNSW インデックスの品質劣化対策として、前回の index rebuild 
 スコープ:
 
 - `rebuild` コマンドの `--if-needed` オプション（条件付き実行）
-- `pipeline_history` テーブルへの `mode` 列追加（rebuild モード識別）
+- `pipeline_history` テーブルへの `mode` / `filter_source_type` / `filter_path` 列追加（rebuild モードと filter スコープの識別）
 - エラー時の Windows ダイアログ通知
 - Windows タスクスケジューラによる定期実行のセットアップ手順
 
@@ -28,7 +28,7 @@ HNSW グラフの劣化はインデックス側の問題であり、ソースフ
 ## 制約
 
 - **index モード限定**: 定期バッチで実行するのは `rebuild --mode index` のみ。full rebuild は手動実行とする
-- **更新判定の基準**: `pipeline_history` の `mode` 列を参照し、最後の `index` または `full` モードの実行以降に新しい `pipeline_history` レコード（`incremental` 等）が存在するかで判定する
+- **更新判定の基準**: `pipeline_history` を参照し、最後の **未フィルタの** `index` または `full` モードの実行（`filter_source_type = ''` かつ `filter_path = ''`）以降に新しい `pipeline_history` レコード（`incremental` や filter 付き rebuild 等）が存在するかで判定する。filter 付き rebuild は subset しか触っていないため判定基準には含めない（filter 付きを「全体 rebuild 完了」と誤認するとスキップ漏れが発生する）
 - **スキップ時の挙動**: 更新がない場合は rebuild を実行せず、正常終了する（exit code 0）
 - **排他制御**: 既存の rebuild ロック機構を使用する。ロック取得失敗時はエラーとする
 - **実行環境**: Windows 11 の開発マシンを前提とする
@@ -49,12 +49,14 @@ uv run python -m rag.cli rebuild --mode index --if-needed
 
 振る舞い:
 
-1. `pipeline_history` から最後の `index` または `full` モードのレコードを取得する
-2. そのレコードより後に他のモードのレコード（`incremental` 等）が存在するか確認する
+1. `pipeline_history` から最後の **未フィルタの** `index` または `full` モードのレコードを取得する（`filter_source_type = ''` かつ `filter_path = ''`）
+2. そのレコードより後に他のレコード（`incremental` や filter 付き rebuild 等）が存在するか確認する
 3. 存在すれば rebuild を実行、存在しなければスキップして正常終了する
-4. `pipeline_history` が空の場合（初回）は rebuild を実行する
+4. 該当レコードが空の場合（初回 / 過去の rebuild がすべて filter 付き）は rebuild を実行する
 
 `--if-needed` は `--mode` が `index` または `full` の場合のみ有効。それ以外のモードで指定された場合はパラメータ検証エラーとする。
+
+`--if-needed` と filter（`--source-type` / `--path`）の併用はパラメータ検証エラーとする。Why: filter 付き rebuild は `pipeline_history` の filter 列に記録され、`needs_index_rebuild()` の判定対象から除外される。filter 付きで `--if-needed` を実行すると「filter スコープが古ければ rebuild される」と誤期待されやすく、実際は「未フィルタの index/full」が古ければ filter スコープで rebuild が走るという挙動の乖離が起きる。スケジューラ運用では未フィルタの `--if-needed` 実行と、アドホックな filter 付き手動 rebuild を分離して運用する。
 
 ### 所要時間の表示形式
 
@@ -90,7 +92,7 @@ rebuild 実行中にエラーが発生した場合、ログ出力に加えて Wi
 ```mermaid
 flowchart TD
     START["rebuild --mode index --if-needed"]
-    GET_LAST["pipeline_history から最後の index/full レコードを取得"]
+    GET_LAST["pipeline_history から最後の未フィルタ index/full レコードを取得"]
     CHECK_EXIST{"レコードが存在する?"}
     CHECK_NEWER{"それ以降に他のレコードがある?"}
     SKIP["スキップ（正常終了）"]
@@ -112,17 +114,23 @@ flowchart TD
     ERROR_LOG --> ERROR_DIALOG
 ```
 
-### `pipeline_history` テーブルの `mode` 列
+### `pipeline_history` テーブルの `mode` / `filter_source_type` / `filter_path` 列
 
-`pipeline_history` テーブルの `mode` 列（[source-store.md](../source-store.md) で定義済み）を使用して、rebuild 実行時のモードを記録する。
+`pipeline_history` テーブルの `mode` 列（[source-store.md](../source-store.md) で定義済み）に加え、`filter_source_type` / `filter_path` 列で filter 付き rebuild のスコープを記録する。
 
-マイグレーション: `mode` 列が存在しない既存 DB に対しては `ALTER TABLE pipeline_history ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'` を実行する。既存レコードは `incremental` として扱う（安全側に倒す: index rebuild が必要と判定される）。
+マイグレーション:
 
-最後の index/full rebuild の取得:
+- `mode` 列: `ALTER TABLE pipeline_history ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'`。既存レコードは `incremental` として扱う（安全側に倒す: index rebuild が必要と判定される）
+- `filter_source_type` 列: `ALTER TABLE pipeline_history ADD COLUMN filter_source_type TEXT NOT NULL DEFAULT ''`。既存レコードは未フィルタ扱い
+- `filter_path` 列: `ALTER TABLE pipeline_history ADD COLUMN filter_path TEXT NOT NULL DEFAULT ''`。既存レコードは未フィルタ扱い
+
+最後の **未フィルタの** index/full rebuild の取得:
 
 ```
 SELECT id FROM pipeline_history
 WHERE mode IN ('index', 'full')
+  AND filter_source_type = ''
+  AND filter_path = ''
 ORDER BY id DESC LIMIT 1
 ```
 
@@ -140,7 +148,7 @@ SELECT EXISTS(
 | ファイル | 変更内容 |
 |---------|---------|
 | `src/rag/cli.py` | `--if-needed` オプション追加、所要時間の時分秒表記、エラー時 Windows ダイアログ |
-| `src/rag/store/metadata_db.py` | `pipeline_history` への `mode` 列追加、マイグレーション、判定クエリ |
+| `src/rag/store/metadata_db.py` | `pipeline_history` への `mode` / `filter_source_type` / `filter_path` 列追加、マイグレーション、判定クエリ |
 | `src/rag/pipeline/controller.py` | `pipeline_history` 記録時に `mode` を渡す |
 
 ## タスクスケジューラ設定手順

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -66,15 +66,30 @@ path フィルタの SSoT セクション。CLI / MCP インターフェース�
 | 0 件正常終了 | 配下に該当ソースが 1 件もない場合（attachment ディレクトリのみを指定した場合等。例: `bluesky/{did}/{年}/{月}/media/{rkey}/`）は対象 0 件として正常終了する。クリアも空対象のため実質 no-op |
 | attachment の暗黙解決を行わない | rebuild は明示再構築のため、attachment 単独指定時の親ソースへの暗黙解決（`find_existing_parent`）は行わない。Why: ユーザー指定パスを暗黙拡張すると意図しないソースまで対象化されるため。incremental の差分処理での attachment 取扱いとは振る舞いが異なる |
 | 正規化 | 受け取った path はバックスラッシュを `/` に変換し、両端のスラッシュを除去する |
-| 無効パスのバリデーション | 以下を満たさない path はパラメータ検証エラー: <br>- 空文字列・正規化後に空となるもの（`/`, `//` 等）<br>- 先頭が `/` で始まる絶対パス、`X:` で始まる Windows ドライブレター<br>- `..` セグメントを含むパス（パストラバーサル）<br>- `.` セグメントを含むパス（冗長表現）<br>- 先頭セグメントが既知の `source_type`（`web`/`bluesky`/`zenn`/`youtube`/`aozora`/`local`/`journal`）でないもの。SSoT は [`_schema/enums.yml`](../../_schema/enums.yml) |
-| 多層防御 | バリデーションは CLI / MCP の入口で実施し、下層（metadata.db `search_sources`/`delete_sources_by_path`、source_store `list_files`/`rebuild_db`、converter `clear`、indexer `clear`、vector_store `delete_by_source_id_prefix`、bm25_index `delete_by_source_id_prefix`）でも同じバリデータを再実施する。Why: source_store / converted_store のルート外を誤って削除・走査する事故を防ぐ |
+| 無効パスのバリデーション | 詳細は下記「無効パスのバリデーション」を参照（パラメータ検証エラー） |
+| 多層防御 | バリデーションは CLI / MCP の入口で実施し、下層（metadata.db / source_store / converter / indexer / vector_store / bm25_index の各 path 受け取り経路）でも同じバリデータを再実施する。Why: source_store / converted_store のルート外を誤って削除・走査する事故を防ぐ |
 | ChromaDB 削除の最適化 | path の先頭セグメントから `source_type` を導出し、`where={"source_type": ...}` で事前絞り込みしてから Python 側で `source_id` の prefix 一致をフィルタする。ChromaDB は metadata に対する LIKE/startswith や文字列範囲比較をサポートしないため、媒体絞り込み + Python フィルタの組み合わせでスキャン量を圧縮する |
+
+##### 無効パスのバリデーション
+
+以下を満たさない path はパラメータ検証エラーとして拒否する:
+
+- 空文字列・正規化後に空となるもの（`/`, `//` 等）
+- 先頭が `/` で始まる絶対パス、`X:` で始まる Windows ドライブレター
+- `..` セグメントを含むパス（パストラバーサル）
+- `.` セグメントを含むパス（冗長表現）
+- 先頭セグメントが既知の `source_type` でないもの
+
+`source_type` の値リストの SSoT は [`_schema/enums.yml`](../../_schema/enums.yml) を参照。
 
 #### filter 付き rebuild と --if-needed
 
 `--if-needed`（[infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) 参照）は「前回の **未フィルタの** index/full rebuild 以降に更新がなければスキップ」する判定を行う。
 
-filter 付き rebuild（`--source-type` / `--path`）は subset しか触っていないため、`pipeline_history` には `mode` に加えて `filter_source_type` / `filter_path` 列を記録し、`needs_index_rebuild()` は **両 filter 列が空**（未フィルタ）の `mode='full'` / `mode='index'` 行のみを判定基準にする。
+filter 付き rebuild（`--source-type` / `--path`）は subset しか触っていないため、
+`pipeline_history` には `mode` に加えて `filter_source_type` / `filter_path` 列を記録し、
+`needs_index_rebuild()` は **両 filter 列が空**（未フィルタ）の
+`mode='full'` / `mode='index'` 行のみを判定基準にする。
 
 Why: filter 付き rebuild を「全体 rebuild 完了」と誤認すると、配下外のソースが古いままでも `--if-needed` がスキップしてしまう。スケジューラ運用で「定期全体 rebuild」と「アドホックな部分 rebuild」を併用しても整合が取れる設計とする。
 

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -49,10 +49,34 @@
 | 操作 | 入力 | 出力 | 振る舞い |
 |------|------|------|---------|
 | 差分更新 | なし（自動検知） | 処理結果サマリ | source_store に未コミットの変更がある場合は自動コミットし、`last_commit_id` と HEAD の差分を検知して変更ファイルのみをパイプライン処理する。通常運用のデフォルト操作 |
-| 全再構築 | source_type フィルタ（任意） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合はエラー |
-| コンバートのみ再実行 | source_type フィルタ（任意） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合はエラー |
-| インデックスのみ再構築 | source_type フィルタ（任意） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラー |
+| 全再構築 | source_type フィルタ または path フィルタ（任意・排他） | 処理結果サマリ | converted_store とインデックスをクリアし、source_store 全ファイルをパイプライン処理する。source_type 指定時はその媒体のみ対象。path 指定時はそのディレクトリ配下（再帰的）のみ対象。データ破損時や大規模な設計変更時に使用。source_store に未コミットの変更がある場合はエラー |
+| コンバートのみ再実行 | source_type フィルタ または path フィルタ（任意・排他） | 処理結果サマリ | converted_store をクリアし、source_store 全ファイルをコンバーターで再処理する。source_type 指定時はその媒体のみ対象。path 指定時はそのディレクトリ配下（再帰的）のみ対象。コンバーターの変換ロジック改修時に使用。インデックスは後続のインデックス再構築で更新する。source_store に未コミットの変更がある場合はエラー |
+| インデックスのみ再構築 | source_type フィルタ または path フィルタ（任意・排他） | 処理結果サマリ | ChromaDB + BM25 をクリアし、converted_store 全ファイルからインデックスを再構築する。source_type 指定時はその媒体のインデックスのみ削除して再構築する（他の source_type のインデックスは維持）。path 指定時はそのディレクトリ配下のソースのインデックスのみ削除して再構築する（配下外のインデックスは維持）。Embedding モデル変更時やチャンクパラメータ変更時に使用。source_store に未コミットの変更がある場合はエラー |
 | 取り込み実行 | コミットメッセージ | 処理結果サマリ | インジェスター実行後の後処理を一括実行する。source_store の変更を `git add -A` + `git commit` し、差分更新を実行する。インジェスターと後続パイプライン処理を結合する便利操作 |
+
+source_type フィルタと path フィルタは排他指定で、両者を同時に指定するとパラメータ検証エラーとなる。Why: 両者は異なる粒度の絞り込みであり、同時指定の意味（AND? path 優先?）を曖昧にしないため。path は `local/unity-docs` のように source_type ディレクトリを含むパスを指定できるため表現力は損なわれない。
+
+#### path フィルタ
+
+path フィルタの SSoT セクション。CLI / MCP インターフェース定義は [rebuild-stats.md](rebuild-stats.md) を参照。
+
+| 項目 | 振る舞い |
+|------|---------|
+| 解釈 | ディレクトリ prefix。指定パス配下（再帰的な全サブディレクトリを含む）の `is_source_file == True` のソースを処理対象とする（ソース判定の SSoT は <<### ソース判定@source-store.md>>） |
+| 0 件正常終了 | 配下に該当ソースが 1 件もない場合（attachment ディレクトリのみを指定した場合等。例: `bluesky/{did}/{年}/{月}/media/{rkey}/`）は対象 0 件として正常終了する。クリアも空対象のため実質 no-op |
+| attachment の暗黙解決を行わない | rebuild は明示再構築のため、attachment 単独指定時の親ソースへの暗黙解決（`find_existing_parent`）は行わない。Why: ユーザー指定パスを暗黙拡張すると意図しないソースまで対象化されるため。incremental の差分処理での attachment 取扱いとは振る舞いが異なる |
+| 正規化 | 受け取った path はバックスラッシュを `/` に変換し、両端のスラッシュを除去する |
+| 無効パスのバリデーション | 以下を満たさない path はパラメータ検証エラー: <br>- 空文字列・正規化後に空となるもの（`/`, `//` 等）<br>- 先頭が `/` で始まる絶対パス、`X:` で始まる Windows ドライブレター<br>- `..` セグメントを含むパス（パストラバーサル）<br>- `.` セグメントを含むパス（冗長表現）<br>- 先頭セグメントが既知の `source_type`（`web`/`bluesky`/`zenn`/`youtube`/`aozora`/`local`/`journal`）でないもの。SSoT は [`_schema/enums.yml`](../../_schema/enums.yml) |
+| 多層防御 | バリデーションは CLI / MCP の入口で実施し、下層（metadata.db `search_sources`/`delete_sources_by_path`、source_store `list_files`/`rebuild_db`、converter `clear`、indexer `clear`、vector_store `delete_by_source_id_prefix`、bm25_index `delete_by_source_id_prefix`）でも同じバリデータを再実施する。Why: source_store / converted_store のルート外を誤って削除・走査する事故を防ぐ |
+| ChromaDB 削除の最適化 | path の先頭セグメントから `source_type` を導出し、`where={"source_type": ...}` で事前絞り込みしてから Python 側で `source_id` の prefix 一致をフィルタする。ChromaDB は metadata に対する LIKE/startswith や文字列範囲比較をサポートしないため、媒体絞り込み + Python フィルタの組み合わせでスキャン量を圧縮する |
+
+#### filter 付き rebuild と --if-needed
+
+`--if-needed`（[infrastructure/scheduled-rebuild.md](infrastructure/scheduled-rebuild.md) 参照）は「前回の **未フィルタの** index/full rebuild 以降に更新がなければスキップ」する判定を行う。
+
+filter 付き rebuild（`--source-type` / `--path`）は subset しか触っていないため、`pipeline_history` には `mode` に加えて `filter_source_type` / `filter_path` 列を記録し、`needs_index_rebuild()` は **両 filter 列が空**（未フィルタ）の `mode='full'` / `mode='index'` 行のみを判定基準にする。
+
+Why: filter 付き rebuild を「全体 rebuild 完了」と誤認すると、配下外のソースが古いままでも `--if-needed` がスキップしてしまう。スケジューラ運用で「定期全体 rebuild」と「アドホックな部分 rebuild」を併用しても整合が取れる設計とする。
 
 差分更新・コンバートのみ再実行・インデックスのみ再構築は処理結果サマリ（`PipelineSummary`）を返す。全再構築は convert フェーズと index フェーズそれぞれの `PipelineSummary` を保持する `FullRebuildResult` を返す。
 
@@ -127,12 +151,13 @@
 
 #### 再構築操作の未コミットチェック
 
-再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）は、未コミットの変更がある場合エラーとする。`source_type` 指定時はそのディレクトリのみをチェックする。
+再構築操作（全再構築・コンバートのみ再実行・インデックスのみ再構築）は、未コミットの変更がある場合エラーとする。`source_type` または `path` 指定時はそのディレクトリのみをチェックする。
 
-| source_type | 未コミットチェックの範囲 |
-|-------------|---------------------|
-| 指定あり | `git status --porcelain -- {source_type}/` でそのディレクトリのみチェック |
-| 指定なし | `git status --porcelain` で全体チェック |
+| 指定 | 未コミットチェックの範囲 |
+|------|---------------------|
+| `source_type` 指定あり | `git status --porcelain -- {source_type}/` でそのディレクトリのみチェック |
+| `path` 指定あり | `git status --porcelain -- {path}/` でそのディレクトリのみチェック |
+| いずれも指定なし | `git status --porcelain` で全体チェック |
 
 ### git 操作
 

--- a/docs/specs/rebuild-stats.md
+++ b/docs/specs/rebuild-stats.md
@@ -55,17 +55,20 @@
 |-----------|-----|------|------|
 | `mode` | str | はい | 再構築モード（下表参照） |
 | `source_type` | str | いいえ | 対象媒体フィルタ（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照）。未指定時は全媒体 |
+| `path` | str | いいえ | source_store ルート相対のディレクトリパス。指定したディレクトリ配下（再帰的な全サブディレクトリを含む）のソースのみを対象にする。未指定時は全パス |
 
 再構築モード:
 
-| モード値 | 対応するパイプライン操作 | `source_type` フィルタ | 用途 |
+| モード値 | 対応するパイプライン操作 | `source_type` / `path` フィルタ | 用途 |
 |---------|----------------------|----------------------|------|
 | `full` | 全再構築 | 適用可 | データ破損時や大規模な設計変更時。未コミット変更があればエラー |
 | `convert` | コンバートのみ再実行 | 適用可 | コンバーターの変換ロジック改修時。未コミット変更があればエラー |
 | `index` | インデックスのみ再構築 | 適用可 | Embedding モデル変更時やチャンクパラメータ変更時。未コミット変更があればエラー |
 | `incremental` | 差分更新 | 適用不可（git diff に従う） | 通常運用。未コミット変更は自動コミットされる |
 
-- `source_type` フィルタが適用不可のモード（`incremental`）で `source_type` が指定された場合、エラーを返す
+- `source_type` / `path` フィルタが適用不可のモード（`incremental`）でこれらが指定された場合、エラーを返す
+- `source_type` と `path` の同時指定はエラーを返す
+- `path` の解釈・正規化・バリデーション・配下解決の振る舞いは [pipeline-controller.md](pipeline-controller.md) の「path フィルタ」セクションを参照（SSoT）。本ドキュメントは CLI / MCP のインターフェース定義のみを扱う
 - 戻り値: 処理結果サマリ（処理件数、エラー件数、所要時間）をテキストで返す。`full` モードは Convert / Index の2フェーズ結果を表示する
 
 #### rag_stats（拡張）
@@ -80,13 +83,14 @@
 #### rebuild コマンド
 
 ```
-uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE>]
+uv run python -m rag.cli rebuild --mode <MODE> [--source-type <TYPE> | --path <PATH>]
 ```
 
 | オプション | 型 | 必須 | 内容 |
 |-----------|-----|------|------|
 | `--mode` | str | はい | 再構築モード: `full`、`convert`、`index`、`incremental` |
 | `--source-type` | str | いいえ | 対象媒体フィルタ（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
+| `--path` | str | いいえ | source_store ルート相対のディレクトリパス。指定したディレクトリ配下（再帰的な全サブディレクトリを含む）のソースのみを対象にする |
 | `--if-needed` | flag | いいえ | 前回の index/full rebuild 以降に更新がなければスキップする。`--mode` が `index` または `full` の場合のみ有効 |
 | `--concurrency` | int | いいえ | インデックス再構築の並列数。`.env` の `RAG_EMBEDDING_CONCURRENCY` を上書きする。`index` / `full` モードで有効。CLI 限定（MCP ツールでは `.env` の設定値が使用される） |
 
@@ -374,9 +378,12 @@ source_store のパスは [source-store.md](source-store.md) の設定項目、c
 | `CONVERTED_STORE_DIR` が未設定の場合 | `rag_stats` は converted_store セクションを「未設定」と表示する。`rag_rebuild` はエラーを返す |
 | source_store ディレクトリが存在しない場合 | `rag_stats` は source_store の各項目を 0 で表示する。`rag_rebuild` はエラーを返す |
 | 再構築中に別の再構築が要求された場合 | 後発の要求にエラーを返す（排他制御） |
-| `incremental` モードで `source_type` が指定された場合 | パラメータ検証エラーを返す |
+| `incremental` モードで `source_type` または `path` が指定された場合 | パラメータ検証エラーを返す |
+| `source_type` と `path` が同時に指定された場合 | パラメータ検証エラーを返す（排他指定） |
 | metadata.db が存在しない場合の `rag_stats` | パイプラインセクションを「未初期化」と表示する。source_store のファイルシステムベースの統計は表示する |
 | `full` モードで `source_type` が指定された場合 | metadata.db の再構築は指定 type のレコードのみ削除・再登録する。他の type のレコードは保持される。converted_store・インデックスも指定 type のみクリア・再構築する |
+| `full` / `convert` / `index` モードで `path` が指定された場合の振る舞い・無効パスのバリデーション・attachment 単独指定時の振る舞い | [pipeline-controller.md](pipeline-controller.md) の「path フィルタ」セクションを参照 |
+| `--if-needed` と filter 付き rebuild の関係 | filter 付き rebuild は subset しか触らないため `pipeline_history` の `mode='full'`/`'index'` 行であっても `--if-needed` の判定材料にはならない。詳細は [pipeline-controller.md](pipeline-controller.md) の「filter 付き rebuild と --if-needed」を参照 |
 | 再構築中にエラーが発生した場合 | パイプライン制御のエラーハンドリングに従う（エラーファイルをスキップし残りを処理続行。`pipeline_history` に履歴を追加しない） |
 
 ## 関連ドキュメント

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -569,6 +569,8 @@ source_store 内の全ファイルのメタデータ索引。
 | `to_commit_id` | TEXT | NOT NULL | 処理後のコミット ID |
 | `processed_at` | TEXT | NOT NULL | 処理日時（ISO 8601） |
 | `mode` | TEXT | NOT NULL | 実行モード: `full`, `convert`, `index`, `incremental` |
+| `filter_source_type` | TEXT | NOT NULL, DEFAULT '' | filter 付き rebuild の `source_type` フィルタ値（未フィルタは空文字列）。`--if-needed` 判定で「未フィルタの全体 rebuild」のみを参照対象にするために使用する |
+| `filter_path` | TEXT | NOT NULL, DEFAULT '' | filter 付き rebuild の `path` フィルタ値（未フィルタは空文字列）。詳細は [pipeline-controller.md](pipeline-controller.md) の「filter 付き rebuild と --if-needed」を参照 |
 
 - `last_commit_id` の取得: `SELECT to_commit_id FROM pipeline_history ORDER BY id DESC LIMIT 1`
 - 初回実行時の `from_commit_id` には git の null commit hash `0000000000000000000000000000000000000000`（40文字ゼロ）を使用する

--- a/src/rag/bm25_index.py
+++ b/src/rag/bm25_index.py
@@ -222,6 +222,31 @@ class _BM25Store:
             self._conn.commit()
         return deleted_ids
 
+    def delete_by_source_id_prefix(self, path_prefix: str) -> list[str]:
+        """source_id の prefix で削除し、削除された doc_id リストを返す.
+
+        Args:
+            path_prefix: source_store ルート相対のディレクトリパス
+        """
+        from rag.store.path_filter import escape_like, normalize_path_prefix
+
+        normalized = normalize_path_prefix(path_prefix)
+        escaped = escape_like(normalized)
+        like_pattern = f"{escaped}/%"
+        rows = self._conn.execute(
+            r"SELECT doc_id FROM chunks WHERE source_id LIKE ? ESCAPE '\'",
+            (like_pattern,),
+        ).fetchall()
+        deleted_ids = [r[0] for r in rows]
+        if deleted_ids:
+            self._conn.execute(
+                r"DELETE FROM chunks WHERE source_id LIKE ? ESCAPE '\'",
+                (like_pattern,),
+            )
+            self._delete_token_cache(deleted_ids)
+            self._conn.commit()
+        return deleted_ids
+
     def delete_stale(self, source_id: str, valid_ids: set[str]) -> list[str]:
         """source_id のチャンクのうち valid_ids に含まれないものを削除する."""
         rows = self._conn.execute(
@@ -581,6 +606,28 @@ class BM25Index:
             logger.debug(
                 "Deleted %d documents from BM25 index (source_type: %s)",
                 len(deleted_ids), source_type,
+            )
+            if not self._deferred_save:
+                self._save_bm25s()
+
+        return len(deleted_ids)
+
+    def delete_by_source_id_prefix(self, path_prefix: str) -> int:
+        """source_id の prefix 指定でドキュメントを一括削除する.
+
+        Args:
+            path_prefix: source_store ルート相対のディレクトリパス
+
+        Returns:
+            削除されたドキュメント数
+        """
+        deleted_ids = self._store.delete_by_source_id_prefix(path_prefix)
+
+        if deleted_ids:
+            self._needs_rebuild = True
+            logger.debug(
+                "Deleted %d documents from BM25 index (path: %s)",
+                len(deleted_ids), path_prefix,
             )
             if not self._deferred_save:
                 self._save_bm25s()

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -559,7 +559,17 @@ def main() -> None:
         "--source-type",
         choices=["web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"],
         default=None,
-        help="対象媒体フィルタ（incremental では指定不可）",
+        help="対象媒体フィルタ（incremental では指定不可、--path と排他）",
+    )
+    rebuild_parser.add_argument(
+        "--path",
+        default=None,
+        help=(
+            "対象パスフィルタ。source_store ルート相対のディレクトリパスを指定し、"
+            "配下（再帰的）のソースのみを対象にする。"
+            "空文字列・絶対パス・`..`/`.` を含むパスはバリデーションエラー。"
+            "incremental では指定不可、--source-type と排他"
+        ),
     )
     rebuild_parser.add_argument(
         "--commit-message",
@@ -1421,11 +1431,25 @@ async def run_rebuild(args: argparse.Namespace) -> None:
 
     json_out = _is_json_output(args)
 
+    from .store.path_filter import PathFilterError, normalize_path_prefix
+
     mode: str = args.mode
     source_type: SourceType | None = args.source_type
+    path: str | None = args.path
     if_needed: bool = args.if_needed
 
-    # incremental + source_type のバリデーション
+    # path 指定時は早期に正規化・バリデーション（空文字列・パストラバーサル拒否）
+    if path is not None:
+        try:
+            path = normalize_path_prefix(path)
+        except PathFilterError as e:
+            msg = f"--path が不正です: {e}"
+            if json_out:
+                _output_error(CliErrorCode.VALIDATION_ERROR, msg)
+            logger.error(msg)
+            sys.exit(1)
+
+    # incremental + source_type / path のバリデーション
     if mode == "incremental" and source_type is not None:
         if json_out:
             _output_error(CliErrorCode.VALIDATION_ERROR, "incremental モードでは source_type を指定できません")
@@ -1433,10 +1457,39 @@ async def run_rebuild(args: argparse.Namespace) -> None:
             "incremental モードでは source_type を指定できません"
         )
         sys.exit(1)
+    if mode == "incremental" and path is not None:
+        msg = "incremental モードでは path を指定できません"
+        if json_out:
+            _output_error(CliErrorCode.VALIDATION_ERROR, msg)
+        logger.error(msg)
+        sys.exit(1)
+    if source_type is not None and path is not None:
+        msg = "--source-type と --path は同時に指定できません"
+        if json_out:
+            _output_error(CliErrorCode.VALIDATION_ERROR, msg)
+        logger.error(msg)
+        sys.exit(1)
 
     # --if-needed は index/full のみ有効
     if if_needed and mode not in ("index", "full"):
         msg = "--if-needed は --mode index または --mode full でのみ使用できます"
+        if json_out:
+            _output_error(CliErrorCode.VALIDATION_ERROR, msg)
+        logger.error(msg)
+        sys.exit(1)
+
+    # --if-needed と filter（--source-type / --path）の併用は禁止
+    # Why: filter 付き rebuild は pipeline_history の filter 列に記録され、
+    # needs_index_rebuild() の判定対象から除外される（subset しか触っていない
+    # ため「全体 rebuild 完了」と誤認するとスキップ漏れが発生する）。
+    # filter 付きで --if-needed を実行すると「filter スコープが古ければ
+    # rebuild される」と誤期待されやすいため明示的に禁止する。
+    # 詳細は docs/specs/infrastructure/scheduled-rebuild.md を参照
+    if if_needed and (source_type is not None or path is not None):
+        msg = (
+            "--if-needed は --source-type / --path と併用できません"
+            "（filter 付き rebuild は --if-needed の判定対象外）"
+        )
         if json_out:
             _output_error(CliErrorCode.VALIDATION_ERROR, msg)
         logger.error(msg)
@@ -1507,6 +1560,8 @@ async def run_rebuild(args: argparse.Namespace) -> None:
         logger.info("再構築を開始します（モード: %s）", mode)
         if source_type:
             logger.info("対象媒体: %s", source_type)
+        if path:
+            logger.info("対象パス: %s", path)
 
         start = time.monotonic()
 
@@ -1536,18 +1591,21 @@ async def run_rebuild(args: argparse.Namespace) -> None:
         if mode == "full":
             full_result = await controller.run_full_rebuild(
                 source_type=source_type,
+                path=path,
                 progress_callback=progress_cb,
                 concurrency=concurrency,
             )
         elif mode == "convert":
             summary = await controller.run_convert_only(
                 source_type=source_type,
+                path=path,
                 progress_callback=progress_cb,
                 concurrency=concurrency,
             )
         elif mode == "index":
             summary = await controller.run_index_only(
                 source_type=source_type,
+                path=path,
                 progress_callback=progress_cb,
                 concurrency=concurrency,
             )

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -250,14 +250,29 @@ class Converter:
         self,
         converted_store_dir: Path,
         source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
     ) -> None:
         """converted_store をクリアする.
 
         Args:
             converted_store_dir: converted_store のルートディレクトリ
             source_type: 指定時はその媒体のディレクトリのみクリア
+            path: 指定時はそのディレクトリ配下（再帰的）のみクリア
+                （source_type と排他）
         """
-        if source_type is not None:
+        if source_type is not None and path is not None:
+            msg = "source_type と path は同時に指定できません"
+            raise ValueError(msg)
+        if path is not None:
+            from rag.store.path_filter import normalize_path_prefix
+
+            normalized = normalize_path_prefix(path)
+            target_dir = converted_store_dir / normalized
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+                logger.info("Cleared converted_store: %s", target_dir)
+        elif source_type is not None:
             target_dir = converted_store_dir / source_type
             if target_dir.exists():
                 shutil.rmtree(target_dir)

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -242,13 +242,25 @@ class Indexer:
             self.set_bm25_deferred_save(False)
             self.flush_bm25()
 
-    async def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(
+        self,
+        source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
+    ) -> None:
         """インデックスをクリアする.
 
         Args:
             source_type: 指定時はその媒体のみクリア
+            path: 指定時はそのディレクトリ配下（再帰的）のみクリア
+                （source_type と排他）
         """
-        if source_type is None:
+        if source_type is not None and path is not None:
+            msg = "source_type と path は同時に指定できません"
+            raise ValueError(msg)
+        if path is not None:
+            await self._clear_by_path(path)
+        elif source_type is None:
             await self._clear_all()
         else:
             await self._clear_by_source_type(source_type)
@@ -382,6 +394,16 @@ class Indexer:
         logger.info(
             "source_type=%s のインデックスをクリア (vector: %d, bm25: %d)",
             source_type, vector_count, bm25_count,
+        )
+
+    async def _clear_by_path(self, path: str) -> None:
+        """指定パス配下のインデックスを一括クリアする."""
+        vector_count = await self._vector_store.delete_by_source_id_prefix(path)
+        bm25_count = self._bm25.delete_by_source_id_prefix(path)
+
+        logger.info(
+            "path=%s 配下のインデックスをクリア (vector: %d, bm25: %d)",
+            path, vector_count, bm25_count,
         )
 
 

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -238,6 +238,7 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
+        path: str | None = None,
         progress_callback: ProgressCallback | None = None,
         concurrency: int = 1,
     ) -> FullRebuildResult:
@@ -248,26 +249,32 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
+            path: パスフィルタ（source_type と排他）。指定時は配下の
+                ソースのみを対象にする
             progress_callback: 進捗コールバック
             concurrency: convert / index フェーズの同時実行数
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+            ValueError: source_type と path が同時指定された場合
         """
+        _validate_filter_exclusivity(source_type, path)
         logger.info(
-            "Full rebuild started (source_type=%s)", source_type or "all",
+            "Full rebuild started (source_type=%s, path=%s)",
+            source_type or "all", path or "-",
         )
         self._git.init_repo()
-        self._check_uncommitted_changes(source_type)
+        self._check_uncommitted_changes(source_type, path=path)
 
         # 1. metadata.db 再構築
-        self._source_store.rebuild_db(source_type)
+        self._source_store.rebuild_db(source_type, path=path)
 
         # 2. active レコードを取得（rebuild_db が list_files 経由で登録するため、
         # is_source_file=False のファイルは DB に登録されない）
         records = list(self.db.search_sources(
             source_type=source_type,
             status="active",
+            path_prefix=path,
         ))
 
         empty_convert = PipelineSummary(
@@ -292,7 +299,7 @@ class PipelineController:
 
         # --- Phase 1: Convert ---
         logger.info("Phase 1: Convert started (%d files)", len(records))
-        self._converter.clear(self._converted_store_dir, source_type)
+        self._converter.clear(self._converted_store_dir, source_type, path=path)
 
         def _convert_single(record: SourceRecord) -> None:
             self._converter.convert(
@@ -319,7 +326,7 @@ class PipelineController:
         )
 
         # --- Phase 2: Index (convert 成功分のみ) ---
-        await self._indexer.clear(source_type)
+        await self._indexer.clear(source_type, path=path)
 
         convert_failed = convert_summary.failed_paths()
         convert_warned: set[str] = set()
@@ -390,6 +397,8 @@ class PipelineController:
                 to_commit_id=to_commit,
                 processed_at=datetime.now(timezone.utc).isoformat(),
                 mode="full",
+                filter_source_type=source_type or "",
+                filter_path=path or "",
             )
 
         return FullRebuildResult(convert=convert_summary, index=index_summary)
@@ -397,17 +406,29 @@ class PipelineController:
     def _check_uncommitted_changes(
         self,
         source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
     ) -> None:
         """source_store に未コミットの変更がないか確認する.
 
         Args:
             source_type: チェック対象の媒体ディレクトリ（None で全体）
+            path: チェック対象のディレクトリパス（source_type と排他）
 
         Raises:
             RuntimeError: 未コミットの変更がある場合
+            ValueError: source_type と path が同時指定された場合
         """
+        _validate_filter_exclusivity(source_type, path)
+        check_path: str | None
+        if path is not None:
+            from rag.store.path_filter import normalize_path_prefix
+
+            check_path = normalize_path_prefix(path)
+        else:
+            check_path = source_type
         if self._git.has_uncommitted_changes(
-            path=source_type,
+            path=check_path,
         ):
             msg = (
                 "source_store に未コミットの変更があります。"
@@ -429,6 +450,7 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
+        path: str | None = None,
         progress_callback: ProgressCallback | None = None,
         concurrency: int = 1,
     ) -> PipelineSummary:
@@ -439,27 +461,31 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
+            path: パスフィルタ（source_type と排他）
             progress_callback: 進捗コールバック
             concurrency: 同時実行数
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+            ValueError: source_type と path が同時指定された場合
         """
+        _validate_filter_exclusivity(source_type, path)
         logger.info(
-            "Convert-only rebuild started (source_type=%s)",
-            source_type or "all",
+            "Convert-only rebuild started (source_type=%s, path=%s)",
+            source_type or "all", path or "-",
         )
         self._git.init_repo()
-        self._check_uncommitted_changes(source_type)
+        self._check_uncommitted_changes(source_type, path=path)
 
         # 1. converted_store クリア
-        self._converter.clear(self._converted_store_dir, source_type)
+        self._converter.clear(self._converted_store_dir, source_type, path=path)
 
         # 2. active レコードを取得（is_source_file=False のファイルは rebuild_db で
         # 登録されないため、DB 側フィルタは不要）
         records = list(self.db.search_sources(
             source_type=source_type,
             status="active",
+            path_prefix=path,
         ))
 
         logger.info("Target files: %d", len(records))
@@ -501,6 +527,7 @@ class PipelineController:
         self,
         source_type: SourceType | None = None,
         *,
+        path: str | None = None,
         progress_callback: ProgressCallback | None = None,
         concurrency: int = 1,
     ) -> PipelineSummary:
@@ -511,25 +538,29 @@ class PipelineController:
 
         Args:
             source_type: 対象媒体フィルタ（None で全媒体）
+            path: パスフィルタ（source_type と排他）
 
         Raises:
             RuntimeError: source_store に未コミットの変更がある場合
+            ValueError: source_type と path が同時指定された場合
         """
+        _validate_filter_exclusivity(source_type, path)
         logger.info(
-            "Index-only rebuild started (source_type=%s)",
-            source_type or "all",
+            "Index-only rebuild started (source_type=%s, path=%s)",
+            source_type or "all", path or "-",
         )
         self._git.init_repo()
-        self._check_uncommitted_changes(source_type)
+        self._check_uncommitted_changes(source_type, path=path)
 
         # 1. インデックスクリア
-        await self._indexer.clear(source_type)
+        await self._indexer.clear(source_type, path=path)
 
         # 2. active なレコードを取得（is_source_file=False のファイルは DB に登録
         # されないため、フィルタは不要）
         records = list(self.db.search_sources(
             source_type=source_type,
             status="active",
+            path_prefix=path,
         ))
 
         logger.info("Target files: %d", len(records))
@@ -582,6 +613,8 @@ class PipelineController:
                 to_commit_id=to_commit,
                 processed_at=datetime.now(timezone.utc).isoformat(),
                 mode="index",
+                filter_source_type=source_type or "",
+                filter_path=path or "",
             )
 
         return summary
@@ -1154,3 +1187,13 @@ class PipelineController:
 # --- モジュールレベルユーティリティ ---
 # resolve_title / resolve_published_at は rag.store.resolve に一元化
 # source_id は file_path をそのまま使用（resolve 不要）
+
+
+def _validate_filter_exclusivity(
+    source_type: SourceType | None,
+    path: str | None,
+) -> None:
+    """source_type と path の排他性を検証する."""
+    if source_type is not None and path is not None:
+        msg = "source_type と path は同時に指定できません"
+        raise ValueError(msg)

--- a/src/rag/pipeline/protocols.py
+++ b/src/rag/pipeline/protocols.py
@@ -57,12 +57,15 @@ class ConverterProtocol(Protocol):
         self,
         converted_store_dir: Path,
         source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
     ) -> None:
         """converted_store をクリアする.
 
         Args:
             converted_store_dir: converted_store のルートディレクトリ
             source_type: 指定時はその媒体のみクリア
+            path: 指定時はそのディレクトリ配下のみクリア（source_type と排他）
         """
         ...
 
@@ -140,10 +143,16 @@ class IndexerProtocol(Protocol):
         """BM25 遅延 save のコンテキストマネージャ."""
         ...
 
-    async def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(
+        self,
+        source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
+    ) -> None:
         """インデックスをクリアする.
 
         Args:
             source_type: 指定時はその媒体のみクリア
+            path: 指定時はそのディレクトリ配下のみクリア（source_type と排他）
         """
         ...

--- a/src/rag/server.py
+++ b/src/rag/server.py
@@ -953,6 +953,7 @@ _SEGFAULT_EXIT_CODES: frozenset[int] = frozenset({-1073741819, 3221225477, -11, 
 async def rag_rebuild(
     mode: str,
     source_type: str | None = None,
+    path: str | None = None,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG rebuild - ナレッジベースの再構築を実行する.
@@ -969,7 +970,12 @@ async def rag_rebuild(
             "index" — インデックスのみ再構築（Embedding モデル変更時）
             "incremental" — 差分更新（通常運用。未コミット変更は自動コミット）
         source_type: 対象媒体フィルタ: "web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"。
-            未指定時は全媒体。incremental モードでは指定不可。
+            未指定時は全媒体。incremental モードでは指定不可。path と排他指定。
+        path: 対象パスフィルタ。source_store ルート相対のディレクトリパスを指定し、
+            配下（再帰的）のソースのみを対象にする。
+            未指定時は全パス。incremental モードでは指定不可。source_type と排他指定。
+            空文字列・絶対パス・`..`/`.` を含むパスはバリデーションエラー
+            （全パス対象は引数を省略する）。
 
     Returns:
         処理結果サマリ（処理件数、エラー件数、所要時間）
@@ -977,6 +983,8 @@ async def rag_rebuild(
     args: list[str] = ["--mode", mode]
     if source_type is not None:
         args.extend(["--source-type", source_type])
+    if path is not None:
+        args.extend(["--path", path])
 
     try:
         result = await _run_cli_subprocess("rebuild", args, ctx=ctx)

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -22,6 +22,7 @@ from rag.store.models import (
     SourceStatus,
     SourceType,
 )
+from rag.store.path_filter import escape_like, normalize_path_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +44,13 @@ CREATE TABLE IF NOT EXISTS sources (
 );
 
 CREATE TABLE IF NOT EXISTS pipeline_history (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    from_commit_id TEXT NOT NULL,
-    to_commit_id   TEXT NOT NULL,
-    processed_at   TEXT NOT NULL,
-    mode           TEXT NOT NULL DEFAULT 'incremental'
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_commit_id     TEXT NOT NULL,
+    to_commit_id       TEXT NOT NULL,
+    processed_at       TEXT NOT NULL,
+    mode               TEXT NOT NULL DEFAULT 'incremental',
+    filter_source_type TEXT NOT NULL DEFAULT '',
+    filter_path        TEXT NOT NULL DEFAULT ''
 );
 """
 
@@ -113,6 +116,29 @@ class MetadataDB:
             self._connection.commit()
             applied.append("pipeline_history に mode 列を追加")
             logger.info("pipeline_history に mode 列を追加しました")
+
+        # pipeline_history に filter_source_type / filter_path 列を追加
+        # （既存レコードは「未フィルタ」扱いで空文字列がデフォルト）
+        if "filter_source_type" not in ph_columns:
+            self._connection.execute(
+                "ALTER TABLE pipeline_history"
+                " ADD COLUMN filter_source_type TEXT NOT NULL DEFAULT ''"
+            )
+            self._connection.commit()
+            applied.append("pipeline_history に filter_source_type 列を追加")
+            logger.info(
+                "pipeline_history に filter_source_type 列を追加しました",
+            )
+        if "filter_path" not in ph_columns:
+            self._connection.execute(
+                "ALTER TABLE pipeline_history"
+                " ADD COLUMN filter_path TEXT NOT NULL DEFAULT ''"
+            )
+            self._connection.commit()
+            applied.append("pipeline_history に filter_path 列を追加")
+            logger.info(
+                "pipeline_history に filter_path 列を追加しました",
+            )
 
         # sources に published_at 列を追加（既存レコードは collected_at で埋める）
         cursor = self._connection.execute("PRAGMA table_info(sources)")
@@ -361,8 +387,17 @@ class MetadataDB:
         *,
         source_type: SourceType | None = None,
         status: SourceStatus | None = None,
+        path_prefix: str | None = None,
     ) -> list[SourceRecord]:
-        """条件に合致するソースを検索する."""
+        """条件に合致するソースを検索する.
+
+        Args:
+            source_type: 媒体フィルタ
+            status: ステータスフィルタ
+            path_prefix: source_id（= source_store 内 rel_path）の prefix
+                一致フィルタ。指定パス配下（再帰的）のソースのみを返す。
+                LIKE のメタ文字（%, _, バックスラッシュ）は ESCAPE される
+        """
         conditions: list[str] = []
         params: list[Any] = []
 
@@ -372,6 +407,11 @@ class MetadataDB:
         if status is not None:
             conditions.append("status = ?")
             params.append(status)
+        if path_prefix is not None:
+            normalized = normalize_path_prefix(path_prefix)
+            escaped = escape_like(normalized)
+            conditions.append(r"source_id LIKE ? ESCAPE '\'")
+            params.append(f"{escaped}/%")
 
         where = " AND ".join(conditions) if conditions else "1=1"
         rows = self._connection.execute(
@@ -408,6 +448,21 @@ class MetadataDB:
         )
         self._connection.commit()
 
+    def delete_sources_by_path(self, path_prefix: str) -> None:
+        """指定パス配下のソースレコードを削除する（DB 部分再構築用）.
+
+        Args:
+            path_prefix: source_id の prefix。指定パス配下（再帰的）の
+                レコードを削除する
+        """
+        normalized = normalize_path_prefix(path_prefix)
+        escaped = escape_like(normalized)
+        self._connection.execute(
+            r"DELETE FROM sources WHERE source_id LIKE ? ESCAPE '\'",
+            (f"{escaped}/%",),
+        )
+        self._connection.commit()
+
     # --- pipeline_history ---
 
     def add_pipeline_history(
@@ -417,15 +472,28 @@ class MetadataDB:
         to_commit_id: str,
         processed_at: str,
         mode: str = "incremental",
+        filter_source_type: str = "",
+        filter_path: str = "",
     ) -> None:
-        """パイプライン実行履歴を追加する."""
+        """パイプライン実行履歴を追加する.
+
+        Args:
+            filter_source_type: source_type フィルタ付き rebuild の場合に
+                媒体名を記録（filter なしは空文字列）
+            filter_path: path フィルタ付き rebuild の場合にパスを記録
+                （filter なしは空文字列）
+        """
         self._connection.execute(
             """\
             INSERT INTO pipeline_history
-                (from_commit_id, to_commit_id, processed_at, mode)
-            VALUES (?, ?, ?, ?)
+                (from_commit_id, to_commit_id, processed_at, mode,
+                 filter_source_type, filter_path)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (from_commit_id, to_commit_id, processed_at, mode),
+            (
+                from_commit_id, to_commit_id, processed_at, mode,
+                filter_source_type, filter_path,
+            ),
         )
         self._connection.commit()
 
@@ -454,26 +522,34 @@ class MetadataDB:
                 to_commit_id=row["to_commit_id"],
                 processed_at=row["processed_at"],
                 mode=row["mode"],
+                filter_source_type=row["filter_source_type"],
+                filter_path=row["filter_path"],
             )
             for row in rows
         ]
 
     def needs_index_rebuild(self) -> bool:
-        """前回の index/full rebuild 以降に更新があったかを判定する.
+        """前回の「未フィルタの index/full rebuild」以降に更新があったかを判定する.
+
+        filter 付き rebuild（source_type / path フィルタ）は subset しか
+        触っていないため、判定基準には含めない（filter 付きを「全体 rebuild
+        完了」と誤認するとスキップ漏れが発生する）。
 
         Returns:
-            True: rebuild が必要（更新あり or 履歴なし）
-            False: rebuild 不要（更新なし）
+            True: rebuild が必要（更新あり or 全体 rebuild 履歴なし）
+            False: rebuild 不要（前回の全体 rebuild 以降に更新なし）
         """
-        # 最後の index/full rebuild を取得
+        # 最後の「未フィルタの」index/full rebuild を取得
         row = self._connection.execute(
             "SELECT id FROM pipeline_history"
             " WHERE mode IN ('index', 'full')"
+            " AND filter_source_type = ''"
+            " AND filter_path = ''"
             " ORDER BY id DESC LIMIT 1"
         ).fetchone()
 
         if row is None:
-            # index/full rebuild の履歴なし → 必要
+            # 全体 index/full rebuild の履歴なし → 必要
             return True
 
         last_id = row["id"]

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -44,6 +44,8 @@ class PipelineHistoryRecord:
     to_commit_id: str
     processed_at: str
     mode: str = "incremental"
+    filter_source_type: str = ""
+    filter_path: str = ""
 
 
 @dataclass

--- a/src/rag/store/path_filter.py
+++ b/src/rag/store/path_filter.py
@@ -1,0 +1,107 @@
+"""path フィルタの正規化・エスケープ・バリデーション.
+
+仕様: docs/specs/rebuild-stats.md / docs/specs/pipeline-controller.md
+
+rebuild の `--path` / MCP `rag_rebuild` の `path` パラメータが下層
+（metadata_db / source_store / converter / indexer / vector_store / bm25_index）
+に渡る前段で正規化・検証を行う共通ユーティリティ。
+
+空文字列やパストラバーサル (`..`)・絶対パスを多層で防御することで、
+converted_store / source_store のルート外を誤って削除・走査する事故を防ぐ。
+"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+from rag.store.models import SourceType
+
+# source_type の SSoT は _schema/enums.yml。SourceType Literal 自体は CI で
+# enums.yml と同期検証されるため、本モジュールでは Literal から導出する
+_VALID_ROOT_SOURCE_TYPES: frozenset[str] = frozenset(get_args(SourceType))
+
+
+class PathFilterError(ValueError):
+    """path 引数のバリデーションエラー."""
+
+
+def normalize_path_prefix(path: str) -> str:
+    """path 引数を POSIX 形式に正規化する.
+
+    - バックスラッシュをスラッシュに変換
+    - 先頭/末尾のスラッシュを除去
+    - 空文字列・絶対パス・`..` を含むパスは PathFilterError
+
+    Args:
+        path: ユーザー入力の path 文字列
+
+    Returns:
+        正規化済みの相対パス（スラッシュ区切り、両端スラッシュなし）
+
+    Raises:
+        PathFilterError: バリデーション失敗時
+    """
+    # path は source_store ルート相対のディレクトリパスでなければならない。
+    # 以下のいずれかに該当する入力は受け付けない (ユーザー視点で 1 つの説明に
+    # 統一することで、Windows + Git Bash の MSYS パス変換 (`/abs` →
+    # `C:/Program Files/Git/abs`) で経路が変わっても同じメッセージで弾く):
+    # - 空文字列 / `/` のみのパス
+    # - 先頭スラッシュ付きの絶対パス
+    # - Windows ドライブレター (`X:`) で始まるパス
+    # - `..` / `.` セグメントを含むパス
+    # - 先頭セグメントが既知の source_type でないパス
+    valid_roots = sorted(_VALID_ROOT_SOURCE_TYPES)
+    invalid_msg = (
+        f"path は source_store ルート相対のディレクトリパスを指定してください "
+        f"(先頭セグメントが {valid_roots} のいずれか、空文字列・絶対パス・"
+        f"Windows ドライブレター・`..`/`.` セグメント不可): {path!r}"
+    )
+    if path is None or path == "":
+        raise PathFilterError(invalid_msg)
+    posix = path.replace("\\", "/")
+    if posix.startswith("/"):
+        raise PathFilterError(invalid_msg)
+    if len(posix) >= 2 and posix[1] == ":":
+        raise PathFilterError(invalid_msg)
+    stripped = posix.strip("/")
+    if stripped == "":
+        raise PathFilterError(invalid_msg)
+    segments = stripped.split("/")
+    if any(seg in ("..", ".") for seg in segments):
+        raise PathFilterError(invalid_msg)
+    root_segment = segments[0]
+    if root_segment not in _VALID_ROOT_SOURCE_TYPES:
+        raise PathFilterError(invalid_msg)
+    return stripped
+
+
+def derive_source_type(path_prefix: str) -> str:
+    """正規化済み path の先頭セグメントから source_type を返す.
+
+    `normalize_path_prefix` を通過した path のみを受け付ける契約。契約違反
+    （空文字列・先頭スラッシュ・先頭セグメントが既知 source_type でない）は
+    fail-fast のため `PathFilterError` を送出する。
+    """
+    if not path_prefix or path_prefix.startswith("/"):
+        msg = (
+            f"derive_source_type には正規化済み path を渡す必要があります: "
+            f"{path_prefix!r}"
+        )
+        raise PathFilterError(msg)
+    root = path_prefix.split("/", 1)[0]
+    if root not in _VALID_ROOT_SOURCE_TYPES:
+        msg = (
+            f"derive_source_type には正規化済み path を渡す必要があります "
+            f"（先頭セグメントが既知の source_type でない）: {path_prefix!r}"
+        )
+        raise PathFilterError(msg)
+    return root
+
+
+def escape_like(value: str) -> str:
+    """SQLite LIKE のメタ文字をエスケープする (ESCAPE '\\' 前提).
+
+    LIKE のメタ文字は `%` (任意 0+ 文字) と `_` (任意 1 文字)。
+    バックスラッシュ自身も併せてエスケープする。
+    """
+    return value.replace("\\", r"\\").replace("%", r"\%").replace("_", r"\_")

--- a/src/rag/store/path_filter.py
+++ b/src/rag/store/path_filter.py
@@ -48,13 +48,16 @@ def normalize_path_prefix(path: str) -> str:
     # - 空文字列 / `/` のみのパス
     # - 先頭スラッシュ付きの絶対パス
     # - Windows ドライブレター (`X:`) で始まるパス
+    # - 連続スラッシュを含むパス (DB の LIKE や prefix 文字列比較で別文字列扱い
+    #   になり、Path 結合は許容しても下流で no-op になるため一律拒否)
     # - `..` / `.` セグメントを含むパス
     # - 先頭セグメントが既知の source_type でないパス
     valid_roots = sorted(_VALID_ROOT_SOURCE_TYPES)
     invalid_msg = (
         f"path は source_store ルート相対のディレクトリパスを指定してください "
         f"(先頭セグメントが {valid_roots} のいずれか、空文字列・絶対パス・"
-        f"Windows ドライブレター・`..`/`.` セグメント不可): {path!r}"
+        f"Windows ドライブレター・連続スラッシュ・`..`/`.` セグメント不可): "
+        f"{path!r}"
     )
     if path is None or path == "":
         raise PathFilterError(invalid_msg)
@@ -67,6 +70,8 @@ def normalize_path_prefix(path: str) -> str:
     if stripped == "":
         raise PathFilterError(invalid_msg)
     segments = stripped.split("/")
+    if any(seg == "" for seg in segments):
+        raise PathFilterError(invalid_msg)
     if any(seg in ("..", ".") for seg in segments):
         raise PathFilterError(invalid_msg)
     root_segment = segments[0]

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -16,7 +16,7 @@ import shutil
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import pathspec
 
@@ -71,10 +71,9 @@ _EXCLUDE_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(
     "gitignore", _EXCLUDE_PATTERNS,
 )
 
-# source_type 値の集合（_schema/enums.yml が SSoT）
-_SOURCE_TYPE_VALUES: frozenset[SourceType] = frozenset(
-    {"web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"},
-)
+# source_type 値の集合: SourceType Literal から導出する
+# （SourceType Literal 自体は CI で _schema/enums.yml と同期検証される）
+_SOURCE_TYPE_VALUES: frozenset[SourceType] = frozenset(get_args(SourceType))
 
 
 def detect_source_type(rel_path: str) -> SourceType:
@@ -433,6 +432,7 @@ class SourceStore:
         self,
         *,
         source_type: SourceType | None = None,
+        path: str | None = None,
     ) -> list[Path]:
         """source_store 内の独立ソースを列挙する.
 
@@ -442,12 +442,21 @@ class SourceStore:
 
         Args:
             source_type: 指定時はそのディレクトリのみ
+            path: 指定時はそのディレクトリ配下（再帰的）のみ。
+                source_store ルート相対のディレクトリパス（POSIX 形式）
 
         Returns:
             独立ソースのパスリスト（source_store ルートからの相対パス）
         """
+        if source_type and path:
+            msg = "source_type と path は同時に指定できません"
+            raise ValueError(msg)
         if source_type:
             search_dir = self._root / source_type
+        elif path:
+            from rag.store.path_filter import normalize_path_prefix
+
+            search_dir = self._root / normalize_path_prefix(path)
         else:
             search_dir = self._root
 
@@ -560,22 +569,34 @@ class SourceStore:
 
     # --- DB 再構築 ---
 
-    def rebuild_db(self, source_type: SourceType | None = None) -> int:
+    def rebuild_db(
+        self,
+        source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
+    ) -> int:
         """source_store のファイルと .meta から metadata.db を再構築する.
 
         Args:
             source_type: 対象媒体フィルタ。指定時は対象 type のみ
-                DELETE → INSERT する。None で全件再構築。
+                DELETE → INSERT する。None で全件再構築
+            path: パスフィルタ（source_type と排他）。指定時は配下の
+                レコードのみ DELETE → INSERT する
 
         Returns:
             登録されたソース数
         """
-        if source_type is not None:
+        if source_type is not None and path is not None:
+            msg = "source_type と path は同時に指定できません"
+            raise ValueError(msg)
+        if path is not None:
+            self._db.delete_sources_by_path(path)
+        elif source_type is not None:
             self._db.delete_sources_by_type(source_type)
         else:
             self._db.delete_all_sources()
 
-        files = self.list_files(source_type=source_type)
+        files = self.list_files(source_type=source_type, path=path)
         count = 0
         now = datetime.now(timezone.utc).isoformat()
 

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -471,6 +471,59 @@ class VectorStore:
             )
         return count
 
+    async def delete_by_source_id_prefix(self, path_prefix: str) -> int:
+        """source_id の prefix 指定でチャンクを一括削除する.
+
+        ChromaDB は metadata に対する LIKE/startswith や文字列範囲比較を
+        サポートしないため、コレクションから metadata を取得して Python 側で
+        prefix 一致をフィルタする。path の先頭セグメントは必ず source_type で
+        あるため（path_filter で検証済み）、`source_type` の事前 where 絞りで
+        スキャン量を媒体単位に圧縮する。
+
+        Args:
+            path_prefix: source_store ルート相対のディレクトリパス
+
+        Returns:
+            削除件数
+        """
+        from rag.store.path_filter import (
+            derive_source_type,
+            normalize_path_prefix,
+        )
+
+        normalized = normalize_path_prefix(path_prefix)
+        prefix = f"{normalized}/"
+        source_type = derive_source_type(normalized)
+
+        results = await asyncio.to_thread(
+            self._collection.get,
+            where={"source_type": source_type},
+            include=["metadatas"],
+        )
+        chunk_ids: list[str] = results["ids"]
+        metadatas = results["metadatas"] or []
+
+        ids_to_delete: list[str] = []
+        for chunk_id, metadata in zip(chunk_ids, metadatas, strict=True):
+            source_id = (metadata or {}).get("source_id", "")
+            if isinstance(source_id, str) and source_id.startswith(prefix):
+                ids_to_delete.append(chunk_id)
+
+        count = len(ids_to_delete)
+        if count == 0:
+            return 0
+
+        for offset in range(0, count, self._BATCH_SIZE):
+            batch = ids_to_delete[offset : offset + self._BATCH_SIZE]
+            await asyncio.to_thread(
+                self._collection.delete,
+                ids=batch,
+            )
+        logger.info(
+            "Deleted %d documents from vector store (path: %s)", count, normalized,
+        )
+        return count
+
     async def delete_stale_chunks(self, source_id: str, valid_ids: set[str]) -> int:
         """ソースのチャンクのうち、valid_idsに含まれないものを削除.
 

--- a/src/rag/vector_store.py
+++ b/src/rag/vector_store.py
@@ -480,6 +480,9 @@ class VectorStore:
         あるため（path_filter で検証済み）、`source_type` の事前 where 絞りで
         スキャン量を媒体単位に圧縮する。
 
+        媒体内チャンク数が多くても一括取得でメモリを圧迫しないよう、
+        ChromaDB の `limit`/`offset` で分割取得しながら ids_to_delete を構築する。
+
         Args:
             path_prefix: source_store ルート相対のディレクトリパス
 
@@ -495,26 +498,49 @@ class VectorStore:
         prefix = f"{normalized}/"
         source_type = derive_source_type(normalized)
 
-        results = await asyncio.to_thread(
-            self._collection.get,
-            where={"source_type": source_type},
-            include=["metadatas"],
-        )
-        chunk_ids: list[str] = results["ids"]
-        metadatas = results["metadatas"] or []
-
         ids_to_delete: list[str] = []
-        for chunk_id, metadata in zip(chunk_ids, metadatas, strict=True):
-            source_id = (metadata or {}).get("source_id", "")
-            if isinstance(source_id, str) and source_id.startswith(prefix):
-                ids_to_delete.append(chunk_id)
+        page_size = self._BATCH_SIZE
+        offset = 0
+
+        while True:
+            results = await asyncio.to_thread(
+                self._collection.get,
+                where={"source_type": source_type},
+                include=["metadatas"],
+                limit=page_size,
+                offset=offset,
+            )
+            chunk_ids: list[str] = results["ids"]
+            # ChromaDB は include="metadatas" 指定時に通常 ids と同じ長さで
+            # metadatas を返すが、None や長さ不一致が返る防御として ids 長に揃える
+            raw_metadatas = results["metadatas"] or []
+            if len(raw_metadatas) < len(chunk_ids):
+                metadatas = [
+                    *raw_metadatas,
+                    *([{}] * (len(chunk_ids) - len(raw_metadatas))),
+                ]
+            else:
+                metadatas = list(raw_metadatas[: len(chunk_ids)])
+
+            if not chunk_ids:
+                break
+
+            for chunk_id, metadata in zip(chunk_ids, metadatas, strict=True):
+                source_id = (metadata or {}).get("source_id", "")
+                if isinstance(source_id, str) and source_id.startswith(prefix):
+                    ids_to_delete.append(chunk_id)
+
+            fetched_count = len(chunk_ids)
+            offset += fetched_count
+            if fetched_count < page_size:
+                break
 
         count = len(ids_to_delete)
         if count == 0:
             return 0
 
-        for offset in range(0, count, self._BATCH_SIZE):
-            batch = ids_to_delete[offset : offset + self._BATCH_SIZE]
+        for batch_offset in range(0, count, self._BATCH_SIZE):
+            batch = ids_to_delete[batch_offset : batch_offset + self._BATCH_SIZE]
             await asyncio.to_thread(
                 self._collection.delete,
                 ids=batch,

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -109,6 +109,48 @@ class TestBM25Index:
         assert deleted == 0
         assert index.get_document_count() == 1
 
+    def test_delete_by_source_id_prefix(self) -> None:
+        """path prefix 指定でドキュメントを一括削除できる (#678)."""
+        index = make_bm25_index()
+        docs = [
+            ("doc1", "intro", "local/unity-docs/intro.md", "local"),
+            ("doc2", "api", "local/unity-docs/sub/api.md", "local"),
+            ("doc3", "other", "local/other/x.md", "local"),
+        ]
+        index.add_documents(docs)
+
+        deleted = index.delete_by_source_id_prefix("local/unity-docs")
+        assert deleted == 2
+        assert index.get_document_count() == 1
+
+    def test_delete_by_source_id_prefix_excludes_sibling_starting_with_same_chars(
+        self,
+    ) -> None:
+        """`local/foo` 指定は `local/foobar/...` にはマッチしない (#678)."""
+        index = make_bm25_index()
+        docs = [
+            ("doc1", "in foo", "local/foo/a.md", "local"),
+            ("doc2", "in foobar", "local/foobar/a.md", "local"),
+        ]
+        index.add_documents(docs)
+
+        deleted = index.delete_by_source_id_prefix("local/foo")
+        assert deleted == 1
+        assert index.get_document_count() == 1
+
+    def test_delete_by_source_id_prefix_escapes_metacharacters(self) -> None:
+        """LIKE のメタ文字（_）を含むパスでも誤マッチしない (#678)."""
+        index = make_bm25_index()
+        docs = [
+            ("doc1", "match", "local/a_dir/x.md", "local"),
+            ("doc2", "no match", "local/aXdir/y.md", "local"),
+        ]
+        index.add_documents(docs)
+
+        deleted = index.delete_by_source_id_prefix("local/a_dir")
+        assert deleted == 1
+        assert index.get_document_count() == 1
+
     def test_search_empty_index_returns_empty_list(self) -> None:
         """AC6: 空のインデックスへの検索は空リストを返す."""
         index = make_bm25_index()

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -106,8 +106,9 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # 4件のマイグレーションが適用される
-        assert len(applied) == 4
+        # 6件のマイグレーションが適用される
+        # (mode + filter_source_type + filter_path + published_at + file_path 移行 + meta)
+        assert len(applied) == 6
 
         # file_path カラムが削除されている
         cursor = db._connection.execute("PRAGMA table_info(sources)")
@@ -120,10 +121,12 @@ class TestMigrateExplicit:
         assert record is not None
         assert record.published_at == "2026-01-15T10:00:00Z"
 
-        # pipeline_history に mode 列が追加されている
+        # pipeline_history に mode / filter_source_type / filter_path 列が追加されている
         cursor = db._connection.execute("PRAGMA table_info(pipeline_history)")
         ph_columns = {row["name"] for row in cursor.fetchall()}
         assert "mode" in ph_columns
+        assert "filter_source_type" in ph_columns
+        assert "filter_path" in ph_columns
 
         db.close()
 
@@ -163,7 +166,7 @@ class TestMigrateExplicit:
         db.initialize()
 
         first = db.migrate()
-        assert len(first) == 4
+        assert len(first) == 6
 
         second = db.migrate()
         assert len(second) == 0
@@ -221,8 +224,8 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # published_at + file_path 移行 + meta の 3 件
-        assert len(applied) == 3
+        # filter_source_type + filter_path + published_at + file_path 移行 + meta の 5 件
+        assert len(applied) == 5
 
         for i in range(3):
             record = db.get_source(f"web/s{i}.html")
@@ -269,8 +272,9 @@ class TestMetaMigration:
         db.initialize()
         applied = db.migrate()
 
-        assert len(applied) == 1
-        assert "meta" in applied[0]
+        # filter_source_type + filter_path + meta の 3 件
+        assert len(applied) == 3
+        assert any("meta" in m for m in applied)
 
         cursor = db._connection.execute("PRAGMA table_info(sources)")
         columns = {row["name"] for row in cursor.fetchall()}
@@ -312,8 +316,9 @@ class TestMetaMigration:
         db.initialize()
         applied = db.migrate(source_store_dir=source_store)
 
-        assert len(applied) == 1
-        assert "1 件" in applied[0]
+        # filter_source_type + filter_path + meta の 3 件
+        assert len(applied) == 3
+        assert any("1 件" in m for m in applied)
 
         record = db.get_source("journal/repo-a/entry.md")
         assert record is not None
@@ -341,8 +346,9 @@ class TestMetaMigration:
         db.initialize()
         applied = db.migrate()
 
-        assert len(applied) == 1
-        assert "0 件" in applied[0]
+        # filter_source_type + filter_path + meta の 3 件
+        assert len(applied) == 3
+        assert any("0 件" in m for m in applied)
 
         record = db.get_source("local/test.md")
         assert record is not None

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -38,6 +38,7 @@ class StubConverter:
         self.converted: list[str] = []
         self.deleted: list[str] = []
         self.cleared: list[SourceType | None] = []
+        self.cleared_calls: list[tuple[SourceType | None, str | None]] = []
         self.fail_on: set[str] = set()
         # ConversionFailedError を送出させたいパス（convert 系のエラー経路検証用）
         self.fail_on_with_failed_error: set[str] = set()
@@ -75,9 +76,14 @@ class StubConverter:
         self,
         converted_store_dir: Path,
         source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
     ) -> None:
         self.cleared.append(source_type)
-        if source_type:
+        self.cleared_calls.append((source_type, path))
+        if path:
+            target = converted_store_dir / path
+        elif source_type:
             target = converted_store_dir / source_type
         else:
             target = converted_store_dir
@@ -95,6 +101,7 @@ class StubIndexer:
         self.deleted_ids: list[str] = []
         self.upserted: list[str] = []
         self.cleared: list[SourceType | None] = []
+        self.cleared_calls: list[tuple[SourceType | None, str | None]] = []
         self.fail_on: set[str] = set()
 
     async def add(
@@ -126,8 +133,14 @@ class StubIndexer:
     ) -> None:
         self.upserted.append(source_id)
 
-    async def clear(self, source_type: SourceType | None = None) -> None:
+    async def clear(
+        self,
+        source_type: SourceType | None = None,
+        *,
+        path: str | None = None,
+    ) -> None:
         self.cleared.append(source_type)
+        self.cleared_calls.append((source_type, path))
 
     def set_bm25_deferred_save(self, enabled: bool) -> None:
         pass
@@ -953,6 +966,89 @@ class TestRunFullRebuild:
         result = await ctrl.run_full_rebuild()
         assert result.convert.total_files == 0
         assert result.index.total_files == 0
+
+    async def test_path_filter_targets_subdirectory_only(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """path 指定の rebuild が指定パス配下（再帰的）のみを対象にする."""
+        ctrl, converter, indexer = controller
+        _place_local_file(workspace["source"], "local/unity-docs/intro.md")
+        _place_local_file(workspace["source"], "local/unity-docs/sub/api.md")
+        _place_local_file(workspace["source"], "local/other/x.md")
+        ctrl.commit("initial")
+        await ctrl.run_incremental()
+
+        converter.converted.clear()
+        indexer.added.clear()
+
+        result = await ctrl.run_full_rebuild(path="local/unity-docs")
+
+        assert result.convert.processed == 2
+        assert sorted(converter.converted) == [
+            "local/unity-docs/intro.md",
+            "local/unity-docs/sub/api.md",
+        ]
+        assert converter.cleared_calls[-1] == (None, "local/unity-docs")
+        assert indexer.cleared_calls[-1] == (None, "local/unity-docs")
+
+        # path 配下外のレコードは保持される
+        other_record = ctrl.db.get_source("local/other/x.md")
+        assert other_record is not None
+
+    async def test_path_filter_with_no_matching_sources_returns_empty(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        workspace: dict[str, Path],
+    ) -> None:
+        """配下に is_source_file=True のソースがない path 指定は対象 0 件で正常終了."""
+        ctrl, converter, _ = controller
+        _place_local_file(workspace["source"], "local/foo/x.md")
+        ctrl.commit("initial")
+        await ctrl.run_incremental()
+
+        converter.converted.clear()
+
+        # 存在しないパス（attachment 単独想定）
+        result = await ctrl.run_full_rebuild(path="local/foo/empty-subdir")
+
+        assert result.convert.total_files == 0
+        assert result.index.total_files == 0
+        assert converter.converted == []
+
+    async def test_source_type_and_path_exclusive(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+    ) -> None:
+        """source_type と path の併用は ValueError を返す."""
+        ctrl, _, _ = controller
+        ctrl.init_repo()
+        ctrl.commit("initial")
+        with pytest.raises(ValueError, match="同時に指定"):
+            await ctrl.run_full_rebuild(source_type="local", path="local/foo")
+        with pytest.raises(ValueError, match="同時に指定"):
+            await ctrl.run_convert_only(source_type="local", path="local/foo")
+        with pytest.raises(ValueError, match="同時に指定"):
+            await ctrl.run_index_only(source_type="local", path="local/foo")
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["", "/", "..", "../foo", "local/../etc", "/abs/path", "."],
+    )
+    async def test_path_validation_rejects_unsafe_input(
+        self,
+        controller: tuple[PipelineController, StubConverter, StubIndexer],
+        bad_path: str,
+    ) -> None:
+        """空文字列・絶対パス・`..`/`.` を含む path は PathFilterError."""
+        from rag.store.path_filter import PathFilterError
+
+        ctrl, _, _ = controller
+        ctrl.init_repo()
+        ctrl.commit("initial")
+        with pytest.raises(PathFilterError):
+            await ctrl.run_full_rebuild(path=bad_path)
 
     async def test_concurrent_full_rebuild(
         self,

--- a/tests/test_rebuild_stats.py
+++ b/tests/test_rebuild_stats.py
@@ -7,6 +7,8 @@ rag_rebuild MCP ツール・CLI、rag_stats 拡張の振る舞いを検証する
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -187,6 +189,35 @@ class TestRagRebuild:
         )
 
     @pytest.mark.asyncio
+    async def test_rebuild_with_path(self) -> None:
+        """path 指定の rebuild が正しい引数で CLI を呼ぶこと."""
+        from rag.server import rag_rebuild
+
+        mock_cli_result: dict[str, object] = {
+            "type": "result",
+            "mode": "convert",
+            "total_files": 2,
+            "processed": 2,
+            "errors": [],
+            "warnings": [],
+            "elapsed": 0.3,
+        }
+
+        with patch(
+            "rag.server._run_cli_subprocess",
+            new_callable=AsyncMock,
+            return_value=mock_cli_result,
+        ) as mock_subprocess:
+            result = await rag_rebuild(mode="convert", path="local/unity-docs")
+
+        assert "再構築完了" in result
+        mock_subprocess.assert_called_once_with(
+            "rebuild",
+            ["--mode", "convert", "--path", "local/unity-docs"],
+            ctx=None,
+        )
+
+    @pytest.mark.asyncio
     async def test_incremental_mode(self) -> None:
         """incremental モードが正常に動作すること."""
         from rag.server import rag_rebuild
@@ -212,6 +243,113 @@ class TestRagRebuild:
         mock_subprocess.assert_called_once_with(
             "rebuild", ["--mode", "incremental"], ctx=None,
         )
+
+
+class TestRebuildCliValidation:
+    """CLI run_rebuild のバリデーションテスト."""
+
+    @staticmethod
+    def _make_args(
+        *,
+        mode: str = "full",
+        source_type: str | None = None,
+        path: str | None = None,
+    ) -> argparse.Namespace:
+        return argparse.Namespace(
+            mode=mode,
+            source_type=source_type,
+            path=path,
+            commit_message=None,
+            if_needed=False,
+            concurrency=None,
+            output_format="json",
+        )
+
+    def _parse_error(self, captured_out: str) -> dict[str, object]:
+        parsed: dict[str, object] = json.loads(captured_out.strip())
+        assert parsed["type"] == "error", parsed
+        return parsed
+
+    def test_source_type_and_path_combination_rejected(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--source-type と --path 同時指定はバリデーションエラー."""
+        from rag.cli import run_rebuild
+
+        args = self._make_args(source_type="local", path="local/foo")
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(run_rebuild(args))
+        assert exc.value.code == 1
+        parsed = self._parse_error(capsys.readouterr().out)
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert "source-type" in str(parsed["message"])
+        assert "path" in str(parsed["message"])
+
+    def test_incremental_with_path_rejected(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """incremental モードでは --path 指定はバリデーションエラー."""
+        from rag.cli import run_rebuild
+
+        args = self._make_args(mode="incremental", path="local/foo")
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(run_rebuild(args))
+        assert exc.value.code == 1
+        parsed = self._parse_error(capsys.readouterr().out)
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert "path" in str(parsed["message"])
+
+    def test_if_needed_with_source_type_rejected(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--if-needed` と --source-type の併用はバリデーションエラー (#678)."""
+        from rag.cli import run_rebuild
+
+        args = self._make_args(mode="full", source_type="local")
+        args.if_needed = True
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(run_rebuild(args))
+        assert exc.value.code == 1
+        parsed = self._parse_error(capsys.readouterr().out)
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert "--if-needed" in str(parsed["message"])
+
+    def test_if_needed_with_path_rejected(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`--if-needed` と --path の併用はバリデーションエラー (#678)."""
+        from rag.cli import run_rebuild
+
+        args = self._make_args(mode="index", path="local/foo")
+        args.if_needed = True
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(run_rebuild(args))
+        assert exc.value.code == 1
+        parsed = self._parse_error(capsys.readouterr().out)
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert "--if-needed" in str(parsed["message"])
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["", "/", "..", "../foo", "local/../etc", "/abs/path", "."],
+    )
+    def test_unsafe_path_rejected(
+        self, capsys: pytest.CaptureFixture[str], bad_path: str,
+    ) -> None:
+        """空文字列・絶対パス・`..`/`.` を含む --path はバリデーションエラー."""
+        from rag.cli import run_rebuild
+
+        args = self._make_args(mode="full", path=bad_path)
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(run_rebuild(args))
+        assert exc.value.code == 1
+        parsed = self._parse_error(capsys.readouterr().out)
+        assert parsed["code"] == "VALIDATION_ERROR"
+        assert "path" in str(parsed["message"])
+
+
+class TestRebuildStructuredErrors:
+    """非バリデーション系の rag_rebuild MCP レスポンスのテスト."""
 
     @pytest.mark.asyncio
     async def test_structured_errors_reach_mcp_response(self) -> None:

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -164,6 +164,77 @@ class TestSourcesCRUD:
         assert len(web_results) == 1
         assert web_results[0].source_id == "web/https/a.com/p.html"
 
+    def test_search_by_path_prefix(self, db: MetadataDB) -> None:
+        for source_id in (
+            "local/unity-docs/intro.md",
+            "local/unity-docs/sub/api.md",
+            "local/other/x.md",
+        ):
+            db.register_source(
+                source_id=source_id,
+                source_type="local",
+                title=source_id,
+                content_hash="h",
+                file_size=10,
+                collected_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+            )
+
+        results = db.search_sources(path_prefix="local/unity-docs")
+        ids = sorted(r.source_id for r in results)
+        assert ids == [
+            "local/unity-docs/intro.md",
+            "local/unity-docs/sub/api.md",
+        ]
+
+    def test_search_by_path_prefix_escapes_like_metacharacters(
+        self, db: MetadataDB,
+    ) -> None:
+        """LIKE のメタ文字（%, _）が含まれるパスでも誤マッチしない."""
+        db.register_source(
+            source_id="local/a_dir/x.md",  # LIKE _ は任意1文字なので注意
+            source_type="local",
+            title="t",
+            content_hash="h",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+        db.register_source(
+            source_id="local/aXdir/y.md",  # _ が任意1文字としてマッチしてはならない
+            source_type="local",
+            title="t",
+            content_hash="h",
+            file_size=10,
+            collected_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        )
+
+        results = db.search_sources(path_prefix="local/a_dir")
+        ids = [r.source_id for r in results]
+        assert ids == ["local/a_dir/x.md"]
+
+    def test_delete_sources_by_path(self, db: MetadataDB) -> None:
+        for source_id in (
+            "local/foo/x.md",
+            "local/foo/sub/y.md",
+            "local/bar/z.md",
+        ):
+            db.register_source(
+                source_id=source_id,
+                source_type="local",
+                title=source_id,
+                content_hash="h",
+                file_size=10,
+                collected_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+            )
+
+        db.delete_sources_by_path("local/foo")
+
+        remaining = sorted(r.source_id for r in db.search_sources())
+        assert remaining == ["local/bar/z.md"]
+
     def test_search_by_status(self, db: MetadataDB) -> None:
         db.register_source(
             source_id="local/active.md",
@@ -560,6 +631,81 @@ class TestPipelineHistory:
             mode="incremental",
         )
         assert db.needs_index_rebuild() is True
+
+    def test_needs_index_rebuild_ignores_filtered_full(
+        self, db: MetadataDB,
+    ) -> None:
+        """filter 付き full rebuild は判定基準から除外される (#678).
+
+        filter 付きは subset しか触っていないため、未フィルタの full/index
+        履歴がない限り True（rebuild 必要）を返す。
+        """
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="full",
+            filter_path="local/foo",
+        )
+        assert db.needs_index_rebuild() is True
+
+    def test_needs_index_rebuild_ignores_filtered_source_type(
+        self, db: MetadataDB,
+    ) -> None:
+        """filter (source_type) 付き index rebuild も判定基準から除外される."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="index",
+            filter_source_type="local",
+        )
+        assert db.needs_index_rebuild() is True
+
+    def test_needs_index_rebuild_unfiltered_after_filtered(
+        self, db: MetadataDB,
+    ) -> None:
+        """filter 付き → 未フィルタの順で記録されると未フィルタが基準になる."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="full",
+            filter_path="local/foo",
+        )
+        db.add_pipeline_history(
+            from_commit_id="c1",
+            to_commit_id="c2",
+            processed_at="2026-01-02T00:00:00Z",
+            mode="full",
+        )
+        assert db.needs_index_rebuild() is False
+
+    def test_add_pipeline_history_records_filter(
+        self, db: MetadataDB,
+    ) -> None:
+        """filter スコープが pipeline_history に保存される."""
+        db.add_pipeline_history(
+            from_commit_id=NULL_COMMIT_HASH,
+            to_commit_id="c1",
+            processed_at="2026-01-01T00:00:00Z",
+            mode="full",
+            filter_source_type="local",
+            filter_path="",
+        )
+        db.add_pipeline_history(
+            from_commit_id="c1",
+            to_commit_id="c2",
+            processed_at="2026-01-02T00:00:00Z",
+            mode="index",
+            filter_source_type="",
+            filter_path="local/foo",
+        )
+        history = db.get_pipeline_history()
+        assert history[0].filter_source_type == "local"
+        assert history[0].filter_path == ""
+        assert history[1].filter_source_type == ""
+        assert history[1].filter_path == "local/foo"
 
 
 class TestDeleteAllSources:

--- a/tests/test_store_path_filter.py
+++ b/tests/test_store_path_filter.py
@@ -52,6 +52,15 @@ class TestNormalizePathPrefix:
 
     @pytest.mark.parametrize(
         "bad_path",
+        ["local//foo", "local///foo", "local/foo//bar"],
+    )
+    def test_rejects_consecutive_slashes(self, bad_path: str) -> None:
+        """連続スラッシュは下流で別文字列扱いになるため拒否 (#694 review)."""
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix(bad_path)
+
+    @pytest.mark.parametrize(
+        "bad_path",
         ["unknown_root/foo", "Local/foo", "tmp/foo"],
     )
     def test_rejects_unknown_root_source_type(self, bad_path: str) -> None:

--- a/tests/test_store_path_filter.py
+++ b/tests/test_store_path_filter.py
@@ -1,0 +1,100 @@
+"""path_filter ユーティリティのテスト.
+
+仕様: docs/specs/rebuild-stats.md / docs/specs/pipeline-controller.md
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rag.store.path_filter import (
+    PathFilterError,
+    derive_source_type,
+    escape_like,
+    normalize_path_prefix,
+)
+
+
+class TestNormalizePathPrefix:
+    """normalize_path_prefix の正規化・バリデーション."""
+
+    def test_returns_stripped_posix_path(self) -> None:
+        assert normalize_path_prefix("local/foo") == "local/foo"
+        assert normalize_path_prefix("local/foo/") == "local/foo"
+        assert normalize_path_prefix("local\\foo") == "local/foo"
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix("")
+
+    def test_rejects_only_slashes(self) -> None:
+        """`/` や `//` は strip 後に空文字列となるため拒否."""
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix("/")
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix("//")
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["..", "../foo", "local/../etc", "local/.."],
+    )
+    def test_rejects_parent_traversal(self, bad_path: str) -> None:
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix(bad_path)
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [".", "./foo", "local/./bar"],
+    )
+    def test_rejects_current_dir_segment(self, bad_path: str) -> None:
+        with pytest.raises(PathFilterError):
+            normalize_path_prefix(bad_path)
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["unknown_root/foo", "Local/foo", "tmp/foo"],
+    )
+    def test_rejects_unknown_root_source_type(self, bad_path: str) -> None:
+        """先頭セグメントが既知の source_type でない path は拒否."""
+        with pytest.raises(PathFilterError, match="source_store"):
+            normalize_path_prefix(bad_path)
+
+    @pytest.mark.parametrize(
+        "ok_path",
+        ["web", "bluesky/foo", "zenn/user/articles", "local/sub/x.md"],
+    )
+    def test_accepts_known_source_type_roots(self, ok_path: str) -> None:
+        normalize_path_prefix(ok_path)
+
+
+class TestDeriveSourceType:
+    """derive_source_type は path の先頭セグメントを返す."""
+
+    def test_returns_first_segment(self) -> None:
+        assert derive_source_type("local/foo/bar.md") == "local"
+        assert derive_source_type("bluesky") == "bluesky"
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        ["", "/web/foo", "unknown_root/foo"],
+    )
+    def test_rejects_unnormalized_input(self, bad_path: str) -> None:
+        """正規化済みでない入力は契約違反として PathFilterError を送出."""
+        with pytest.raises(PathFilterError, match="正規化済み"):
+            derive_source_type(bad_path)
+
+
+class TestEscapeLike:
+    """escape_like の SQLite LIKE メタ文字エスケープ."""
+
+    def test_escapes_percent(self) -> None:
+        assert escape_like("a%b") == r"a\%b"
+
+    def test_escapes_underscore(self) -> None:
+        assert escape_like("a_b") == r"a\_b"
+
+    def test_escapes_backslash(self) -> None:
+        assert escape_like("a\\b") == r"a\\b"
+
+    def test_passthrough_normal_chars(self) -> None:
+        assert escape_like("local/unity-docs") == "local/unity-docs"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -272,6 +272,81 @@ class TestDeleteBySourceType:
         assert stats["total_chunks"] == 1
 
 
+class TestDeleteBySourceIdPrefix:
+    """VectorStore.delete_by_source_id_prefix() の path prefix 一括削除 (#678)."""
+
+    @pytest.mark.asyncio
+    async def test_delete_by_source_id_prefix(self, ephemeral_store: VectorStore) -> None:
+        """指定パス配下（再帰的）のチャンクを一括削除できる."""
+        chunks = [
+            DocumentChunk(
+                id="c1",
+                text="intro",
+                metadata={
+                    "source_id": "local/unity-docs/intro.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            ),
+            DocumentChunk(
+                id="c2",
+                text="api",
+                metadata={
+                    "source_id": "local/unity-docs/sub/api.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            ),
+            DocumentChunk(
+                id="c3",
+                text="other",
+                metadata={
+                    "source_id": "local/other/x.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            ),
+        ]
+        await ephemeral_store.add_documents(chunks)
+
+        deleted = await ephemeral_store.delete_by_source_id_prefix(
+            "local/unity-docs",
+        )
+        assert deleted == 2
+        assert ephemeral_store.get_stats()["total_chunks"] == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_by_source_id_prefix_excludes_sibling(
+        self, ephemeral_store: VectorStore,
+    ) -> None:
+        """`local/foo` 指定は `local/foobar/...` にはマッチしない (lex range の境界)."""
+        chunks = [
+            DocumentChunk(
+                id="c1",
+                text="in foo",
+                metadata={
+                    "source_id": "local/foo/a.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            ),
+            DocumentChunk(
+                id="c2",
+                text="in foobar",
+                metadata={
+                    "source_id": "local/foobar/a.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            ),
+        ]
+        await ephemeral_store.add_documents(chunks)
+
+        deleted = await ephemeral_store.delete_by_source_id_prefix("local/foo")
+        assert deleted == 1
+        assert ephemeral_store.get_stats()["total_chunks"] == 1
+
+
 class TestAC11GetStats:
     """AC11: VectorStore.get_stats() で総チャンク数を取得できること."""
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -316,6 +316,34 @@ class TestDeleteBySourceIdPrefix:
         assert ephemeral_store.get_stats()["total_chunks"] == 1
 
     @pytest.mark.asyncio
+    async def test_delete_by_source_id_prefix_paginated(
+        self, ephemeral_store: VectorStore, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ChromaDB の limit/offset で分割取得しながら削除できる (#694 review)."""
+        # 小さい page size で複数ページに分かれるデータを構築
+        monkeypatch.setattr(type(ephemeral_store), "_BATCH_SIZE", 2)
+
+        chunks = [
+            DocumentChunk(
+                id=f"c{i}",
+                text=f"chunk {i}",
+                metadata={
+                    "source_id": f"local/target/{i}.md",
+                    "source_type": "local",
+                    "chunk_index": 0,
+                },
+            )
+            for i in range(5)
+        ]
+        await ephemeral_store.add_documents(chunks)
+
+        deleted = await ephemeral_store.delete_by_source_id_prefix(
+            "local/target",
+        )
+        assert deleted == 5
+        assert ephemeral_store.get_stats()["total_chunks"] == 0
+
+    @pytest.mark.asyncio
     async def test_delete_by_source_id_prefix_excludes_sibling(
         self, ephemeral_store: VectorStore,
     ) -> None:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装

## Summary

- CLI `rebuild --path` / MCP `rag_rebuild(path=...)` を追加し、source_store ルート相対のディレクトリパス配下のみ再構築できるようにした
- `--source-type` と `--path` は排他指定（同時指定エラー）。`--if-needed` と filter（`--source-type`/`--path`）の併用もエラー化
- path バリデーション: 空文字列・絶対パス・Windows ドライブレター・`..`/`.`・未知 source_type を統合エラーメッセージで拒否（CLI 入口 + 各下層で多層防御）
- `pipeline_history` に `filter_source_type` / `filter_path` 列を追加（マイグレーション込み）。`needs_index_rebuild()` は「未フィルタの index/full 履歴のみ」で判定するよう修正し、filter 付き rebuild を「全体 rebuild 完了」と誤認するスキップ漏れを防止
- ChromaDB の path-prefix 削除を `source_type` 事前絞り込み + Python 側 prefix フィルタで実装（ChromaDB が metadata 文字列範囲比較非対応のため）。BM25 は SQL `LIKE ESCAPE` で実装
- 仕様書 SSoT 集約: path フィルタの解釈・バリデーション・振る舞いを `pipeline-controller.md` に集約、`rebuild-stats.md` は CLI/MCP インターフェース定義に絞り込み
- 共通 `path_filter` ヘルパーモジュール新設（`normalize_path_prefix` / `escape_like` / `derive_source_type` / `PathFilterError`）

## Test plan

- [x] `uv run pytest -n auto` 1825 件 PASS（path フィルタ動作・各種バリデーション・排他チェック・pipeline_history filter 列・needs_index_rebuild 新動作・vector_store/bm25 prefix 削除・path traversal 防御を含む 41 件追加）
- [x] `uv run ruff check .` クリア
- [x] `uv run mypy src` クリア
- [x] CLI QA: rebuild 各 mode、`--path` 動作、7 ケースのバリデーション（空/絶対/`..`/`.`/未知 root 等）、5 ケースの排他、`pipeline_history` filter 列確認、`--if-needed` 新動作（filter 付き履歴を判定対象外、未フィルタ後は skip）
- [x] MCP QA: `rag_rebuild(path=...)` 動作確認、`path="../etc"`/未知 source_type/空文字列/source_type 同時/incremental 同時 のバリデーション拒否を確認
- [x] code-reviewer / doc-reviewer 2 ラウンド（Critical 2 件即修正、要相談 6 件はユーザー判断で対応決定）

## Related issues

Closes #678