### PR TITLE
refactor(indexer,pipeline-controller): IndexWriteStrategy 抽象化による BM25 漏洩解消 (#729)

### DIFF
--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -130,7 +130,22 @@ subprocess を起動し、Scrapy 等の外部プロセスで取得を行う経�
 
 他 Ingester から web 取り込みへの委譲は `WebDelegator` Protocol 経由で行う（直接 import を禁止）。委譲経路の構造は youtube への委譲（`YoutubeDelegator`）と同型。
 
-### 3.4 BaseIngester 抽象化の対象範囲
+### 3.4 IndexWriteStrategy（インデクサー内部 Port）
+
+`Indexer` は媒体ごとに性質の異なる書き込み戦略を持つインデックス（BM25・Vector Store 等）を保有する。
+これらの「バッチ書き込み手順」を `IndexWriteStrategy` Protocol（context manager）で抽象化し、
+`Indexer.batch_writes()` が保有する全 strategy を nest して enter/exit する。
+
+| 観点 | 内容 |
+|---|---|
+| 役割 | バッチ処理時の書き込み戦略をインデックス実装ごとに表現する |
+| 各実装の例 | `BM25WriteStrategy`（deferred save → flush）/ Vector Store は逐次 upsert のため独立 strategy を持たない |
+| 呼び出し側 | `PipelineController` の `run_incremental` / `run_full_rebuild` / `run_index_only` が `with self._indexer.batch_writes():` 経由で利用 |
+
+`IndexerProtocol` は BM25 等の実装詳細名を露出させない（呼び出し側は `batch_writes()` のみを知る）。
+配置・各実装の詳細は [indexer.md「バッチ書き込み戦略（IndexWriteStrategy）」](indexer.md#バッチ書き込み戦略indexwritestrategy) を参照。
+
+### 3.5 BaseIngester 抽象化の対象範囲
 
 - Ingester ファミリーの全クラスが `BaseIngester` 継承対象（対象 `source_type` の SSoT は [`_schema/enums.yml`](../../_schema/enums.yml)、継承の実体は各 Ingester のコードが SSoT）
 - `BaseIngester` は Ingester ファミリーの共通 Port（Protocol / ABC）として位置付ける。§1 の Dependency Rule に従い、パイプライン制御層は具象 Ingester ではなく `BaseIngester` 経由で操作する
@@ -168,7 +183,7 @@ subprocess を起動し、Scrapy 等の外部プロセスで取得を行う経�
 | 契約の種類 | 定義場所 | 表現 |
 |---|---|---|
 | 内部 dto / モデル | `<package>/models.py`（例: `store/models.py` / `pipeline/models.py`） | dataclass / Enum / TypedDict |
-| Port（Adapter が従う interface 契約） | `<package>/<feature>_<role>.py`（例: `pipeline/ingesters/youtube_fetcher.py`） | Protocol / ABC |
+| Port（Adapter が従う interface 契約） | `<package>/<feature>_<role>.py`（例: `pipeline/ingesters/youtube_fetcher.py`）。Protocol と複数実装を 1 ファイルに集約する場合は `<package>/<feature>.py` 形式（例: `indexer/write_strategy.py`）も許容する | Protocol / ABC |
 | 公開 API contract | MCP ツール定義（`src/rag/server/tools/`）/ HTTP スキーマ（`pydantic` BaseModel） | pydantic BaseModel / Discriminated Union |
 
 `dict[str, Any]` は境界（外部 API レスポンス・JSON 応答・MCP 応答テキスト等）でのみ許容し、越境後は構造化型（dataclass / Enum / TypedDict）に変換する。

--- a/docs/specs/indexer.md
+++ b/docs/specs/indexer.md
@@ -127,7 +127,13 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 - ChromaDB は upsert 方式で冪等性を確保する。同一チャンク ID で再実行しても結果が変わらない
 - BM25 インデックスはドキュメント追加・削除後にインメモリインデックスの再構築が必要（lazy rebuild: 検索実行時に自動再構築）
 - BM25 の永続化はアトミックスワップ（一時ディレクトリ + リネーム）で破損を防止する
-- バッチ処理（全再構築・インデックス再構築・差分更新）時、パイプライン制御は BM25 の遅延 save モードを有効にし、個別の add/delete ごとの rebuild + 永続化をスキップする。バッチ完了後に一括で rebuild + 永続化を実行する。これにより N 件のソース処理で N 回発生していた BM25 rebuild が 1 回に削減される
+- バッチ処理（全再構築・インデックス再構築・差分更新）時、パイプライン制御は
+  `Indexer.batch_writes()` 経由でバッチ書き込みコンテキストを宣言する。
+  `Indexer` は内部で保有する `IndexWriteStrategy` 群（インデックスごとの書き込み戦略）を
+  nest して enter/exit し、各インデックス実装が「自分の書き込み戦略」を選択する。
+  呼び出し側は実装詳細（BM25 / Vector 等）を意識しない。
+  BM25 用 strategy はバッチ中の rebuild + 永続化を抑止し、バッチ完了時に一括実行する。
+  これにより N 件のソース処理で N 回発生していた BM25 rebuild が 1 回に削減される
 
 ### バッチサイズ
 
@@ -177,8 +183,23 @@ Embedding に渡る最終テキストは「Embedding プレフィックス + チ
 | インデックス削除 | source_id | なし | 指定 source_id に紐づく全チャンクを ChromaDB と BM25 から削除する |
 | メタデータ更新 | source_id、メタデータ | なし | チャンクの再生成は行わず、ChromaDB 内の既存チャンクのメタデータのみを upsert する。BM25 はメタデータを保持しないため更新不要 |
 | インデックスクリア | source_type フィルタ（任意） | なし | インデックスをクリアする。source_type 指定時は該当 source_type のチャンクのみ削除する（他の source_type のインデックスは維持）。フィルタなしの場合は ChromaDB と BM25 を全クリアする |
+| バッチ書き込みコンテキスト | なし | context manager | `with indexer.batch_writes():` でバッチ書き込みスコープを宣言する。スコープ内では各 `IndexWriteStrategy` 実装が自身の書き込み戦略を適用し、スコープ終了時に一括 flush する |
 
 インデックス全再構築（`clear` + 全ファイル `add`）はパイプライン制御（`run_index_only` / `run_full_rebuild`）がオーケストレーションする。インデクサー自体は個別操作のみを提供する。
+
+### バッチ書き込み戦略（IndexWriteStrategy）
+
+`Indexer` 内部の各インデックス（BM25 / Vector Store 等）は性質の異なる書き込み戦略を持つ。これを `IndexWriteStrategy` Protocol（context manager）で抽象化し、`Indexer.batch_writes()` がインデックス実装ごとの戦略を nest して enter/exit する。
+
+| 観点 | 内容 |
+|---|---|
+| Protocol 配置 | `src/rag/indexer/write_strategy.py` |
+| インターフェース | `__enter__()` / `__exit__(exc_type, exc, tb)` を持つ context manager protocol |
+| BM25 用実装 | `BM25WriteStrategy`（enter で deferred save 有効化、exit で flush）。例外時も exit は flush を試行する |
+| Vector Store | 逐次 upsert で完結するため独立 strategy を持たない（Indexer が strategy リストに追加しない） |
+| 呼び出し側の責務 | `pipeline/controller.py` は `with self._indexer.batch_writes():` を宣言するのみ。インデックス実装の詳細を知らない |
+
+設計意図: 「BM25」という実装詳細名を `IndexerProtocol` から排除し、各インデックス実装が自分の書き込み戦略を選択する構造にする。新しいインデックス追加時は対応する `IndexWriteStrategy` 実装を `Indexer.__init__` で組み立てて strategy リストに追加するだけで、呼び出し側のコードは変更不要。
 
 ### インデックス追加・更新の処理手順
 

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -209,6 +209,8 @@ git diff から取得する変更ファイルリストの各エントリが持�
 8. 削除ファイルはインデクサーでインデックスから削除し、metadata.db で論理削除する
 9. `pipeline_history` に実行履歴を追加する
 
+インデクサーへのインデックス追加・更新・削除は、`Indexer.batch_writes()` のバッチ書き込みコンテキスト内で実行する。コンテキスト内では各 `IndexWriteStrategy` が自身の戦略（BM25 は deferred save → flush 等）を適用し、コンテキスト終了時に一括 flush する。詳細は [indexer.md](indexer.md) の「バッチ書き込み戦略（IndexWriteStrategy）」を参照。
+
 ```mermaid
 flowchart TD
     START["パイプライン開始"]

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -225,8 +225,12 @@ class Indexer:
 
         保有する全 ``IndexWriteStrategy`` を ``ExitStack`` で nest し、enter/exit する。
         各 strategy がインデックス実装ごとの戦略（BM25 は deferred save → flush 等）を
-        適用する。例外時も既に enter 済みの strategy は exit される（部分失敗は
-        ``PipelineSummary.errors`` で管理）。
+        適用する。``with`` ブロック内で例外が発生した場合も、すでに enter 済みの
+        strategy は LIFO 順で確実に exit される（``ExitStack`` の保証）。
+
+        strategy の ``__exit__`` 自体が例外を投げた場合は呼び出し側に伝播し、
+        パイプラインを中断する。with ブロック内のソース処理エラーは
+        ``_run_processing_loop`` 側で ``PipelineSummary.errors`` に集約される。
         """
         with contextlib.ExitStack() as stack:
             for strategy in self._write_strategies:

--- a/src/rag/indexer/indexer.py
+++ b/src/rag/indexer/indexer.py
@@ -20,6 +20,7 @@ from rag.content_detector import ContentType, detect_content_type
 from rag.heading_chunker import chunk_by_headings
 from rag.indexer.chunk_id import generate_chunk_id, parse_chunk_index
 from rag.indexer.metadata import build_chunk_metadata
+from rag.indexer.write_strategy import BM25WriteStrategy, IndexWriteStrategy
 from rag.store.metadata_db import MetadataDB
 from rag.store.models import SourceMetadata, SourceType
 from rag.table_chunker import chunk_table_data
@@ -67,6 +68,9 @@ class Indexer:
         self._chunk_overlap = chunk_overlap
         self._embedding_checked = False
         self._embedding_lock = asyncio.Lock()
+        self._write_strategies: list[IndexWriteStrategy] = [
+            BM25WriteStrategy(bm25_index),
+        ]
 
         # 実効サイズの算出: min(chunk_size, 安全上限 - overhead)
         # 仕様: docs/specs/indexer.md「オーバーヘッドと実効サイズ」
@@ -215,32 +219,19 @@ class Indexer:
             "メタデータを更新: %s (%d チャンク)", source_id, total_chunks,
         )
 
-    def set_bm25_deferred_save(self, enabled: bool) -> None:
-        """BM25 の遅延 save モードを切り替える.
-
-        Args:
-            enabled: True で遅延モード有効
-        """
-        self._bm25.set_deferred_save(enabled)
-
-    def flush_bm25(self) -> None:
-        """BM25 の未保存変更を一括 rebuild + 永続化する."""
-        self._bm25.flush()
-
     @contextlib.contextmanager
-    def bm25_deferred(self) -> Iterator[None]:
-        """BM25 遅延 save のコンテキストマネージャ.
+    def batch_writes(self) -> Iterator[None]:
+        """バッチ書き込みコンテキスト.
 
-        バッチ処理中は個別の rebuild + 永続化をスキップし、
-        ブロック終了時に一括で実行する。
-        エラー時も処理済み分を永続化する（部分失敗は PipelineSummary.errors で管理）。
+        保有する全 ``IndexWriteStrategy`` を ``ExitStack`` で nest し、enter/exit する。
+        各 strategy がインデックス実装ごとの戦略（BM25 は deferred save → flush 等）を
+        適用する。例外時も既に enter 済みの strategy は exit される（部分失敗は
+        ``PipelineSummary.errors`` で管理）。
         """
-        self.set_bm25_deferred_save(True)
-        try:
+        with contextlib.ExitStack() as stack:
+            for strategy in self._write_strategies:
+                stack.enter_context(strategy)
             yield
-        finally:
-            self.set_bm25_deferred_save(False)
-            self.flush_bm25()
 
     async def clear(
         self,

--- a/src/rag/indexer/write_strategy.py
+++ b/src/rag/indexer/write_strategy.py
@@ -1,0 +1,58 @@
+"""インデックス書き込み戦略 — IndexWriteStrategy Protocol と実装.
+
+仕様: docs/specs/indexer.md「バッチ書き込み戦略（IndexWriteStrategy）」
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Protocol
+
+from rag.bm25_index import BM25Index
+
+
+class IndexWriteStrategy(Protocol):
+    """インデックスのバッチ書き込み戦略.
+
+    各インデックス実装（BM25 / Vector Store 等）が「自身の書き込み戦略」を
+    context manager として表現する。`Indexer.batch_writes()` は保有する全
+    strategy を nest して enter/exit する。
+    """
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+
+
+class BM25WriteStrategy:
+    """BM25 用のバッチ書き込み戦略.
+
+    enter 時に deferred save モードを有効化し、exit 時に必ず flush + 解除する。
+    例外発生時も flush を試行する（部分失敗は呼び出し側のエラー集約で扱う）。
+    """
+
+    def __init__(self, bm25_index: BM25Index) -> None:
+        self._bm25 = bm25_index
+
+    def __enter__(self) -> None:
+        self._bm25.set_deferred_save(True)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        # flush() が失敗した場合も deferred モードを必ず解除するため try/finally で囲む。
+        # ``BM25Index.flush`` は ``_deferred_save`` フラグを参照しないため、flush と
+        # deferred 解除の順序は最終状態に影響しない（旧 ``Indexer.bm25_deferred()`` は
+        # 解除→flush の順だったが等価）。
+        try:
+            self._bm25.flush()
+        finally:
+            self._bm25.set_deferred_save(False)

--- a/src/rag/indexer/write_strategy.py
+++ b/src/rag/indexer/write_strategy.py
@@ -15,8 +15,11 @@ class IndexWriteStrategy(Protocol):
     """インデックスのバッチ書き込み戦略.
 
     各インデックス実装（BM25 / Vector Store 等）が「自身の書き込み戦略」を
-    context manager として表現する。`Indexer.batch_writes()` は保有する全
+    context manager として表現する。``Indexer.batch_writes()`` は保有する全
     strategy を nest して enter/exit する。
+
+    ``__exit__`` の戻り値は ``contextlib.AbstractContextManager`` と同じく
+    ``bool | None``（``True`` で例外抑止、``None`` / ``False`` で伝播）。
     """
 
     def __enter__(self) -> None: ...
@@ -26,14 +29,15 @@ class IndexWriteStrategy(Protocol):
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         tb: TracebackType | None,
-    ) -> None: ...
+    ) -> bool | None: ...
 
 
 class BM25WriteStrategy:
     """BM25 用のバッチ書き込み戦略.
 
     enter 時に deferred save モードを有効化し、exit 時に必ず flush + 解除する。
-    例外発生時も flush を試行する（部分失敗は呼び出し側のエラー集約で扱う）。
+    flush が失敗した場合は deferred モードを解除した上で例外を伝播させ、
+    パイプラインを中断する（BM25 の永続化失敗はインデックスの完全性を損なうため致命的）。
     """
 
     def __init__(self, bm25_index: BM25Index) -> None:

--- a/src/rag/pipeline/controller.py
+++ b/src/rag/pipeline/controller.py
@@ -364,7 +364,7 @@ class PipelineController:
             await self._indexer.add(record.source_id, converted_path, metadata)
 
         logger.info("Phase 2: Index started (%d files)", len(index_records))
-        with self._indexer.bm25_deferred():
+        with self._indexer.batch_writes():
             index_summary = await self._run_processing_loop(
                 index_records,
                 process_fn=_index_single,
@@ -581,7 +581,7 @@ class PipelineController:
         if self._git.has_commits():
             to_commit = self._git.get_head_commit()
 
-        with self._indexer.bm25_deferred():
+        with self._indexer.batch_writes():
             summary = await self._run_processing_loop(
                 records,
                 process_fn=_index_single,
@@ -909,7 +909,7 @@ class PipelineController:
         concurrency: int = 1,
     ) -> PipelineSummary:
         """変更エントリを処理する."""
-        with self._indexer.bm25_deferred():
+        with self._indexer.batch_writes():
             summary = await self._run_processing_loop(
                 changes,
                 process_fn=self._process_single_change,

--- a/src/rag/pipeline/protocols.py
+++ b/src/rag/pipeline/protocols.py
@@ -127,20 +127,13 @@ class IndexerProtocol(Protocol):
         """
         ...
 
-    def set_bm25_deferred_save(self, enabled: bool) -> None:
-        """BM25 の遅延 save モードを切り替える.
+    def batch_writes(self) -> contextlib.AbstractContextManager[None]:
+        """バッチ書き込みコンテキスト.
 
-        Args:
-            enabled: True で遅延モード有効
+        各インデックス実装が保有する ``IndexWriteStrategy``
+        （BM25 用の deferred save → flush 等）を nest して enter/exit する。
+        呼び出し側はインデックスの種類（BM25 / Vector 等）を意識しない。
         """
-        ...
-
-    def flush_bm25(self) -> None:
-        """BM25 の未保存変更を一括 rebuild + 永続化する."""
-        ...
-
-    def bm25_deferred(self) -> contextlib.AbstractContextManager[None]:
-        """BM25 遅延 save のコンテキストマネージャ."""
         ...
 
     async def clear(

--- a/tests/test_index_write_strategy.py
+++ b/tests/test_index_write_strategy.py
@@ -1,0 +1,178 @@
+"""IndexWriteStrategy / BM25WriteStrategy / Indexer.batch_writes の単体テスト.
+
+仕様: docs/specs/indexer.md「バッチ書き込み戦略（IndexWriteStrategy）」
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from rag.indexer.write_strategy import BM25WriteStrategy, IndexWriteStrategy
+
+
+class TestBM25WriteStrategy:
+    def test_enter_enables_deferred_save(self) -> None:
+        bm25 = MagicMock()
+        strategy = BM25WriteStrategy(bm25)
+
+        strategy.__enter__()
+
+        bm25.set_deferred_save.assert_called_once_with(True)
+        bm25.flush.assert_not_called()
+
+    def test_exit_flushes_and_disables_deferred(self) -> None:
+        bm25 = MagicMock()
+        strategy = BM25WriteStrategy(bm25)
+
+        strategy.__enter__()
+        bm25.set_deferred_save.reset_mock()
+        strategy.__exit__(None, None, None)
+
+        bm25.flush.assert_called_once()
+        bm25.set_deferred_save.assert_called_once_with(False)
+
+    def test_with_block_normal_path(self) -> None:
+        bm25 = MagicMock()
+        strategy = BM25WriteStrategy(bm25)
+
+        with strategy:
+            assert bm25.set_deferred_save.call_args_list[-1].args == (True,)
+
+        # exit で flush + set_deferred_save(False) が呼ばれる
+        bm25.flush.assert_called_once()
+        assert bm25.set_deferred_save.call_args_list[-1].args == (False,)
+
+    def test_exit_on_exception_still_flushes(self) -> None:
+        bm25 = MagicMock()
+        strategy = BM25WriteStrategy(bm25)
+
+        with pytest.raises(RuntimeError, match="boom"), strategy:
+            raise RuntimeError("boom")
+
+        # 例外発生時も flush と deferred 解除は実行される
+        bm25.flush.assert_called_once()
+        assert bm25.set_deferred_save.call_args_list[-1].args == (False,)
+
+    def test_flush_failure_still_disables_deferred(self) -> None:
+        bm25 = MagicMock()
+        bm25.flush.side_effect = RuntimeError("flush failed")
+        strategy = BM25WriteStrategy(bm25)
+        strategy.__enter__()
+        bm25.set_deferred_save.reset_mock()
+
+        with pytest.raises(RuntimeError, match="flush failed"):
+            strategy.__exit__(None, None, None)
+
+        # flush が失敗しても deferred 解除は確実に実行される
+        bm25.set_deferred_save.assert_called_once_with(False)
+
+
+class _RecordingStrategy:
+    """テスト用 strategy: enter/exit 順序を記録する."""
+
+    def __init__(
+        self, name: str, log: list[str], *, raise_on_exit: bool = False,
+    ) -> None:
+        self.name = name
+        self.log = log
+        self._raise_on_exit = raise_on_exit
+
+    def __enter__(self) -> None:
+        self.log.append(f"enter:{self.name}")
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.log.append(f"exit:{self.name}")
+        if self._raise_on_exit:
+            raise RuntimeError(f"{self.name} exit error")
+
+
+def _build_indexer() -> "Indexer":
+    """テスト用に Indexer を最小依存（MagicMock）で構築する."""
+    from rag.indexer.indexer import Indexer
+
+    return Indexer(
+        vector_store=MagicMock(),
+        bm25_index=MagicMock(),
+        metadata_db=MagicMock(),
+        chunk_size=200,
+        chunk_overlap=20,
+        embedding_prefix_enabled=True,
+        embedding_context_length=512,
+        worst_token_char_ratio=0.7,
+    )
+
+
+if False:  # type checking only
+    from rag.indexer.indexer import Indexer
+
+
+class TestIndexerBatchWrites:
+    def test_protocol_compatibility(self) -> None:
+        """BM25WriteStrategy が IndexWriteStrategy Protocol を満たすことを検証."""
+        bm25 = MagicMock()
+        strategy: IndexWriteStrategy = BM25WriteStrategy(bm25)
+        assert hasattr(strategy, "__enter__")
+        assert hasattr(strategy, "__exit__")
+
+    def test_default_strategies_includes_bm25(self) -> None:
+        """Indexer.__init__ で BM25WriteStrategy が組み立てられることを検証."""
+        indexer = _build_indexer()
+        # 直接の private 参照は意図的: _write_strategies の組み立てが
+        # batch_writes() のリグレッション保護対象であるため
+        assert len(indexer._write_strategies) == 1
+        assert isinstance(indexer._write_strategies[0], BM25WriteStrategy)
+
+    def test_batch_writes_invokes_bm25_strategy(self) -> None:
+        """Indexer.batch_writes() で BM25Index の deferred save / flush が呼ばれる."""
+        indexer = _build_indexer()
+        bm25 = cast("MagicMock", indexer._bm25)
+
+        with indexer.batch_writes():
+            assert bm25.set_deferred_save.call_args_list[-1].args == (True,)
+
+        bm25.flush.assert_called_once()
+        assert bm25.set_deferred_save.call_args_list[-1].args == (False,)
+
+    def test_batch_writes_enters_all_strategies_in_order(self) -> None:
+        """複数 strategy を持つ Indexer の batch_writes が enter/exit 順序を保つ."""
+        indexer = _build_indexer()
+        log: list[str] = []
+        # _write_strategies を _RecordingStrategy 2 個に差し替え
+        indexer._write_strategies = [
+            _RecordingStrategy("a", log),
+            _RecordingStrategy("b", log),
+        ]
+
+        with indexer.batch_writes():
+            log.append("inside")
+
+        assert log == [
+            "enter:a", "enter:b",
+            "inside",
+            # exit は LIFO 順（ExitStack 仕様）
+            "exit:b", "exit:a",
+        ]
+
+    def test_batch_writes_exits_all_on_exception(self) -> None:
+        """with ブロック内例外時も全 strategy が exit される."""
+        indexer = _build_indexer()
+        log: list[str] = []
+        indexer._write_strategies = [
+            _RecordingStrategy("a", log),
+            _RecordingStrategy("b", log),
+        ]
+
+        with pytest.raises(RuntimeError, match="inside"), indexer.batch_writes():
+            raise RuntimeError("inside")
+
+        assert "exit:a" in log
+        assert "exit:b" in log

--- a/tests/test_index_write_strategy.py
+++ b/tests/test_index_write_strategy.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from types import TracebackType
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from rag.indexer.write_strategy import BM25WriteStrategy, IndexWriteStrategy
+
+if TYPE_CHECKING:
+    from rag.indexer.indexer import Indexer
 
 
 class TestBM25WriteStrategy:
@@ -109,10 +112,6 @@ def _build_indexer() -> "Indexer":
         embedding_context_length=512,
         worst_token_char_ratio=0.7,
     )
-
-
-if False:  # type checking only
-    from rag.indexer.indexer import Indexer
 
 
 class TestIndexerBatchWrites:

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -142,14 +142,8 @@ class StubIndexer:
         self.cleared.append(source_type)
         self.cleared_calls.append((source_type, path))
 
-    def set_bm25_deferred_save(self, enabled: bool) -> None:
-        pass
-
-    def flush_bm25(self) -> None:
-        pass
-
     @contextlib.contextmanager
-    def bm25_deferred(self) -> Iterator[None]:
+    def batch_writes(self) -> Iterator[None]:
         yield
 
 


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング ★
- [x] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）

## Summary

- `IndexerProtocol` から BM25 固有メソッド 3 つ（`set_bm25_deferred_save` / `flush_bm25` / `bm25_deferred`）を削除し、汎用バッチコンテキスト `batch_writes()` 1 個に集約。controller.py から「BM25」という実装詳細名を排除した
- `src/rag/indexer/write_strategy.py` を新設し、`IndexWriteStrategy` Protocol と `BM25WriteStrategy` 実装を定義。各インデックス実装が「自分の書き込み戦略」を選択する構造に変更
- `Indexer` に `batch_writes()` を追加（`ExitStack` で全 strategy を nest enter/exit。例外時も partial enter された strategy は確実に exit）
- `pipeline/controller.py` の 3 箇所（`run_full_rebuild` Phase 2 / `run_index_only` / `_process_changes`）を `with self._indexer.batch_writes():` に置換
- 仕様書 3 種を `docs(pre-impl)` 運用で先行更新（`indexer.md` のバッチ書き込み戦略セクション新設・`pipeline-controller.md` の差分更新フロー追記・`architecture.md` §3.4 の Port 配置整理）
- 親 Issue #728（pipeline / Indexer 構造改善 epic）のサブ 1。サブ 2（#730 — RAGKnowledgeService / PipelineController の Port 分離）は本 PR マージ後に着手

## Test plan

- [x] 新規テスト `tests/test_index_write_strategy.py`（10 件）: BM25WriteStrategy の enter/exit・例外時の flush 試行・Indexer.batch_writes の strategy nest 順序を検証
- [x] 既存テスト `tests/test_pipeline_controller.py` の StubIndexer を `batch_writes()` に追従
- [x] pytest 全 2026 件 pass
- [x] ruff / mypy / markdownlint 全 pass
- [x] code-reviewer / doc-reviewer の指摘対応完了

## Related issues

Closes #729

Parent epic: #728