### PR TITLE
feat(lmstudio-reference,lmstudio-operation): LM Studio 管理基盤整備 (#721)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -63,7 +63,7 @@ QA 検証グループ:
 4. ストレージパスは相対パスのため worktree ディレクトリ基準で解決される（書き換え不要）。以下を確認・設定する:
    - `CHROMADB_AUTO_START` はデフォルト（`true`）のままでよい（`ChromaDBServerManager` は起動前に heartbeat チェックを行い、既存インスタンスが応答すれば起動をスキップするため競合しない）
    - ポート競合時（前セッションの停止漏れ等）は `CHROMADB_SERVER_PORT` を変更すること
-5. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
+5. LM Studio のセットアップ・モデルロード手順は [docs/specs/infrastructure/lmstudio-operation.md](../../../docs/specs/infrastructure/lmstudio-operation.md) を参照する
 6. `.tmp` ディレクトリを作成する
 7. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
 8. ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）
@@ -76,8 +76,12 @@ QA 検証グループ:
 - 現在のブランチ・作業ディレクトリを表示
 - MCP サーバーの状態確認（CLI 検証時は停止推奨、MCP 検証時は HTTP モードで起動中かつ `/mcp` で enabled であることを確認）。disabled の場合はユーザーに有効化を依頼する
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認
-- LM Studio の接続確認（Embedding API が必要なグループの場合）
-- LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）: `curl http://localhost:1234/v1/models` で Vision 対応モデルがロードされているか確認する
+- LM Studio の状態確認（Embedding API が必要なグループの場合）
+  - `lms server status` でサーバー起動を確認
+  - `lms ps` でロード中モデルを確認、未ロードなら `lms load <key>`（key は `lmstudio.toml` の `models.embedding.key`）
+  - 詳細手順: [docs/specs/infrastructure/lmstudio-operation.md](../../../docs/specs/infrastructure/lmstudio-operation.md)
+- LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）
+  - `lms ps` で `lmstudio.toml` の `models.vision.key` がロード中であることを確認、未ロードなら `lms load <key>`
 - ffmpeg の確認（メディア解析の動画処理を検証する場合）: `ffmpeg -version` で利用可能か確認する
 - 問題があればユーザーに報告し、解決してから続行
 
@@ -182,7 +186,8 @@ NG を検出した場合、Issue 起票を提案する。
 `.qa/` ディレクトリはテストリソースの置き場（git 管理外）。以下のファイルを事前に配置しておくこと:
 
 - `.qa/pdf_add_test.pdf` — PDF 取り込みテスト用
-- `.qa/image_add_test.jpg` — 画像取り込みテスト用（メディア解析検証）
+- `.qa/image_add_test.jpg` — 画像取り込みテスト用（メディア解析検証。A-3 で使用、A-4b の上書き先）
+- `.qa/image_replace_test.jpg` — 画像上書きテスト用（A-4a で `image_add_test.jpg` にコピーする別バイトの画像）
 - `.qa/video_add_test.mp4` — 動画取り込みテスト用（メディア解析検証、ffmpeg 必要）
 - `.qa/journal_add_test.md` — add-journal テスト用
 - `.qa/journal_upload_test.md` — Upload journal テスト用
@@ -194,6 +199,7 @@ NG を検出した場合、Issue 起票を提案する。
 | A) Local | add-document（Markdown） | リポジトリの `README.md` |
 | A) Local | add-document（PDF） | `.qa/pdf_add_test.pdf` |
 | A) Local | add-document（画像） | `.qa/image_add_test.jpg`（メディア解析検証。LM Studio Vision が必要） |
+| A) Local | add-document（画像上書き） | `.qa/image_replace_test.jpg`（A-4a で `image_add_test.jpg` にコピーして上書きパスを通すための別バイト画像） |
 | A) Local | add-document（動画） | `.qa/video_add_test.mp4`（メディア解析検証。LM Studio Vision + ffmpeg が必要） |
 | A) Local | add-document（上書き） | `README.md` を再取り込み（CLI: `--upload-mode replace` / MCP: `upload_mode="replace"`） |
 | A) Local | crawl-documents | リポジトリの `docs/specs/` ディレクトリ全体 |
@@ -233,8 +239,9 @@ NG を検出した場合、Issue 起票を提案する。
 |---|----------------|---------|---------|
 | 1 | `add-document --file README.md` | Markdown 取り込み成功 | `ingest` |
 | 2 | `add-document --file .qa/pdf_add_test.pdf` | PDF 取り込み成功 | `ingest` |
-| 3 | LM Studio を停止した状態で `add-document --file .qa/image_add_test.jpg` | 取り込み成功するがメディア解析テキストなし（フォールバック動作）。エラーで中断しないこと | `ingest` |
-| 4 | LM Studio を起動した状態で `add-document --file .qa/image_add_test.jpg --upload-mode replace` | 画像取り込み成功。メディア解析テキストが生成されること。search 結果に画像の解析テキストが含まれることを確認する | `ingest` |
+| 3 | LM Studio Vision モデルを `lms unload` した状態（Embedding モデルは load 中）で `add-document --file .qa/image_add_test.jpg` | 取り込み成功するがメディア解析テキストなし（フォールバック動作）。エラーで中断しないこと | `ingest` |
+| 4a | `cp .qa/image_replace_test.jpg .qa/image_add_test.jpg`（A-3 と内容バイトが異なる別画像で上書きするための事前準備） | コピー成功（同名ファイルが別バイトに置き換わる） | `none` |
+| 4b | LM Studio Vision モデルを `lms load <key>` した状態で `add-document --file .qa/image_add_test.jpg --upload-mode replace` | 上書き成功（`overwritten=1`）。pipeline が変更検知して Vision 解析を実行。メディア解析テキストが生成されること。search 結果に新画像の解析テキストが含まれることを確認する | `ingest` |
 | 5 | `add-document --file .qa/video_add_test.mp4` | 動画取り込み成功。ffmpeg フレーム抽出 → Vision モデルで各フレーム解析 → タイムスタンプ付きテキスト生成。search 結果に動画の解析テキストが含まれること | `ingest` |
 | 6 | `add-document --file README.md --upload-mode replace` | 上書き成功、エラーなし | `none` |
 | 7 | `crawl-documents docs/specs/`（`dir_path` は positional 引数） | ディレクトリ一括取り込み成功 | `ingest` |
@@ -254,8 +261,9 @@ MCP 対応コマンド:
 **MCP テスト時の注意:**
 
 - A-2 (PDF): 大きい PDF は MCP パラメータサイズ制約で失敗する場合がある。失敗時は CLI で代替実行する
-- A-3 (フォールバック): LM Studio の停止・再起動はユーザーの手動操作が必要。MCP テスト時はスキップする
-- A-4 (画像), A-5 (動画): LM Studio Vision モデルが未ロードの場合はスキップする
+- A-3 (フォールバック): Vision モデル unload が必要。`lms unload <key>` で実施する
+  - 手順: [docs/specs/infrastructure/lmstudio-operation.md](../../../docs/specs/infrastructure/lmstudio-operation.md)
+- A-4 (画像), A-5 (動画): LM Studio Vision モデルが未ロードの場合はスキップする（`lms ps` で確認）
 - A-7 (crawl-documents): HTTP モード非対応のため MCP テスト時はスキップする
 
 ### B) Web

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -78,6 +78,8 @@ QA 検証グループ:
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認
 - LM Studio の状態確認（Embedding API が必要なグループの場合）
   - `lms server status` でサーバー起動を確認
+  - `.env` の `LMSTUDIO_BASE_URL` のホスト/ポートと `lms server status` のリッスン先が一致することを確認
+    - 不一致だと `lms load` してもアプリは別サーバーへ接続し続けるため要注意
   - `lms ps` でロード中モデルを確認、未ロードなら `lms load <key>`（key は `lmstudio.toml` の `models.embedding.key`）
   - 詳細手順: [docs/specs/infrastructure/lmstudio-operation.md](../../../docs/specs/infrastructure/lmstudio-operation.md)
 - LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,8 @@
 | `infrastructure/upload-auth.md` | `src/rag/server.py`, `src/rag/config.py` |
 | `infrastructure/scheduled-rebuild.md` | `src/rag/server.py` |
 | `infrastructure/media-analysis.md` | `src/rag/media/` |
