### PR TITLE
fix(youtube): yt-dlp の JS ランタイム明示化と動画失敗時 traceback 出力 + mutate 防御 (#750)

### DIFF
--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -73,6 +73,7 @@ youtube-transcript-api は非公式 API を使用しており、短時間に多�
 ### 外部ツール依存
 
 - **FFmpeg**: yt-dlp の音声変換（`FFmpegExtractAudio`）に必要。Whisper フォールバック時に音声を WAV 形式に変換する際に使用する。未インストールの場合、音声文字起こしが失敗する
+- **JS ランタイム**: yt-dlp の JS challenge 評価に必要。`deno` / `node` / `bun` / `quickjs` のいずれか 1 つを OS にインストールしておく。未インストールの場合、yt-dlp が劣化抽出モード（公式で deprecated 警告）に移行し、音声ダウンロード経路で transient エラーを引き起こすことがある
 
 ### バリデーションとクランプの使い分け
 

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -448,7 +448,12 @@ class YoutubeIngester(BaseIngester):
                     consecutive_errors = 0
 
             except Exception as e:
-                logger.error("動画処理失敗 (video_id=%s): %s", video_id, e)
+                # transient な外部ライブラリ起因エラーの原因特定のため
+                # traceback を残す（外部 lib 内部の None 参照等の発生箇所を追跡可能にする）
+                logger.error(
+                    "動画処理失敗 (video_id=%s): %s",
+                    video_id, e, exc_info=True,
+                )
                 result.errors += 1
                 result.error_details.append(IngestErrorDetail(
                     category=IngestErrorCategory.METADATA_FETCH.value,

--- a/src/rag/pipeline/ingesters/youtube_fetcher.py
+++ b/src/rag/pipeline/ingesters/youtube_fetcher.py
@@ -34,7 +34,12 @@ logger = logging.getLogger(__name__)
 # 全候補を有効化する。未インストールのランタイムはサイレントにスキップされる。
 # JS ランタイム不在時の劣化抽出モードでは音声 DL 経路が transient TypeError を
 # 引き起こすことがあり、それを防ぐ目的で必要。
-_YTDLP_JS_RUNTIMES: dict[str, dict[str, str]] = {
+# 型は yt-dlp 公式契約（YoutubeDL.py docstring）に合わせて inner を Any にする
+# （path/args 等を将来渡す際に型修正不要にする）。
+# 渡し方は ydl_opts 構築時に dict() で shallow copy する
+# （YoutubeDL.__init__ が _clean_js_runtimes 経由で渡された dict を pop で
+# mutate するため、モジュール定数の共有破壊を防ぐ）。
+_YTDLP_JS_RUNTIMES: dict[str, dict[str, Any]] = {
     "deno": {},
     "node": {},
     "bun": {},
@@ -116,7 +121,7 @@ class RealYoutubeFetcher:
                 "quiet": True,
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
-                "js_runtimes": _YTDLP_JS_RUNTIMES,
+                "js_runtimes": dict(_YTDLP_JS_RUNTIMES),
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info: dict[str, Any] = ydl.extract_info(
@@ -220,7 +225,7 @@ class RealYoutubeFetcher:
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
                 "playlistend": max_videos,
-                "js_runtimes": _YTDLP_JS_RUNTIMES,
+                "js_runtimes": dict(_YTDLP_JS_RUNTIMES),
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info: dict[str, Any] = ydl.extract_info(playlist_url, download=False)
@@ -247,7 +252,7 @@ class RealYoutubeFetcher:
                 "quiet": True,
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
-                "js_runtimes": _YTDLP_JS_RUNTIMES,
+                "js_runtimes": dict(_YTDLP_JS_RUNTIMES),
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([f"https://www.youtube.com/watch?v={video_id}"])

--- a/src/rag/pipeline/ingesters/youtube_fetcher.py
+++ b/src/rag/pipeline/ingesters/youtube_fetcher.py
@@ -29,6 +29,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# yt-dlp が JS challenge 評価に使う候補ランタイム。
+# yt-dlp 既定は deno のみだが、OS にインストール済みのいずれかが選ばれるよう
+# 全候補を有効化する。未インストールのランタイムはサイレントにスキップされる。
+# JS ランタイム不在時の劣化抽出モードでは音声 DL 経路が transient TypeError を
+# 引き起こすことがあり、それを防ぐ目的で必要。
+_YTDLP_JS_RUNTIMES: dict[str, dict[str, str]] = {
+    "deno": {},
+    "node": {},
+    "bun": {},
+    "quickjs": {},
+}
+
 
 class YoutubeFetcher(Protocol):
     """YouTube 外部アクセス処理の抽象 Port.
@@ -104,6 +116,7 @@ class RealYoutubeFetcher:
                 "quiet": True,
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
+                "js_runtimes": _YTDLP_JS_RUNTIMES,
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info: dict[str, Any] = ydl.extract_info(
@@ -207,6 +220,7 @@ class RealYoutubeFetcher:
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
                 "playlistend": max_videos,
+                "js_runtimes": _YTDLP_JS_RUNTIMES,
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info: dict[str, Any] = ydl.extract_info(playlist_url, download=False)
@@ -233,6 +247,7 @@ class RealYoutubeFetcher:
                 "quiet": True,
                 "no_warnings": True,
                 "socket_timeout": request_timeout,
+                "js_runtimes": _YTDLP_JS_RUNTIMES,
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([f"https://www.youtube.com/watch?v={video_id}"])


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新

## Summary

- **yt-dlp `js_runtimes` 明示化**: `RealYoutubeFetcher` の 3 箇所の `ydl_opts`（メタデータ取得 / プレイリスト展開 / 音声ダウンロード）に `js_runtimes={deno,node,bun,quickjs}` を追加。yt-dlp 既定の deno-only では JS ランタイム未検出時に劣化抽出モード（公式で deprecated 警告）に陥り、音声 DL 経路で transient TypeError を引き起こすことがあった
- **動画失敗ログに traceback 追加**: `crawl_playlist` の動画失敗ログに `exc_info=True` を追加。外部ライブラリ起因の TypeError 等でも発生位置が完全追跡可能に
- **mutate 防御 + 型契約整備**（review fixup）: `_YTDLP_JS_RUNTIMES` の型注釈を yt-dlp 公式契約（`YoutubeDL.py:536-544` docstring）に合わせて `dict[str, dict[str, Any]]` に緩和。3 箇所の参照は `dict(_YTDLP_JS_RUNTIMES)` で shallow copy し、yt-dlp の `_clean_js_runtimes` が `runtimes.pop(rt)` でモジュール定数を破壊する経路（将来 yt-dlp がサポートランタイムを変更した場合の latent bug）を防御
- **仕様書追記**: `docs/specs/ingesters/youtube.md` の `### 外部ツール依存` に JS ランタイム要件を 1 行追記（既存 FFmpeg 項と同粒度）

## Background

F プレイリスト取り込み中に字幕無効動画 1 件で `'NoneType' object is not subscriptable` の TypeError が発生。当初は traceback が取れず原因特定に時間を要した。調査で以下が判明:

1. **yt-dlp の JS ランタイム不在**: yt-dlp は既定で deno のみを JS ランタイム候補とし、node 等が PATH にあっても自動検出しない。本番環境に node を導入し、コード側で全候補を `js_runtimes` に明示することで完全抽出モードに切り替え
2. **エラー時の traceback 欠損**: `logger.error(...)` に `exc_info=True` がなく外部ライブラリ起因例外の発生箇所がロストしていた

なお、F で発生した TypeError 自体は本変更と独立した psutil メタデータ破損が原因（別途修正済み）。本 PR の `exc_info=True` が原因特定を可能にした関係で両者は密接に関連する。

## Test plan

- [x] L1 ユニットテスト: pytest 149 passed（変更ファイル関連）
- [x] ruff / mypy / markdownlint 全 pass
- [x] code-review（diff モード）: triage 対応後、Critical/Warning/Suggestion 全 0
- [x] doc-review（diff モード）: 指摘なし
- [x] L3 本番相当 QA: 不要（外部ライブラリ option 追加・logger 引数追加のため unit test で検証する性質ではなく、Real 経路は既に本番環境調査時点で挙動確認済み）

## Related issues

Closes #750