### PR TITLE
feat(architecture,enums): architecture spec 新設 + SSoT 階層の徹底（Enum 化・enums.yml 拡張）(#703)

### DIFF
--- a/_schema/enums.yml
+++ b/_schema/enums.yml
@@ -5,21 +5,52 @@
 
 source_type:
   description: データソースの種別
+  attributes:
+    has_meta:
+      type: bool
+      description: source_store に .meta サイドカーを持つか（false の場合は source_store 自体が SSoT）
   values:
     - value: web
       description: 外部 Web ページ
+      has_meta: true
     - value: zenn
       description: Zenn 記事・スクラップ
+      has_meta: true
     - value: bluesky
       description: BlueSky 投稿
+      has_meta: true
     - value: youtube
       description: YouTube 動画（字幕・音声文字起こし）
+      has_meta: true
     - value: aozora
       description: 青空文庫の作品
+      has_meta: true
     - value: local
       description: ローカルドキュメント（Markdown、テキスト、PDF、AsciiDoc）
+      has_meta: false
     - value: journal
       description: 開発ジャーナル（セッション作業記録）
+      has_meta: true
+
+source_status:
+  description: ソースの論理的な状態
+  values:
+    - value: active
+      description: 有効（検索・取得対象）
+    - value: deleted
+      description: 論理削除（検索対象外、source_store からは削除されるが metadata.db に履歴を保持）
+
+ingest_error_category:
+  description: インジェスト失敗の種別。IngestResult.error_details / partial_failure_details の category フィールドに記録される
+  values:
+    - value: metadata_fetch
+      description: メタデータ取得失敗（一覧 API / 詳細 API のレスポンス不正・タイムアウト等）
+    - value: media_download
+      description: メディアダウンロード失敗（HLS / 音声 / 動画 / 添付ファイル等）
+    - value: placement
+      description: source_store への配置失敗（書き込みエラー・パス変換失敗等）
+    - value: delegation
+      description: 別インジェスター・別ランナーへの委譲失敗（YouTube 委譲・site-ingest 委譲等）
 
 pipeline_mode:
   description: パイプライン実行モード

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -1,0 +1,101 @@
+# rag-knowledge アーキテクチャ
+
+rag-knowledge プロジェクトのアーキテクチャ説明・採用方針・構造判断 SSoT。
+個別仕様書の上位にあたる構造判断はここに集約する。
+
+用語の定義は agent-commons の `architecture-guide.md`（語彙集）を参照する。
+本仕様書は語彙の上に乗る形で rag-knowledge 固有の採用方針・構造判断を記述する。
+
+## 1. アーキテクチャ概要
+
+rag-knowledge は **Ports and Adapters**（hexagonal）スタイルを採用する。
+パイプラインの入出力は Port（Protocol / ABC）で表現し、外部依存（HTTP / ChromaDB / LM Studio / yt-dlp 等）は Adapter として注入する。
+
+主要な層（依存方向は上から下、Dependency Rule に従い逆方向の依存は禁止）:
+
+| 層 | 責務 | 主なモジュール |
+|---|---|---|
+| Adapter（境界） | 外部システムとの入出力 | `pipeline/ingesters/<source>` の Fetcher / `vector_store.py` / `embedding/` / `scrapy/` |
+| パイプライン制御 | 取り込み・変換・索引のオーケストレーション | `pipeline/controller.py` |
+| インジェスター | 媒体ごとの取得・配置 | `pipeline/ingesters/*.py` |
+| ストア | データ・メタデータの永続化 | `store/source_store.py` / `store/metadata_db.py` / `vector_store.py` |
+| 共通契約・モデル | dto / Port / Enum / 設定 | `store/models.py` / `pipeline/models.py` / `pipeline/ingesters/_common.py` / `config.py` |
+
+### Dependency Rule
+
+- 上位層は下位層に依存してよい
+- 下位層は上位層に依存しない
+- Adapter（境界）は Port（共通契約）にのみ依存し、パイプライン制御層からは Adapter ではなく Port 経由で操作する
+
+## 2. 正解パターン: youtube インジェスター
+
+新規 / 改修するインジェスター・Adapter は **youtube インジェスターを正解パターン** として参照する。
+youtube パターンは以下の構造を満たす:
+
+| 要素 | 配置 | 役割 |
+|---|---|---|
+| インジェスター本体 | `pipeline/ingesters/youtube.py` | 取得結果を `IngestResult` に集約。Fetcher は Protocol 経由で注入される |
+| Fetcher Protocol | `pipeline/ingesters/youtube_fetcher.py` の `YoutubeFetcher` Protocol | 外部依存（youtube-transcript-api / yt-dlp）を抽象化する Port |
+| Real Fetcher | `pipeline/ingesters/youtube_fetcher.py` の `RealYoutubeFetcher` | 本番用 Adapter（実外部アクセス） |
+| Fake Fetcher | `_fake/youtube/` の `FakeYoutubeFetcher` | テスト・Fake モード用 Adapter（実外部アクセスなし、JSON fixture から応答を返却） |
+| Fake モード切替 | `RAG_YOUTUBE_FAKE_MODE` 環境変数 + production fake モード基盤 | テスト・QA・運用環境で Adapter 注入を切り替え可能 |
+
+このパターンの本質は **Port を介した Adapter 注入**であり、Real / Fake の切替を構造的に保証することで、L2 Mock E2E テスト（[QA 戦略](workflows/qa-strategy.md)）を成立させる。
+
+## 3. 構造判断の定量基準（参考値）
+
+以下は構造問題のシグナルとなる定量値。**閾値超過は即座にリファクタ義務とはせず、レビュー / Issue 起票時の参考値として用いる**。
+
+| 指標 | 参考値 | 構造問題の典型 |
+|---|---|---|
+| 1 ファイルの LOC | 800 LOC | 単一クラスに複数責務が同居している（HLS DL / URL 分類 / 媒体委譲等） |
+| 越境直 import 系統数 | 2 系統 | あるインジェスターが他媒体や Scrapy ランナーを直 import している（Port 化されていない） |
+| 単体テスト mock 比 | 2.0（mock 数 / テストケース数） | 構造的に注入できない依存を mock で吸収しているサイン。Adapter 化を検討 |
+
+これらは [Issue #702 のロードマップ](https://github.com/becky3/rag-knowledge/issues/702) で検出された具体的な構造問題（bluesky.py 1319 LOC / mock 比 4.4 等）から導出した経験値である。
+
+## 4. SSoT 階層と所在
+
+設定値・列挙値・契約は SSoT 階層と所在の 2 軸で管理する（agent-commons `spec-driven.md` の SSoT 2 軸併置に従う）。
+
+### 軸 1: 設定値・制約の競合解決
+
+| 優先度 | 情報源 | 役割 |
+|---|---|---|
+| 1 | pydantic Field 定義（`src/rag/config.py`） | 型・制約値・デフォルト値の SSoT |
+| 2 | `_schema/enums.yml` | 横断列挙値の SSoT（`source_type` / `source_status` / `pipeline_mode` / `cli_error_code` / `ingest_error_category`） |
+| 3 | py-common-lib `ConstrainedClient` 定数 | 解除不能なハードリミット（リクエスト総数上限・最低リクエスト間隔等） |
+| 4 | 仕様書 | 設計意図（Why）・振る舞いの定義 |
+
+`_schema/enums.yml` と Python 側（Literal / Enum）の整合性は [`scripts/validate_enums.py`](../../scripts/validate_enums.py) が CI で検証する。
+
+### 軸 2: 契約の所在
+
+| 契約の種類 | 定義場所 | 表現 |
+|---|---|---|
+| 内部 dto / モデル | `<package>/models.py`（例: `store/models.py` / `pipeline/models.py`） | dataclass / Enum / TypedDict |
+| Port（Adapter が従う interface 契約） | `<package>/<feature>_<role>.py`（例: `pipeline/ingesters/youtube_fetcher.py`） | Protocol / ABC |
+| 公開 API contract | MCP ツール定義（`server.py`）/ HTTP スキーマ（`pydantic` BaseModel） | pydantic BaseModel / Discriminated Union |
+
+`dict[str, Any]` は境界（外部 API レスポンス・JSON 応答・MCP 応答テキスト等）でのみ許容し、越境後は構造化型（dataclass / Enum / TypedDict）に変換する。
+
+## 5. Fake モード基盤
+
+外部 API・ライブラリの実アクセスを排除する仕組み。詳細は [Fake モード基盤仕様](infrastructure/fake-mode.md) を参照。
+
+| 観点 | 採用方針 |
+|---|---|
+| 注入方法 | Fetcher Protocol 経由で Real / Fake を切替 |
+| 切替トリガー | `RAG_<SOURCE>_FAKE_MODE` 環境変数 |
+| デフォルト | 安全側（fake 有効） |
+| 起動ログ | `[FAKE MODE: <source>]` ラベルを stderr / 応答冒頭に明示 |
+
+新規インジェスターは原則として Fake Adapter を備える（youtube パターン）。Fake Adapter なしでの追加は QA 戦略の L2 Mock E2E テストが書けなくなるため、構造レビューの対象とする。
+
+## 6. 関連ドキュメント
+
+- [全体仕様概要](overview.md) — 機能一覧と仕様書マップ
+- [QA 戦略](workflows/qa-strategy.md) — L1 / L2 / L3 の責務分離
+- [Fake モード基盤](infrastructure/fake-mode.md) — Fake Adapter 注入の仕様
+- agent-commons `architecture-guide.md` — 用語定義（語彙集）
+- agent-commons `spec-driven.md` — SSoT 2 軸併置・契約所在ルール

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -156,13 +156,13 @@ ConstrainedClient はサーキットブレーカーの責務（HTTP レスポン
 
 | フィールド | 必須 | 内容 |
 |---|:-:|---|
-| `category` | 必須 | 失敗種別（下記 4 種のいずれか） |
+| `category` | 必須 | 失敗種別。値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `ingest_error_category` カテゴリを参照（`IngestErrorCategory` Enum の `value`） |
 | `target` | 必須 | 失敗対象の識別子（`rel_path` / `source_id` / `slug` / `book_id` 等） |
 | `status` | 任意 | HTTP ステータスコード（HTTP 系失敗のみ） |
 | `url` | 任意 | 失敗した URL（HTTP 系失敗のみ） |
 | `message` | 任意（例外由来では推奨） | 追加説明（例外メッセージ等。例外由来の失敗では `str(exc)` を記録することを推奨） |
 
-`category` は全媒体で以下の 4 種に統一する。集計・再取り込み判定で信頼できる集合として扱えるようにするため、列挙外の値は使用しない。
+`category` は全媒体で `IngestErrorCategory` Enum の値に統一する。集計・再取り込み判定で信頼できる集合として扱えるようにするため、列挙外の値は使用しない。値定義の SSoT は [`_schema/enums.yml`](../../../_schema/enums.yml) の `ingest_error_category` カテゴリ。
 
 | 値 | 用途 |
 |---|---|

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -38,6 +38,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 28 | Fake モード基盤 | 外部 API・ライブラリの Fake Adapter 注入による実アクセス排除（テスト・QA・運用環境共通） | [infrastructure/fake-mode.md](infrastructure/fake-mode.md) |
 | 29 | YouTube Fake Adapter | YouTube インジェスター用 FakeYoutubeFetcher（シナリオ切替・JSON 返却） | [infrastructure/fake-adapters/youtube.md](infrastructure/fake-adapters/youtube.md) |
 | 30 | QA 戦略（3 レイヤー） | L1 Unit Test / L2 Mock E2E / L3 本番相当 QA の責務分離と実施頻度ポリシー | [workflows/qa-strategy.md](workflows/qa-strategy.md) |
+| 31 | アーキテクチャ採用方針 | rag-knowledge のアーキテクチャ説明・正解パターン（youtube）・構造判断 SSoT | [architecture.md](architecture.md) |
 
 ## 3. 技術スタック
 

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -550,7 +550,7 @@ source_store 内の全ファイルのメタデータ索引。
 | `source_id` | TEXT | PRIMARY KEY | ソース識別子（= source_store 内の相対パス） |
 | `source_type` | TEXT | NOT NULL | 媒体種別（値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_type` を参照） |
 | `title` | TEXT | NOT NULL | コンテンツのタイトル |
-| `status` | TEXT | NOT NULL, DEFAULT 'active' | `active` または `deleted` |
+| `status` | TEXT | NOT NULL, DEFAULT 'active' | ソースの論理状態。値は [`_schema/enums.yml`](../../_schema/enums.yml) の `source_status` を参照（`active` / `deleted`） |
 | `content_hash` | TEXT | NOT NULL | ファイル内容の SHA-256 ハッシュ |
 | `file_size` | INTEGER | NOT NULL | ファイルサイズ（バイト） |
 | `collected_at` | TEXT | NOT NULL | 初回取り込み日時（ISO 8601） |

--- a/scripts/validate_enums.py
+++ b/scripts/validate_enums.py
@@ -112,6 +112,12 @@ def _parse_attributes(attrs: Any, key: str) -> dict[str, type]:
             )
             sys.exit(1)
         type_name = spec["type"]
+        if not isinstance(type_name, str):
+            print(
+                f"ERROR: enums.yml の '{key}.attributes.{attr_name}.type' は str で "
+                f"指定してください: {type_name!r} ({type(type_name).__name__})"
+            )
+            sys.exit(1)
         if type_name not in _ATTR_TYPE_MAP:
             print(
                 f"ERROR: enums.yml の '{key}.attributes.{attr_name}.type' が未対応です: "

--- a/scripts/validate_enums.py
+++ b/scripts/validate_enums.py
@@ -2,6 +2,11 @@
 
 enums.yml を SSoT として、Python 側の定義と値が一致することを確認する。
 不一致時は差分を表示して exit 1 で終了する。
+
+検証内容:
+- カテゴリごとの値集合が Python 側（Literal / Enum）と一致すること
+- 値の重複がないこと
+- attributes が宣言されている場合、各 value にその属性が宣言された型で含まれていること
 """
 
 from __future__ import annotations
@@ -12,6 +17,12 @@ from pathlib import Path
 from typing import Any, get_args
 
 import yaml
+
+_ATTR_TYPE_MAP: dict[str, type] = {
+    "bool": bool,
+    "str": str,
+    "int": int,
+}
 
 
 def _load_enums_yml(path: Path) -> dict[str, Any]:
@@ -29,7 +40,10 @@ def _load_enums_yml(path: Path) -> dict[str, Any]:
 
 
 def _extract_yml_values(data: dict[str, Any], key: str) -> set[str]:
-    """enums.yml の指定キーから値の集合を取得する."""
+    """enums.yml の指定キーから値の集合を取得する.
+
+    `attributes` が宣言されている場合、各 value がその属性を宣言された型で持つかも検証する。
+    """
     entry = data.get(key)
     if entry is None:
         print(f"ERROR: enums.yml に '{key}' が定義されていません")
@@ -41,6 +55,7 @@ def _extract_yml_values(data: dict[str, Any], key: str) -> set[str]:
     if not isinstance(values, list) or not values:
         print(f"ERROR: enums.yml の '{key}.values' が空、または list ではありません: {values}")
         sys.exit(1)
+    attr_specs = _parse_attributes(entry.get("attributes"), key)
     result: set[str] = set()
     duplicates: set[str] = set()
     for i, item in enumerate(values):
@@ -57,9 +72,53 @@ def _extract_yml_values(data: dict[str, Any], key: str) -> set[str]:
         if value in result:
             duplicates.add(value)
         result.add(value)
+        for attr_name, attr_type in attr_specs.items():
+            if attr_name not in item:
+                print(
+                    f"ERROR: enums.yml の '{key}.values[{i}]' に属性 '{attr_name}' が "
+                    f"ありません: {item}"
+                )
+                sys.exit(1)
+            attr_value = item[attr_name]
+            if not isinstance(attr_value, attr_type):
+                print(
+                    f"ERROR: enums.yml の '{key}.values[{i}].{attr_name}' は "
+                    f"{attr_type.__name__} ではありません: "
+                    f"{attr_value!r} ({type(attr_value).__name__})"
+                )
+                sys.exit(1)
     if duplicates:
         print(f"ERROR: enums.yml の '{key}.values' に重複値があります: {sorted(duplicates)}")
         sys.exit(1)
+    return result
+
+
+def _parse_attributes(attrs: Any, key: str) -> dict[str, type]:
+    """attributes 宣言をパースして属性名 → Python 型の dict を返す.
+
+    attributes が未定義の場合は空 dict を返す。
+    """
+    if attrs is None:
+        return {}
+    if not isinstance(attrs, dict):
+        print(f"ERROR: enums.yml の '{key}.attributes' は dict ではありません: {type(attrs)}")
+        sys.exit(1)
+    result: dict[str, type] = {}
+    for attr_name, spec in attrs.items():
+        if not isinstance(spec, dict) or "type" not in spec:
+            print(
+                f"ERROR: enums.yml の '{key}.attributes.{attr_name}' に 'type' キーが "
+                f"ありません: {spec}"
+            )
+            sys.exit(1)
+        type_name = spec["type"]
+        if type_name not in _ATTR_TYPE_MAP:
+            print(
+                f"ERROR: enums.yml の '{key}.attributes.{attr_name}.type' が未対応です: "
+                f"{type_name!r} (対応: {sorted(_ATTR_TYPE_MAP)})"
+            )
+            sys.exit(1)
+        result[attr_name] = _ATTR_TYPE_MAP[type_name]
     return result
 
 
@@ -102,8 +161,14 @@ def main() -> None:
 
     # Python 定義をインポート
     from rag.errors import CliErrorCode  # type: ignore[import-untyped]
+    from rag.pipeline.ingesters._common import (  # type: ignore[import-untyped]
+        IngestErrorCategory,
+    )
     from rag.pipeline.models import PipelineMode  # type: ignore[import-untyped]
-    from rag.store.models import SourceType  # type: ignore[import-untyped]
+    from rag.store.models import (  # type: ignore[import-untyped]
+        SourceStatus,
+        SourceType,
+    )
 
     ok = True
 
@@ -111,6 +176,12 @@ def main() -> None:
     yml_source_types = _extract_yml_values(data, "source_type")
     python_source_types = _extract_literal_values(SourceType)
     if not _check_match("source_type (SourceType)", yml_source_types, python_source_types):
+        ok = False
+
+    # source_status: Enum クラス
+    yml_source_status = _extract_yml_values(data, "source_status")
+    python_source_status = _extract_enum_values(SourceStatus)
+    if not _check_match("source_status (SourceStatus)", yml_source_status, python_source_status):
         ok = False
 
     # pipeline_mode: Enum クラス
@@ -123,6 +194,16 @@ def main() -> None:
     yml_error_codes = _extract_yml_values(data, "cli_error_code")
     python_error_codes = _extract_enum_values(CliErrorCode)
     if not _check_match("cli_error_code (CliErrorCode)", yml_error_codes, python_error_codes):
+        ok = False
+
+    # ingest_error_category: Enum クラス
+    yml_ingest_error_categories = _extract_yml_values(data, "ingest_error_category")
+    python_ingest_error_categories = _extract_enum_values(IngestErrorCategory)
+    if not _check_match(
+        "ingest_error_category (IngestErrorCategory)",
+        yml_ingest_error_categories,
+        python_ingest_error_categories,
+    ):
         ok = False
 
     if not ok:

--- a/src/rag/_schema_loader.py
+++ b/src/rag/_schema_loader.py
@@ -23,7 +23,20 @@ _ENUMS_PATH = _REPO_ROOT / "_schema" / "enums.yml"
 
 @lru_cache(maxsize=1)
 def _load_enums() -> dict[str, Any]:
-    """`_schema/enums.yml` を読み込みパース済み dict を返す（キャッシュ）."""
+    """`_schema/enums.yml` を読み込みパース済み dict を返す（キャッシュ）.
+
+    rag-knowledge は editable install（uv sync）でリポジトリルートから運用する前提のため、
+    通常はリポジトリ内に enums.yml が存在する。万一見つからない場合は、運用形態の誤りや
+    パス解決の異常を示す可能性が高いため、対処の手がかりを含めた明示的エラーを送出する。
+    """
+    if not _ENUMS_PATH.exists():
+        msg = (
+            f"enums.yml が見つかりません: {_ENUMS_PATH}\n"
+            f"rag-knowledge は editable install で運用してください "
+            f"（uv sync 後、リポジトリルートで実行）。"
+            f"詳細は docs/specs/architecture.md を参照。"
+        )
+        raise FileNotFoundError(msg)
     with _ENUMS_PATH.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if not isinstance(data, dict):

--- a/src/rag/_schema_loader.py
+++ b/src/rag/_schema_loader.py
@@ -1,0 +1,47 @@
+"""enums.yml ローダー — 列挙値の属性を実行時に取得する.
+
+`_schema/enums.yml` は列挙値の SSoT（仕様: docs/specs/architecture.md）。
+列挙値の集合自体は Python 側の Literal / Enum で表現し、
+CI（`scripts/validate_enums.py`）で同期検証されるが、
+属性（`has_meta` 等）は本モジュールが実行時に YAML から取得する。
+
+rag-knowledge はソースツリーからの editable install で運用するため、
+`_schema/enums.yml` をリポジトリルートからの相対パスで解決できる。
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENUMS_PATH = _REPO_ROOT / "_schema" / "enums.yml"
+
+
+@lru_cache(maxsize=1)
+def _load_enums() -> dict[str, Any]:
+    """`_schema/enums.yml` を読み込みパース済み dict を返す（キャッシュ）."""
+    with _ENUMS_PATH.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        msg = f"enums.yml のトップレベルが dict ではありません: {_ENUMS_PATH}"
+        raise TypeError(msg)
+    return data
+
+
+def source_types_without_meta() -> frozenset[str]:
+    """`.meta` サイドカーを持たない source_type の集合を返す.
+
+    enums.yml の `source_type` カテゴリで `has_meta: false` の値を抽出する。
+    """
+    data = _load_enums()
+    entry = data.get("source_type", {})
+    values = entry.get("values", [])
+    return frozenset(
+        item["value"]
+        for item in values
+        if isinstance(item, dict) and item.get("has_meta") is False
+    )

--- a/src/rag/_schema_loader.py
+++ b/src/rag/_schema_loader.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, cast, get_args
 
 import yaml
+
+from rag.store.models import SourceType
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ENUMS_PATH = _REPO_ROOT / "_schema" / "enums.yml"
@@ -45,16 +47,51 @@ def _load_enums() -> dict[str, Any]:
     return data
 
 
-def source_types_without_meta() -> frozenset[str]:
+def source_types_without_meta() -> frozenset[SourceType]:
     """`.meta` サイドカーを持たない source_type の集合を返す.
 
     enums.yml の `source_type` カテゴリで `has_meta: false` の値を抽出する。
+    enums.yml の構造異常（`source_type` キー欠落・`values` 不正・`has_meta` 欠落等）は
+    `validate_enums.py` の CI 検証で防がれる前提だが、ランタイムでも構造を検証して
+    異常時には説明的な例外を送出する。
     """
     data = _load_enums()
-    entry = data.get("source_type", {})
-    values = entry.get("values", [])
-    return frozenset(
-        item["value"]
-        for item in values
-        if isinstance(item, dict) and item.get("has_meta") is False
-    )
+    entry = data.get("source_type")
+    if not isinstance(entry, dict):
+        msg = (
+            f"enums.yml の 'source_type' エントリが dict ではありません: "
+            f"{type(entry).__name__}"
+        )
+        raise TypeError(msg)
+    values = entry.get("values")
+    if not isinstance(values, list) or not values:
+        msg = (
+            f"enums.yml の 'source_type.values' が list でないか空です: "
+            f"{type(values).__name__}"
+        )
+        raise TypeError(msg)
+    valid_source_types: frozenset[str] = frozenset(get_args(SourceType))
+    result: set[SourceType] = set()
+    for i, item in enumerate(values):
+        if not isinstance(item, dict):
+            msg = f"enums.yml の 'source_type.values[{i}]' が dict ではありません"
+            raise TypeError(msg)
+        if "value" not in item:
+            msg = f"enums.yml の 'source_type.values[{i}]' に 'value' キーがありません"
+            raise KeyError(msg)
+        if "has_meta" not in item:
+            msg = (
+                f"enums.yml の 'source_type.values[{i}]' に 'has_meta' 属性がありません"
+            )
+            raise KeyError(msg)
+        value = item["value"]
+        if value not in valid_source_types:
+            msg = (
+                f"enums.yml の 'source_type.values[{i}].value' が SourceType Literal に "
+                f"含まれません: {value!r} "
+                f"（CI: scripts/validate_enums.py で同期検証されます）"
+            )
+            raise ValueError(msg)
+        if item["has_meta"] is False:
+            result.add(cast("SourceType", value))
+    return frozenset(result)

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -24,6 +24,7 @@ from urllib.parse import urldefrag
 from .errors import CliErrorCode
 from .filter_parser import parse_filters
 from .pipeline.models import PipelinePhase, format_pipeline_error as _format_pipeline_error
+from .store.models import SourceStatus
 from .evaluation import (
     EvaluationReport,
     FailureTag,
@@ -1821,8 +1822,8 @@ def run_stats(args: argparse.Namespace) -> None:
                 db.initialize()
                 history = db.get_pipeline_history()
                 last_commit_id = db.get_last_commit_id()
-                deleted_count = db.source_count(status="deleted")
-                active_count = db.source_count(status="active")
+                deleted_count = db.source_count(status=SourceStatus.DELETED)
+                active_count = db.source_count(status=SourceStatus.ACTIVE)
                 index_data["source_count"] = active_count
                 pipeline_data["last_processed_at"] = (
                     history[-1].processed_at if history else None

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -42,6 +42,7 @@ from rag.store.models import (
     NULL_COMMIT_HASH,
     SourceMetadata,
     SourceRecord,
+    SourceStatus,
     SourceType,
 )
 from rag.store.resolve import resolve_published_at, resolve_title
@@ -273,7 +274,7 @@ class PipelineController:
         # is_source_file=False のファイルは DB に登録されない）
         records = list(self.db.search_sources(
             source_type=source_type,
-            status="active",
+            status=SourceStatus.ACTIVE,
             path_prefix=path,
         ))
 
@@ -484,7 +485,7 @@ class PipelineController:
         # 登録されないため、DB 側フィルタは不要）
         records = list(self.db.search_sources(
             source_type=source_type,
-            status="active",
+            status=SourceStatus.ACTIVE,
             path_prefix=path,
         ))
 
@@ -559,7 +560,7 @@ class PipelineController:
         # されないため、フィルタは不要）
         records = list(self.db.search_sources(
             source_type=source_type,
-            status="active",
+            status=SourceStatus.ACTIVE,
             path_prefix=path,
         ))
 
@@ -943,7 +944,7 @@ class PipelineController:
         # （DB=active / インデックス未登録の不整合を防止）
         source_id = self._resolve_source_id(entry.file_path)
         existing = self.db.get_source(source_id)
-        if existing is not None and existing.status == "deleted":
+        if existing is not None and existing.status is SourceStatus.DELETED:
             return
 
         self._register_in_db(entry.file_path)
@@ -975,7 +976,7 @@ class PipelineController:
         self._converter.delete(entry.file_path, self._converted_store_dir)
         await self._indexer.delete(source_id)
         try:
-            self.db.set_status(source_id, "deleted")
+            self.db.set_status(source_id, SourceStatus.DELETED)
         except KeyError:
             logger.warning(
                 "削除対象が metadata.db に存在しません: %s", source_id,
@@ -1005,7 +1006,7 @@ class PipelineController:
         # metadata.db 更新: source_id = file_path なのでリネーム = source_id 変更
         # 全 source_type で DELETE old + INSERT new に統一
         try:
-            self.db.set_status(old_source_id, "deleted")
+            self.db.set_status(old_source_id, SourceStatus.DELETED)
         except KeyError:
             pass
         self._register_in_db(entry.file_path)

--- a/src/rag/pipeline/ingesters/_common.py
+++ b/src/rag/pipeline/ingesters/_common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -18,6 +19,20 @@ if TYPE_CHECKING:
 ProgressCallback = Callable[[int, int, str], None]
 
 
+class IngestErrorCategory(Enum):
+    """インジェスト失敗の種別.
+
+    値定義の SSoT は `_schema/enums.yml` の `ingest_error_category` カテゴリ。
+    `IngestResult.error_details` / `partial_failure_details` の `category`
+    フィールドにはこの Enum の `value`（snake_case 文字列）を記録する。
+    """
+
+    METADATA_FETCH = "metadata_fetch"
+    MEDIA_DOWNLOAD = "media_download"
+    PLACEMENT = "placement"
+    DELEGATION = "delegation"
+
+
 @dataclass
 class IngestResult:
     """インジェスターの配置結果.
@@ -26,13 +41,13 @@ class IngestResult:
 
     | フィールド | 必須 | 内容 |
     |---|:-:|---|
-    | `category` | 必須 | 失敗種別。以下のいずれか: `metadata_fetch` / `media_download` / `placement` / `delegation` |
+    | `category` | 必須 | 失敗種別。`IngestErrorCategory` の `value`（`metadata_fetch` / `media_download` / `placement` / `delegation`） |
     | `target` | 必須 | 識別子（`rel_path` / `source_id` / `slug` / `book_id` 等） |
     | `status` | 任意 | HTTP ステータスコード |
     | `url` | 任意 | 失敗した URL |
     | `message` | 任意 | 追加説明（例外メッセージ等） |
 
-    `category` は全媒体で上記 4 種に統一する（仕様: `docs/specs/ingesters/common.md`）。
+    `category` は `IngestErrorCategory` の Enum 値に統一する（仕様: `docs/specs/ingesters/common.md`）。
     列挙外の値は使用しない。集計・再取り込み判定で信頼できる集合として扱えるようにするため。
 
     不変条件:

--- a/src/rag/pipeline/ingesters/aozora.py
+++ b/src/rag/pipeline/ingesters/aozora.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import httpx
 
 from rag.pipeline.ingesters._common import (
+    IngestErrorCategory,
     IngestResult,
     ProgressCallback,
     fetch_get,
@@ -349,7 +350,7 @@ class AozoraIngester:
                 logger.exception("作品の取得・配置に失敗しました: %s", book_id)
                 result.errors += 1
                 detail: dict[str, Any] = {
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": f"book_id={book_id}",
                     "message": str(exc),
                 }
@@ -400,7 +401,7 @@ class AozoraIngester:
             logger.warning("XHTML URL が欠落: book_id=%s", book_id)
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": f"book_id={book_id}",
                 "message": "XHTML URL missing",
             })
@@ -429,7 +430,7 @@ class AozoraIngester:
             )
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": f"book_id={book_id}",
                 "status": status_code,
                 "url": github_url,
@@ -468,7 +469,7 @@ class AozoraIngester:
             logger.exception("作品の配置に失敗しました: %s", rel_path)
             result.errors += 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": rel_path,
                 "message": str(exc),
             })

--- a/src/rag/pipeline/ingesters/bluesky.py
+++ b/src/rag/pipeline/ingesters/bluesky.py
@@ -20,6 +20,7 @@ from urllib.parse import urlencode, urljoin, urlparse
 import httpx
 
 from rag.pipeline.ingesters._common import (
+    IngestErrorCategory,
     IngestResult,
     ProgressCallback,
     extract_http_status,
@@ -567,7 +568,7 @@ class BlueskyIngester:
             result.errors += 1
             result.error_details.append(
                 {
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": rel_path,
                     "message": str(exc),
                 },
@@ -627,7 +628,7 @@ class BlueskyIngester:
                 result.errors += 1
                 result.error_details.append(
                     {
-                        "category": "metadata_fetch",
+                        "category": IngestErrorCategory.METADATA_FETCH.value,
                         "target": url,
                         "message": "Invalid BlueSky URL format",
                     },
@@ -665,7 +666,7 @@ class BlueskyIngester:
                 result.errors += 1
                 result.error_details.append(
                     {
-                        "category": "metadata_fetch",
+                        "category": IngestErrorCategory.METADATA_FETCH.value,
                         "target": f"https://bsky.app/profile/{handle}/post/{rkey}",
                         "message": f"Failed to resolve DID for handle: {handle}",
                     },
@@ -687,7 +688,7 @@ class BlueskyIngester:
                 result.errors += 1
                 result.error_details.append(
                     {
-                        "category": "metadata_fetch",
+                        "category": IngestErrorCategory.METADATA_FETCH.value,
                         "target": f"https://bsky.app/profile/{handle}/post/{rkey}",
                         "message": str(exc),
                     },
@@ -699,7 +700,7 @@ class BlueskyIngester:
                 result.errors += 1
                 result.error_details.append(
                     {
-                        "category": "metadata_fetch",
+                        "category": IngestErrorCategory.METADATA_FETCH.value,
                         "target": f"https://bsky.app/profile/{handle}/post/{rkey}",
                         "message": "Post not found (may be deleted)",
                     },
@@ -769,7 +770,7 @@ class BlueskyIngester:
                 logger.exception("画像の DL に失敗しました: %s", img_url)
                 result.partial_failures += 1
                 detail: dict[str, Any] = {
-                    "category": "media_download",
+                    "category": IngestErrorCategory.MEDIA_DOWNLOAD.value,
                     "target": rel_path,
                     "url": img_url,
                     "message": str(exc),
@@ -793,7 +794,7 @@ class BlueskyIngester:
                 logger.exception("動画の DL に失敗しました: %s", playlist_url)
                 result.partial_failures += 1
                 detail_video: dict[str, Any] = {
-                    "category": "media_download",
+                    "category": IngestErrorCategory.MEDIA_DOWNLOAD.value,
                     "target": rel_path,
                     "url": playlist_url,
                     "message": str(exc),
@@ -840,7 +841,7 @@ class BlueskyIngester:
                 result.partial_failures += 1
                 result.partial_failure_details.append(
                     {
-                        "category": "media_download",
+                        "category": IngestErrorCategory.MEDIA_DOWNLOAD.value,
                         "target": rel_path,
                         "url": playlist_url,
                         "message": "HLS variant not selectable",
@@ -868,7 +869,7 @@ class BlueskyIngester:
             result.partial_failures += 1
             result.partial_failure_details.append(
                 {
-                    "category": "media_download",
+                    "category": IngestErrorCategory.MEDIA_DOWNLOAD.value,
                     "target": rel_path,
                     "url": playlist_url,
                     "message": "HLS playlist has no ts segments",
@@ -1131,7 +1132,7 @@ class BlueskyIngester:
                             result.errors += 1
                             result.error_details.append(
                                 {
-                                    "category": "delegation",
+                                    "category": IngestErrorCategory.DELEGATION.value,
                                     "target": url,
                                     "url": url,
                                     "message": "invalid youtube url",
@@ -1192,7 +1193,7 @@ class BlueskyIngester:
                             result.errors += 1
                             result.error_details.append(
                                 {
-                                    "category": "delegation",
+                                    "category": IngestErrorCategory.DELEGATION.value,
                                     "target": url,
                                     "url": url,
                                     "message": f"youtube delegation failed: {exc}",
@@ -1256,7 +1257,7 @@ class BlueskyIngester:
                 logger.warning("Web URL バリデーション失敗: %s (%s)", url, exc)
                 validation_errors.append(
                     {
-                        "category": "delegation",
+                        "category": IngestErrorCategory.DELEGATION.value,
                         "target": url,
                         "url": url,
                         "message": f"url validation failed: {exc}",
@@ -1278,7 +1279,7 @@ class BlueskyIngester:
             logger.exception("site-ingest 実行に失敗: %d 件", len(validated_urls))
             execute_errors = [
                 {
-                    "category": "delegation",
+                    "category": IngestErrorCategory.DELEGATION.value,
                     "target": url,
                     "url": url,
                     "message": f"site-ingest failed: {exc}",
@@ -1297,7 +1298,7 @@ class BlueskyIngester:
         if bridge.parse_errors > 0:
             error_details.append(
                 {
-                    "category": "delegation",
+                    "category": IngestErrorCategory.DELEGATION.value,
                     "target": "site-ingest:jsonl",
                     "message": (
                         f"JSONL のパースに失敗した行が {bridge.parse_errors} 件"

--- a/src/rag/pipeline/ingesters/journal.py
+++ b/src/rag/pipeline/ingesters/journal.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from rag.pipeline.ingesters._common import IngestResult
+from rag.pipeline.ingesters._common import IngestErrorCategory, IngestResult
 
 if TYPE_CHECKING:
     from rag.store.source_store import SourceStore
@@ -86,7 +86,7 @@ class JournalIngester:
         except ValueError as e:
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": entry_id or title,
                 "message": str(e),
             })
@@ -94,7 +94,7 @@ class JournalIngester:
             logger.exception("Failed to place journal entry")
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": entry_id or title,
                 "message": str(e),
             })
@@ -118,7 +118,7 @@ class JournalIngester:
         except ValueError as e:
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": dir_path,
                 "message": str(e),
             })
@@ -128,7 +128,7 @@ class JournalIngester:
         if not resolved_dir.exists():
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": str(resolved_dir),
                 "message": f"Directory not found: {resolved_dir}",
             })
@@ -136,7 +136,7 @@ class JournalIngester:
         if not resolved_dir.is_dir():
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": str(resolved_dir),
                 "message": f"Path is not a directory: {resolved_dir}",
             })
@@ -196,7 +196,7 @@ class JournalIngester:
                 logger.exception("Failed to import journal file: %s", fp)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": str(fp),
                     "message": str(exc),
                 })

--- a/src/rag/pipeline/ingesters/local.py
+++ b/src/rag/pipeline/ingesters/local.py
@@ -10,7 +10,11 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from rag.pipeline.ingesters._common import IngestResult, ProgressCallback
+from rag.pipeline.ingesters._common import (
+    IngestErrorCategory,
+    IngestResult,
+    ProgressCallback,
+)
 
 if TYPE_CHECKING:
     from rag.store.source_store import SourceStore
@@ -65,7 +69,7 @@ class LocalIngester:
                 msg = f"同名ファイルが既に存在します: {rel_path}"
                 result.errors = 1
                 result.error_details.append({
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": rel_path,
                     "message": msg,
                 })
@@ -81,7 +85,7 @@ class LocalIngester:
         except ValueError as e:
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": filename,
                 "message": str(e),
             })
@@ -89,7 +93,7 @@ class LocalIngester:
             logger.exception("Failed to place file: %s", filename)
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": filename,
                 "message": str(e),
             })
@@ -118,7 +122,7 @@ class LocalIngester:
         except ValueError as e:
             result.errors = 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": dir_path,
                 "message": str(e),
             })
@@ -162,7 +166,7 @@ class LocalIngester:
                 logger.exception("Failed to copy file: %s", fp)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": str(fp),
                     "message": str(exc),
                 })

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -20,7 +20,12 @@ import re
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import parse_qs, urlparse
 
-from rag.pipeline.ingesters._common import IngestResult, ProgressCallback, now_iso
+from rag.pipeline.ingesters._common import (
+    IngestErrorCategory,
+    IngestResult,
+    ProgressCallback,
+    now_iso,
+)
 
 if TYPE_CHECKING:
     from rag.pipeline.ingesters.youtube_fetcher import YoutubeFetcher
@@ -222,7 +227,7 @@ class YoutubeIngester:
             logger.error("メタデータ取得失敗 (video_id=%s): %s", video_id, e)
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": video_id,
                 "message": f"メタデータ取得失敗: {e}",
             })
@@ -253,7 +258,7 @@ class YoutubeIngester:
             logger.error("channel_id が取得できません (video_id=%s)", video_id)
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": video_id,
                 "message": "channel_id missing",
             })
@@ -273,7 +278,7 @@ class YoutubeIngester:
             logger.error("字幕/文字起こし失敗 (video_id=%s): %s", video_id, e)
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": video_id,
                 "message": f"字幕/文字起こし失敗: {e}",
             })
@@ -330,7 +335,7 @@ class YoutubeIngester:
             logger.exception("動画の配置に失敗しました: %s", rel_path)
             result.errors += 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": rel_path,
                 "message": str(exc),
             })
@@ -386,7 +391,7 @@ class YoutubeIngester:
             logger.error("プレイリスト展開失敗: %s", e)
             result.errors += 1
             result.error_details.append({
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": playlist_id,
                 "message": f"プレイリスト展開失敗: {e}",
             })
@@ -408,7 +413,7 @@ class YoutubeIngester:
             if not video_id:
                 result.errors += 1
                 result.error_details.append({
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": f"entry_{i}",
                     "message": "video_id missing",
                 })
@@ -444,7 +449,7 @@ class YoutubeIngester:
                 logger.error("動画処理失敗 (video_id=%s): %s", video_id, e)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": video_id,
                     "message": f"動画処理失敗: {e}",
                 })

--- a/src/rag/pipeline/ingesters/zenn.py
+++ b/src/rag/pipeline/ingesters/zenn.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from rag.pipeline.ingesters._common import (
+    IngestErrorCategory,
     IngestResult,
     ProgressCallback,
     fetch_get,
@@ -225,7 +226,7 @@ class ZennIngester:
                 logger.exception("記事の取得に失敗しました: %s", slug)
                 result.errors += 1
                 fetch_detail: dict[str, Any] = {
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": f"articles/{slug}",
                     "message": str(exc),
                 }
@@ -254,7 +255,7 @@ class ZennIngester:
                 logger.exception("記事の配置に失敗しました: %s", rel_path)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": rel_path,
                     "message": str(exc),
                 })
@@ -324,7 +325,7 @@ class ZennIngester:
                 logger.exception("スクラップの取得に失敗しました: %s", slug)
                 result.errors += 1
                 fetch_detail: dict[str, Any] = {
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": f"scraps/{slug}",
                     "message": str(exc),
                 }
@@ -353,7 +354,7 @@ class ZennIngester:
                 logger.exception("スクラップの配置に失敗しました: %s", rel_path)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "placement",
+                    "category": IngestErrorCategory.PLACEMENT.value,
                     "target": rel_path,
                     "message": str(exc),
                 })
@@ -486,7 +487,7 @@ class ZennIngester:
                 logger.warning("コンテンツオブジェクトが空です: %s/%s", kind, slug)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": f"{kind}/{slug}",
                     "message": "Empty content object",
                 })
@@ -535,7 +536,7 @@ class ZennIngester:
             logger.exception("コンテンツの取得に失敗しました: %s/%s", kind, slug)
             result.errors += 1
             fetch_detail: dict[str, Any] = {
-                "category": "metadata_fetch",
+                "category": IngestErrorCategory.METADATA_FETCH.value,
                 "target": f"{kind}/{slug}",
                 "message": str(exc),
             }
@@ -561,7 +562,7 @@ class ZennIngester:
             logger.exception("コンテンツの配置に失敗しました: %s", rel_path)
             result.errors += 1
             result.error_details.append({
-                "category": "placement",
+                "category": IngestErrorCategory.PLACEMENT.value,
                 "target": rel_path,
                 "message": str(exc),
             })
@@ -587,7 +588,7 @@ class ZennIngester:
                 logger.warning("Zenn URL のパースに失敗しました: %s", url)
                 result.errors += 1
                 result.error_details.append({
-                    "category": "metadata_fetch",
+                    "category": IngestErrorCategory.METADATA_FETCH.value,
                     "target": url,
                     "message": "Invalid Zenn URL format",
                 })

--- a/src/rag/pipeline/models.py
+++ b/src/rag/pipeline/models.py
@@ -40,28 +40,32 @@ class PipelineMode(Enum):
 class PipelinePhase(Enum):
     """パイプライン処理のフェーズ.
 
-    display は progress 通知のプレフィックス（人間向け表示）、
-    error_key は `PipelineErrorEntry.phase` に記録される列挙値。
+    値は `PipelineErrorEntry.phase` に記録される snake_case キー。
+    progress 表示用のラベルは `PIPELINE_PHASE_DISPLAY` mapping で管理する。
     """
 
-    FETCH = ("Fetch", "fetch")
-    CONVERT = ("Convert", "convert")
-    INDEX = ("Index", "index")
-    CONVERT_AND_INDEX = ("Convert & Index", "convert_and_index")
-
-    def __init__(self, display: str, error_key: str) -> None:
-        self._display = display
-        self._error_key = error_key
-
-    @property
-    def display(self) -> str:
-        """progress 表示・ログ出力用のフェーズ名."""
-        return self._display
+    FETCH = "fetch"
+    CONVERT = "convert"
+    INDEX = "index"
+    CONVERT_AND_INDEX = "convert_and_index"
 
     @property
     def error_key(self) -> str:
         """PipelineErrorEntry.phase に記録される snake_case キー."""
-        return self._error_key
+        return self.value
+
+    @property
+    def display(self) -> str:
+        """progress 表示・ログ出力用のフェーズ名."""
+        return PIPELINE_PHASE_DISPLAY[self]
+
+
+PIPELINE_PHASE_DISPLAY: dict[PipelinePhase, str] = {
+    PipelinePhase.FETCH: "Fetch",
+    PipelinePhase.CONVERT: "Convert",
+    PipelinePhase.INDEX: "Index",
+    PipelinePhase.CONVERT_AND_INDEX: "Convert & Index",
+}
 
 
 class PipelineErrorEntry(TypedDict):

--- a/src/rag/scrapy/bridge.py
+++ b/src/rag/scrapy/bridge.py
@@ -15,7 +15,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from rag.pipeline.ingesters._common import IngestResult
+from rag.pipeline.ingesters._common import IngestErrorCategory, IngestResult
 from rag.store.path_converter import url_to_path
 
 # .html 付与をスキップする拡張子
@@ -208,7 +208,7 @@ def _process_record(
         )
         result.ingest.errors += 1
         result.ingest.error_details.append({
-            "category": "placement",
+            "category": IngestErrorCategory.PLACEMENT.value,
             "target": record.url,
             "message": "HTML not found",
         })
@@ -223,7 +223,7 @@ def _process_record(
         )
         result.ingest.errors += 1
         result.ingest.error_details.append({
-            "category": "placement",
+            "category": IngestErrorCategory.PLACEMENT.value,
             "target": record.url,
             "message": f"Read error: {exc}",
         })
@@ -259,7 +259,7 @@ def _process_record(
         )
         result.ingest.errors += 1
         result.ingest.error_details.append({
-            "category": "placement",
+            "category": IngestErrorCategory.PLACEMENT.value,
             "target": record.url,
             "message": str(exc),
         })

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -29,18 +29,22 @@ logger = logging.getLogger(__name__)
 # json_extract の JSON パスに埋め込むキー名の許容パターン
 _VALID_FILTER_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
-_SCHEMA_SQL = """\
+# SQL 内の status リテラルは SourceStatus Enum の value から導出する。
+# 値定義の SSoT は _schema/enums.yml の source_status カテゴリ。
+_STATUS_ACTIVE = SourceStatus.ACTIVE.value
+
+_SCHEMA_SQL = f"""\
 CREATE TABLE IF NOT EXISTS sources (
     source_id    TEXT PRIMARY KEY,
     source_type  TEXT NOT NULL,
     title        TEXT NOT NULL,
-    status       TEXT NOT NULL DEFAULT 'active',
+    status       TEXT NOT NULL DEFAULT '{_STATUS_ACTIVE}',
     content_hash TEXT NOT NULL,
     file_size    INTEGER NOT NULL,
     collected_at TEXT NOT NULL,
     updated_at   TEXT NOT NULL,
     published_at TEXT NOT NULL DEFAULT '',
-    meta         TEXT NOT NULL DEFAULT '{}'
+    meta         TEXT NOT NULL DEFAULT '{{}}'
 );
 
 CREATE TABLE IF NOT EXISTS pipeline_history (
@@ -159,13 +163,13 @@ class MetadataDB:
         # source_id = file_path 統合: file_path カラムが残っている旧スキーマを移行
         if "file_path" in src_columns:
             # file_path を新 source_id として直接 INSERT（UPDATE での PK 衝突を回避）
-            self._connection.executescript("""\
+            self._connection.executescript(f"""\
                 DROP TABLE IF EXISTS sources_new;
                 CREATE TABLE sources_new (
                     source_id    TEXT PRIMARY KEY,
                     source_type  TEXT NOT NULL,
                     title        TEXT NOT NULL,
-                    status       TEXT NOT NULL DEFAULT 'active',
+                    status       TEXT NOT NULL DEFAULT '{_STATUS_ACTIVE}',
                     content_hash TEXT NOT NULL,
                     file_size    INTEGER NOT NULL,
                     collected_at TEXT NOT NULL,
@@ -304,11 +308,11 @@ class MetadataDB:
                 (source_id, source_type, title, status,
                  content_hash, file_size, collected_at, updated_at,
                  published_at, meta)
-            VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(source_id) DO UPDATE SET
                 source_type = excluded.source_type,
                 title = excluded.title,
-                status = 'active',
+                status = excluded.status,
                 content_hash = excluded.content_hash,
                 file_size = excluded.file_size,
                 updated_at = excluded.updated_at,
@@ -318,6 +322,7 @@ class MetadataDB:
                 source_id,
                 source_type,
                 title,
+                _STATUS_ACTIVE,
                 content_hash,
                 file_size,
                 collected_at,
@@ -406,7 +411,7 @@ class MetadataDB:
             params.append(source_type)
         if status is not None:
             conditions.append("status = ?")
-            params.append(status)
+            params.append(status.value)
         if path_prefix is not None:
             normalized = normalize_path_prefix(path_prefix)
             escaped = escape_like(normalized)
@@ -428,7 +433,7 @@ class MetadataDB:
         """
         cursor = self._connection.execute(
             "UPDATE sources SET status = ? WHERE source_id = ?",
-            (status, source_id),
+            (status.value, source_id),
         )
         if cursor.rowcount == 0:
             msg = f"source_id が見つかりません: {source_id}"
@@ -574,7 +579,7 @@ class MetadataDB:
         if status is not None:
             row = self._connection.execute(
                 "SELECT COUNT(*) as cnt FROM sources WHERE status = ?",
-                (status,),
+                (status.value,),
             ).fetchone()
         else:
             row = self._connection.execute(
@@ -627,8 +632,8 @@ class MetadataDB:
             ValueError: filters のキー名に不正な文字が含まれる場合
         """
         direction = "ASC" if ascending else "DESC"
-        conditions = ["source_type = ?", "status = 'active'"]
-        params: list[Any] = [source_type]
+        conditions = ["source_type = ?", "status = ?"]
+        params: list[Any] = [source_type, _STATUS_ACTIVE]
 
         if filters:
             self._build_meta_filter_conditions(filters, conditions, params)
@@ -660,8 +665,8 @@ class MetadataDB:
         Raises:
             ValueError: filters のキー名に不正な文字が含まれる場合
         """
-        conditions = ["source_type = ?", "status = 'active'"]
-        params: list[Any] = [source_type]
+        conditions = ["source_type = ?", "status = ?"]
+        params: list[Any] = [source_type, _STATUS_ACTIVE]
 
         if filters:
             self._build_meta_filter_conditions(filters, conditions, params)
@@ -680,7 +685,7 @@ def _row_to_source_record(row: sqlite3.Row) -> SourceRecord:
         source_id=row["source_id"],
         source_type=row["source_type"],
         title=row["title"],
-        status=row["status"],
+        status=SourceStatus(row["status"]),
         content_hash=row["content_hash"],
         file_size=row["file_size"],
         collected_at=row["collected_at"],

--- a/src/rag/store/models.py
+++ b/src/rag/store/models.py
@@ -6,10 +6,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Literal
 
 SourceType = Literal["web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"]
-SourceStatus = Literal["active", "deleted"]
+
+
+class SourceStatus(Enum):
+    """ソースの論理状態.
+
+    値定義の SSoT は `_schema/enums.yml` の `source_status` カテゴリ。
+    """
+
+    ACTIVE = "active"
+    DELETED = "deleted"
+
 
 # git null commit hash（初回パイプライン実行時の from_commit_id）
 NULL_COMMIT_HASH = "0" * 40

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -20,6 +20,7 @@ from typing import Any, get_args
 
 import pathspec
 
+from rag._schema_loader import source_types_without_meta
 from rag.infrastructure.file_lock import REBUILD_LOCK_FILENAME, WRITE_LOCK_FILENAME
 from rag.store.meta import meta_path_for, read_meta, write_meta
 from rag.store.metadata_db import MetadataDB
@@ -27,6 +28,7 @@ from rag.store.models import (
     FileData,
     SourceMetadata,
     SourceRecord,
+    SourceStatus,
     SourceType,
 )
 from rag.store.path_converter import url_to_path
@@ -35,7 +37,8 @@ from rag.store.resolve import resolve_published_at, resolve_title
 logger = logging.getLogger(__name__)
 
 # .meta を持たない媒体（source_store が SSoT）
-NO_META_TYPES: frozenset[SourceType] = frozenset({"local"})
+# enums.yml の `source_type.has_meta=false` から導出する。
+NO_META_TYPES: frozenset[SourceType] = source_types_without_meta()  # type: ignore[assignment]
 
 # --- ソース判定 ---
 #
@@ -71,16 +74,12 @@ _EXCLUDE_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(
     "gitignore", _EXCLUDE_PATTERNS,
 )
 
-# source_type 値の集合: SourceType Literal から導出する
-# （SourceType Literal 自体は CI で _schema/enums.yml と同期検証される）
-_SOURCE_TYPE_VALUES: frozenset[SourceType] = frozenset(get_args(SourceType))
-
-
 def detect_source_type(rel_path: str) -> SourceType:
     """相対パスから source_type を判定する.
 
     先頭ディレクトリが _schema/enums.yml の source_type 値に一致しない場合は
-    ValueError を送出する。
+    ValueError を送出する。値の集合は SourceType Literal から導出する
+    （Literal 自体は CI で _schema/enums.yml と同期検証される）。
 
     Args:
         rel_path: source_store ルート基準の相対パス
@@ -93,7 +92,7 @@ def detect_source_type(rel_path: str) -> SourceType:
     """
     normalized = rel_path.replace("\\", "/")
     first = normalized.split("/", 1)[0]
-    if first in _SOURCE_TYPE_VALUES:
+    if first in get_args(SourceType):
         # Literal への narrowing
         return first  # type: ignore[return-value]
     msg = f"未知の source_type プレフィックス: {rel_path!r}"
@@ -171,7 +170,7 @@ def is_source_file(rel_path: str) -> bool:
         return False
     # invariant 担保: detect_source_type が ValueError を送出するパスを False にする
     first = normalized.split("/", 1)[0]
-    if first not in _SOURCE_TYPE_VALUES:
+    if first not in get_args(SourceType):
         return False
     return True
 
@@ -557,7 +556,7 @@ class SourceStore:
         Raises:
             KeyError: source_id が存在しない場合
         """
-        self._db.set_status(source_id, "deleted")
+        self._db.set_status(source_id, SourceStatus.DELETED)
 
     def restore(self, source_id: str) -> None:
         """論理削除を解除する.
@@ -565,7 +564,7 @@ class SourceStore:
         Raises:
             KeyError: source_id が存在しない場合
         """
-        self._db.set_status(source_id, "active")
+        self._db.set_status(source_id, SourceStatus.ACTIVE)
 
     # --- DB 再構築 ---
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -40,6 +40,11 @@ logger = logging.getLogger(__name__)
 # enums.yml の `source_type.has_meta=false` から導出する。
 NO_META_TYPES: frozenset[SourceType] = source_types_without_meta()  # type: ignore[assignment]
 
+# source_type 値の集合: SourceType Literal から導出する
+# （SourceType Literal 自体は CI で _schema/enums.yml と同期検証されるため二重管理にならない）
+# detect_source_type / is_source_file の判定で使い回すモジュール定数。
+_SOURCE_TYPE_VALUES: frozenset[SourceType] = frozenset(get_args(SourceType))
+
 # --- ソース判定 ---
 #
 # is_source_file / resolve_attachment_parent / find_existing_parent /
@@ -92,7 +97,7 @@ def detect_source_type(rel_path: str) -> SourceType:
     """
     normalized = rel_path.replace("\\", "/")
     first = normalized.split("/", 1)[0]
-    if first in get_args(SourceType):
+    if first in _SOURCE_TYPE_VALUES:
         # Literal への narrowing
         return first  # type: ignore[return-value]
     msg = f"未知の source_type プレフィックス: {rel_path!r}"
@@ -170,7 +175,7 @@ def is_source_file(rel_path: str) -> bool:
         return False
     # invariant 担保: detect_source_type が ValueError を送出するパスを False にする
     first = normalized.split("/", 1)[0]
-    if first not in get_args(SourceType):
+    if first not in _SOURCE_TYPE_VALUES:
         return False
     return True
 

--- a/src/rag/store/source_store.py
+++ b/src/rag/store/source_store.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 # .meta を持たない媒体（source_store が SSoT）
 # enums.yml の `source_type.has_meta=false` から導出する。
-NO_META_TYPES: frozenset[SourceType] = source_types_without_meta()  # type: ignore[assignment]
+NO_META_TYPES: frozenset[SourceType] = source_types_without_meta()
 
 # source_type 値の集合: SourceType Literal から導出する
 # （SourceType Literal 自体は CI で _schema/enums.yml と同期検証されるため二重管理にならない）

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from rag.store.metadata_db import MetadataDB
+from rag.store.models import SourceStatus
 
 
 @pytest.fixture()
@@ -50,7 +51,7 @@ def _register(
         meta=meta,
     )
     if status == "deleted":
-        db.set_status(source_id, "deleted")
+        db.set_status(source_id, SourceStatus.DELETED)
 
 
 class TestListSources:

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -24,7 +24,7 @@ import yaml
 
 from rag.pipeline.controller import PipelineController
 from rag.pipeline.models import PipelineMode
-from rag.store.models import NULL_COMMIT_HASH, SourceMetadata, SourceType
+from rag.store.models import NULL_COMMIT_HASH, SourceMetadata, SourceStatus, SourceType
 from rag.store.source_store import SourceStore
 
 
@@ -371,7 +371,7 @@ class TestRunIncremental:
         # metadata.db で論理削除されている
         record = ctrl.db.get_source("local/a.txt")
         assert record is not None
-        assert record.status == "deleted"
+        assert record.status is SourceStatus.DELETED
 
     async def test_incremental_detects_renamed(
         self,
@@ -575,7 +575,7 @@ class TestDeleteAndReAdd:
         assert "local/a.txt" in indexer.deleted_ids
         record = ctrl.db.get_source("local/a.txt")
         assert record is not None
-        assert record.status == "deleted"
+        assert record.status is SourceStatus.DELETED
 
         # スタブをリセット
         indexer.added.clear()
@@ -602,7 +602,7 @@ class TestDeleteAndReAdd:
         assert "local/a.txt" in indexer.added
         record = ctrl.db.get_source("local/a.txt")
         assert record is not None
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
 
     async def test_delete_and_readd_different_content(
         self,
@@ -1598,7 +1598,7 @@ class TestRenamedLocalSourceId:
 
         old_record = ctrl.db.get_source("local/old.txt")
         assert old_record is not None
-        assert old_record.status == "active"
+        assert old_record.status is SourceStatus.ACTIVE
 
         src = workspace["source"] / "local" / "old.txt"
         src.rename(workspace["source"] / "local" / "new.txt")
@@ -1608,12 +1608,12 @@ class TestRenamedLocalSourceId:
         # 旧レコードは論理削除
         old_record = ctrl.db.get_source("local/old.txt")
         assert old_record is not None
-        assert old_record.status == "deleted"
+        assert old_record.status is SourceStatus.DELETED
 
         # 新レコードが作成されている
         new_record = ctrl.db.get_source("local/new.txt")
         assert new_record is not None
-        assert new_record.status == "active"
+        assert new_record.status is SourceStatus.ACTIVE
 
         # インデクサー: 旧削除 + 新追加
         assert "local/old.txt" in indexer.deleted_ids

--- a/tests/test_schema_enums.py
+++ b/tests/test_schema_enums.py
@@ -10,6 +10,11 @@ Covers:
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
+from rag import _schema_loader
 from rag._schema_loader import source_types_without_meta
 from rag.pipeline.ingesters._common import IngestErrorCategory
 from rag.pipeline.models import PIPELINE_PHASE_DISPLAY, PipelinePhase
@@ -22,6 +27,17 @@ class TestSchemaLoader:
     def test_returns_local_only(self) -> None:
         """`has_meta: false` の集合は local のみを含む."""
         assert source_types_without_meta() == frozenset({"local"})
+
+    def test_returns_typed_frozenset(self) -> None:
+        """戻り値型は SourceType Literal の値のみを含む（type: ignore 不要を保証）."""
+        from typing import get_args
+
+        from rag.store.models import SourceType
+
+        result = source_types_without_meta()
+        valid = frozenset(get_args(SourceType))
+        # 全ての値が SourceType Literal 値の部分集合であること
+        assert result <= valid
 
 
 class TestSourceStatus:
@@ -80,3 +96,72 @@ class TestPipelinePhase:
         assert PipelinePhase.CONVERT.display == "Convert"
         assert PipelinePhase.INDEX.display == "Index"
         assert PipelinePhase.CONVERT_AND_INDEX.display == "Convert & Index"
+
+
+class TestSourceTypesWithoutMetaValidation:
+    """source_types_without_meta() の構造検証テスト（enums.yml 異常時の説明的例外）."""
+
+    def _patch_enums(
+        self, monkeypatch: pytest.MonkeyPatch, data: Any,
+    ) -> None:
+        """`_load_enums` の戻り値を monkeypatch で差し替える."""
+        _schema_loader._load_enums.cache_clear()
+        monkeypatch.setattr(_schema_loader, "_load_enums", lambda: data)
+
+    def test_source_type_entry_not_dict(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """source_type エントリが dict でない場合 TypeError."""
+        self._patch_enums(monkeypatch, {"source_type": "not a dict"})
+        with pytest.raises(TypeError, match="'source_type' エントリが dict ではありません"):
+            source_types_without_meta()
+
+    def test_values_not_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """values が list でない場合 TypeError."""
+        self._patch_enums(monkeypatch, {"source_type": {"values": "not a list"}})
+        with pytest.raises(TypeError, match="'source_type.values' が list でないか空"):
+            source_types_without_meta()
+
+    def test_values_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """values が空 list の場合 TypeError."""
+        self._patch_enums(monkeypatch, {"source_type": {"values": []}})
+        with pytest.raises(TypeError, match="空"):
+            source_types_without_meta()
+
+    def test_item_missing_value_key(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """value キー欠落時 KeyError."""
+        self._patch_enums(
+            monkeypatch,
+            {"source_type": {"values": [{"has_meta": True}]}},
+        )
+        with pytest.raises(KeyError, match="'value' キーがありません"):
+            source_types_without_meta()
+
+    def test_item_missing_has_meta(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """has_meta 属性欠落時 KeyError."""
+        self._patch_enums(
+            monkeypatch,
+            {"source_type": {"values": [{"value": "local"}]}},
+        )
+        with pytest.raises(KeyError, match="'has_meta' 属性がありません"):
+            source_types_without_meta()
+
+    def test_value_not_in_source_type_literal(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SourceType Literal に含まれない値の場合 ValueError."""
+        self._patch_enums(
+            monkeypatch,
+            {"source_type": {"values": [{"value": "unknown_type", "has_meta": True}]}},
+        )
+        with pytest.raises(ValueError, match=r"SourceType Literal"):
+            source_types_without_meta()
+
+    def test_clear_cache_after_test(self) -> None:
+        """テストの後始末で lru_cache をクリアして実 enums.yml の結果に戻す."""
+        _schema_loader._load_enums.cache_clear()
+        assert source_types_without_meta() == frozenset({"local"})

--- a/tests/test_schema_enums.py
+++ b/tests/test_schema_enums.py
@@ -1,0 +1,82 @@
+"""列挙値・属性スキーマ関連のテスト.
+
+Covers:
+- `_schema_loader.source_types_without_meta()` が enums.yml の `has_meta: false` 集合を返す
+- `SourceStatus` / `IngestErrorCategory` / `PipelinePhase` の Enum 振る舞い
+- PipelinePhase の `display` mapping / `error_key` プロパティ
+
+仕様: docs/specs/architecture.md（SSoT 階層）
+"""
+
+from __future__ import annotations
+
+from rag._schema_loader import source_types_without_meta
+from rag.pipeline.ingesters._common import IngestErrorCategory
+from rag.pipeline.models import PIPELINE_PHASE_DISPLAY, PipelinePhase
+from rag.store.models import SourceStatus
+
+
+class TestSchemaLoader:
+    """_schema_loader.source_types_without_meta のテスト."""
+
+    def test_returns_local_only(self) -> None:
+        """`has_meta: false` の集合は local のみを含む."""
+        assert source_types_without_meta() == frozenset({"local"})
+
+
+class TestSourceStatus:
+    """SourceStatus Enum のテスト."""
+
+    def test_values_match_enums_yml(self) -> None:
+        """active / deleted の 2 値を持つ."""
+        assert {member.value for member in SourceStatus} == {"active", "deleted"}
+
+    def test_round_trip_via_value(self) -> None:
+        """value からの再構築が等価."""
+        for member in SourceStatus:
+            assert SourceStatus(member.value) is member
+
+
+class TestIngestErrorCategory:
+    """IngestErrorCategory Enum のテスト."""
+
+    def test_values_match_enums_yml(self) -> None:
+        """4 値を持ち enums.yml と一致."""
+        assert {member.value for member in IngestErrorCategory} == {
+            "metadata_fetch",
+            "media_download",
+            "placement",
+            "delegation",
+        }
+
+    def test_round_trip_via_value(self) -> None:
+        """value からの再構築が等価."""
+        for member in IngestErrorCategory:
+            assert IngestErrorCategory(member.value) is member
+
+
+class TestPipelinePhase:
+    """PipelinePhase Enum と display mapping のテスト."""
+
+    def test_value_is_snake_case_error_key(self) -> None:
+        """value は error_key と同等の snake_case 文字列."""
+        assert PipelinePhase.FETCH.value == "fetch"
+        assert PipelinePhase.CONVERT.value == "convert"
+        assert PipelinePhase.INDEX.value == "index"
+        assert PipelinePhase.CONVERT_AND_INDEX.value == "convert_and_index"
+
+    def test_error_key_property(self) -> None:
+        """error_key プロパティは value と一致."""
+        for phase in PipelinePhase:
+            assert phase.error_key == phase.value
+
+    def test_display_mapping_covers_all_members(self) -> None:
+        """全 Enum メンバが display mapping に含まれる."""
+        assert set(PIPELINE_PHASE_DISPLAY.keys()) == set(PipelinePhase)
+
+    def test_display_property(self) -> None:
+        """display プロパティは PIPELINE_PHASE_DISPLAY からラベルを返す."""
+        assert PipelinePhase.FETCH.display == "Fetch"
+        assert PipelinePhase.CONVERT.display == "Convert"
+        assert PipelinePhase.INDEX.display == "Index"
+        assert PipelinePhase.CONVERT_AND_INDEX.display == "Convert & Index"

--- a/tests/test_store_metadata_db.py
+++ b/tests/test_store_metadata_db.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from rag.store.metadata_db import MetadataDB
-from rag.store.models import NULL_COMMIT_HASH
+from rag.store.models import NULL_COMMIT_HASH, SourceStatus
 
 
 @pytest.fixture()
@@ -41,7 +41,7 @@ class TestSourcesCRUD:
         assert record.source_id == "web/https/example.com/page.html"
         assert record.source_type == "web"
         assert record.title == "Test Page"
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
         assert record.file_size == 1024
 
     def test_register_upsert(self, db: MetadataDB) -> None:
@@ -69,7 +69,7 @@ class TestSourcesCRUD:
         assert record is not None
         assert record.title == "New Title"
         assert record.content_hash == "new"
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
 
     def test_register_restores_deleted(self, db: MetadataDB) -> None:
         """deleted 状態のソースへの再登録で active に復帰する."""
@@ -82,7 +82,7 @@ class TestSourcesCRUD:
             collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
-        db.set_status("local/test.md", "deleted")
+        db.set_status("local/test.md", SourceStatus.DELETED)
 
         db.register_source(
             source_id="local/test.md",
@@ -96,7 +96,7 @@ class TestSourcesCRUD:
 
         record = db.get_source("local/test.md")
         assert record is not None
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
         assert record.title == "Test Updated"
 
     def test_get_nonexistent(self, db: MetadataDB) -> None:
@@ -254,9 +254,9 @@ class TestSourcesCRUD:
             collected_at="2026-01-02T00:00:00Z",
             updated_at="2026-01-02T00:00:00Z",
         )
-        db.set_status("local/deleted.md", "deleted")
+        db.set_status("local/deleted.md", SourceStatus.DELETED)
 
-        active = db.search_sources(status="active")
+        active = db.search_sources(status=SourceStatus.ACTIVE)
         assert len(active) == 1
         assert active[0].source_id == "local/active.md"
 
@@ -271,19 +271,19 @@ class TestSourcesCRUD:
             updated_at="2026-01-01T00:00:00Z",
         )
 
-        db.set_status("local/test.md", "deleted")
+        db.set_status("local/test.md", SourceStatus.DELETED)
         record = db.get_source("local/test.md")
         assert record is not None
-        assert record.status == "deleted"
+        assert record.status is SourceStatus.DELETED
 
-        db.set_status("local/test.md", "active")
+        db.set_status("local/test.md", SourceStatus.ACTIVE)
         record = db.get_source("local/test.md")
         assert record is not None
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
 
     def test_set_status_nonexistent(self, db: MetadataDB) -> None:
         with pytest.raises(KeyError):
-            db.set_status("nonexistent", "deleted")
+            db.set_status("nonexistent", SourceStatus.DELETED)
 
     def test_source_count(self, db: MetadataDB) -> None:
         assert db.source_count() == 0
@@ -306,11 +306,11 @@ class TestSourcesCRUD:
             collected_at="2026-01-01T00:00:00Z",
             updated_at="2026-01-01T00:00:00Z",
         )
-        db.set_status("local/s2.md", "deleted")
+        db.set_status("local/s2.md", SourceStatus.DELETED)
 
         assert db.source_count() == 2
-        assert db.source_count(status="active") == 1
-        assert db.source_count(status="deleted") == 1
+        assert db.source_count(status=SourceStatus.ACTIVE) == 1
+        assert db.source_count(status=SourceStatus.DELETED) == 1
 
 
 class TestMetaColumn:

--- a/tests/test_store_source_store.py
+++ b/tests/test_store_source_store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from rag.store.models import SourceStatus
 from rag.store.source_store import SourceStore
 
 
@@ -41,7 +42,7 @@ class TestPlaceFile:
         assert record is not None
         assert record.source_type == "local"
         assert record.title == "test"
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
         assert record.file_size == len(data)
 
     def test_place_web_file_with_meta(self, store: SourceStore) -> None:
@@ -421,7 +422,7 @@ class TestSoftDelete:
         store.soft_delete("local/test.md")
         record = store.db.get_source("local/test.md")
         assert record is not None
-        assert record.status == "deleted"
+        assert record.status is SourceStatus.DELETED
 
         # ファイルはまだ存在する
         assert (store.root_dir / "local" / "test.md").exists()
@@ -429,7 +430,7 @@ class TestSoftDelete:
         store.restore("local/test.md")
         record = store.db.get_source("local/test.md")
         assert record is not None
-        assert record.status == "active"
+        assert record.status is SourceStatus.ACTIVE
 
     def test_soft_delete_nonexistent(self, store: SourceStore) -> None:
         with pytest.raises(KeyError):

--- a/tests/test_validate_enums_parser.py
+++ b/tests/test_validate_enums_parser.py
@@ -102,3 +102,12 @@ class TestWithAttributes:
         )
         with pytest.raises(SystemExit):
             extract_values(data, "test_cat")
+
+    def test_type_field_must_be_str(self, extract_values: Callable[..., set[str]]) -> None:
+        """attributes.type に str 以外（list/dict 等）を指定した場合は SystemExit."""
+        data = _make_data(
+            values=[{"value": "a"}],
+            attributes={"x": {"type": ["bool"], "description": "..."}},
+        )
+        with pytest.raises(SystemExit):
+            extract_values(data, "test_cat")

--- a/tests/test_validate_enums_parser.py
+++ b/tests/test_validate_enums_parser.py
@@ -1,0 +1,104 @@
+"""validate_enums.py の属性付き value パーサ単体テスト.
+
+仕様: docs/specs/architecture.md（SSoT 階層）
+- attributes 宣言が無い従来形式は従来通り動作する
+- attributes 宣言がある場合、各 value が宣言された型で属性を持つことを検証する
+- attributes の type が未対応 / 値の型不一致 / 属性欠落で SystemExit する
+
+scripts/ ディレクトリは sys.path に含まれないため、importlib で動的にロードする。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _load_validate_enums() -> ModuleType:
+    """scripts/validate_enums.py を動的にロードする."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "validate_enums.py"
+    spec = importlib.util.spec_from_file_location("validate_enums", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["validate_enums"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def ve() -> ModuleType:
+    """validate_enums モジュール."""
+    return _load_validate_enums()
+
+
+@pytest.fixture()
+def extract_values(ve: ModuleType) -> Callable[..., set[str]]:
+    """_extract_yml_values へのアクセスヘルパー."""
+    return ve._extract_yml_values  # type: ignore[no-any-return]
+
+
+def _make_data(values: list[dict[str, Any]], attributes: dict[str, Any] | None = None) -> dict[str, Any]:
+    """テスト用 enums.yml ライクな dict を構築する."""
+    entry: dict[str, Any] = {"description": "test", "values": values}
+    if attributes is not None:
+        entry["attributes"] = attributes
+    return {"test_cat": entry}
+
+
+class TestNoAttributes:
+    """attributes 宣言なし（従来形式）が引き続き動作する."""
+
+    def test_simple_values(self, extract_values: Callable[..., set[str]]) -> None:
+        data = _make_data(values=[{"value": "a"}, {"value": "b"}])
+        assert extract_values(data, "test_cat") == {"a", "b"}
+
+
+class TestWithAttributes:
+    """attributes 宣言ありのパーサ."""
+
+    def test_bool_attribute_pass(self, extract_values: Callable[..., set[str]]) -> None:
+        data = _make_data(
+            values=[
+                {"value": "a", "has_meta": True},
+                {"value": "b", "has_meta": False},
+            ],
+            attributes={"has_meta": {"type": "bool", "description": "..."}},
+        )
+        assert extract_values(data, "test_cat") == {"a", "b"}
+
+    def test_attribute_missing(self, extract_values: Callable[..., set[str]]) -> None:
+        """value に宣言された属性が含まれていない場合は SystemExit."""
+        data = _make_data(
+            values=[{"value": "a"}],
+            attributes={"has_meta": {"type": "bool", "description": "..."}},
+        )
+        with pytest.raises(SystemExit):
+            extract_values(data, "test_cat")
+
+    def test_attribute_type_mismatch(self, extract_values: Callable[..., set[str]]) -> None:
+        """値の型が宣言と不一致の場合は SystemExit."""
+        data = _make_data(
+            values=[{"value": "a", "has_meta": "yes"}],  # str ではなく bool が必要
+            attributes={"has_meta": {"type": "bool", "description": "..."}},
+        )
+        with pytest.raises(SystemExit):
+            extract_values(data, "test_cat")
+
+    def test_unsupported_type(self, extract_values: Callable[..., set[str]]) -> None:
+        """attributes.type が未対応の場合は SystemExit."""
+        data = _make_data(
+            values=[{"value": "a", "x": [1, 2]}],
+            attributes={"x": {"type": "list", "description": "..."}},
+        )
+        with pytest.raises(SystemExit):
+            extract_values(data, "test_cat")


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★（architecture spec 新設 + Enum 化リファクタ）
- [x] refactor: リファクタリング
- [x] docs: ドキュメント更新

## Summary

- `docs/specs/architecture.md` 新設: rag-knowledge アーキテクチャ説明・採用方針・構造判断 SSoT。**youtube パターンを正解パターンとして宣言**（Fetcher Protocol + Real/Fake Adapter）、定量基準（800 LOC / 越境 import 2 系統 / mock 比 2.0）、SSoT 階層、Fake モード基盤の採用方針を記述
- `_schema/enums.yml` 拡張: `source_type` に `has_meta` 属性、`source_status` / `ingest_error_category` カテゴリ新設
- `scripts/validate_enums.py` 拡張: 属性付き value パーサ + 新規カテゴリ検証 + 型検証
- 3 Enum 新設・改修: `SourceStatus(Enum)` / `IngestErrorCategory(Enum)` / `PipelinePhase` を単一値 Enum + `PIPELINE_PHASE_DISPLAY` mapping に分離
- 文字列比較 21 箇所を Enum 比較に置換（実測値、Issue 本文 14 から増加）
- SQL 内 `'active'` リテラルを `_STATUS_ACTIVE = SourceStatus.ACTIVE.value` 由来に統一（DDL / INSERT / WHERE）
- `src/rag/_schema_loader.py` 新設: `enums.yml` 動的読み込み。`NO_META_TYPES` を `source_types_without_meta()` 経由に変更、`_SOURCE_TYPE_VALUES` 撤去
- 8 ingester + `scrapy/bridge` の `error_details["category"]` を `IngestErrorCategory.X.value` に置換
- `docs/specs/source-store.md` / `ingesters/common.md` / `overview.md` 更新

**Closes #703**（epic #702 サブ Issue 順 1）

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src` — 72 source files no issues
- [x] `uv run python scripts/validate_enums.py` — 5 カテゴリ全件 PASS
- [x] `uv run pytest` — 1888 passed（新規 14 件: `test_schema_enums.py` 9 + `test_validate_enums_parser.py` 5）
- [x] markdownlint-cli2 — 0 errors（変更 4 .md）
- [x] CLI end-to-end QA: stats / add-document / list-recent / search / delete / 復帰 add-document / rebuild × 4 mode（incremental / convert / index / full）
- [x] 実 LM Studio + 実 ChromaDB 経由で SQL バインディング・Enum 経路を全件確認
- [x] 実 LocalIngester で `error_details[0]["category"] == "placement"` を実値検証
- [x] MCP HTTP サーバー経由で `rag_stats` / `rag_crawl_zenn`（Zenn API 接続）/ `rag_list_recent` / `rag_search` を実行確認

## Related issues

Closes #703