+| `infrastructure/lmstudio-reference.md` | `src/rag/config.py`（`_load_lmstudio_config`, `_LMSTUDIO_TOML_PATHS`）, `src/rag/embedding/factory.py`, `src/rag/pipeline/factory.py`, `lmstudio.toml` |
+| `infrastructure/lmstudio-operation.md` | （運用手順書、対応実装なし） |
 | `infrastructure/fake-mode.md` | `src/rag/config.py`（`*_fake_*` フィールド + `log_fake_mode_status`）, `src/rag/pipeline/ingesters/{source_type}_fetcher.py` 群, `src/rag/pipeline/ingesters/_fake/`, `tests/conftest.py` |
 | `infrastructure/fake-adapters/youtube.md` | `src/rag/pipeline/ingesters/youtube_fetcher.py`, `src/rag/pipeline/ingesters/_fake/youtube/` |
 | `ingesters/common.md` | `src/rag/pipeline/ingesters/_common.py` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,23 +59,20 @@ worktree で CLI 操作・動作確認を行う場合、以下のセットアッ
    cp .env <worktree-path>/.env
    ```
 
-2. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する:
-
-   ```
-   LMSTUDIO_BASE_URL=http://localhost:1234/v1
-   ```
-
-3. `.tmp` ディレクトリを作成する:
+2. `.tmp` ディレクトリを作成する:
 
    ```bash
    mkdir -p <worktree-path>/.tmp
    ```
 
-4. ChromaDB サーバーを起動する。ポート競合時（前セッションの停止漏れ等）は `.env` で `CHROMADB_SERVER_PORT` を変更すること。初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
+3. ChromaDB サーバーを起動する。ポート競合時（前セッションの停止漏れ等）は `.env` で `CHROMADB_SERVER_PORT` を変更すること
+   - 初回は venv 構築のため起動に時間がかかる（目安: 10〜20 秒）。heartbeat 確認前に十分待機すること:
 
    ```bash
    uv run chroma run --path <worktree-path>/.tmp/test_chroma_db
    ```
+
+LM Studio の起動・モデルロードは [docs/specs/infrastructure/lmstudio-operation.md](docs/specs/infrastructure/lmstudio-operation.md) を参照。
 
 ### CLI 動作確認の確認観点
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,12 @@ cp .env.example .env
 
 ### 3. LM Studio
 
-`EMBEDDING_PROVIDER=local` の場合に LM Studio が必要となる。LM Studio で読み込むモデル key は `lmstudio.toml` を SSoT として管理する。
+LM Studio は以下のいずれかで必要となる。
+
+- `EMBEDDING_PROVIDER=local` のとき（Embedding 用）
+- メディア解析（画像・動画の Vision 解析）を使用するとき（`EMBEDDING_PROVIDER=online` でも常に必要）
+
+LM Studio で読み込むモデル key は `lmstudio.toml` を SSoT として管理する。
 
 - セットアップ・運用手順: [docs/specs/infrastructure/lmstudio-operation.md](docs/specs/infrastructure/lmstudio-operation.md)
 - CLI 仕様参照: [docs/specs/infrastructure/lmstudio-reference.md](docs/specs/infrastructure/lmstudio-reference.md)

--- a/README.md
+++ b/README.md
@@ -167,11 +167,10 @@ cp .env.example .env
 
 ### 3. LM Studio
 
-`EMBEDDING_PROVIDER=local` の場合、LM Studio が必要:
+`EMBEDDING_PROVIDER=local` の場合に LM Studio が必要となる。LM Studio で読み込むモデル key は `lmstudio.toml` を SSoT として管理する。
 
-1. [LM Studio](https://lmstudio.ai/) をインストール
-2. Embedding モデル（config.toml の `embedding_model_local` に対応するモデル）を読み込み
-3. LM Studio のサーバーを起動（デフォルト: `http://localhost:1234`）
+- セットアップ・運用手順: [docs/specs/infrastructure/lmstudio-operation.md](docs/specs/infrastructure/lmstudio-operation.md)
+- CLI 仕様参照: [docs/specs/infrastructure/lmstudio-reference.md](docs/specs/infrastructure/lmstudio-reference.md)
 
 ### 4. API キー（keyring）
 
@@ -213,7 +212,7 @@ API キー（`UPLOAD_API_KEY`）の事前登録が必要（上記「API キー�
 |---|--------|---------|---------|
 | シークレット | OS セキュアストレージ (keyring) | 管理外 | 漏洩時に直接被害が発生する値（API キー、トークン、パスワード） |
 | 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値（接続先 URL、ストレージパス、ネットワーク設定、デバッグフラグ） |
