### PR TITLE
fix(site-ingest): url_pattern 自動生成でファイル URL 起点の同ディレクトリ展開を有効化 (#754)

### DIFF
--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -69,10 +69,10 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 ### パスプレフィックス制約
 
 - `url_pattern` が未指定の場合、開始 URL のパスプレフィックスから正規表現パターンを自動生成する
-- 例: `https://example.com/docs/` → `^https://example\.com/docs/`
-- 開始 URL のパス末尾セグメントが Web 系拡張子（`_WEB_EXTENSIONS`）で終わる場合は、親ディレクトリまで丸めてパターンを生成する。これにより、開始 URL `.../vol1/index.html` を渡したときに同ディレクトリの `index2.html` 等にも展開される
+- 例: `https://example.com/docs/` → `^https://example\.com/docs(?:/|$)`
+- 開始 URL のパス末尾セグメントが Web 系拡張子（`WEB_EXTENSIONS`）で終わる場合は、親ディレクトリまで丸めてパターンを生成する。これにより、開始 URL `.../vol1/index.html` を渡したときに同ディレクトリの `index2.html` 等にも展開される
   - 例: `https://example.com/docs/vol1/index.html` → `^https://example\.com/docs/vol1(?:/|$)`
-  - 判定対象の拡張子セット `_WEB_EXTENSIONS`（`src/rag/scrapy/spider.py` で定義、`runner.py` から import して共有）: `.html` `.htm` `.xhtml` `.shtml` `.php` `.asp` `.aspx` `.jsp`
+  - 判定対象の拡張子セット `WEB_EXTENSIONS`（`src/rag/scrapy/_constants.py` で定義、`spider.py` / `runner.py` / `bridge.py` から import して共有）: `.html` `.htm` `.xhtml` `.shtml` `.php` `.asp` `.aspx` `.jsp`
   - 上記セットに含まれない拡張子（`.pdf`、`.txt`、`.md` 等）の場合は丸めず、開始 URL 自身のパスプレフィックスをそのまま使用する。これによりバージョン番号風セグメント（`/api/v1.0` 等）の誤検出を回避する
     - 例: `https://example.com/docs/manual.pdf` → `^https://example\.com/docs/manual\.pdf(?:/|$)`（開始 URL 自身のみマッチ）
   - 先頭ドットの dotfile 形式（`.gitignore` 等）は `Path.suffix` が空文字列となり、対象外

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -70,6 +70,13 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 - `url_pattern` が未指定の場合、開始 URL のパスプレフィックスから正規表現パターンを自動生成する
 - 例: `https://example.com/docs/` → `^https://example\.com/docs/`
+- 開始 URL のパス末尾セグメントが Web 系拡張子（`_WEB_EXTENSIONS`）で終わる場合は、親ディレクトリまで丸めてパターンを生成する。これにより、開始 URL `.../vol1/index.html` を渡したときに同ディレクトリの `index2.html` 等にも展開される
+  - 例: `https://example.com/docs/vol1/index.html` → `^https://example\.com/docs/vol1(?:/|$)`
+  - 判定対象の拡張子セット `_WEB_EXTENSIONS`（`src/rag/scrapy/spider.py` で定義、`runner.py` から import して共有）: `.html` `.htm` `.xhtml` `.shtml` `.php` `.asp` `.aspx` `.jsp`
+  - 上記セットに含まれない拡張子（`.pdf`、`.txt`、`.md` 等）の場合は丸めず、開始 URL 自身のパスプレフィックスをそのまま使用する。これによりバージョン番号風セグメント（`/api/v1.0` 等）の誤検出を回避する
+    - 例: `https://example.com/docs/manual.pdf` → `^https://example\.com/docs/manual\.pdf(?:/|$)`（開始 URL 自身のみマッチ）
+  - 先頭ドットの dotfile 形式（`.gitignore` 等）は `Path.suffix` が空文字列となり、対象外
+  - 親ディレクトリがルート（`/`）になる場合（例: `https://example.com/index.html`）は丸めず、開始 URL 自身のみマッチするパターンを生成する（例: `^https://example\.com/index\.html(?:/|$)`）。これは意図しない全ドメインクロールを防ぐための既存挙動を保持する目的
 - パスが `/` のみの場合はパターンを生成しない（ドメイン全体が対象）
 - ユーザーが `url_pattern` を明示的に指定した場合はその値を優先する
 

--- a/src/rag/scrapy/_constants.py
+++ b/src/rag/scrapy/_constants.py
@@ -1,0 +1,15 @@
+"""rag.scrapy パッケージ内で共有する Scrapy 非依存の定数モジュール.
+
+spider.py（subprocess 内で実行される）から runner.py / bridge.py（main プロセスで実行される）へ
+直接 import すると、main プロセスにも scrapy / Twisted がロードされる。これは subprocess 分離の
+設計意図に反するため、Scrapy 非依存で共有可能な定数は本モジュールに集約する。
+"""
+
+from __future__ import annotations
+
+# Web 系拡張子（HTML 系コンテンツとみなす拡張子のセット）
+# spider.py の `.html` 付加判定（`SiteSpider._url_to_filename`）と
+# runner.py の url_pattern 自動生成判定で共有する
+WEB_EXTENSIONS: frozenset[str] = frozenset(
+    {".html", ".htm", ".xhtml", ".shtml", ".php", ".asp", ".aspx", ".jsp"},
+)

--- a/src/rag/scrapy/bridge.py
+++ b/src/rag/scrapy/bridge.py
@@ -20,15 +20,15 @@ from rag.pipeline.ingesters._common import (
     IngestErrorDetail,
     IngestResult,
 )
-from rag.scrapy.spider import _WEB_EXTENSIONS
+from rag.scrapy._constants import WEB_EXTENSIONS
 from rag.store.path_converter import url_to_path
 
 # converter 系の追加拡張子（Web 系拡張子に加えて bridge で認識する拡張子）
 _CONVERTER_EXTENSIONS: frozenset[str] = frozenset({".pdf", ".json", ".md", ".txt", ".adoc"})
 
 # .html 付与をスキップする拡張子
-# Web 系拡張子（spider.py の _WEB_EXTENSIONS が SSoT）+ converter が認識する拡張子の和集合
-_KNOWN_WEB_EXTENSIONS: frozenset[str] = frozenset(_WEB_EXTENSIONS) | _CONVERTER_EXTENSIONS
+# Web 系拡張子（rag.scrapy._constants の WEB_EXTENSIONS が SSoT）+ converter が認識する拡張子の和集合
+_KNOWN_WEB_EXTENSIONS: frozenset[str] = WEB_EXTENSIONS | _CONVERTER_EXTENSIONS
 
 
 def _needs_html_extension(url: str) -> bool:

--- a/src/rag/scrapy/bridge.py
+++ b/src/rag/scrapy/bridge.py
@@ -20,15 +20,15 @@ from rag.pipeline.ingesters._common import (
     IngestErrorDetail,
     IngestResult,
 )
+from rag.scrapy.spider import _WEB_EXTENSIONS
 from rag.store.path_converter import url_to_path
 
+# converter 系の追加拡張子（Web 系拡張子に加えて bridge で認識する拡張子）
+_CONVERTER_EXTENSIONS: frozenset[str] = frozenset({".pdf", ".json", ".md", ".txt", ".adoc"})
+
 # .html 付与をスキップする拡張子
-# converter が認識する拡張子 + Spider が Web 系と見なす拡張子の和集合
-# Spider._WEB_EXTENSIONS と整合させること
-_KNOWN_WEB_EXTENSIONS: frozenset[str] = frozenset(
-    {".html", ".htm", ".xhtml", ".shtml", ".php", ".asp", ".aspx", ".jsp",
-     ".pdf", ".json", ".md", ".txt", ".adoc"},
-)
+# Web 系拡張子（spider.py の _WEB_EXTENSIONS が SSoT）+ converter が認識する拡張子の和集合
+_KNOWN_WEB_EXTENSIONS: frozenset[str] = frozenset(_WEB_EXTENSIONS) | _CONVERTER_EXTENSIONS
 
 
 def _needs_html_extension(url: str) -> bool:

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlparse
 
-from rag.scrapy.spider import _WEB_EXTENSIONS
+from rag.scrapy._constants import WEB_EXTENSIONS
 
 if TYPE_CHECKING:
     from rag.config import RAGSettings
@@ -196,12 +196,12 @@ class RealScrapyRunner:
                 path = parsed.path.rstrip("/")
                 if path and path != "/":
                     # パス末尾セグメントが Web 系拡張子で終わる場合は親ディレクトリまで丸める
-                    # （同ディレクトリ内の他ファイル展開のため）。判定は spider.py の
-                    # _WEB_EXTENSIONS と共有し、HTML 系コンテンツのみを対象とすることで
+                    # （同ディレクトリ内の他ファイル展開のため）。判定は _constants.py の
+                    # WEB_EXTENSIONS を共有し、HTML 系コンテンツのみを対象とすることで
                     # バージョン番号風セグメント（/api/v1.0 等）の誤検出を防ぐ
                     head, _, last_segment = path.rpartition("/")
                     suffix = Path(last_segment).suffix.lower()
-                    if suffix in _WEB_EXTENSIONS and head:
+                    if suffix in WEB_EXTENSIONS and head:
                         # head が空（ルート直下ファイル URL）の場合は丸めず従来挙動を保持
                         path = head
                 if path and path != "/":

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -22,6 +22,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlparse
 
+from rag.scrapy.spider import _WEB_EXTENSIONS
+
 if TYPE_CHECKING:
     from rag.config import RAGSettings
 
@@ -192,6 +194,16 @@ class RealScrapyRunner:
             parsed = urlparse(effective_start_url)
             if not url_pattern:
                 path = parsed.path.rstrip("/")
+                if path and path != "/":
+                    # パス末尾セグメントが Web 系拡張子で終わる場合は親ディレクトリまで丸める
+                    # （同ディレクトリ内の他ファイル展開のため）。判定は spider.py の
+                    # _WEB_EXTENSIONS と共有し、HTML 系コンテンツのみを対象とすることで
+                    # バージョン番号風セグメント（/api/v1.0 等）の誤検出を防ぐ
+                    head, _, last_segment = path.rpartition("/")
+                    suffix = Path(last_segment).suffix.lower()
+                    if suffix in _WEB_EXTENSIONS and head:
+                        # head が空（ルート直下ファイル URL）の場合は丸めず従来挙動を保持
+                        path = head
                 if path and path != "/":
                     base_prefix = f"{parsed.scheme}://{parsed.hostname}{path}"
                     url_pattern = f"^{re.escape(base_prefix)}(?:/|$)"

--- a/src/rag/scrapy/spider.py
+++ b/src/rag/scrapy/spider.py
@@ -21,6 +21,10 @@ from urllib.parse import urldefrag, urlparse
 import scrapy
 from scrapy.http import Response
 
+# Web 系拡張子（HTML 系コンテンツとみなす拡張子のセット）
+# spider.py の `.html` 付加判定と runner.py の url_pattern 自動生成判定で共有する
+_WEB_EXTENSIONS = {".html", ".htm", ".xhtml", ".shtml", ".php", ".asp", ".aspx", ".jsp"}
+
 
 class SiteSpider(scrapy.Spider):  # type: ignore[misc]
     """汎用サイトクロール Spider.
@@ -226,9 +230,6 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
             return None
         return resolved_filepath
 
-    # .html 付加をスキップする Web 系拡張子
-    _WEB_EXTENSIONS = {".html", ".htm", ".xhtml", ".shtml", ".php", ".asp", ".aspx", ".jsp"}
-
     @staticmethod
     def _url_to_filename(url: str) -> str:
         """URL からファイル相対パスを生成する.
@@ -243,7 +244,7 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
         if not path:
             return "index.html"
         suffix = Path(path).suffix.lower()
-        if suffix in SiteSpider._WEB_EXTENSIONS:
+        if suffix in _WEB_EXTENSIONS:
             return path
         return f"{path}.html"
 

--- a/src/rag/scrapy/spider.py
+++ b/src/rag/scrapy/spider.py
@@ -21,9 +21,7 @@ from urllib.parse import urldefrag, urlparse
 import scrapy
 from scrapy.http import Response
 
-# Web 系拡張子（HTML 系コンテンツとみなす拡張子のセット）
-# spider.py の `.html` 付加判定と runner.py の url_pattern 自動生成判定で共有する
-_WEB_EXTENSIONS = {".html", ".htm", ".xhtml", ".shtml", ".php", ".asp", ".aspx", ".jsp"}
+from rag.scrapy._constants import WEB_EXTENSIONS
 
 
 class SiteSpider(scrapy.Spider):  # type: ignore[misc]
@@ -244,7 +242,7 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
         if not path:
             return "index.html"
         suffix = Path(path).suffix.lower()
-        if suffix in _WEB_EXTENSIONS:
+        if suffix in WEB_EXTENSIONS:
             return path
         return f"{path}.html"
 

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -509,6 +509,111 @@ class TestRealScrapyRunnerRun:
         assert params["url_pattern"] == ""
 
     @pytest.mark.asyncio()
+    async def test_url_pattern_auto_generated_from_file_url(self, tmp_path: Path) -> None:
+        """開始 URL の末尾セグメントが Web 系拡張子の場合、親ディレクトリまで丸めた url_pattern が生成されること."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/docs/vol1/index.html")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # 末尾の index.html を取り除き、親ディレクトリ /docs/vol1 までで丸める
+        assert params["url_pattern"] == r"^https://example\.com/docs/vol1(?:/|$)"
+
+    @pytest.mark.asyncio()
+    async def test_url_pattern_auto_generated_keeps_extensionless_path(
+        self, tmp_path: Path
+    ) -> None:
+        """末尾スラッシュなし + 拡張子なしのケースで丸めが発火しないこと（既存 from_path テストとの境界条件）."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/docs/guide")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # 拡張子なしのパスは既存挙動を維持（/docs/guide まで）
+        assert params["url_pattern"] == r"^https://example\.com/docs/guide(?:/|$)"
+
+    @pytest.mark.asyncio()
+    async def test_url_pattern_root_level_file_url_keeps_self_only(self, tmp_path: Path) -> None:
+        """ルート直下の Web 系拡張子ファイル URL では従来挙動（自身のみマッチ）を保持すること."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/index.html")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # 親ディレクトリがルートになるため丸めず、自身のみマッチするパターン
+        # （意図しない全ドメインクロールを防ぐ）
+        assert params["url_pattern"] == r"^https://example\.com/index\.html(?:/|$)"
+
+    @pytest.mark.asyncio()
+    async def test_url_pattern_non_web_extension_not_rolled_up(self, tmp_path: Path) -> None:
+        """末尾セグメントが Web 系拡張子に含まれない場合は丸めないこと（PDF 等）."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/docs/manual.pdf")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # .pdf は _WEB_EXTENSIONS に含まれないため丸めず
+        assert params["url_pattern"] == r"^https://example\.com/docs/manual\.pdf(?:/|$)"
+
+    @pytest.mark.asyncio()
+    async def test_url_pattern_version_like_segment_not_rolled_up(self, tmp_path: Path) -> None:
+        """バージョン番号風セグメント（/api/v1.0 等）が Web 系拡張子と誤検出されないこと."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/api/v1.0")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # .0 は _WEB_EXTENSIONS に含まれないため丸めず（誤検出回避）
+        assert params["url_pattern"] == r"^https://example\.com/api/v1\.0(?:/|$)"
+
+    @pytest.mark.asyncio()
+    async def test_url_pattern_dotfile_not_rolled_up(self, tmp_path: Path) -> None:
+        """先頭ドットの dotfile 形式（/.gitignore 等）が誤検出されないこと."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/repo/.gitignore")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # dotfile（.gitignore）は Path.suffix が空文字列のため丸めず
+        assert params["url_pattern"] == r"^https://example\.com/repo/\.gitignore(?:/|$)"
+
+    @pytest.mark.asyncio()
     async def test_url_pattern_explicit_takes_priority(self, tmp_path: Path) -> None:
         """url_pattern を明示指定した場合は自動生成より優先されること."""
         runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- クロールモードで開始 URL がファイル末尾（`.../vol1/index.html` 等）の場合、自動生成された `url_pattern` が起点 URL 自身しかマッチせず同ディレクトリの他ファイル（`index2.html` 等）に展開されないバグを修正
