### PR TITLE
fix(youtube): rag_youtube_request_interval の制約厳格化 (#748)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -89,7 +89,7 @@ rag_pdf_quality_sample_pages = 10
 
 # YouTube インジェスター
 rag_youtube_max_videos = 100
-rag_youtube_request_interval = 30.0
+rag_youtube_request_interval = 180.0
 rag_youtube_request_timeout = 30
 rag_youtube_transcript_languages = ["ja", "en"]
 rag_youtube_merge_gap_sec = 2.0

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -315,7 +315,7 @@ class RAGSettings(BaseModel):
 
     # YouTube インジェスター — API BAN 回避のためのレート制限
     rag_youtube_max_videos: int = Field(ge=1, le=500)
-    rag_youtube_request_interval: float = Field(ge=0.1, le=60.0)
+    rag_youtube_request_interval: float = Field(ge=60.0, le=600.0)
     rag_youtube_request_timeout: int = Field(ge=1, le=120)
     # 字幕取得の優先言語順（先頭が最優先）
     rag_youtube_transcript_languages: list[str] = Field(min_length=1)

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -89,7 +89,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_scrapy_fake_mode": True,
     "rag_scrapy_fake_fixture_dir": "src/rag/scrapy/_fake/data",
     "rag_youtube_max_videos": 100,
-    "rag_youtube_request_interval": 30.0,
+    "rag_youtube_request_interval": 60.0,
     "rag_youtube_request_timeout": 30,
     "rag_youtube_transcript_languages": ["ja", "en"],
     "rag_youtube_merge_gap_sec": 2.0,

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -121,6 +121,36 @@ class TestZennRequestInterval:
             _make_settings(rag_zenn_request_interval=60.1)
 
 
+# --- YouTube インジェスター: rag_youtube_request_interval ---
+
+
+class TestYoutubeRequestInterval:
+    """rag_youtube_request_interval のバリデーションテスト (#748)."""
+
+    def test_default_value(self) -> None:
+        """テスト用デフォルト値が 60.0 であること."""
+        settings = _make_settings()
+        assert settings.rag_youtube_request_interval == 60.0
+
+    def test_valid_range(self) -> None:
+        """許容範囲の境界値が設定できること."""
+        settings = _make_settings(rag_youtube_request_interval=60.0)
+        assert settings.rag_youtube_request_interval == 60.0
+
+        settings = _make_settings(rag_youtube_request_interval=600.0)
+        assert settings.rag_youtube_request_interval == 600.0
+
+    def test_below_minimum(self) -> None:
+        """下限未満でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_youtube_request_interval=59.9)
+
+    def test_above_maximum(self) -> None:
+        """上限超過でバリデーションエラーになること."""
+        with pytest.raises(ValidationError):
+            _make_settings(rag_youtube_request_interval=600.1)
+
+
 # --- ログファイル出力: rag_log_dir ---
 
 
@@ -352,7 +382,7 @@ rag_bluesky_request_interval = 1.0
 rag_bluesky_include_reposts = true
 rag_bluesky_force_youtube_reingest = false
 rag_youtube_max_videos = 100
-rag_youtube_request_interval = 30.0
+rag_youtube_request_interval = 60.0
 rag_youtube_request_timeout = 30
 rag_youtube_transcript_languages = ["ja", "en"]
 rag_youtube_merge_gap_sec = 2.0


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正

## Summary

- `rag_youtube_request_interval` の Field 制約を `ge=0.1, le=60.0` → `ge=60.0, le=600.0` に変更
- `config.toml` のデフォルト値を `30.0` → `180.0` に引き上げ
- テスト用デフォルト値を `30.0` → `60.0` に更新
- 境界値テストクラス `TestYoutubeRequestInterval` を追加（4 テストケース）

## Test plan

- [x] `uv run pytest tests/test_rag_config.py` — 45 passed
- [x] `uv run ruff check .` — OK（既存の agent-commons-tmp/ 1件のみ）
- [x] `uv run mypy src` — no issues found in 131 source files

## Related issues

Closes #748

---
Generated with [Claude Code](https://claude.ai/code)