-| 共通設定値 | `config.toml` | **管理する** | プロジェクトとして統一管理する値（チューニングパラメータ、ポリシー設定、モデル名、機能フラグ） |
+| 共通設定値 | `config.toml` / `lmstudio.toml` | **管理する** | プロジェクトとして統一管理する値（チューニングパラメータ、ポリシー設定、モデル名、機能フラグ）。`lmstudio.toml` は LM Studio で読み込むモデル key の SSoT |
 
 新しい設定値を追加する際は、上記の判断基準に従って適切な層に配置すること。詳細は [設定管理仕様](docs/specs/rag-knowledge.md#設定管理) を参照。
 

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 # 設定管理仕様: docs/specs/rag-knowledge.md#設定管理
 
 # Embedding モデル
-embedding_model_local = "text-embedding-nomic-embed-text-v2-moe"
+# embedding_model_local（LM Studio ローカル Embedding モデル）は lmstudio.toml が SSoT
 embedding_model_online = "text-embedding-3-small"
 # Embedding 入力にタスク種別プレフィックス（search_query: / search_document:）を付与
 embedding_prefix_enabled = true
@@ -110,8 +110,7 @@ rag_aozora_request_interval = 1.0
 rag_aozora_request_timeout = 30
 
 # メディア解析（Vision モデル）
-# LM Studio にロードする Vision 対応モデルの識別子
-rag_vision_model = "google/gemma-4-26b-a4b"
+# rag_vision_model（LM Studio Vision モデルの識別子）は lmstudio.toml が SSoT
 # Vision API の推論深度（none / low / medium / high）
 rag_vision_reasoning_effort = "none"
 # 動画フレーム抽出間隔（秒）

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -144,6 +144,8 @@ QA 検証グループ:
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する
 - LM Studio の状態確認（Embedding API が必要なグループの場合）
   - `lms server status` でサーバー起動を確認
+  - `.env` の `LMSTUDIO_BASE_URL` のホスト/ポートと `lms server status` のリッスン先が一致することを確認
+    - 不一致だと `lms load` してもアプリは別サーバーへ接続し続けるため要注意
   - `lms ps` で `lmstudio.toml` の `models.embedding.key` がロード中であることを確認、未ロードなら `lms load <key>`
   - 詳細手順: `docs/specs/infrastructure/lmstudio-operation.md`
 - LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）

--- a/docs/specs/agentic/skills/qa-skill.md
+++ b/docs/specs/agentic/skills/qa-skill.md
@@ -129,7 +129,7 @@ QA 検証グループ:
 3. メインリポジトリから `.env` をコピーし、ストレージパスを worktree 内の絶対パスに変更する。以下も設定する:
    - `CHROMADB_SERVER_PORT=8001`（メインリポジトリの MCP サーバーとのポート競合回避）
    - `CHROMADB_AUTO_START` はデフォルト（`true`）のままでよい（`ChromaDBServerManager` は起動前に heartbeat チェックを行い、既存インスタンスが応答すれば起動をスキップするため競合しない）
-4. LM Studio の接続先を確認し、必要に応じて `localhost` に変更する
+4. LM Studio のセットアップ・モデルロード手順は `docs/specs/infrastructure/lmstudio-operation.md` を参照する
 5. `.tmp` ディレクトリを作成する
 6. メインリポジトリから `.qa/` ディレクトリをコピーする（`.qa/` は `.gitignore` 対象のため worktree に含まれない）
 7. ChromaDB サーバーを手動起動する: `uv run chroma run --path <persist_dir> --port <CHROMADB_SERVER_PORT>`（初回は venv 構築のため起動に時間がかかる。目安: 10〜20 秒。heartbeat 確認前に十分待機すること）
@@ -142,8 +142,12 @@ QA 検証グループ:
 - 現在のブランチ・ディレクトリを確認する
 - MCP サーバーの状態を確認する（MCP フェーズでは HTTP モードで起動中かつ `/mcp` で enabled であること、CLI 検証時は停止推奨）。disabled の場合はユーザーに有効化を依頼する
 - ChromaDB サーバー疎通確認: `curl http://localhost:<CHROMADB_SERVER_PORT>/api/v2/heartbeat` で応答を確認する
-- LM Studio の接続確認（Embedding API が必要なグループの場合）
-- LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）: Vision 対応モデルがロードされているか確認する
+- LM Studio の状態確認（Embedding API が必要なグループの場合）
+  - `lms server status` でサーバー起動を確認
+  - `lms ps` で `lmstudio.toml` の `models.embedding.key` がロード中であることを確認、未ロードなら `lms load <key>`
+  - 詳細手順: `docs/specs/infrastructure/lmstudio-operation.md`
+- LM Studio Vision モデルの確認（グループ A でメディア解析ステップを実行する場合）
+  - `lms ps` で `lmstudio.toml` の `models.vision.key` がロード中であることを確認、未ロードなら `lms load <key>`
 - ffmpeg の確認（メディア解析の動画処理を検証する場合）: `ffmpeg -version` で利用可能か確認する
 - `.env` のストレージパスが worktree 内の絶対パスを指していることを確認する
 
@@ -249,8 +253,9 @@ NG が検出された場合、Issue 起票を提案する。
 |---|----------------|---------|---------|
 | 1 | `add-document --file README.md` | Markdown 取り込み成功 | `ingest` |
 | 2 | `add-document --file .qa/pdf_add_test.pdf` | PDF 取り込み成功 | `ingest` |
-| 3 | LM Studio を停止した状態で `add-document --file .qa/image_add_test.jpg` | 取り込み成功するがメディア解析テキストなし（フォールバック動作）。エラーで中断しないこと | `ingest` |
-| 4 | LM Studio を起動した状態で `add-document --file .qa/image_add_test.jpg --upload-mode replace` | 画像取り込み成功。メディア解析テキストが生成されること。search 結果に画像の解析テキストが含まれることを確認する | `ingest` |
+| 3 | LM Studio Vision モデルを `lms unload` した状態（Embedding モデルは load 中）で `add-document --file .qa/image_add_test.jpg` | 取り込み成功するがメディア解析テキストなし（フォールバック動作）。エラーで中断しないこと | `ingest` |
+| 4a | `cp .qa/image_replace_test.jpg .qa/image_add_test.jpg`（A-3 と内容バイトが異なる別画像で上書きするための事前準備） | コピー成功（同名ファイルが別バイトに置き換わる） | `none` |
+| 4b | LM Studio Vision モデルを `lms load <key>` した状態で `add-document --file .qa/image_add_test.jpg --upload-mode replace` | 上書き成功（`overwritten=1`）。pipeline が変更検知して Vision 解析を実行。メディア解析テキストが生成されること。search 結果に新画像の解析テキストが含まれることを確認する | `ingest` |
 | 5 | `add-document --file .qa/video_add_test.mp4` | 動画取り込み成功。ffmpeg フレーム抽出 → Vision モデルで各フレーム解析 → タイムスタンプ付きテキスト生成。search 結果に動画の解析テキストが含まれること | `ingest` |
 | 6 | `add-document --file README.md --upload-mode replace` | 上書き成功、エラーなし | `none` |
 | 7 | `crawl-documents docs/specs/`（`dir_path` は positional 引数） | ディレクトリ一括取り込み成功 | `ingest` |
@@ -270,8 +275,9 @@ CLI / MCP 対応:
 **MCP テスト時の注意:**
 
 - A-2 (PDF): 大きい PDF は MCP パラメータサイズ制約で失敗する場合がある。失敗時は CLI で代替実行する
-- A-3 (フォールバック): LM Studio の停止・再起動はユーザーの手動操作が必要。MCP テスト時はスキップする
-- A-4 (画像), A-5 (動画): LM Studio Vision モデルが未ロードの場合はスキップする
+- A-3 (フォールバック): Vision モデル unload が必要。`lms unload <key>` で実施する
+  - 手順: `docs/specs/infrastructure/lmstudio-operation.md`
+- A-4 (画像), A-5 (動画): LM Studio Vision モデルが未ロードの場合はスキップする（`lms ps` で確認）
 - A-7 (crawl-documents): HTTP モード非対応のため MCP テスト時はスキップする
 
 ### B) Web

--- a/docs/specs/indexer.md
+++ b/docs/specs/indexer.md
@@ -357,11 +357,16 @@ BM25 のトークナイズには日本語形態素解析（fugashi）を使用�
 | `rag_chunk_overlap` | 共通設定値 | チャンク間のオーバーラップ文字数。文脈の断絶を防ぐ |
 | `rag_embedding_context_length` | 共通設定値 | Embedding モデルのコンテキスト長（トークン数）。トークン安全上限の算出基準 |
 | `rag_worst_token_char_ratio` | 共通設定値 | 最悪ケーストークン/文字比率。導出手順は「トークン/文字比率の導出手順」を参照 |
-| `embedding_model_local` | 共通設定値 | ローカル Embedding モデル名 |
 | `embedding_model_online` | 共通設定値 | オンライン Embedding モデル名 |
 | `embedding_prefix_enabled` | 共通設定値 | Embedding プレフィックス付与の有無。モデルの推奨設定に従う |
 | `rag_bm25_k1` | 共通設定値 | BM25 の用語頻度飽和パラメータ。検索精度チューニング用 |
 | `rag_bm25_b` | 共通設定値 | BM25 の文書長正規化パラメータ。検索精度チューニング用 |
+
+#### `lmstudio.toml`（LM Studio モデル key）
+
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `models.embedding.key` | 共通設定値 | ローカル Embedding モデルの key。`lms load` および API 呼び出しの `model` パラメータで使用される。詳細は [infrastructure/lmstudio-reference.md](infrastructure/lmstudio-reference.md) 参照 |
 
 #### `.env`（環境依存値）
 

--- a/docs/specs/infrastructure/lmstudio-operation.md
+++ b/docs/specs/infrastructure/lmstudio-operation.md
@@ -1,0 +1,69 @@
+# LM Studio 運用手順
+
+## 概要
+
+RAG Knowledge は Embedding（ローカル）と Vision（メディア解析）に LM Studio を使用する。本書は Claude が実施する運用手順を集約する。
+
+`lms` CLI コマンド・API パラメータ等の仕様参照は [lmstudio-reference.md](lmstudio-reference.md) を参照。
+
+## 責務分担
+
+| 担当 | 責務 |
+|---|---|
+| ユーザー | LM Studio 本体のインストール、必要モデル（Embedding / Vision）のダウンロード、初回 GUI セットアップ、per-model preset 設定（context_length / gpu_offload / ttl_seconds / parallel 等のチューニング）、`lmstudio.toml` の key 編集（モデル選定・切替） |
+| Claude | サーバー起動・停止、`lmstudio.toml` の key を見たモデルロード/unload、状態確認、トラブル時の一次対応 |
+
+ロードパラメータ（context_length / gpu_offload 等）は LM Studio の per-model preset に委譲する。`lms load` の引数では指定しない。
+
+## 運用手順（Claude 実施）
+
+### サーバーの起動・停止
+
+```bash
+lms server start       # 起動
+lms server status      # 状態確認
+lms server stop        # 停止
+```
+
+### モデルのロード・unload
+
+`lmstudio.toml` の `models.embedding.key` / `models.vision.key` を参照して `lms load <key>` を実行する。引数なしのため per-model preset に従ってロードされる。
+
+```bash
+# lmstudio.toml で指定されている key を読み出してロード
+lms load <embedding-key>
+lms load <vision-key>
+
+# unload
+lms unload <key>
+lms unload --all
+```
+
+### 状態確認
+
+```bash
+lms ps                 # ロード中モデルの一覧（IDENTIFIER / SIZE / CONTEXT / PARALLEL / TTL）
+lms ls                 # ダウンロード済みモデルの一覧
+lms server status      # サーバー起動状態
+```
+
+### パラメータ調整
+
+LM Studio GUI の per-model preset 設定に従う（CLI 側からは指定しない）。
+
+## トラブルシュート
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `lms load` でエラー | モデル未ダウンロード | `lms ls` で確認後、ユーザーに対応を依頼する（モデルダウンロードはユーザー責務） |
+| API 呼び出しで `ConnectError` | サーバー停止中 | `lms server start` で起動 |
+| Vision API 呼び出しで `Model has crashed` | 入力画像が小さすぎる（1x1 等） | 720x720 以上の実用サイズで再試行 |
+| 同時ロードで VRAM 不足 | GPU メモリ超過 | `lms unload <key>` で不要モデルを開放してから再ロード |
+| `lms load` を再実行すると `:2` サフィックス付きインスタンスが追加される | `lms load` に冪等性なし | 事前に `lms ps` でロード済みを確認し、未ロード時のみ load する |
+
+## 関連ドキュメント
+
+- [lmstudio-reference.md](lmstudio-reference.md) — `lms` CLI 仕様参照
+- [media-analysis.md](media-analysis.md) — メディア解析（Vision モデル）
+- [../indexer.md](../indexer.md) — インデクサー（Embedding）
+- [LM Studio 公式](https://lmstudio.ai/docs)

--- a/docs/specs/infrastructure/lmstudio-operation.md
+++ b/docs/specs/infrastructure/lmstudio-operation.md
@@ -15,6 +15,15 @@ RAG Knowledge は Embedding（ローカル）と Vision（メディア解析）�
 
 ロードパラメータ（context_length / gpu_offload 等）は LM Studio の per-model preset に委譲する。`lms load` の引数では指定しない。
 
+## ユーザーセットアップ
+
+以下の項目は [LM Studio 公式ドキュメント](https://lmstudio.ai/docs) を参照する。本プロジェクトは公式手順に独自の追加要件を持たない。
+
+- LM Studio 本体のインストール
+- 必要モデル（`lmstudio.toml` の `models.*.key` で指定）のダウンロード
+- 初回 GUI セットアップ
+- per-model preset 設定
+
 ## 運用手順（Claude 実施）
 
 ### サーバーの起動・停止
@@ -27,7 +36,8 @@ lms server stop        # 停止
 
 ### モデルのロード・unload
 
-`lmstudio.toml` の `models.embedding.key` / `models.vision.key` を参照して `lms load <key>` を実行する。引数なしのため per-model preset に従ってロードされる。
+`lmstudio.toml` の `models.embedding.key` / `models.vision.key` を参照して `lms load <key>` を実行する。
+追加のロードパラメータを指定しないため、per-model preset に従ってロードされる。
 
 ```bash
 # lmstudio.toml で指定されている key を読み出してロード

--- a/docs/specs/infrastructure/lmstudio-operation.md
+++ b/docs/specs/infrastructure/lmstudio-operation.md
@@ -34,6 +34,18 @@ lms server status      # 状態確認
 lms server stop        # 停止
 ```
 
+### 接続先の確認
+
+`lms` CLI はローカルの LM Studio インスタンスを操作するが、ランタイム（本プロジェクト）が実際に接続する先は `.env` の `LMSTUDIO_BASE_URL` である。
+両者が一致していないと、`lms load` でモデルをロードしてもアプリは別のサーバーへ接続し続けて疎通失敗の原因となる。
+
+操作前に以下を確認する:
+
+- `.env` の `LMSTUDIO_BASE_URL` のホスト/ポート
+- `lms server status` の出力に表示される LM Studio サーバーのリッスン先
+
+両者のホスト/ポートが一致しない場合、`.env` を修正するか、`lms` CLI 側でリモート接続を構成する必要がある。
+
 ### モデルのロード・unload
 
 `lmstudio.toml` の `models.embedding.key` / `models.vision.key` を参照して `lms load <key>` を実行する。

--- a/docs/specs/infrastructure/lmstudio-reference.md
+++ b/docs/specs/infrastructure/lmstudio-reference.md
@@ -1,0 +1,99 @@
+# LM Studio CLI リファレンス
+
+## 概要
+
+LM Studio を Claude 主導で運用するための CLI リファレンス。`lms` CLI コマンド、API 経由の推論パラメータと `config.toml` の対応、ハードウェアサーベイの取得方法を集約する。
+
+セットアップ・運用フロー（読者: ユーザー＋Claude）は [lmstudio-operation.md](lmstudio-operation.md) を参照。
+
+## 背景
+
+「外部 API 以外の Fake モードは責務的にスコープ外」という方針が確定し、Embedding と Vision (MediaAnalyzer) を実 LM Studio 経由で運用することになった。これに伴い、Claude が LM Studio のライフサイクルを CLI 経由で管理するための仕様参照を集約する必要が生じた。
+
+ロードパラメータ（`context_length` / `gpu_offload` / `ttl_seconds` / `parallel` 等）は LM Studio 側の per-model preset に委譲する方針のため、本リファレンスでは推奨値表を持たない。`lms load` の引数は最小（key のみ）で運用する。
+
+## 制約
+
+- 本リファレンスは **読者 = Claude** を前提とした仕様参照。実運用の手順は [lmstudio-operation.md](lmstudio-operation.md) に分離する
+- ロード時パラメータの推奨値表は記載しない（LM Studio per-model preset への委譲方針のため）
+- `lmstudio.toml` ↔ `lms` 引数の対応表は記載しない（`lmstudio.toml` は key のみ保持し、`lms load` には key だけを渡すため）
+- 本リファレンスに記載する CLI コマンドは LM Studio 公式の CLI（`lms`）の挙動を反映する。LM Studio 側のバージョン更新により挙動が変わる可能性がある
+
+## インターフェース
+
+### `lms` CLI 主要コマンド
+
+| コマンド | 用途 | 基本構文 |
+|---|---|---|
+| `lms server start` | LM Studio サーバーを起動する | `lms server start` |
+| `lms server stop` | LM Studio サーバーを停止する | `lms server stop` |
+| `lms server status` | サーバーの起動状態を確認する | `lms server status` |
+| `lms ls` | ローカルにダウンロード済みのモデル一覧を表示する | `lms ls` |
+| `lms ps` | 現在ロード中のモデル一覧を表示する | `lms ps` |
+| `lms load` | モデルをロードする。引数なし時は per-model preset に従う | `lms load <key>` |
+| `lms unload` | モデルを unload する | `lms unload <key>` または `lms unload --all` |
+| `lms get` | モデルをダウンロードする | `lms get <repo>` |
+| `lms runtime survey` | ハードウェア・利用可能ランタイムを調査する | `lms runtime survey` |
+
+### API 経由の推論パラメータと設定ファイルの対応
+
+LM Studio が公開する OpenAI 互換 API（`{LMSTUDIO_BASE_URL}/v1/...`）への呼び出し時に、本プロジェクトでは `config.toml` の値をリクエストパラメータとして渡す。
+
+| API パラメータ | `config.toml` のフィールド | 備考 |
+|---|---|---|
+| `model`（Embedding） | — | `lmstudio.toml` の `models.embedding.key` を使用 |
+| `model`（Vision） | — | `lmstudio.toml` の `models.vision.key` を使用 |
+| `max_tokens`（Vision） | `rag_vision_max_tokens` | Vision API レスポンスの上限トークン数 |
+| `reasoning_effort`（Vision） | `rag_vision_reasoning_effort` | 推論深度（`none` / `low` / `medium` / `high`） |
+| `timeout`（Vision クライアント側） | `rag_vision_api_timeout` | リクエストタイムアウト秒 |
+
+### ハードウェアサーベイの取得方法
+
+`lms runtime survey` で以下を取得できる:
+
+- 検出された GPU の一覧（VRAM・ドライババージョン）
+- 利用可能なランタイム（CUDA / CPU 等）
+- 各ランタイムの対応モデル形式
+
+per-model preset 設定時の `gpu_offload` 値や、同時ロード可能なモデルの判断材料として使用する。
+
+## コンポーネント構成
+
+`lmstudio.toml` がモデル key の SSoT。Claude は `lms load` 実行時に `lmstudio.toml` を参照する。
+ランタイム（`src/rag/embedding/factory.py` / `src/rag/pipeline/factory.py`）も同じ key を `_load_lmstudio_config` 経由で読み込み、`RAGSettings` のフィールド（`embedding_model_local` / `rag_vision_model`）として API 呼び出しに使用する。
+
+```mermaid
+flowchart LR
+    A[lmstudio.toml] -->|key 参照| B[Claude が lms load を手動実行]
+    A -->|_load_lmstudio_config 経由| F[RAGSettings]
+    F -->|settings.embedding_model_local| C[ランタイム embedding/factory.py]
+    F -->|settings.rag_vision_model| D[ランタイム pipeline/factory.py]
+    B -->|モデルロード| E[LM Studio サーバー]
+    C -->|API 呼び出し model=key| E
+    D -->|API 呼び出し model=key| E
+```
+
+## 外部連携
+
+- **LM Studio サーバー**: OpenAI 互換 API（`{LMSTUDIO_BASE_URL}/v1/...`）。`LMSTUDIO_BASE_URL` は `.env` 管理（環境依存値）
+- **`lms` CLI**: LM Studio 公式 CLI。Claude が手動実行で使用する
+
+## エッジケース
+
+| 状況 | 振る舞い |
+|---|---|
+| `lmstudio.toml` が存在しない | `_load_lmstudio_config` が `FileNotFoundError`（fail-fast） |
+| `lmstudio.toml` の `models.embedding.key` または `models.vision.key` が未設定 | `_load_lmstudio_config` が `ValueError`（fail-fast） |
+| `key` が空文字列 | `RAGSettings` の `Field(min_length=1)` でバリデーション失敗（fail-fast） |
+| `key` が文字列以外 | `_load_lmstudio_config` が `ValueError`（fail-fast） |
+| LM Studio サーバーが停止中（Embedding） | API 呼び出しで `httpx.ConnectError` を送出 |
+| LM Studio サーバーが停止中 / Vision モデル未ロード（Vision） | メディア解析モジュールでスキップ＋警告ログ。詳細は [media-analysis.md](media-analysis.md) のエッジケース参照 |
+| 指定 key のモデルが未ダウンロード | `lms load` がエラー終了。モデルダウンロードはユーザー責務（[lmstudio-operation.md](lmstudio-operation.md) の責務分担表参照） |
+| 指定 key のモデルが未ロード（Embedding API 呼び出し時） | 本プロジェクトは事前 `lms load` 必須。未ロード状態で API を叩いた場合の挙動は LM Studio 側に依存し、保証しない |
+
+## 関連ドキュメント
+
+- [lmstudio-operation.md](lmstudio-operation.md) — LM Studio セットアップ・運用手順書
+- [docs/specs/infrastructure/media-analysis.md](media-analysis.md) — メディア解析（Vision モデル）
+- [docs/specs/indexer.md](../indexer.md) — インデクサー（Embedding）
+- [LM Studio 公式ドキュメント](https://lmstudio.ai/docs)

--- a/docs/specs/infrastructure/lmstudio-reference.md
+++ b/docs/specs/infrastructure/lmstudio-reference.md
@@ -30,7 +30,7 @@ LM Studio を Claude 主導で運用するための CLI リファレンス。`lm
 | `lms server status` | サーバーの起動状態を確認する | `lms server status` |
 | `lms ls` | ローカルにダウンロード済みのモデル一覧を表示する | `lms ls` |
 | `lms ps` | 現在ロード中のモデル一覧を表示する | `lms ps` |
-| `lms load` | モデルをロードする。引数なし時は per-model preset に従う | `lms load <key>` |
+| `lms load` | モデルをロードする。追加パラメータなしで `lms load <key>` を実行した場合、per-model preset に従う | `lms load <key>` |
 | `lms unload` | モデルを unload する | `lms unload <key>` または `lms unload --all` |
 | `lms get` | モデルをダウンロードする | `lms get <repo>` |
 | `lms runtime survey` | ハードウェア・利用可能ランタイムを調査する | `lms runtime survey` |

--- a/docs/specs/infrastructure/lmstudio-reference.md
+++ b/docs/specs/infrastructure/lmstudio-reference.md
@@ -37,15 +37,16 @@ LM Studio を Claude 主導で運用するための CLI リファレンス。`lm
 
 ### API 経由の推論パラメータと設定ファイルの対応
 
-LM Studio が公開する OpenAI 互換 API（`{LMSTUDIO_BASE_URL}/v1/...`）への呼び出し時に、本プロジェクトでは `config.toml` の値をリクエストパラメータとして渡す。
+LM Studio が公開する OpenAI 互換 API（`{LMSTUDIO_BASE_URL}/v1/...`）への呼び出し時に、
+本プロジェクトでは下表の通り `lmstudio.toml` および `config.toml` の値をリクエストパラメータとして渡す。
 
-| API パラメータ | `config.toml` のフィールド | 備考 |
+| API パラメータ | 設定値の出所 | 備考 |
 |---|---|---|
-| `model`（Embedding） | — | `lmstudio.toml` の `models.embedding.key` を使用 |
-| `model`（Vision） | — | `lmstudio.toml` の `models.vision.key` を使用 |
-| `max_tokens`（Vision） | `rag_vision_max_tokens` | Vision API レスポンスの上限トークン数 |
-| `reasoning_effort`（Vision） | `rag_vision_reasoning_effort` | 推論深度（`none` / `low` / `medium` / `high`） |
-| `timeout`（Vision クライアント側） | `rag_vision_api_timeout` | リクエストタイムアウト秒 |
+| `model`（Embedding） | `lmstudio.toml` の `models.embedding.key` | — |
+| `model`（Vision） | `lmstudio.toml` の `models.vision.key` | — |
+| `max_tokens`（Vision） | `config.toml` の `rag_vision_max_tokens` | Vision API レスポンスの上限トークン数 |
+| `reasoning_effort`（Vision） | `config.toml` の `rag_vision_reasoning_effort` | 推論深度（`none` / `low` / `medium` / `high`） |
+| `timeout`（Vision クライアント側） | `config.toml` の `rag_vision_api_timeout` | リクエストタイムアウト秒 |
 
 ### ハードウェアサーベイの取得方法
 

--- a/docs/specs/infrastructure/media-analysis.md
+++ b/docs/specs/infrastructure/media-analysis.md
@@ -58,12 +58,21 @@
 
 ### 設定項目
 
+#### `config.toml`（共通設定値）
+
 | 設定項目 | 層 | 設計意図 |
 |---------|-----|---------|
-| `rag_vision_model` | 共通設定値 | Vision モデルの識別子。LM Studio の `/v1/models` で返されるモデル ID と一致させる |
 | `rag_vision_reasoning_effort` | 共通設定値 | Vision API の reasoning_effort パラメータ。推論の深度を制御し、処理速度と品質のバランスを調整する。有効値はモデル・推論エンジンに依存する |
 | `rag_vision_frame_interval` | 共通設定値 | 動画フレーム抽出の間隔（秒）。抽出頻度を制御し、処理時間とカバレッジのバランスを調整する |
 | `rag_vision_max_tokens` | 共通設定値 | Vision API レスポンスの最大トークン数。出力長を制限する |
+
+#### `lmstudio.toml`（LM Studio モデル key）
+
+| 設定項目 | 層 | 設計意図 |
+|---------|-----|---------|
+| `models.vision.key` | 共通設定値 | Vision モデルの識別子。`lms load` および API 呼び出しの `model` パラメータで使用される。詳細は [lmstudio-reference.md](lmstudio-reference.md) 参照 |
+
+#### `.env`（環境依存値）
 
 `LMSTUDIO_BASE_URL` は環境依存値（`.env`）で管理。Embedding と共用する。
 
@@ -147,7 +156,7 @@ API リクエスト形式:
 |-----------|-----|
 | エンドポイント | `{LMSTUDIO_BASE_URL}/chat/completions` |
 | メソッド | POST |
-| `model` | `rag_vision_model` で指定 |
+| `model` | `lmstudio.toml` の `models.vision.key` で指定 |
 | `messages` | `role: "user"`, `content` に画像データ（base64）とプロンプトを含む |
 | `max_tokens` | `rag_vision_max_tokens` で指定 |
 | `reasoning_effort` | `rag_vision_reasoning_effort` で指定 |

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -44,6 +44,7 @@ RAG Knowledge は、外部 Web ページから収集した知識をベクトル 
 | 34 | Zenn Fake Adapter | Zenn API 用 FakeZennFetcher | [infrastructure/fake-adapters/zenn.md](infrastructure/fake-adapters/zenn.md) |
 | 35 | Aozora Fake Adapter | 青空文庫用 FakeAozoraFetcher（カタログ ZIP / XHTML を fixture から bytes 返却） | [infrastructure/fake-adapters/aozora.md](infrastructure/fake-adapters/aozora.md) |
 | 36 | Local Fake Adapter | Local 用 FakeLocalFetcher（filesystem 抽象化のみ。PDF/AsciiDoc 抽出は converter 層） | [infrastructure/fake-adapters/local.md](infrastructure/fake-adapters/local.md) |
+| 37 | LM Studio 管理基盤 | `lmstudio.toml` を SSoT とした LM Studio モデル key の集約と CLI リファレンス | [infrastructure/lmstudio-reference.md](infrastructure/lmstudio-reference.md) |
 
 ## 3. 技術スタック
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -32,7 +32,7 @@ MCP サーバーとして独立動作し、18 個のツールを提供する。
 |---|--------|---------|---------|
 | シークレット | OS セキュアストレージ (keyring) | 管理外 | 漏洩時に直接被害が発生する値。py-common-lib の `get_secret` で取得 |
 | 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値 |
-| 共通設定値 | `config.toml` | **管理する** | プロジェクトとして統一管理する値 |
+| 共通設定値 | `config.toml` / `lmstudio.toml` | **管理する** | プロジェクトとして統一管理する値（`lmstudio.toml` は LM Studio で読み込むモデル key の SSoT） |
 
 #### `.env`（環境依存値）
 
@@ -52,7 +52,7 @@ MCP サーバーとして独立動作し、18 個のツールを提供する。
 
 | カテゴリ | 設定項目 |
 |---------|---------|
-| Embedding モデル | `embedding_model_local`, `embedding_model_online`, `embedding_prefix_enabled`, `rag_embedding_retry_count`, `rag_embedding_retry_base_delay` |
+| Embedding モデル | `embedding_model_online`, `embedding_prefix_enabled`, `rag_embedding_retry_count`, `rag_embedding_retry_base_delay` |
 | チャンキング | `rag_chunk_size`, `rag_chunk_overlap`, `rag_embedding_context_length`, `rag_worst_token_char_ratio` |
 | 検索 | `rag_retrieval_count`, `rag_similarity_threshold` |
 | ハイブリッド検索 | `rag_hybrid_search_enabled`, `rag_vector_weight`, `rag_bm25_k1`, `rag_bm25_b`, `rag_min_combined_score` |
@@ -69,6 +69,18 @@ MCP サーバーとして独立動作し、18 個のツールを提供する。
 | YouTube インジェスター | `rag_youtube_max_videos`, `rag_youtube_request_interval`, `rag_youtube_request_timeout`, `rag_youtube_transcript_languages`, `rag_youtube_merge_gap_sec`, `rag_youtube_merge_max_chars`, `rag_youtube_max_duration` |
 | 青空文庫インジェスター | `rag_aozora_max_works`, `rag_aozora_request_interval`, `rag_aozora_request_timeout` |
 | サイト一括取り込み | `site_ingest_delay_sec`, `site_ingest_max_pages`, `site_ingest_download_timeout`, `site_ingest_timeout_sec`, `site_ingest_error_count` |
+
+#### `lmstudio.toml`（LM Studio モデル key）
+
+| カテゴリ | 設定項目 |
+|---------|---------|
+| Embedding モデル | `models.embedding.key`（ローカル Embedding モデルの key） |
+| Vision モデル | `models.vision.key`（メディア解析用 Vision モデルの key） |
+
+`lmstudio.toml` の詳細・運用は以下を参照。
+
+- [infrastructure/lmstudio-reference.md](infrastructure/lmstudio-reference.md) — CLI 仕様参照
+- [infrastructure/lmstudio-operation.md](infrastructure/lmstudio-operation.md) — 運用手順
 
 - `hnsw_m` と `hnsw_construction_ef` はコレクション作成時のみ適用される（不変）。既存コレクションへの反映には `rebuild --mode full`（コレクション削除 → 再作成）が必要。`hnsw_search_ef` は起動時に `collection.modify()` で既存コレクションにも自動適用される
 - Embedding モデルを変更した場合、既存データとの類似度計算が不正確になるため、コレクション再構築が必要

--- a/lmstudio.toml
+++ b/lmstudio.toml
@@ -1,0 +1,12 @@
+# LM Studio 設定 — Claude が `lms load` で参照するモデル key の SSoT
+# 仕様: docs/specs/infrastructure/lmstudio-reference.md
+# 運用手順: docs/specs/infrastructure/lmstudio-operation.md
+#
+# ロードパラメータ（context_length / gpu_offload / ttl_seconds / parallel 等）は
+# LM Studio 側の per-model preset に委譲する。本ファイルには key のみ保持する。
+
+[models.embedding]
+key = "text-embedding-nomic-embed-text-v2-moe"
+
+[models.vision]
+key = "google/gemma-4-26b-a4b"

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -450,11 +450,26 @@ def _load_toml_config() -> dict[str, Any]:
     return data
 
 
+def _collect_lmstudio_paths(
+    data: Any, prefix: tuple[str, ...] = (),
+) -> set[tuple[str, ...]]:
+    """lmstudio.toml の dict をリーフまで再帰し、全リーフパスを返す."""
+    paths: set[tuple[str, ...]] = set()
+    if isinstance(data, dict):
+        for key, value in data.items():
+            paths.update(_collect_lmstudio_paths(value, (*prefix, key)))
+    else:
+        paths.add(prefix)
+    return paths
+
+
 def _load_lmstudio_config() -> _LMStudioFlatData:
     """lmstudio.toml を読み込み、モデル key を辞書で返す.
 
     返り値のキーは RAGSettings の対応フィールド名（_LMSTUDIO_TOML_PATHS で定義）。
     TOML パスのいずれかが欠損している場合は ValueError を送出（fail-fast）。
+    _LMSTUDIO_TOML_PATHS に列挙されていない未知のキーが含まれている場合も
+    ValueError を送出する（config.toml の未知キー検証と同等の挙動）。
     キーが空文字列の場合は RAGSettings の Field(min_length=1) で fail-fast する。
     """
     if not _LMSTUDIO_TOML_FILE.exists():
@@ -482,6 +497,17 @@ def _load_lmstudio_config() -> _LMStudioFlatData:
             )
             raise ValueError(msg)
         result[field_name] = node
+    # 未知キー/セクションの検出（必須フィールド検証後、config.toml の未知キー検証と整合）
+    known_paths = set(_LMSTUDIO_TOML_PATHS.values())
+    actual_paths = _collect_lmstudio_paths(data)
+    unknown_paths = actual_paths - known_paths
+    if unknown_paths:
+        unknown_keys = sorted(".".join(p) for p in unknown_paths)
+        msg = (
+            f"lmstudio.toml に未知の設定が含まれています "
+            f"(path={_LMSTUDIO_TOML_FILE}): {unknown_keys}"
+        )
+        raise ValueError(msg)
     # _LMSTUDIO_TOML_PATHS の全キーを result に格納したため、TypedDict として扱える
     return cast(_LMStudioFlatData, result)
 

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -23,7 +23,7 @@ import os
 import sys
 import tomllib
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -40,6 +40,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 _PROJECT_ROOT = PROJECT_ROOT  # 後方互換のための旧 private 名
 _ENV_FILE = PROJECT_ROOT / ".env"
 _TOML_FILE = PROJECT_ROOT / "config.toml"
+_LMSTUDIO_TOML_FILE = PROJECT_ROOT / "lmstudio.toml"
 
 
 class _EnvLoader(BaseSettings):
@@ -218,10 +219,15 @@ class RAGSettings(BaseModel):
     site_ingest_temp_dir: str
     rag_embedding_concurrency: int = Field(ge=1)
 
+    # --- lmstudio.toml から取得（LM Studio モデル key） ---
+    # ローカル Embedding モデルの key（lms load で使用）
+    embedding_model_local: str = Field(min_length=1)
+    # Vision モデルの key（lms load で使用）
+    rag_vision_model: str = Field(min_length=1)
+
     # --- config.toml から取得（共通設定値） ---
 
     # Embedding モデル
-    embedding_model_local: str
     embedding_model_online: str
     # 検索クエリに prefix を付与して検索精度を向上させる（モデル依存）
     embedding_prefix_enabled: bool
@@ -341,8 +347,8 @@ class RAGSettings(BaseModel):
     rag_bluesky_force_youtube_reingest: bool
 
     # メディア解析（Vision モデル）
-    # LM Studio 上の Vision モデルを指定
-    rag_vision_model: str
+    # rag_vision_model は lmstudio.toml が SSoT（_load_lmstudio_config 経由で読み込み、
+    # get_settings で RAGSettings に統合）
     # 推論の深度を制御し、処理速度と品質のバランスを調整
     rag_vision_reasoning_effort: Literal["none", "low", "medium", "high"]
     # 動画フレーム抽出の間隔（秒）。抽出頻度を制御し、処理時間とカバレッジのバランスを調整
@@ -389,6 +395,25 @@ class RAGSettings(BaseModel):
         return self
 
 
+# lmstudio.toml の TOML パスと RAGSettings フィールド名の対応表（SSoT）
+# 新フィールド追加時はここだけ更新する。_LMSTUDIO_FIELD_NAMES と _load_lmstudio_config
+# は本定数から派生する。
+_LMSTUDIO_TOML_PATHS: dict[str, tuple[str, ...]] = {
+    "embedding_model_local": ("models", "embedding", "key"),
+    "rag_vision_model": ("models", "vision", "key"),
+}
+
+# lmstudio.toml が SSoT のフィールド名（_LMSTUDIO_TOML_PATHS から派生、重複検出に使用）
+_LMSTUDIO_FIELD_NAMES = frozenset(_LMSTUDIO_TOML_PATHS.keys())
+
+
+class _LMStudioFlatData(TypedDict):
+    """lmstudio.toml から読み込んだフラット辞書（RAGSettings 統合用）."""
+
+    embedding_model_local: str
+    rag_vision_model: str
+
+
 def _load_toml_config() -> dict[str, Any]:
     """config.toml を読み込み、層の重複を検証する."""
     if not _TOML_FILE.exists():
@@ -404,8 +429,20 @@ def _load_toml_config() -> dict[str, Any]:
             f"{sorted(env_overlap)}"
         )
         raise ValueError(msg)
+    # config.toml に lmstudio.toml SSoT のフィールドが混入していないか検証
+    lmstudio_overlap = set(data.keys()) & _LMSTUDIO_FIELD_NAMES
+    if lmstudio_overlap:
+        msg = (
+            f"config.toml に lmstudio.toml で管理する設定が含まれています "
+            f"（lmstudio.toml に移動してください）: {sorted(lmstudio_overlap)}"
+        )
+        raise ValueError(msg)
     # 未知のキーを検証
-    toml_field_names = frozenset(RAGSettings.model_fields.keys()) - _ENV_FIELD_NAMES
+    toml_field_names = (
+        frozenset(RAGSettings.model_fields.keys())
+        - _ENV_FIELD_NAMES
+        - _LMSTUDIO_FIELD_NAMES
+    )
     unknown = set(data.keys()) - toml_field_names
     if unknown:
         msg = f"config.toml に未知の設定が含まれています: {sorted(unknown)}"
@@ -413,16 +450,57 @@ def _load_toml_config() -> dict[str, Any]:
     return data
 
 
+def _load_lmstudio_config() -> _LMStudioFlatData:
+    """lmstudio.toml を読み込み、モデル key を辞書で返す.
+
+    返り値のキーは RAGSettings の対応フィールド名（_LMSTUDIO_TOML_PATHS で定義）。
+    TOML パスのいずれかが欠損している場合は ValueError を送出（fail-fast）。
+    キーが空文字列の場合は RAGSettings の Field(min_length=1) で fail-fast する。
+    """
+    if not _LMSTUDIO_TOML_FILE.exists():
+        msg = f"lmstudio.toml が見つかりません: {_LMSTUDIO_TOML_FILE}"
+        raise FileNotFoundError(msg)
+    with open(_LMSTUDIO_TOML_FILE, "rb") as f:
+        data = tomllib.load(f)
+    result: dict[str, str] = {}
+    for field_name, toml_path in _LMSTUDIO_TOML_PATHS.items():
+        node: Any = data
+        for segment in toml_path:
+            if not isinstance(node, dict) or segment not in node:
+                joined = ".".join(toml_path)
+                msg = (
+                    f"lmstudio.toml に必須フィールドが見つかりません: "
+                    f"{joined} (path={_LMSTUDIO_TOML_FILE})"
+                )
+                raise ValueError(msg)
+            node = node[segment]
+        if not isinstance(node, str):
+            joined = ".".join(toml_path)
+            msg = (
+                f"lmstudio.toml の {joined} は文字列である必要があります "
+                f"(actual type={type(node).__name__}, path={_LMSTUDIO_TOML_FILE})"
+            )
+            raise ValueError(msg)
+        result[field_name] = node
+    # _LMSTUDIO_TOML_PATHS の全キーを result に格納したため、TypedDict として扱える
+    return cast(_LMStudioFlatData, result)
+
+
 @functools.lru_cache(maxsize=1)
 def get_settings() -> RAGSettings:
     """キャッシュ付きでRAGSettingsインスタンスを返す.
 
-    .env から環境依存値、config.toml から共通設定値を取得し、
-    統合した RAGSettings を返す。
+    .env から環境依存値、config.toml から共通設定値、
+    lmstudio.toml から LM Studio モデル key を取得し、統合した RAGSettings を返す。
     """
     env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
     toml_data = _load_toml_config()
-    return RAGSettings(**env_loader.model_dump(), **toml_data)
+    lmstudio_data = _load_lmstudio_config()
+    return RAGSettings(
+        **env_loader.model_dump(),
+        **toml_data,
+        **lmstudio_data,
+    )
 
 
 def log_fake_mode_status(settings: RAGSettings) -> None:

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -24,8 +24,10 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_dns_rebinding_protection": True,
     "rag_debug_log_enabled": False,
     "rag_embedding_concurrency": 32,
-    # config.toml フィールド
+    # lmstudio.toml フィールド
     "embedding_model_local": "nomic-embed-text",
+    "rag_vision_model": "google/gemma-4-26b-a4b",
+    # config.toml フィールド
     "embedding_model_online": "text-embedding-3-small",
     "embedding_prefix_enabled": True,
     "rag_embedding_retry_count": 3,
@@ -107,8 +109,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_aozora_max_works": 200,
     "rag_aozora_request_interval": 1.0,
     "rag_aozora_request_timeout": 30,
-    # メディア解析（Vision モデル）
-    "rag_vision_model": "google/gemma-4-26b-a4b",
+    # メディア解析（Vision モデル） - rag_vision_model は lmstudio.toml フィールドに移動済み
     "rag_vision_reasoning_effort": "none",
     "rag_vision_frame_interval": 5,
     "rag_vision_max_tokens": 1024,

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -18,7 +18,12 @@ import pytest
 from pydantic import ValidationError
 
 from settings_defaults import TEST_SETTINGS_DEFAULTS
-from rag.config import RAGSettings, _ENV_FIELD_NAMES, _load_toml_config
+from rag.config import (
+    RAGSettings,
+    _ENV_FIELD_NAMES,
+    _load_lmstudio_config,
+    _load_toml_config,
+)
 
 
 def _make_settings(**overrides: object) -> RAGSettings:
@@ -186,13 +191,112 @@ class TestTomlConfigValidation:
 
         assert _ENV_FIELD_NAMES == frozenset(_EnvLoader.model_fields.keys())
 
+    def test_rejects_lmstudio_fields_in_toml(self, tmp_path: Path) -> None:
+        """config.toml に lmstudio.toml SSoT のフィールドが含まれている場合 ValueError."""
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text('embedding_model_local = "old-model"\n')
+        with patch("rag.config._TOML_FILE", toml_file):
+            with pytest.raises(ValueError, match="lmstudio.toml"):
+                _load_toml_config()
+
+
+class TestLMStudioConfigValidation:
+    """_load_lmstudio_config のバリデーションテスト (#721)."""
+
+    def test_valid_lmstudio_toml_loads_successfully(self, tmp_path: Path) -> None:
+        """有効な lmstudio.toml が正常に読み込めること."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = "embed-x"\n'
+            '[models.vision]\nkey = "vision-x"\n'
+        )
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            data = _load_lmstudio_config()
+        assert data == {
+            "embedding_model_local": "embed-x",
+            "rag_vision_model": "vision-x",
+        }
+
+    def test_missing_lmstudio_toml_raises_error(self, tmp_path: Path) -> None:
+        """lmstudio.toml が存在しない場合は FileNotFoundError."""
+        with patch("rag.config._LMSTUDIO_TOML_FILE", tmp_path / "nonexistent.toml"):
+            with pytest.raises(FileNotFoundError, match="lmstudio.toml"):
+                _load_lmstudio_config()
+
+    def test_missing_models_section_raises_error(self, tmp_path: Path) -> None:
+        """[models] セクションが欠損している場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text('[other]\nfoo = "bar"\n')
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="必須フィールドが見つかりません"):
+                _load_lmstudio_config()
+
+    def test_intermediate_node_not_dict_raises_error(self, tmp_path: Path) -> None:
+        """中間ノードが dict じゃない場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text('models = "not a section"\n')
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="必須フィールドが見つかりません"):
+                _load_lmstudio_config()
+
+    def test_missing_embedding_key_raises_error(self, tmp_path: Path) -> None:
+        """embedding key が欠損している場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text('[models.vision]\nkey = "vision-x"\n')
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(
+                ValueError, match="models.embedding.key"
+            ):
+                _load_lmstudio_config()
+
+    def test_missing_vision_key_raises_error(self, tmp_path: Path) -> None:
+        """vision key が欠損している場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = "embed-x"\n'
+        )
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="models.vision.key"):
+                _load_lmstudio_config()
+
+    def test_non_string_key_raises_error(self, tmp_path: Path) -> None:
+        """key が文字列以外の場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = 123\n'
+            '[models.vision]\nkey = "vision-x"\n'
+        )
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="文字列である必要があります"):
+                _load_lmstudio_config()
+
+    def test_empty_key_raises_validation_error(self, tmp_path: Path) -> None:
+        """空文字列 key は RAGSettings の Field(min_length=1) で fail-fast."""
+        # _load_lmstudio_config は通すが、RAGSettings 構築時に ValidationError
+        from settings_defaults import TEST_SETTINGS_DEFAULTS
+
+        with pytest.raises(ValidationError):
+            RAGSettings(
+                **{**TEST_SETTINGS_DEFAULTS, "embedding_model_local": ""},
+            )
+        with pytest.raises(ValidationError):
+            RAGSettings(
+                **{**TEST_SETTINGS_DEFAULTS, "rag_vision_model": ""},
+            )
+
+    def test_lmstudio_field_names_derived_from_paths(self) -> None:
+        """_LMSTUDIO_FIELD_NAMES が _LMSTUDIO_TOML_PATHS から派生していること."""
+        from rag.config import _LMSTUDIO_FIELD_NAMES, _LMSTUDIO_TOML_PATHS
+
+        assert _LMSTUDIO_FIELD_NAMES == frozenset(_LMSTUDIO_TOML_PATHS.keys())
+
 
 class TestGetSettingsIntegration:
     """get_settings() の統合テスト (#207)."""
 
     # config.toml の全必須フィールド（TOML形式文字列）