- `spider.py` の `_WEB_EXTENSIONS` を module 定数に昇格し、runner.py と共有してホワイトリスト方式で判定（バージョン番号風セグメント `/api/v1.0` 等の誤検出を回避）
- ルート直下ファイル URL（`https://example.com/index.html` 等）では丸めず従来挙動（自身のみマッチ）を保持し、意図しない全ドメインクロールを防止
- `bridge.py` の `_KNOWN_WEB_EXTENSIONS` を `_WEB_EXTENSIONS` の import + `_CONVERTER_EXTENSIONS` の和集合で構築し、3 箇所散在していた拡張子定義を SSoT 集約
- `docs/specs/site-ingest.md` の「パスプレフィックス制約」にホワイトリスト方式の説明・各分岐の出力例・root URL 挙動を追記

## Test plan

- [x] `uv run pytest tests/test_scrapy_runner.py tests/test_scrapy_bridge.py tests/test_scrapy_spider.py` (104 passed)
- [x] url_pattern 関連 11 件全パス（既存 3 件 + 新規 4 件 + その他 4 件）
  - 新規追加: root file URL / non-Web 拡張子 (.pdf) / version-like (`/api/v1.0`) / dotfile (`.gitignore`)
- [x] `uv run ruff check .` (All checks passed!)
- [x] `uv run mypy src` (Success: no issues found in 131 source files)

## Related issues

Closes #754