### PR TITLE
fix(code-review): .claude/extra/doc-review.md → code-review.md にリネーム + 内容調整 (#719)

### DIFF
--- a/.claude/extra/code-review.md
+++ b/.claude/extra/code-review.md
@@ -1,12 +1,13 @@
-# rag-knowledge: doc-review 追加観点
+# rag-knowledge: code-review 追加観点
 
-agent-commons の `doc-review` skill から読み込まれる、rag-knowledge 固有の構造変化検出パターン定義。
+agent-commons の `code-review` skill から読み込まれる、rag-knowledge 固有の構造変化検出パターン定義。
+観点 #16「実装と仕様の整合性」で参照する。特に `(d) architecture spec 更新` での利用を主目的とする。
 
-## rag-knowledge アーキテクチャ整合性観点
+## rag-knowledge 構造変化検出パターン
 
 `docs/specs/architecture.md` を SSoT とする構造判断との整合を検出する。コードの構造変化が architecture spec に反映されていない場合、レビュー結果として警告する。
 
-### 構造変化検出パターン
+### 検出パターン一覧
 
 | 変化パターン | 確認対象 spec | 確認観点 |
 |---|---|---|
@@ -15,25 +16,25 @@ agent-commons の `doc-review` skill から読み込まれる、rag-knowledge �
 | 新規 Protocol 定義（`class.*\(Protocol\)` パターン）の追加 | `docs/specs/architecture.md`「5. SSoT 階層と所在」セクション（軸 2: 契約の所在）、および新規 Protocol が Port 注入される §3.2（Runner ファミリー）/ §3.3（WebIngester の構造） | 新規 Protocol が Port として位置付けられているか。Port の定義場所（`<package>/<feature>_<role>.py`）の規約に従っているか。Port が注入される側のセクションでも位置付けが明記されているか |
 | 新規抽象基底クラス（`class.*\(ABC\)` / `ABCMeta` 派生）の追加 | `docs/specs/architecture.md`「1. アーキテクチャ概要」セクション（Dependency Rule / 主要な層） | 新規抽象が層構造の中で位置付けられているか。Dependency Rule（上位層は下位層に依存可、逆方向禁止）に違反していないか |
 
-### 検出時の照合方針
+### 照合方向
 
-クラス・ファイル・Protocol の **存在の有無** を照合する。行番号・LOC 等の数値差分は照合対象外とする。
+仕様駆動開発では spec が先行して記述されるため、「spec にあって実装にないもの」は作業途中の通常状態である。照合は **実装側の構造変化が spec に反映されているか** を確認する方向で行う（実装 → spec の整合確認）。すなわち「実装にあって spec にないもの（spec 未更新）」を検出対象とする。行番号・LOC 等の数値差分は照合対象外とする。
 
 ### 検出時のレビュー出力形式
 
 検出した場合、レビューコメントとして以下の構造で報告する:
 
 ```text
-[architecture-spec-drift] <変化パターン名>
+[impl-spec-drift] <変化パターン名>
 - 検出した変化: <ファイルパス + 変化内容>
 - 確認対象 spec: <spec パス + セクション>
 - 推奨アクション: <spec 更新 / 新規 Issue 起票 / 構造判断レビュー依頼>
 ```
 
-skill 本体（agent-commons `doc-review`）の出力フォーマットへの統合は、`Critical` / `Warning` ブロック内の対象セクション項目として埋め込む形で行う。
+skill 本体（agent-commons `code-review`）の観点 #16 `(d) architecture spec 更新` の報告に統合する。
 
 ## 関連
 
 - `docs/specs/architecture.md` — rag-knowledge アーキテクチャ採用方針 SSoT
-- agent-commons `doc-review` skill — 本拡張ファイルを読み込む側の skill
+- agent-commons `code-review` skill — 本拡張ファイルを読み込む側の skill
 - agent-commons `architecture-guide.md` — 用語集（Core / Port / Adapter / dto）


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `.claude/extra/doc-review.md` を `.claude/extra/code-review.md` にリネーム（agent-commons#325 追従）
- 参照 skill を `doc-review` → `code-review` に変更
- セクション名を「アーキテクチャ整合性観点」→「構造変化検出パターン」に変更（code-review SKILL.md の語彙に統一）
- 照合方向を明確化：「存在の有無を照合する」→「実装側の構造変化が spec に反映されているか（実装→spec 方向）」
- 出力ラベルを `[architecture-spec-drift]` → `[impl-spec-drift]` に変更
- 統合先を code-review 観点 #16 `(d) architecture spec 更新` に更新

## Test plan

- [x] markdownlint-cli2 0 エラー確認済み
- [x] doc-reviewer レビュー通過済み

## Related issues

Closes #719