+    # embedding_model_local / rag_vision_model は lmstudio.toml が SSoT のため含めない
     _TOML_CONTENT = """\
-embedding_model_local = "nomic-embed-text"
 embedding_model_online = "text-embedding-3-small"
 embedding_prefix_enabled = true
 rag_chunk_size = 200
@@ -241,7 +345,6 @@ rag_pdf_quality_greek_threshold = 0.15
 rag_pdf_quality_cjk_min_threshold = 0.05
 rag_pdf_quality_min_chars_per_page = 10
 rag_pdf_quality_sample_pages = 10
-rag_vision_model = "google/gemma-4-26b-a4b"
 rag_vision_reasoning_effort = "none"
 rag_vision_frame_interval = 5
 rag_vision_max_tokens = 1024
@@ -257,6 +360,22 @@ site_ingest_error_count = 10
 rag_embedding_retry_count = 3
 rag_embedding_retry_base_delay = 1.0
 """
+
+    _LMSTUDIO_CONTENT = """\
+[models.embedding]
+key = "test-embed-model"
+
+[models.vision]
+key = "test-vision-model"
+"""
+
+    def _setup_files(self, tmp_path: Path) -> tuple[Path, Path]:
+        """テスト用 config.toml / lmstudio.toml を tmp_path に書き出してパスを返す."""
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(self._TOML_CONTENT)
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(self._LMSTUDIO_CONTENT)
+        return toml_file, lmstudio_file
 
     def _set_all_env(self, monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
         """全必須 env フィールドを monkeypatch で設定する."""
@@ -285,10 +404,12 @@ rag_embedding_retry_base_delay = 1.0
         from rag.config import get_settings
 
         get_settings.cache_clear()
-        toml_file = tmp_path / "config.toml"
-        toml_file.write_text(self._TOML_CONTENT)
+        toml_file, lmstudio_file = self._setup_files(tmp_path)
         self._set_all_env(monkeypatch, EMBEDDING_PROVIDER="online")
-        with patch("rag.config._TOML_FILE", toml_file):
+        with (
+            patch("rag.config._TOML_FILE", toml_file),
+            patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file),
+        ):
             settings = get_settings()
             assert settings.embedding_provider == "online"
         get_settings.cache_clear()
@@ -302,8 +423,13 @@ rag_embedding_retry_base_delay = 1.0
         toml_file.write_text(self._TOML_CONTENT.replace(
             "rag_chunk_size = 200", "rag_chunk_size = 999"
         ))
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(self._LMSTUDIO_CONTENT)
         self._set_all_env(monkeypatch)
-        with patch("rag.config._TOML_FILE", toml_file):
+        with (
+            patch("rag.config._TOML_FILE", toml_file),
+            patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file),
+        ):
             settings = get_settings()
             assert settings.rag_chunk_size == 999
         get_settings.cache_clear()
@@ -317,11 +443,40 @@ rag_embedding_retry_base_delay = 1.0
         toml_file.write_text(self._TOML_CONTENT.replace(
             "rag_chunk_size = 200", "rag_chunk_size = 300"
         ))
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(self._LMSTUDIO_CONTENT)
         self._set_all_env(monkeypatch, RAG_TRANSPORT="http")
-        with patch("rag.config._TOML_FILE", toml_file):
+        with (
+            patch("rag.config._TOML_FILE", toml_file),
+            patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file),
+        ):
             settings = get_settings()
             assert settings.rag_chunk_size == 300
             assert settings.rag_transport == "http"
+        get_settings.cache_clear()
+
+    def test_lmstudio_values_reflected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """lmstudio.toml の値が RAGSettings に反映されること."""
+        from rag.config import get_settings
+
+        get_settings.cache_clear()
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(self._TOML_CONTENT)
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = "embed-from-lmstudio"\n'
+            '[models.vision]\nkey = "vision-from-lmstudio"\n'
+        )
+        self._set_all_env(monkeypatch)
+        with (
+            patch("rag.config._TOML_FILE", toml_file),
+            patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file),
+        ):
+            settings = get_settings()
+            assert settings.embedding_model_local == "embed-from-lmstudio"
+            assert settings.rag_vision_model == "vision-from-lmstudio"
         get_settings.cache_clear()
 
 

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -239,6 +239,29 @@ class TestLMStudioConfigValidation:
             with pytest.raises(ValueError, match="必須フィールドが見つかりません"):
                 _load_lmstudio_config()
 
+    def test_unknown_key_raises_error(self, tmp_path: Path) -> None:
+        """lmstudio.toml に未知のキーが含まれている場合は ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = "embed-x"\n'
+            '[models.vision]\nkey = "vision-x"\n'
+            '[server]\nauto_start = true\n'
+        )
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="未知の設定"):
+                _load_lmstudio_config()
+
+    def test_unknown_subkey_raises_error(self, tmp_path: Path) -> None:
+        """既知セクション内の未知のサブキーも ValueError."""
+        lmstudio_file = tmp_path / "lmstudio.toml"
+        lmstudio_file.write_text(
+            '[models.embedding]\nkey = "embed-x"\nlegacy_param = 123\n'
+            '[models.vision]\nkey = "vision-x"\n'
+        )
+        with patch("rag.config._LMSTUDIO_TOML_FILE", lmstudio_file):
+            with pytest.raises(ValueError, match="未知の設定"):
+                _load_lmstudio_config()
+
     def test_missing_embedding_key_raises_error(self, tmp_path: Path) -> None:
         """embedding key が欠損している場合は ValueError."""
         lmstudio_file = tmp_path / "lmstudio.toml"


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

LM Studio で読み込むモデル key を `lmstudio.toml` に集約し、Claude が `lms` CLI 経由で LM Studio のライフサイクル（サーバー起動・モデルロード・unload・状態確認）を管理する基盤を整備した。

- **新規ファイル**: `lmstudio.toml`（key の SSoT、`[server]` なし）/ `docs/specs/infrastructure/lmstudio-reference.md`（CLI 仕様参照）/ `docs/specs/infrastructure/lmstudio-operation.md`（運用手順書）
- **ランタイム**: `_LMSTUDIO_TOML_PATHS` 定数を SSoT として `_load_lmstudio_config` / `_LMSTUDIO_FIELD_NAMES` を派生。TypedDict + cast で型安全な統合。`Field(min_length=1)` で空文字列を fail-fast
- **設定移動**: `embedding_model_local` / `rag_vision_model` を `config.toml` から `lmstudio.toml` へ。`embedding_model_online`（OpenAI）は config.toml 残留
- **仕様書整合**: `overview.md` / `indexer.md` / `media-analysis.md` / `rag-knowledge.md` の SSoT 参照先を `lmstudio.toml` に更新
- **README / CLAUDE.md**: LM Studio セットアップ手順を `lmstudio-operation.md` への 1 行ポインタに集約。CLAUDE.md 「worktree 環境セットアップ」に ChromaDB 起動を含める構成に整理
- **/qa スキル**: 環境確認ステップを `lms ps` / `lms load` ベースに更新。A-3 と A-4a/4b で Vision モデルロード状態を切り替えるシナリオに変更

ロードパラメータ（context_length / gpu_offload / ttl_seconds / parallel）は LM Studio per-model preset に委譲する方針のため、`lmstudio.toml` には key のみ保持する。

## Test plan

- [x] `uv run pytest`（1981 passed、fail-fast テスト 6 件 + SSoT 派生確認 1 件 + 統合テスト追加分含む）
- [x] `uv run ruff check .`（All checks passed）
- [x] `uv run mypy src`（Success: no issues found in 94 source files）
- [x] L3 QA: `/qa` スキル A グループ全体（A-1〜A-9b）を実 LM Studio 環境で実施完了
  - A-3: Vision unload 状態でフォールバック動作確認
  - A-4a/4b: `image_replace_test.jpg` 経由で別バイト上書き → Vision 解析テキスト生成を確認
  - A-5: 動画フレーム解析（4 フレーム + タイムスタンプ）確認

## Related issues

Closes #721