### PR TITLE
feat(rag-knowledge,ingesters/common,site-ingest): 全インジェスターに --skip-pipeline + bulk モード横展開 (#757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,14 +312,14 @@ HTTP モード（`/mcp` パスが必要）:
 
 各コマンドの詳細は `uv run python -m rag.cli <command> --help` を参照。MCP ツール一覧は [rag-knowledge.md](docs/specs/rag-knowledge.md) を参照。
 
-### `--no-pipeline` フラグ（バルク取り込みの高速化）
+### `--skip-pipeline` フラグ（バルク取り込みの高速化）
 
-全 ingest 系・crawl 系コマンドに `--no-pipeline` フラグが用意されている。指定すると source_store への配置 + git commit までで停止し、後段のパイプライン処理（converter + indexer）をスキップする。連続取り込み時の BM25 全体再構築（1 件あたり 1 回発生）をまとめて 1 回にできる。
+全 ingest 系・crawl 系コマンドに `--skip-pipeline` フラグが用意されている。指定すると source_store への配置 + git commit までで停止し、後段のパイプライン処理（converter + indexer）をスキップする。連続取り込み時の BM25 全体再構築（1 件あたり 1 回発生）をまとめて 1 回にできる。
 
 ```bash
 # 連続取り込み（pipeline をスキップ）
-uv run python -m rag.cli ingest-aozora 1234 5678 9012 --no-pipeline
-uv run python -m rag.cli ingest-youtube https://youtu.be/A https://youtu.be/B --no-pipeline
+uv run python -m rag.cli ingest-aozora 1234 5678 9012 --skip-pipeline
+uv run python -m rag.cli ingest-youtube https://youtu.be/A https://youtu.be/B --skip-pipeline
 
 # 末尾にまとめて 1 回 rebuild
 uv run python -m rag.cli rebuild --mode incremental
@@ -327,12 +327,12 @@ uv run python -m rag.cli rebuild --mode incremental
 
 複数引数受付（`ingest-youtube` / `ingest-aozora` の `nargs='+'`、`delete` の `nargs='+'`）と組み合わせて使うと効果的。
 `add-document` / `add-journal` は外部 API 経由の単発取り込みが主用途のため bulk 化対象外（複数件は `crawl-documents` / `migrate-journal` を使用）。
-共通仕様は [docs/specs/ingesters/common.md](docs/specs/ingesters/common.md) の「`--no-pipeline` フラグ共通仕様」を参照。
+共通仕様は [docs/specs/ingesters/common.md](docs/specs/ingesters/common.md) の「`--skip-pipeline` フラグ共通仕様」を参照。
 
 > **破壊的変更（Issue #757）**:
 >
 > - `site-ingest` の `--download-only` フラグおよび MCP `rag_site_ingest` の `download_only` パラメータは廃止
->   （`--no-pipeline` / `defer_indexing` に置き換え、同等の振る舞い）
+>   （`--skip-pipeline` / `skip_pipeline` に置き換え、同等の振る舞い）
 > - MCP `rag_add_youtube` / `rag_add_aozora` / `rag_delete` のパラメータは複数受付に変更
 >   （`video_url: str` → `video_urls: list[str]` / `book_id: str` → `book_ids: list[str]` / `source_id: str` → `source_ids: list[str]`）
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,30 @@ HTTP モード（`/mcp` パスが必要）:
 
 各コマンドの詳細は `uv run python -m rag.cli <command> --help` を参照。MCP ツール一覧は [rag-knowledge.md](docs/specs/rag-knowledge.md) を参照。
 
+### `--no-pipeline` フラグ（バルク取り込みの高速化）
+
+全 ingest 系・crawl 系コマンドに `--no-pipeline` フラグが用意されている。指定すると source_store への配置 + git commit までで停止し、後段のパイプライン処理（converter + indexer）をスキップする。連続取り込み時の BM25 全体再構築（1 件あたり 1 回発生）をまとめて 1 回にできる。
+
+```bash
+# 連続取り込み（pipeline をスキップ）
+uv run python -m rag.cli ingest-aozora 1234 5678 9012 --no-pipeline
+uv run python -m rag.cli ingest-youtube https://youtu.be/A https://youtu.be/B --no-pipeline
+
+# 末尾にまとめて 1 回 rebuild
+uv run python -m rag.cli rebuild --mode incremental
+```
+
+複数引数受付（`ingest-youtube` / `ingest-aozora` の `nargs='+'`、`delete` の `nargs='+'`）と組み合わせて使うと効果的。
+`add-document` / `add-journal` は外部 API 経由の単発取り込みが主用途のため bulk 化対象外（複数件は `crawl-documents` / `migrate-journal` を使用）。
+共通仕様は [docs/specs/ingesters/common.md](docs/specs/ingesters/common.md) の「`--no-pipeline` フラグ共通仕様」を参照。
+
+> **破壊的変更（Issue #757）**:
+>
+> - `site-ingest` の `--download-only` フラグおよび MCP `rag_site_ingest` の `download_only` パラメータは廃止
+>   （`--no-pipeline` / `defer_indexing` に置き換え、同等の振る舞い）
+> - MCP `rag_add_youtube` / `rag_add_aozora` / `rag_delete` のパラメータは複数受付に変更
+>   （`video_url: str` → `video_urls: list[str]` / `book_id: str` → `book_ids: list[str]` / `source_id: str` → `source_ids: list[str]`）
+
 ## Journal CLI
 
 ### 単一エントリ登録

--- a/docs/specs/ingesters/aozora.md
+++ b/docs/specs/ingesters/aozora.md
@@ -163,8 +163,20 @@ source_store への配置は `place_file` API を経由せず、データファ�
 |---------|------|---------|
 | `update-aozora-catalog` | なし | `rag_update_aozora_catalog` と同等の処理を CLI から実行する |
 | `search-aozora` | `--author`（任意）、`--title`（任意）、`--limit`（任意） | `rag_search_aozora` と同等の処理を CLI から実行する |
-| `ingest-aozora` | `book_id` | `rag_add_aozora` と同等の処理を CLI から実行する |
-| `ingest-aozora-author` | `person_id`、`--max-works`（任意） | `rag_crawl_aozora` と同等の処理を CLI から実行する |
+| `ingest-aozora` | `book_id`（1 件以上、`nargs='+'`）、`--no-pipeline`（任意） | `rag_add_aozora` と同等の処理を CLI から実行する。複数 ID 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
+| `ingest-aozora-author` | `person_id`、`--max-works`（任意）、`--no-pipeline`（任意） | `rag_crawl_aozora` と同等の処理を CLI から実行する |
+
+`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
+
+#### `ingest-aozora` 複数 ID 入力時の重複検出
+
+`book_id` を `nargs='+'` で複数指定した際、以下のロジックで重複検出を行う:
+
+1. 各 `book_id` を [URL 変換規則](#url-変換規則) と同じ前処理で正規化（前後空白除去 + 6 桁未満ゼロ埋め）する
+2. 正規化後の値が同一の入力が含まれる場合、stderr に WARN ログを出力する（例: `重複入力を検出: '1234', '001234' は同じ作品 (001234)。1 回のみ処理します`）
+3. 正規化後の値で重複排除し、ingester には 1 件のみ渡す
+
+これは ingester 側の book_id ゼロ埋め自動補完（[URL 変換規則](#url-変換規則)）との整合性を保つための CLI 層の補助処理。重複検出は CLI 入力引数間のみ（同一コマンド内）が対象であり、source_store 上の既存ファイルとの重複は ingester 層の責務。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/aozora.md
+++ b/docs/specs/ingesters/aozora.md
@@ -163,10 +163,10 @@ source_store への配置は `place_file` API を経由せず、データファ�
 |---------|------|---------|
 | `update-aozora-catalog` | なし | `rag_update_aozora_catalog` と同等の処理を CLI から実行する |
 | `search-aozora` | `--author`（任意）、`--title`（任意）、`--limit`（任意） | `rag_search_aozora` と同等の処理を CLI から実行する |
-| `ingest-aozora` | `book_id`（1 件以上、`nargs='+'`）、`--no-pipeline`（任意） | `rag_add_aozora` と同等の処理を CLI から実行する。複数 ID 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
-| `ingest-aozora-author` | `person_id`、`--max-works`（任意）、`--no-pipeline`（任意） | `rag_crawl_aozora` と同等の処理を CLI から実行する |
+| `ingest-aozora` | `book_id`（1 件以上、`nargs='+'`）、`--skip-pipeline`（任意） | `rag_add_aozora` と同等の処理を CLI から実行する。複数 ID 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
+| `ingest-aozora-author` | `person_id`、`--max-works`（任意）、`--skip-pipeline`（任意） | `rag_crawl_aozora` と同等の処理を CLI から実行する |
 
-`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
+`--skip-pipeline` の共通仕様は [common.md](common.md#--skip-pipeline-フラグ共通仕様) を参照。
 
 #### `ingest-aozora` 複数 ID 入力時の重複検出
 

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -123,10 +123,10 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `crawl-bluesky` | `handle`、`--max-posts`（任意）、`--include-reposts`（任意）、`--force`（任意）、`--no-pipeline`（任意） | `rag_crawl_bluesky` と同等の処理を CLI から実行する |
-| `ingest-bluesky` | `url`（1 件以上）、`--no-pipeline`（任意） | `rag_add_bluesky` と同等の処理を CLI から実行する |
+| `crawl-bluesky` | `handle`、`--max-posts`（任意）、`--include-reposts`（任意）、`--force`（任意）、`--skip-pipeline`（任意） | `rag_crawl_bluesky` と同等の処理を CLI から実行する |
+| `ingest-bluesky` | `url`（1 件以上）、`--skip-pipeline`（任意） | `rag_add_bluesky` と同等の処理を CLI から実行する |
 
-`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
+`--skip-pipeline` の共通仕様は [common.md](common.md#--skip-pipeline-フラグ共通仕様) を参照。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -123,8 +123,10 @@ BlueSky 投稿は**複合ソース**として扱われる。投稿 JSON が親�
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `crawl-bluesky` | `handle`、`--max-posts`（任意）、`--include-reposts`（任意）、`--force`（任意） | `rag_crawl_bluesky` と同等の処理を CLI から実行する |
-| `ingest-bluesky` | `url`（1 件以上） | `rag_add_bluesky` と同等の処理を CLI から実行する |
+| `crawl-bluesky` | `handle`、`--max-posts`（任意）、`--include-reposts`（任意）、`--force`（任意）、`--no-pipeline`（任意） | `rag_crawl_bluesky` と同等の処理を CLI から実行する |
+| `ingest-bluesky` | `url`（1 件以上）、`--no-pipeline`（任意） | `rag_add_bluesky` と同等の処理を CLI から実行する |
+
+`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -286,6 +286,64 @@ CLI `--output json` 出力は MCP 応答経路および外部スケジューラ�
 
 インジェスター共通の追加設定はない。source_store のパスは [source-store.md](../source-store.md) の `SOURCE_STORE_DIR` を使用する。各媒体固有の設定は媒体別仕様書で定義する。
 
+### `--no-pipeline` フラグ共通仕様
+
+CLI および MCP / HTTP API で共通の **後段 pipeline 処理スキップ機構**。bulk 取り込み運用の高速化を目的とする。
+
+#### 振る舞い
+
+`--no-pipeline` 指定時 / `defer_indexing=True` 指定時に **スキップされる処理**:
+
+- パイプライン制御 (`controller.ingest_and_index`) による converter 実行
+- 同呼び出しによる indexer 実行（チャンキング・Embedding・ChromaDB 書込み・BM25 再構築）
+
+`--no-pipeline` 指定時にも **実行される処理**:
+
+- インジェスターによる source_store へのファイル配置
+- 配置後の git add + git commit（パイプライン制御の `commit` を介して実行）
+- 入力バリデーション・stdout / JSON 出力
+
+これにより、複数件の `--no-pipeline` 取り込みを連続実行しても、BM25 全体再構築（`fugashi` 初期化 + 全コーパス再構築）は走らない。最後にユーザーが `rebuild --mode incremental` を 1 回実行することでまとめて差分処理する運用パターンを想定する。
+
+**Why**: 1 件取り込みあたり BM25 全体再構築（数百万件規模で約 15 秒）が支配的な所要時間となる事象に対する現実的な改善策。bm25s 0.3.2.post1 は IDF が doc count に依存するため真の差分更新 API を持たず、再構築回数を減らす方針を採る。
+
+#### 対象コマンド・ツール
+
+| 経路 | フラグ / パラメータ | 対象 |
+|------|---------------------|------|
+| CLI | `--no-pipeline` | `ingest-youtube` / `ingest-youtube-playlist` / `crawl-bluesky` / `crawl-zenn` / `ingest-bluesky` / `ingest-zenn` / `crawl-documents` / `site-ingest` / `ingest-aozora` / `ingest-aozora-author` / `delete` |
+| MCP | `defer_indexing: bool = False` | 同等の `rag_*` ツール群（[rag-knowledge.md](../rag-knowledge.md) の MCP ツール一覧参照）|
+
+**対象外**:
+
+- `add-document` / `rag_add_document`、`add-journal` / `rag_add_journal`、HTTP `POST /upload/document` / `POST /upload/journal`:
+  外部 API 経由の単発取り込みが主用途であり、bulk 取り込みのニーズが低いため対象外。
+  複数件を取り込みたい場合は `crawl-documents` / `migrate-journal` を使う
+- `migrate-journal`: `controller.ingest_and_index` を呼ばないため対象外（ファイル配置のみ。後段 rebuild はユーザーが別途実行）
+
+#### stdout 案内文
+
+`--no-pipeline` 指定時かつ JSON 出力でない場合、stdout に以下の案内文を 1 行で出力する:
+
+```text
+パイプライン未実行（--no-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。
+```
+
+JSON 出力時は案内文を出力せず、`pipeline` フィールドは **省略**する（key 自体を含めない。後続のスケジューラはフィールドの有無で判定可能）。
+MCP / HTTP API 経由の場合、CLI subprocess の stdout / stderr がそのまま応答メッセージに含まれる。
+
+#### 後段 rebuild の運用
+
+`--no-pipeline` で複数件取り込んだ後、最後に 1 回 `rebuild --mode incremental` を実行することで一括 index 更新を行う。`rebuild --mode incremental` は最後の commit 以降の差分を検出して処理するため、`--no-pipeline` 取り込みで作成された commit 群がまとめて処理される。
+
+自動連鎖（取り込み末尾で自動 rebuild 実行）は本仕様の対象外。ユーザーが明示的に rebuild を呼び出す運用とする。
+
+#### 取り込み失敗との関係
+
+`--no-pipeline` の挙動はインジェスター段の成否とは独立。
+インジェスターが部分失敗 (`partial_failures`) や全件失敗（例外）したとしても、`--no-pipeline` の解釈は変わらず「pipeline をスキップする」の意味を持つ。
+ただし `is_empty()` で 0 件配置だった場合は pipeline 呼び出し自体が省略されるため、`--no-pipeline` 指定の有無で振る舞いに差はない。
+
 ## コンポーネント構成
 
 ### 新アーキテクチャでのインジェスターの位置付け

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -286,24 +286,24 @@ CLI `--output json` 出力は MCP 応答経路および外部スケジューラ�
 
 インジェスター共通の追加設定はない。source_store のパスは [source-store.md](../source-store.md) の `SOURCE_STORE_DIR` を使用する。各媒体固有の設定は媒体別仕様書で定義する。
 
-### `--no-pipeline` フラグ共通仕様
+### `--skip-pipeline` フラグ共通仕様
 
 CLI および MCP / HTTP API で共通の **後段 pipeline 処理スキップ機構**。bulk 取り込み運用の高速化を目的とする。
 
 #### 振る舞い
 
-`--no-pipeline` 指定時 / `defer_indexing=True` 指定時に **スキップされる処理**:
+`--skip-pipeline` 指定時 / `skip_pipeline=True` 指定時に **スキップされる処理**:
 
 - パイプライン制御 (`controller.ingest_and_index`) による converter 実行
 - 同呼び出しによる indexer 実行（チャンキング・Embedding・ChromaDB 書込み・BM25 再構築）
 
-`--no-pipeline` 指定時にも **実行される処理**:
+`--skip-pipeline` 指定時にも **実行される処理**:
 
 - インジェスターによる source_store へのファイル配置
 - 配置後の git add + git commit（パイプライン制御の `commit` を介して実行）
 - 入力バリデーション・stdout / JSON 出力
 
-これにより、複数件の `--no-pipeline` 取り込みを連続実行しても、BM25 全体再構築（`fugashi` 初期化 + 全コーパス再構築）は走らない。最後にユーザーが `rebuild --mode incremental` を 1 回実行することでまとめて差分処理する運用パターンを想定する。
+これにより、複数件の `--skip-pipeline` 取り込みを連続実行しても、BM25 全体再構築（`fugashi` 初期化 + 全コーパス再構築）は走らない。最後にユーザーが `rebuild --mode incremental` を 1 回実行することでまとめて差分処理する運用パターンを想定する。
 
 **Why**: 1 件取り込みあたり BM25 全体再構築（数百万件規模で約 15 秒）が支配的な所要時間となる事象に対する現実的な改善策。bm25s 0.3.2.post1 は IDF が doc count に依存するため真の差分更新 API を持たず、再構築回数を減らす方針を採る。
 
@@ -311,8 +311,8 @@ CLI および MCP / HTTP API で共通の **後段 pipeline 処理スキップ�
 
 | 経路 | フラグ / パラメータ | 対象 |
 |------|---------------------|------|
-| CLI | `--no-pipeline` | `ingest-youtube` / `ingest-youtube-playlist` / `crawl-bluesky` / `crawl-zenn` / `ingest-bluesky` / `ingest-zenn` / `crawl-documents` / `site-ingest` / `ingest-aozora` / `ingest-aozora-author` / `delete` |
-| MCP | `defer_indexing: bool = False` | 同等の `rag_*` ツール群（[rag-knowledge.md](../rag-knowledge.md) の MCP ツール一覧参照）|
+| CLI | `--skip-pipeline` | `ingest-youtube` / `ingest-youtube-playlist` / `crawl-bluesky` / `crawl-zenn` / `ingest-bluesky` / `ingest-zenn` / `crawl-documents` / `site-ingest` / `ingest-aozora` / `ingest-aozora-author` / `delete` |
+| MCP | `skip_pipeline: bool = False` | 同等の `rag_*` ツール群（[rag-knowledge.md](../rag-knowledge.md) の MCP ツール一覧参照）|
 
 **対象外**:
 
@@ -323,26 +323,26 @@ CLI および MCP / HTTP API で共通の **後段 pipeline 処理スキップ�
 
 #### stdout 案内文
 
-`--no-pipeline` 指定時かつ JSON 出力でない場合、stdout に以下の案内文を 1 行で出力する:
+`--skip-pipeline` 指定時かつ JSON 出力でない場合、stdout に以下の案内文を 1 行で出力する:
 
 ```text
-パイプライン未実行（--no-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。
+パイプライン未実行（--skip-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。
 ```
 
 JSON 出力時は案内文を出力せず、`pipeline` フィールドは **省略**する（key 自体を含めない。後続のスケジューラはフィールドの有無で判定可能）。
-MCP / HTTP API 経由の場合、CLI subprocess の stdout / stderr がそのまま応答メッセージに含まれる。
+MCP / HTTP API 経由の場合、CLI subprocess は常に `--output json` で起動され、JSON Lines の `type=result` / `type=error` のみがパースされる。通常の stdout / stderr 行（`--skip-pipeline` 案内文等）は応答本文に含まれず、stderr は server 側のログに転送されるのみとなる。MCP / HTTP API 経由のクライアントが `--skip-pipeline` 相当（`skip_pipeline=True`）を使う場合、案内文を見るには CLI 直接実行か、サーバー側のログ確認が必要。
 
 #### 後段 rebuild の運用
 
-`--no-pipeline` で複数件取り込んだ後、最後に 1 回 `rebuild --mode incremental` を実行することで一括 index 更新を行う。`rebuild --mode incremental` は最後の commit 以降の差分を検出して処理するため、`--no-pipeline` 取り込みで作成された commit 群がまとめて処理される。
+`--skip-pipeline` で複数件取り込んだ後、最後に 1 回 `rebuild --mode incremental` を実行することで一括 index 更新を行う。`rebuild --mode incremental` は最後の commit 以降の差分を検出して処理するため、`--skip-pipeline` 取り込みで作成された commit 群がまとめて処理される。
 
 自動連鎖（取り込み末尾で自動 rebuild 実行）は本仕様の対象外。ユーザーが明示的に rebuild を呼び出す運用とする。
 
 #### 取り込み失敗との関係
 
-`--no-pipeline` の挙動はインジェスター段の成否とは独立。
-インジェスターが部分失敗 (`partial_failures`) や全件失敗（例外）したとしても、`--no-pipeline` の解釈は変わらず「pipeline をスキップする」の意味を持つ。
-ただし `is_empty()` で 0 件配置だった場合は pipeline 呼び出し自体が省略されるため、`--no-pipeline` 指定の有無で振る舞いに差はない。
+`--skip-pipeline` の挙動はインジェスター段の成否とは独立。
+インジェスターが部分失敗 (`partial_failures`) や全件失敗（例外）したとしても、`--skip-pipeline` の解釈は変わらず「pipeline をスキップする」の意味を持つ。
+ただし `is_empty()` で 0 件配置だった場合は pipeline 呼び出し自体が省略されるため、`--skip-pipeline` 指定の有無で振る舞いに差はない。
 
 ## コンポーネント構成
 

--- a/docs/specs/ingesters/common.md
+++ b/docs/specs/ingesters/common.md
@@ -330,7 +330,9 @@ CLI および MCP / HTTP API で共通の **後段 pipeline 処理スキップ�
 ```
 
 JSON 出力時は案内文を出力せず、`pipeline` フィールドは **省略**する（key 自体を含めない。後続のスケジューラはフィールドの有無で判定可能）。
-MCP / HTTP API 経由の場合、CLI subprocess は常に `--output json` で起動され、JSON Lines の `type=result` / `type=error` のみがパースされる。通常の stdout / stderr 行（`--skip-pipeline` 案内文等）は応答本文に含まれず、stderr は server 側のログに転送されるのみとなる。MCP / HTTP API 経由のクライアントが `--skip-pipeline` 相当（`skip_pipeline=True`）を使う場合、案内文を見るには CLI 直接実行か、サーバー側のログ確認が必要。
+MCP / HTTP API 経由の場合、CLI subprocess は常に `--output json` で起動され、JSON Lines の `type=result` / `type=error` のみがパースされる。
+通常の stdout / stderr 行（`--skip-pipeline` 案内文等）は応答本文に含まれず、stderr は server 側のログに転送されるのみとなる。
+MCP / HTTP API 経由のクライアントが `--skip-pipeline` 相当（`skip_pipeline=True`）を使う場合、案内文を見るには CLI 直接実行か、サーバー側のログ確認が必要。
 
 #### 後段 rebuild の運用
 

--- a/docs/specs/ingesters/journal.md
+++ b/docs/specs/ingesters/journal.md
@@ -81,7 +81,7 @@ Journal インジェスターは、開発ジャーナル（セッションごと
 | `--entry-id` | `-e` | いいえ | エントリ識別子（省略時は自動生成） |
 
 MCP ツール（`rag_add_journal`）経由では `content` パラメータに Markdown 文字列を直接渡す。CLI は `--file` で指定したファイルを読み込み、同じインジェスターインターフェースを呼び出す。
-`add-journal` は `--no-pipeline` 対象外（外部 API 経由の単発取り込みが主用途のため）。
+`add-journal` は `--skip-pipeline` 対象外（外部 API 経由の単発取り込みが主用途のため）。
 
 #### migrate-journal パラメータ
 

--- a/docs/specs/ingesters/journal.md
+++ b/docs/specs/ingesters/journal.md
@@ -67,7 +67,7 @@ Journal インジェスターは、開発ジャーナル（セッションごと
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `add-journal` | `--title`, `--file`, `--repository`, `--entry-id`（任意） | 単一ジャーナルエントリを登録する。パイプライン処理（convert → index）まで一貫して実行する |
+| `add-journal` | `--title`, `--file` または `--stdin`（排他）, `--repository`, `--entry-id`（任意） | 単一ジャーナルエントリを登録する。パイプライン処理（convert → index）まで一貫して実行する。bulk 取り込みは対象外（session 記録 = 1 件運用のため） |
 | `migrate-journal` | `--dir`, `--repository` | 既存ジャーナルファイルを一括で source_store に配置する。パイプライン処理は含まない（事後に `rebuild --mode incremental` を実行する） |
 
 #### add-journal パラメータ
@@ -75,11 +75,13 @@ Journal インジェスターは、開発ジャーナル（セッションごと
 | パラメータ | 短縮 | 必須 | 説明 |
 |-----------|------|------|------|
 | `--title` | `-t` | はい | エントリタイトル |
-| `--file` | `-f` | はい | 本文 Markdown ファイルのパス。CLI がファイルを読み込んでコンテンツをインジェスターに渡す |
+| `--file` | `-f` | はい（`--stdin` と排他） | 本文 Markdown ファイルのパス。CLI がファイルを読み込んでコンテンツをインジェスターに渡す |
+| `--stdin` | — | はい（`--file` と排他） | stdin から Markdown を読み込む |
 | `--repository` | `-r` | はい | リポジトリ名 |
 | `--entry-id` | `-e` | いいえ | エントリ識別子（省略時は自動生成） |
 
 MCP ツール（`rag_add_journal`）経由では `content` パラメータに Markdown 文字列を直接渡す。CLI は `--file` で指定したファイルを読み込み、同じインジェスターインターフェースを呼び出す。
+`add-journal` は `--no-pipeline` 対象外（外部 API 経由の単発取り込みが主用途のため）。
 
 #### migrate-journal パラメータ
 

--- a/docs/specs/ingesters/local.md
+++ b/docs/specs/ingesters/local.md
@@ -148,9 +148,9 @@ source_store 内の相対パスを source_id として使用する。
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
 | `add-document` | `--file` または `--stdin`（排他）、`--filename`（`--stdin` 使用時に必須）、`--encoding`（任意）、`--upload-mode`（任意） | `rag_add_document` と同等の処理を CLI から実行する。単一ファイル/コンテンツのみ対応（外部 API 経由の単発取り込みが主用途のため bulk 化対象外） |
-| `crawl-documents` | `dir_path`、`--pattern`（任意）、`--upload-mode`（任意）、`--no-pipeline`（任意） | `rag_crawl_documents` と同等の処理を CLI から実行する |
+| `crawl-documents` | `dir_path`、`--pattern`（任意）、`--upload-mode`（任意）、`--skip-pipeline`（任意） | `rag_crawl_documents` と同等の処理を CLI から実行する |
 
-`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。`add-document` は `--no-pipeline` 対象外（単発取り込みのため）。
+`--skip-pipeline` の共通仕様は [common.md](common.md#--skip-pipeline-フラグ共通仕様) を参照。`add-document` は `--skip-pipeline` 対象外（単発取り込みのため）。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/local.md
+++ b/docs/specs/ingesters/local.md
@@ -143,6 +143,15 @@ source_store 内の相対パスを source_id として使用する。
 - ファイルの存在有無で重複を判定する
 - 重複時は上書き（再取り込みの更新動作）
 
+### CLI コマンド
+
+| コマンド | 引数 | 振る舞い |
+|---------|------|---------|
+| `add-document` | `--file` または `--stdin`（排他）、`--filename`（`--stdin` 使用時に必須）、`--encoding`（任意）、`--upload-mode`（任意） | `rag_add_document` と同等の処理を CLI から実行する。単一ファイル/コンテンツのみ対応（外部 API 経由の単発取り込みが主用途のため bulk 化対象外） |
+| `crawl-documents` | `dir_path`、`--pattern`（任意）、`--upload-mode`（任意）、`--no-pipeline`（任意） | `rag_crawl_documents` と同等の処理を CLI から実行する |
+
+`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。`add-document` は `--no-pipeline` 対象外（単発取り込みのため）。
+
 ### 設定項目
 
 | 設定項目 | 層 | 設計意図 |

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -155,10 +155,10 @@ YouTube インジェスターは以下の URL パターンを単一動画とし�
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `ingest-youtube` | `video_url`（1 件以上、`nargs='+'`）、`--no-pipeline`（任意） | `rag_add_youtube` と同等の処理を CLI から実行する。複数 URL 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
-| `ingest-youtube-playlist` | `playlist_url`、`--max-videos`（任意）、`--no-pipeline`（任意） | `rag_crawl_youtube` と同等の処理を CLI から実行する |
+| `ingest-youtube` | `video_url`（1 件以上、`nargs='+'`）、`--skip-pipeline`（任意） | `rag_add_youtube` と同等の処理を CLI から実行する。複数 URL 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
+| `ingest-youtube-playlist` | `playlist_url`、`--max-videos`（任意）、`--skip-pipeline`（任意） | `rag_crawl_youtube` と同等の処理を CLI から実行する |
 
-`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。MCP の `defer_indexing` パラメータと同等の振る舞いを CLI から指定可能。
+`--skip-pipeline` の共通仕様は [common.md](common.md#--skip-pipeline-フラグ共通仕様) を参照。MCP の `skip_pipeline` パラメータと同等の振る舞いを CLI から指定可能。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -155,8 +155,10 @@ YouTube インジェスターは以下の URL パターンを単一動画とし�
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `ingest-youtube` | `video_url` | `rag_add_youtube` と同等の処理を CLI から実行する |
-| `ingest-youtube-playlist` | `playlist_url`、`--max-videos`（任意） | `rag_crawl_youtube` と同等の処理を CLI から実行する |
+| `ingest-youtube` | `video_url`（1 件以上、`nargs='+'`）、`--no-pipeline`（任意） | `rag_add_youtube` と同等の処理を CLI から実行する。複数 URL 指定時は逐次取り込み後、末尾 1 回だけ pipeline 実行 |
+| `ingest-youtube-playlist` | `playlist_url`、`--max-videos`（任意）、`--no-pipeline`（任意） | `rag_crawl_youtube` と同等の処理を CLI から実行する |
+
+`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。MCP の `defer_indexing` パラメータと同等の振る舞いを CLI から指定可能。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/zenn.md
+++ b/docs/specs/ingesters/zenn.md
@@ -120,10 +120,10 @@ site_ingest（URL ベースの Web クロール）とは独立したツールと
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意）、`--force`（任意）、`--no-pipeline`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
-| `ingest-zenn` | `url`（1 件以上）、`--no-pipeline`（任意） | `rag_add_zenn` と同等の処理を CLI から実行する |
+| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意）、`--force`（任意）、`--skip-pipeline`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
+| `ingest-zenn` | `url`（1 件以上）、`--skip-pipeline`（任意） | `rag_add_zenn` と同等の処理を CLI から実行する |
 
-`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
+`--skip-pipeline` の共通仕様は [common.md](common.md#--skip-pipeline-フラグ共通仕様) を参照。
 
 ### 設定項目
 

--- a/docs/specs/ingesters/zenn.md
+++ b/docs/specs/ingesters/zenn.md
@@ -120,8 +120,10 @@ site_ingest（URL ベースの Web クロール）とは独立したツールと
 
 | コマンド | 引数 | 振る舞い |
 |---------|------|---------|
-| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意）、`--force`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
-| `ingest-zenn` | `url`（1 件以上） | `rag_add_zenn` と同等の処理を CLI から実行する |
+| `crawl-zenn` | `username`、`--max-articles`（任意）、`--content-type`（任意）、`--force`（任意）、`--no-pipeline`（任意） | `rag_crawl_zenn` と同等の処理を CLI から実行する |
+| `ingest-zenn` | `url`（1 件以上）、`--no-pipeline`（任意） | `rag_add_zenn` と同等の処理を CLI から実行する |
+
+`--no-pipeline` の共通仕様は [common.md](common.md#--no-pipeline-フラグ共通仕様) を参照。
 
 ### 設定項目
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -297,6 +297,15 @@ MCP サーバーが公開するツール群。
 | `source_id` | str | Yes | — | ソース識別子（rag_search の Source 値） |
 | `format` | str | No | `"text"` | 取得形式。`"text"`（変換済みテキスト）または `"original"`（オリジナル） |
 
+#### rag_add_zenn
+
+Zenn 記事・スクラップを **URL 指定で 1 件以上** 取り込む。同一記事の再取り込み時は `source_id` の一致で検出し、既存の知識を最新に置き換える。
+
+| 引数 | 型 | 必須 | デフォルト | 説明 |
+|------|-----|------|-----------|------|
+| `urls` | list[str] | Yes | — | Zenn コンテンツの URL リスト（1 件以上） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
+
 #### rag_crawl_zenn
 
 指定ユーザーの Zenn 記事・スクラップを API 経由で取得し、ナレッジベースに取り込む。同一記事の再取り込み時は `source_id`（source_store 内の相対パス）の一致で検出し、既存の知識を最新に置き換える。
@@ -307,6 +316,16 @@ MCP サーバーが公開するツール群。
 | `max_articles` | int \| None | No | None（設定値を使用） | 取得する最大コンテンツ数 |
 | `content_type` | str | No | `"all"` | 取得対象。`"articles"`（記事のみ）、`"scraps"`（スクラップのみ）、`"all"`（両方） |
 | `force` | bool | No | `false` | 既存ファイルを上書きするか |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+
+#### rag_add_bluesky
+
+BlueSky 投稿を **URL 指定で 1 件以上** 取り込む。同一投稿の再取り込み時は上書きする。
+
+| 引数 | 型 | 必須 | デフォルト | 説明 |
+|------|-----|------|-----------|------|
+| `urls` | list[str] | Yes | — | BlueSky 投稿の URL リスト（1 件以上） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_crawl_bluesky
 
@@ -317,14 +336,16 @@ MCP サーバーが公開するツール群。
 | `handle` | str | Yes | — | BlueSky ハンドル（例: user.bsky.social）。DID 形式は不可 |
 | `max_posts` | int \| None | No | None（設定値を使用） | 取得する最大投稿数 |
 | `include_reposts` | bool \| None | No | None（設定値を使用） | タイムラインにリポストを含めるか |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_add_youtube
 
-単一 YouTube 動画の字幕/文字起こしを取得し、ナレッジベースに取り込む。詳細は [ingesters/youtube.md](ingesters/youtube.md) を参照。
+YouTube 動画の字幕/文字起こしを **URL 指定で 1 件以上** 取り込む。詳細は [ingesters/youtube.md](ingesters/youtube.md) を参照。
 
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
-| `video_url` | str | Yes | — | YouTube 動画 URL（`youtube.com/watch?v=` または `youtu.be/` 形式） |
+| `video_urls` | list[str] | Yes | — | YouTube 動画 URL リスト（1 件以上、`youtube.com/watch?v=` または `youtu.be/` 形式） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_crawl_youtube
 
@@ -334,6 +355,7 @@ YouTube プレイリスト内の動画を一括取り込みする。詳細は [i
 |------|-----|------|-----------|------|
 | `playlist_url` | str | Yes | — | YouTube プレイリスト URL（`youtube.com/playlist?list=` 形式） |
 | `max_videos` | int \| None | No | None（設定値を使用） | 取得する最大動画数 |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_add_document
 
@@ -355,6 +377,7 @@ YouTube プレイリスト内の動画を一括取り込みする。詳細は [i
 | `dir_path` | str | Yes | — | 取り込み対象ディレクトリのパス |
 | `pattern` | str | No | `"**/*"` | glob パターン（再帰的に全対応ファイルを検索） |
 | `upload_mode` | str | No | `"fail"` | 同名ファイル存在時の動作。`"fail"`（スキップ）または `"replace"`（上書き） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_add_journal
 
@@ -379,15 +402,17 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 | `url_pattern` | str | No | `""` | URL フィルタパターン（正規表現、クロールモードのみ） |
 | `max_pages` | int \| None | No | None（設定値を使用） | ページ数上限（クロールモードのみ） |
 | `force` | bool | No | `false` | JOBDIR を削除して最初からクロール（クロールモードのみ） |
-| `download_only` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行 |
+| `defer_indexing` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行（CLI の `--no-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様)）|
 
 #### rag_delete
 
 ソース識別子指定で source_store からファイルを物理削除し、パイプライン経由でインデックス・metadata.db を更新する。git 管理下のため、削除後も git checkout で復旧可能。
+複数 `source_id` を 1 リクエストで処理可能（bulk 削除）。末尾 1 回だけパイプラインが走る。
 
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
-| `source_id` | str | Yes | — | 削除するソース識別子 |
+| `source_ids` | list[str] | Yes | — | 削除するソース識別子のリスト（1 件以上） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_rebuild
 
@@ -414,11 +439,12 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 
 #### rag_add_aozora
 
-指定作品の XHTML を取得し、ナレッジベースに取り込む。著作権フリーの作品のみ対応。
+指定作品の XHTML を **作品 ID 1 件以上** 指定で取得し、ナレッジベースに取り込む。著作権フリーの作品のみ対応。zfill(6) 後の重複入力は自動排除される（詳細は [ingesters/aozora.md](ingesters/aozora.md#ingest-aozora-複数-id-入力時の重複検出) を参照）。
 
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
-| `book_id` | str | Yes | — | 青空文庫の作品 ID（カタログ検索で取得） |
+| `book_ids` | list[str] | Yes | — | 青空文庫の作品 ID リスト（1 件以上、カタログ検索で取得） |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_crawl_aozora
 
@@ -428,6 +454,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 |------|-----|------|-----------|------|
 | `person_id` | str | Yes | — | 著者の人物 ID（rag_search_aozora で確認可能） |
 | `max_works` | int \| None | No | None（設定値を使用） | 取得する最大作品数 |
+| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
 
 #### rag_list_recent
 
@@ -579,18 +606,20 @@ MCP サーバーの全ツールは CLI サブプロセスに委譲する。設�
 | `rag_stats` | `stats` | |
 | `rag_list_recent` | `list-recent` | |
 | `rag_search_aozora` | `search-aozora` | |
+| `rag_add_zenn` | `ingest-zenn` | bulk 対応 (`urls: list[str]`) |
 | `rag_crawl_zenn` | `crawl-zenn` | |
+| `rag_add_bluesky` | `ingest-bluesky` | bulk 対応 (`urls: list[str]`) |
 | `rag_crawl_bluesky` | `crawl-bluesky` | |
-| `rag_add_youtube` | `ingest-youtube` | |
+| `rag_add_youtube` | `ingest-youtube` | bulk 対応 (`video_urls: list[str]`) |
 | `rag_crawl_youtube` | `ingest-youtube-playlist` | |
 | `rag_add_document` | `add-document` | stdin 入力（後述） |
 | `rag_crawl_documents` | `crawl-documents` | |
 | `rag_add_journal` | `add-journal` | stdin 入力（後述） |
 | `rag_site_ingest` | `site-ingest` | |
-| `rag_add_aozora` | `ingest-aozora` | |
+| `rag_add_aozora` | `ingest-aozora` | bulk 対応 (`book_ids: list[str]`) |
 | `rag_crawl_aozora` | `ingest-aozora-author` | |
+| `rag_delete` | `delete` | bulk 対応 (`source_ids: list[str]`) |
 | `rag_update_aozora_catalog` | `update-aozora-catalog` | |
-| `rag_delete` | `delete` | |
 | `rag_rebuild` | `rebuild` | |
 | `/upload/document` | `add-document` | 一時ファイル経由 |
 | `/upload/journal` | `add-journal` | 一時ファイル経由 |

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -304,7 +304,7 @@ Zenn 記事・スクラップを **URL 指定で 1 件以上** 取り込む。�
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
 | `urls` | list[str] | Yes | — | Zenn コンテンツの URL リスト（1 件以上） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
 
 #### rag_crawl_zenn
 
@@ -316,7 +316,7 @@ Zenn 記事・スクラップを **URL 指定で 1 件以上** 取り込む。�
 | `max_articles` | int \| None | No | None（設定値を使用） | 取得する最大コンテンツ数 |
 | `content_type` | str | No | `"all"` | 取得対象。`"articles"`（記事のみ）、`"scraps"`（スクラップのみ）、`"all"`（両方） |
 | `force` | bool | No | `false` | 既存ファイルを上書きするか |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_add_bluesky
 
@@ -325,7 +325,7 @@ BlueSky 投稿を **URL 指定で 1 件以上** 取り込む。同一投稿の�
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
 | `urls` | list[str] | Yes | — | BlueSky 投稿の URL リスト（1 件以上） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_crawl_bluesky
 
@@ -336,7 +336,7 @@ BlueSky 投稿を **URL 指定で 1 件以上** 取り込む。同一投稿の�
 | `handle` | str | Yes | — | BlueSky ハンドル（例: user.bsky.social）。DID 形式は不可 |
 | `max_posts` | int \| None | No | None（設定値を使用） | 取得する最大投稿数 |
 | `include_reposts` | bool \| None | No | None（設定値を使用） | タイムラインにリポストを含めるか |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_add_youtube
 
@@ -345,7 +345,7 @@ YouTube 動画の字幕/文字起こしを **URL 指定で 1 件以上** 取り�
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
 | `video_urls` | list[str] | Yes | — | YouTube 動画 URL リスト（1 件以上、`youtube.com/watch?v=` または `youtu.be/` 形式） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_crawl_youtube
 
@@ -355,7 +355,7 @@ YouTube プレイリスト内の動画を一括取り込みする。詳細は [i
 |------|-----|------|-----------|------|
 | `playlist_url` | str | Yes | — | YouTube プレイリスト URL（`youtube.com/playlist?list=` 形式） |
 | `max_videos` | int \| None | No | None（設定値を使用） | 取得する最大動画数 |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_add_document
 
@@ -377,7 +377,7 @@ YouTube プレイリスト内の動画を一括取り込みする。詳細は [i
 | `dir_path` | str | Yes | — | 取り込み対象ディレクトリのパス |
 | `pattern` | str | No | `"**/*"` | glob パターン（再帰的に全対応ファイルを検索） |
 | `upload_mode` | str | No | `"fail"` | 同名ファイル存在時の動作。`"fail"`（スキップ）または `"replace"`（上書き） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_add_journal
 
@@ -402,7 +402,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 | `url_pattern` | str | No | `""` | URL フィルタパターン（正規表現、クロールモードのみ） |
 | `max_pages` | int \| None | No | None（設定値を使用） | ページ数上限（クロールモードのみ） |
 | `force` | bool | No | `false` | JOBDIR を削除して最初からクロール（クロールモードのみ） |
-| `defer_indexing` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行（CLI の `--no-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様)）|
+| `skip_pipeline` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行（CLI の `--skip-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様)）|
 
 #### rag_delete
 
@@ -412,7 +412,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
 | `source_ids` | list[str] | Yes | — | 削除するソース識別子のリスト（1 件以上） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_rebuild
 
@@ -444,7 +444,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
 | `book_ids` | list[str] | Yes | — | 青空文庫の作品 ID リスト（1 件以上、カタログ検索で取得） |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_crawl_aozora
 
@@ -454,7 +454,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 |------|-----|------|-----------|------|
 | `person_id` | str | Yes | — | 著者の人物 ID（rag_search_aozora で確認可能） |
 | `max_works` | int \| None | No | None（設定値を使用） | 取得する最大作品数 |
-| `defer_indexing` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--no-pipeline` と等価 |
+| `skip_pipeline` | bool | No | `false` | 後段のパイプライン処理（converter + indexer）をスキップする。CLI の `--skip-pipeline` と等価 |
 
 #### rag_list_recent
 

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -142,7 +142,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| `rag_site_ingest` | `url` または `urls`（排他）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`download_only`（任意） | Scrapy subprocess でページを取得し、HTML を source_store に配置後、パイプライン処理を実行する（`download_only` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
+| `rag_site_ingest` | `url` または `urls`（排他）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`defer_indexing`（任意） | Scrapy subprocess でページを取得し、HTML を source_store に配置後、パイプライン処理を実行する（`defer_indexing=true` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
 
 #### `rag_site_ingest` パラメータ
 
@@ -153,7 +153,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。クロールモードのみ有効。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
 | `max_pages` | int | `site_ingest_max_pages` | ページ数上限。クロールモードのみ有効。config.toml の値を上書き可能 |
 | `force` | bool | `false` | `true` の場合、クロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする。クロールモードのみ有効 |
-| `download_only` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能 |
+| `defer_indexing` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
 
 `url` と `urls` の入力規則:
 
@@ -177,7 +177,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `--url-pattern` | str | なし | URL フィルタパターン（クロールモードのみ） |
 | `--max-pages` | int | `site_ingest_max_pages` | ページ数上限（クロールモードのみ） |
 | `--force` | フラグ | `false` | クロールディレクトリ全体を削除して再クロール（クロールモードのみ） |
-| `--download-only` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ |
+| `--no-pipeline` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
 
 ### 取り込み結果の出力形式
 
@@ -380,13 +380,13 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 
 ### 正常完了後のクリーンアップ
 
-Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）全体を削除する。bridge 完了後は全データが source_store に配置済みであり、一時ファイルは不要。大規模サイトのクロールを繰り返すとディスクを圧迫するため、自動削除する。`download_only` の場合も bridge は完了しているため同様に削除する。
+Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）全体を削除する。bridge 完了後は全データが source_store に配置済みであり、一時ファイルは不要。大規模サイトのクロールを繰り返すとディスクを圧迫するため、自動削除する。`--no-pipeline` 指定時も bridge は完了しているため同様に削除する。
 
 クリーンアップの実行条件:
 
 | 条件 | クリーンアップ |
 |------|-------------|
-| Scrapy 正常完了 + bridge 完了 | 実行する（`download_only` の有無を問わない。bridge 完了時点で source_store に配置済み） |
+| Scrapy 正常完了 + bridge 完了 | 実行する（`--no-pipeline` の有無を問わない。bridge 完了時点で source_store に配置済み） |
 | Scrapy 異常終了（exit_code != 0） | 実行しない（JOBDIR によるレジュームを維持） |
 | クリーンアップ自体が失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする |
 
@@ -413,10 +413,10 @@ sequenceDiagram
     CMD->>BRIDGE: JSONL + HTML → source_store 変換
     BRIDGE->>SS: ファイル配置 + .meta 生成
     BRIDGE->>CMD: 配置結果
-    alt download_only = false
+    alt no_pipeline = false
         CMD->>PC: パイプライン処理（git commit + converter + indexer、MCP: CLI サブプロセス経由）
         PC->>CMD: パイプライン処理結果
-    else download_only = true
+    else no_pipeline = true
         CMD->>PC: git commit（source_store のみ）
         Note over CMD: パイプライン処理（converter + indexer）をスキップ
     end
@@ -458,7 +458,7 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--force` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
 | DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
-| `download_only` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
+| `--no-pipeline` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
 | 同一ドメインへの異なるパラメータでの複数回クロール | クロールキー（`start_url` + effective `url_pattern` のハッシュ）により JOBDIR が分離されるため、前回クロールの URL キューが残留しない |
 | 複数 URL モードで無効なスキームの URL が混在 | バリデーションで全 URL を検証し、不正な URL があればエラーを返す |
 | 複数 URL モードで SSRF 対象の URL が混在 | 全 URL に対して SSRF チェックを実行し、1 つでも違反があればエラーを返す |

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -142,7 +142,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| `rag_site_ingest` | `url` または `urls`（排他）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`defer_indexing`（任意） | Scrapy subprocess でページを取得し、HTML を source_store に配置後、パイプライン処理を実行する（`defer_indexing=true` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
+| `rag_site_ingest` | `url` または `urls`（排他）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`skip_pipeline`（任意） | Scrapy subprocess でページを取得し、HTML を source_store に配置後、パイプライン処理を実行する（`skip_pipeline=true` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
 
 #### `rag_site_ingest` パラメータ
 
@@ -153,7 +153,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。クロールモードのみ有効。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
 | `max_pages` | int | `site_ingest_max_pages` | ページ数上限。クロールモードのみ有効。config.toml の値を上書き可能 |
 | `force` | bool | `false` | `true` の場合、クロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする。クロールモードのみ有効 |
-| `defer_indexing` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
+| `skip_pipeline` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
 
 `url` と `urls` の入力規則:
 
@@ -177,7 +177,7 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 | `--url-pattern` | str | なし | URL フィルタパターン（クロールモードのみ） |
 | `--max-pages` | int | `site_ingest_max_pages` | ページ数上限（クロールモードのみ） |
 | `--force` | フラグ | `false` | クロールディレクトリ全体を削除して再クロール（クロールモードのみ） |
-| `--no-pipeline` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。共通仕様は [ingesters/common.md](ingesters/common.md#--no-pipeline-フラグ共通仕様) を参照 |
+| `--skip-pipeline` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
 
 ### 取り込み結果の出力形式
 
@@ -380,13 +380,13 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 
 ### 正常完了後のクリーンアップ
 
-Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）全体を削除する。bridge 完了後は全データが source_store に配置済みであり、一時ファイルは不要。大規模サイトのクロールを繰り返すとディスクを圧迫するため、自動削除する。`--no-pipeline` 指定時も bridge は完了しているため同様に削除する。
+Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{domain}/{crawl_key}/`）全体を削除する。bridge 完了後は全データが source_store に配置済みであり、一時ファイルは不要。大規模サイトのクロールを繰り返すとディスクを圧迫するため、自動削除する。`--skip-pipeline` 指定時も bridge は完了しているため同様に削除する。
 
 クリーンアップの実行条件:
 
 | 条件 | クリーンアップ |
 |------|-------------|
-| Scrapy 正常完了 + bridge 完了 | 実行する（`--no-pipeline` の有無を問わない。bridge 完了時点で source_store に配置済み） |
+| Scrapy 正常完了 + bridge 完了 | 実行する（`--skip-pipeline` の有無を問わない。bridge 完了時点で source_store に配置済み） |
 | Scrapy 異常終了（exit_code != 0） | 実行しない（JOBDIR によるレジュームを維持） |
 | クリーンアップ自体が失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする |
 
@@ -413,10 +413,10 @@ sequenceDiagram
     CMD->>BRIDGE: JSONL + HTML → source_store 変換
     BRIDGE->>SS: ファイル配置 + .meta 生成
     BRIDGE->>CMD: 配置結果
-    alt no_pipeline = false
+    alt skip_pipeline = false
         CMD->>PC: パイプライン処理（git commit + converter + indexer、MCP: CLI サブプロセス経由）
         PC->>CMD: パイプライン処理結果
-    else no_pipeline = true
+    else skip_pipeline = true
         CMD->>PC: git commit（source_store のみ）
         Note over CMD: パイプライン処理（converter + indexer）をスキップ
     end
@@ -458,7 +458,7 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--force` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
 | DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
-| `--no-pipeline` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
+| `--skip-pipeline` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
 | 同一ドメインへの異なるパラメータでの複数回クロール | クロールキー（`start_url` + effective `url_pattern` のハッシュ）により JOBDIR が分離されるため、前回クロールの URL キューが残留しない |
 | 複数 URL モードで無効なスキームの URL が混在 | バリデーションで全 URL を検証し、不正な URL があればエラーを返す |
 | 複数 URL モードで SSRF 対象の URL が混在 | 全 URL に対して SSRF チェックを実行し、1 つでも違反があればエラーを返す |

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -358,6 +358,91 @@ def _add_output_option(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_no_pipeline_option(parser: argparse.ArgumentParser) -> None:
+    """サブコマンドパーサーに --no-pipeline オプションを追加する.
+
+    共通仕様は docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」を参照。
+    """
+    parser.add_argument(
+        "--no-pipeline",
+        action="store_true",
+        default=False,
+        help=(
+            "取り込み後のパイプライン処理（converter + indexer）を行わない。"
+            "source_store への git commit は実行される。"
+            "一括取り込み時の高速化用。後で `rebuild --mode incremental` を実行する必要がある"
+        ),
+    )
+
+
+def _is_no_pipeline(args: argparse.Namespace) -> bool:
+    """args から --no-pipeline 指定の有無を取得する.
+
+    `getattr` でデフォルトを偽として扱うため、--no-pipeline 未対応のサブコマンドが
+    呼ばれた場合でも安全に False を返す。
+    """
+    return bool(getattr(args, "no_pipeline", False))
+
+
+def _print_no_pipeline_notice(json_out: bool) -> None:
+    """--no-pipeline 指定時に stdout へ案内文を出力する.
+
+    `json_out=True` で呼ばれた場合は早期 return し何も出力しない（JSON 構造への反映は
+    呼び出し側で `pipeline` フィールドの省略等で行う前提）。
+    共通仕様は docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」を参照。
+    """
+    if json_out:
+        return
+    print(
+        "パイプライン未実行（--no-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。",
+    )
+
+
+def _commit_for_no_pipeline(
+    controller: "PipelineController",
+    commit_message: str,
+) -> None:
+    """`--no-pipeline` 経路の commit のみ実行（pipeline 処理はスキップ）.
+
+    `controller.ingest_and_index()` 内では git commit + converter + indexer が一括実行されるが、
+    `--no-pipeline` 指定時は converter / indexer をスキップしつつ source_store の commit は
+    実行する必要がある（後段の `rebuild --mode incremental` が差分を検出できるようにするため）。
+    本ヘルパーは commit のみ実行し pipeline は呼ばない。
+
+    仕様: docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」
+    """
+    controller.commit(commit_message)
+
+
+def _merge_ingest_results(results: "list[IngestResult]") -> "IngestResult":
+    """複数の IngestResult を 1 件に集約する.
+
+    bulk 系 CLI handler が 1 件ずつ ingester を呼んだ結果をまとめる用途。
+    集約規則:
+    - counters (placed / skipped / overwritten / errors / partial_failures): 単純加算
+    - details (error_details / partial_failure_details): リスト連結（順序保持）
+    - aborted: OR 集約（いずれか True なら True）
+    - abort_reason: **最初に aborted=True になった IngestResult の abort_reason を採用**
+      （後続の aborted=True は無視）。bulk 処理は最初のサーキットブレーカー発動が
+      もっとも有意な情報のため
+    """
+    from .pipeline.ingesters._common import IngestResult as _IngestResult
+
+    merged = _IngestResult()
+    for r in results:
+        merged.placed += r.placed
+        merged.skipped += r.skipped
+        merged.overwritten += r.overwritten
+        merged.errors += r.errors
+        merged.error_details.extend(r.error_details)
+        merged.partial_failures += r.partial_failures
+        merged.partial_failure_details.extend(r.partial_failure_details)
+        if r.aborted and not merged.aborted:
+            merged.aborted = True
+            merged.abort_reason = r.abort_reason
+    return merged
+
+
 def _validate_bm25_k1(value: str) -> float:
     try:
         f = float(value)
@@ -386,8 +471,12 @@ def _validate_bm25_b(value: str) -> float:
     return f
 
 
-def main() -> None:
-    """CLIエントリポイント."""
+def _build_parser() -> "_JsonAwareArgumentParser":
+    """CLI 用のサブコマンド定義済み ArgumentParser を返す.
+
+    main() から argparse 構築部分を切り出した関数。
+    テストから直接 parse_args するために公開する。
+    """
     parser = _JsonAwareArgumentParser(description="RAG Knowledge CLI")
     # サブパーサーにも _JsonAwareArgumentParser を使わせる。
     # argparse のデフォルトは ArgumentParser 固定で、親クラスを継承しない。
@@ -676,20 +765,23 @@ def main() -> None:
 
     # delete サブコマンド
     delete_parser = subparsers.add_parser("delete", help="ソースをナレッジベースから論理削除")
-    delete_parser.add_argument("source_id", help="削除するソース識別子（source_id）")
+    delete_parser.add_argument("source_id", nargs="+", help="削除するソース識別子（source_id、1 件以上）")
+    _add_no_pipeline_option(delete_parser)
     _add_output_option(delete_parser)
 
     # --- インジェスト系サブコマンド ---
 
     # ingest-youtube: YouTube 単一動画取り込み
     yt_parser = subparsers.add_parser("ingest-youtube", help="YouTube 動画を取り込み")
-    yt_parser.add_argument("video_url", help="YouTube 動画 URL")
+    yt_parser.add_argument("video_url", nargs="+", help="YouTube 動画 URL（1 件以上）")
+    _add_no_pipeline_option(yt_parser)
     _add_output_option(yt_parser)
 
     # ingest-youtube-playlist: YouTube プレイリスト一括取り込み
     ytpl_parser = subparsers.add_parser("ingest-youtube-playlist", help="YouTube プレイリストを一括取り込み")
     ytpl_parser.add_argument("playlist_url", help="YouTube プレイリスト URL")
     ytpl_parser.add_argument("--max-videos", type=int, default=None, help="取得する最大動画数")
+    _add_no_pipeline_option(ytpl_parser)
     _add_output_option(ytpl_parser)
 
     # crawl-bluesky: BlueSky 取り込み
@@ -705,11 +797,13 @@ def main() -> None:
         help="リポストを含めるか（--no-include-reposts で除外）",
     )
     bs_parser.add_argument("--force", action="store_true", default=False, help="上書き再取得モード（既存ファイルを上書き + メディア再DL）")
+    _add_no_pipeline_option(bs_parser)
     _add_output_option(bs_parser)
 
     # ingest-bluesky: BlueSky 単一投稿取り込み
     rbs_parser = subparsers.add_parser("ingest-bluesky", help="BlueSky 投稿を URL 指定で取り込み")
     rbs_parser.add_argument("url", nargs="+", help="BlueSky 投稿の URL（1 件以上）")
+    _add_no_pipeline_option(rbs_parser)
     _add_output_option(rbs_parser)
 
     # crawl-zenn: Zenn 取り込み
@@ -718,11 +812,13 @@ def main() -> None:
     zenn_parser.add_argument("--max-articles", type=int, default=None, help="取得する最大コンテンツ数")
     zenn_parser.add_argument("--content-type", choices=["articles", "scraps", "all"], default="all", help="取得対象")
     zenn_parser.add_argument("--force", action="store_true", default=False, help="既存ファイルを上書きする（デフォルト: スキップ）")
+    _add_no_pipeline_option(zenn_parser)
     _add_output_option(zenn_parser)
 
     # ingest-zenn: Zenn 単一コンテンツ取り込み
     rzenn_parser = subparsers.add_parser("ingest-zenn", help="Zenn コンテンツを URL 指定で取り込み")
     rzenn_parser.add_argument("url", nargs="+", help="Zenn コンテンツの URL（1 件以上）")
+    _add_no_pipeline_option(rzenn_parser)
     _add_output_option(rzenn_parser)
 
     # add-document: 単一ドキュメント取り込み
@@ -740,6 +836,7 @@ def main() -> None:
     crawldoc_parser.add_argument("dir_path", help="取り込み対象ディレクトリのパス")
     crawldoc_parser.add_argument("--pattern", default="**/*", help="glob パターン")
     crawldoc_parser.add_argument("--upload-mode", choices=["fail", "replace"], default="fail", help="同名ファイル存在時の動作")
+    _add_no_pipeline_option(crawldoc_parser)
     _add_output_option(crawldoc_parser)
 
     # site-ingest: Scrapy によるサイト一括取り込み
@@ -748,12 +845,7 @@ def main() -> None:
     siteingest_parser.add_argument("--url-pattern", default="", help="URL フィルタパターン（正規表現、クロールモードのみ）")
     siteingest_parser.add_argument("--max-pages", type=int, default=None, help="ページ数上限（クロールモードのみ）")
     siteingest_parser.add_argument("--force", action="store_true", help="JOBDIR を削除して再クロール（クロールモードのみ）")
-    siteingest_parser.add_argument(
-        "--download-only",
-        action="store_true",
-        default=False,
-        help="Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理をスキップ",
-    )
+    _add_no_pipeline_option(siteingest_parser)
     _add_output_option(siteingest_parser)
 
     # update-aozora-catalog: 青空文庫カタログ更新
@@ -767,15 +859,17 @@ def main() -> None:
     search_aozora_parser.add_argument("--limit", type=int, default=20, help="最大表示件数（デフォルト: 20）")
     _add_output_option(search_aozora_parser)
 
-    # ingest-aozora: 青空文庫作品取り込み
+    # ingest-aozora: 青空文庫作品取り込み（バルク対応）
     ingest_aozora_parser = subparsers.add_parser("ingest-aozora", help="青空文庫の作品を取り込み")
-    ingest_aozora_parser.add_argument("book_id", help="青空文庫の作品 ID")
+    ingest_aozora_parser.add_argument("book_id", nargs="+", help="青空文庫の作品 ID（1 件以上）")
+    _add_no_pipeline_option(ingest_aozora_parser)
     _add_output_option(ingest_aozora_parser)
 
     # ingest-aozora-author: 青空文庫著者一括取り込み
     ingest_aozora_author_parser = subparsers.add_parser("ingest-aozora-author", help="青空文庫の著者作品を一括取り込み")
     ingest_aozora_author_parser.add_argument("person_id", help="著者の人物 ID（search-aozora で確認）")
     ingest_aozora_author_parser.add_argument("--max-works", type=int, default=None, help="取得する最大作品数")
+    _add_no_pipeline_option(ingest_aozora_author_parser)
     _add_output_option(ingest_aozora_author_parser)
 
     # add-journal: 単一ジャーナルエントリの登録
@@ -806,6 +900,12 @@ def main() -> None:
         help="--save 時に既存キーがある場合、確認なしで上書きする",
     )
 
+    return parser
+
+
+def main() -> None:
+    """CLIエントリポイント."""
+    parser = _build_parser()
     args = parser.parse_args()
 
     # --output json モード時は stdout を保護する
@@ -2187,72 +2287,115 @@ def run_search(args: argparse.Namespace) -> None:
 
 
 async def run_delete(args: argparse.Namespace) -> None:
-    """ソースをナレッジベースから削除する.
+    """ソースをナレッジベースから削除する（1 件以上を逐次削除）.
 
     MCP ツール rag_delete と同等の削除を CLI で実行する。
     ファイルを物理削除し、パイプライン経由でインデックス・metadata.db を更新する。
+    `--no-pipeline` 指定時は pipeline をスキップし git commit のみ実行する。
 
     Args:
         args: コマンドライン引数
     """
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
+    no_pipeline = _is_no_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
-    source_id: str = args.source_id
+    source_ids: list[str] = list(args.source_id)
 
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
-        try:
-            controller.source_store.remove_file(source_id)
-        except KeyError:
+        deleted: list[str] = []
+        not_found: list[str] = []
+        for sid in source_ids:
+            try:
+                controller.source_store.remove_file(sid)
+                deleted.append(sid)
+            except KeyError:
+                not_found.append(sid)
+
+        if not deleted:
+            # 全件 not_found → エラー終了 (既存挙動と整合)
             if json_out:
                 _output_result_logged(
-                    {"deleted": False, "not_found": True},
-                    "delete: source_id=%s, not_found=True",
-                    source_id,
+                    {"deleted": False, "not_found_ids": not_found},
+                    "delete: not_found_count=%d",
+                    len(not_found),
                 )
                 return
-            print(f"該当するソースが見つかりませんでした: {source_id}", file=sys.stderr)
-            sys.exit(1)
-
-        try:
-            summary = await controller.ingest_and_index(
-                f"delete: {source_id}",
-                progress_callback=progress_cb,
-                concurrency=settings.rag_embedding_concurrency,
-            )
-        except Exception:
-            logger.exception("削除パイプライン実行に失敗: %s", source_id)
-            if json_out:
-                _output_error(CliErrorCode.INTERNAL_ERROR, f"削除に失敗しました: {source_id}")
             print(
-                f"エラー: 削除に失敗しました: {source_id}",
+                f"該当するソースが見つかりませんでした: {', '.join(not_found)}",
                 file=sys.stderr,
             )
             sys.exit(1)
 
+        commit_message = (
+            f"delete: {deleted[0]}"
+            if len(deleted) == 1
+            else f"delete: {len(deleted)} 件"
+        )
+        summary = None
+        if no_pipeline:
+            controller.commit(commit_message)
+        else:
+            try:
+                summary = await controller.ingest_and_index(
+                    commit_message,
+                    progress_callback=progress_cb,
+                    concurrency=settings.rag_embedding_concurrency,
+                )
+            except Exception:
+                logger.exception("削除パイプライン実行に失敗: %s", commit_message)
+                if json_out:
+                    _output_error(CliErrorCode.INTERNAL_ERROR, f"削除に失敗しました: {commit_message}")
+                print(
+                    f"エラー: 削除に失敗しました: {commit_message}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
         if json_out:
+            data: dict[str, object] = {
+                "deleted": True,
+                "deleted_ids": deleted,
+                "deleted_count": len(deleted),
+                "not_found_ids": not_found,
+            }
+            # 共通仕様: --no-pipeline 時は pipeline フィールドを省略する
+            # （docs/specs/ingesters/common.md「stdout 案内文」セクション）
+            if summary is not None:
+                data["pipeline"] = _summary_to_dict(summary)
             _output_result_logged(
-                {
-                    "deleted": True,
-                    "pipeline": _summary_to_dict(summary),
-                },
-                "delete: source_id=%s, deleted=True",
-                source_id,
+                data,
+                "delete: deleted_count=%d, not_found_count=%d",
+                len(deleted),
+                len(not_found),
             )
             return
 
-        if summary.warnings:
-            print(f"パイプライン警告: {len(summary.warnings)}件")
-            for warn in summary.warnings:
-                print(f"  - {_format_pipeline_warning(warn)}")
-        if summary.errors:
-            print(f"パイプラインエラー: {len(summary.errors)}件")
-            for entry in summary.errors:
-                print(f"  - {_format_pipeline_error(entry)}")
-        print(f"削除しました: {source_id}")
+        if summary is not None:
+            if summary.warnings:
+                print(f"パイプライン警告: {len(summary.warnings)}件")
+                for warn in summary.warnings:
+                    print(f"  - {_format_pipeline_warning(warn)}")
+            if summary.errors:
+                print(f"パイプラインエラー: {len(summary.errors)}件")
+                for entry in summary.errors:
+                    print(f"  - {_format_pipeline_error(entry)}")
+        if not_found:
+            print(f"見つからなかったソース: {len(not_found)}件")
+            for sid in not_found:
+                print(f"  - {sid}")
+        # 単一削除時は source_id を併記（運用時のログ追跡性のため）
+        if len(deleted) == 1:
+            print(f"削除しました: {deleted[0]}")
+        else:
+            print(f"削除しました: {len(deleted)}件")
+            for sid in deleted:
+                print(f"  - {sid}")
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_add_journal(args: argparse.Namespace) -> None:
@@ -2307,7 +2450,7 @@ async def run_add_journal(args: argparse.Namespace) -> None:
         pipeline_summary = await controller.ingest_and_index(
             f"ingest(journal): add {args.title}",
             progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
+            concurrency=settings.rag_embedding_concurrency,
         )
         _print_ingest_result(
             ingest_result, pipeline_summary, context=f"journal/{args.repository}",
@@ -2538,11 +2681,12 @@ def _emit_bluesky_result(
 
 
 async def run_ingest_youtube(args: argparse.Namespace) -> None:
-    """YouTube 単一動画取り込み."""
+    """YouTube 動画取り込み（1 件以上の URL を逐次取り込み）."""
     from .pipeline.ingesters.youtube import YoutubeIngester
 
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
+    no_pipeline = _is_no_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
 
@@ -2560,27 +2704,59 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
         max_duration=settings.rag_youtube_max_duration,
     )
 
+    video_urls: list[str] = list(args.video_url)
+    context = f"動画: {video_urls[0]}" if len(video_urls) == 1 else f"動画 {len(video_urls)} 件"
+
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
-        try:
-            ingest_result = await youtube_ingester.ingest_video(args.video_url)
-        except (ValueError, TypeError) as e:
-            if json_out:
-                _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
-            logger.error("エラー: %s", e)
+        from .pipeline.ingesters._common import IngestErrorCategory, IngestErrorDetail
+        from .pipeline.ingesters._common import IngestResult as _IngestResult
+
+        results: "list[IngestResult]" = []
+        for url in video_urls:
+            try:
+                results.append(await youtube_ingester.ingest_video(url))
+            except (ValueError, TypeError) as e:
+                logger.error("ingest-youtube エラー (url=%s): %s", url, e)
+                err = _IngestResult()
+                err.errors = 1
+                err.error_details.append(IngestErrorDetail(
+                    category=IngestErrorCategory.METADATA_FETCH.value,
+                    target=url,
+                    message=f"取り込み失敗: {e}",
+                ))
+                results.append(err)
+
+        ingest_result = _merge_ingest_results(results)
+
+        # 全件失敗（placed=0 and overwritten=0 and errors>0）は設定エラー疑いのため exit 1
+        # 仕様: docs/specs/rebuild-stats.md「CLI exit code 体系」
+        if (
+            ingest_result.placed == 0
+            and ingest_result.overwritten == 0
+            and ingest_result.errors > 0
+        ):
+            _print_ingest_result(ingest_result, None, context=context, json_output=json_out)
             sys.exit(1)
 
         if ingest_result.is_empty():
-            _print_ingest_result(ingest_result, None, context=f"動画: {args.video_url}", json_output=json_out)
+            _print_ingest_result(ingest_result, None, context=context, json_output=json_out)
             return
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(youtube): {args.video_url}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
-        _print_ingest_result(ingest_result, pipeline_summary, context=f"動画: {args.video_url}", json_output=json_out)
+        commit_message = f"ingest(youtube): {len(video_urls)} 件"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
+        _print_ingest_result(ingest_result, pipeline_summary, context=context, json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
@@ -2628,12 +2804,20 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context=f"プレイリスト: {args.playlist_url}", json_output=json_out)
             return
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(youtube-playlist): {args.playlist_url}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = f"ingest(youtube-playlist): {args.playlist_url}"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"プレイリスト: {args.playlist_url}", json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 
@@ -2750,11 +2934,17 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             logger.error("エラー: %s", e)
             sys.exit(1)
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(bluesky): {args.handle}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = f"ingest(bluesky): {args.handle}"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _emit_bluesky_result(
             json_out=json_out,
             ingest_result=ingest_result,
@@ -2762,6 +2952,8 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             url_stats=url_stats,
             context=f"ハンドル: {args.handle}",
         )
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_crawl_zenn(args: argparse.Namespace) -> None:
@@ -2807,12 +2999,20 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 print("（上書きするには --force を指定してください）")
             return
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(zenn): {args.username}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = f"ingest(zenn): {args.username}"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"ユーザー: {args.username}", json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_ingest_bluesky(args: argparse.Namespace) -> None:
@@ -2862,11 +3062,17 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context="BlueSky ingest", json_output=json_out)
             return
 
-        pipeline_summary = await controller.ingest_and_index(
-            "ingest(bluesky/url)",
-            progress_callback=_output_progress if json_out else None,
-            concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = "ingest(bluesky/url)"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=_output_progress if json_out else None,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _emit_bluesky_result(
             json_out=json_out,
             ingest_result=ingest_result,
@@ -2874,6 +3080,8 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
             url_stats=url_stats,
             context="BlueSky ingest",
         )
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_ingest_zenn(args: argparse.Namespace) -> None:
@@ -2905,12 +3113,20 @@ async def run_ingest_zenn(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context="Zenn ingest", json_output=json_out)
             return
 
-        pipeline_summary = await controller.ingest_and_index(
-            "ingest(zenn/url)",
-            progress_callback=_output_progress if json_out else None,
-            concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = "ingest(zenn/url)"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=_output_progress if json_out else None,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _print_ingest_result(ingest_result, pipeline_summary, context="Zenn ingest", json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_add_document(args: argparse.Namespace) -> None:
@@ -3036,7 +3252,7 @@ async def run_add_document(args: argparse.Namespace) -> None:
         pipeline_summary = await controller.ingest_and_index(
             f"ingest(local): add {filename}",
             progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
+            concurrency=settings.rag_embedding_concurrency,
         )
         _print_ingest_result(ingest_result, pipeline_summary, context=display_name, json_output=json_out)
 
@@ -3086,12 +3302,20 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
             print(f"エラー: {first_detail}", file=sys.stderr)
             raise SystemExit(1)
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(local): crawl {args.dir_path}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
+        no_pipeline = _is_no_pipeline(args)
+        commit_message = f"ingest(local): crawl {args.dir_path}"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"ディレクトリ: {args.dir_path}", json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_site_ingest(args: argparse.Namespace) -> None:
@@ -3188,16 +3412,17 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             return
 
         # パイプライン処理
+        no_pipeline = _is_no_pipeline(args)
         pipeline_summary = None
         has_changes = (execution.ingest.placed + execution.ingest.overwritten) > 0
-        if has_changes and not args.download_only:
+        if has_changes and not no_pipeline:
             pipeline_summary = await controller.ingest_and_index(
                 f"ingest(web): site-ingest {display_url}",
                 progress_callback=progress_cb,
                 concurrency=settings.rag_embedding_concurrency,
             )
-        elif has_changes and args.download_only:
-            controller.commit(f"ingest(web): site-ingest {display_url} (download_only)")
+        elif has_changes and no_pipeline:
+            controller.commit(f"ingest(web): site-ingest {display_url} (no_pipeline)")
 
         # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
         if execution.scrapy_success and execution.crawl_result is not None:
@@ -3211,7 +3436,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 execution.ingest, pipeline_summary,
             )
             data["elapsed"] = round(elapsed, 1)
-            data["download_only"] = args.download_only
+            data["no_pipeline"] = no_pipeline
             if not execution.scrapy_success:
                 data["scrapy_exit_code"] = execution.scrapy_exit_code
             _output_result(data)
@@ -3223,8 +3448,8 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 json_output=False,
             )
             print(f"所要時間: {elapsed:.1f}秒")
-            if args.download_only:
-                print("パイプライン処理: スキップ（download_only）")
+            if no_pipeline:
+                _print_no_pipeline_notice(json_out=False)
             if not execution.scrapy_success:
                 print(
                     f"Scrapy exit_code={execution.scrapy_exit_code}（部分的な結果）",
@@ -3325,18 +3550,64 @@ def run_search_aozora(args: argparse.Namespace) -> None:
         )
 
 
+def _normalize_aozora_id(value: str) -> str:
+    """青空文庫の book_id / person_id を正規化する.
+
+    aozora ingester の AozoraIngester.add_work / crawl_author 内部で行う
+    ``s.strip().zfill(6)`` と同じロジック。CLI の bulk 入力で重複検出に使う。
+    SSoT は aozora ingester 側の実装。
+
+    空文字列・空白のみの入力も同じロジック (`"".strip().zfill(6) = "000000"`) で
+    正規化する。これにより、ingester 側の `if not book_id or not book_id.strip(): raise` で
+    エラーになる入力も bulk 内では一貫した識別子で集約される。
+    """
+    return value.strip().zfill(6)
+
+
 async def run_ingest_aozora(args: argparse.Namespace) -> None:
-    """青空文庫作品取り込み."""
+    """青空文庫作品取り込み（1 件以上の book_id を逐次取り込み）."""
     from .pipeline.ingesters.aozora import AozoraIngester, create_aozora_fetcher
 
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
+    no_pipeline = _is_no_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
+
+    raw_book_ids: list[str] = list(args.book_id)
+
+    # zfill 正規化後の重複検出（仕様: docs/specs/ingesters/aozora.md
+    # 「ingest-aozora 複数 ID 入力時の重複検出」）
+    seen: set[str] = set()
+    deduped: list[str] = []
+    duplicates: dict[str, list[str]] = {}
+    for raw in raw_book_ids:
+        normalized = _normalize_aozora_id(raw)
+        if normalized in seen:
+            duplicates.setdefault(normalized, []).append(raw)
+        else:
+            seen.add(normalized)
+            deduped.append(raw)
+            # 重複の発端入力を記録（後で WARN 出力時に元の入力もまとめる）
+            duplicates.setdefault(normalized, [raw])
+    for normalized_id, originals in duplicates.items():
+        if len(originals) > 1:
+            logger.warning(
+                "重複入力を検出: %s は同じ作品 (%s)。1 回のみ処理します",
+                ", ".join(repr(o) for o in originals),
+                normalized_id,
+            )
+
+    book_ids: list[str] = deduped
+    context = f"作品ID: {book_ids[0]}" if len(book_ids) == 1 else f"作品 {len(book_ids)} 件"
 
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
+        from .pipeline.ingesters._common import IngestErrorCategory, IngestErrorDetail
+        from .pipeline.ingesters._common import IngestResult as _IngestResult
+
+        results: "list[IngestResult]" = []
         try:
             async with create_aozora_fetcher(settings) as fetcher:
                 aozora_ingester = AozoraIngester(
@@ -3344,19 +3615,55 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
                     fetcher=fetcher,
                     max_works=settings.rag_aozora_max_works,
                 )
-                ingest_result = await aozora_ingester.add_work(args.book_id)
+                for bid in book_ids:
+                    try:
+                        results.append(await aozora_ingester.add_work(bid))
+                    except (ValueError, TypeError) as e:
+                        logger.error("ingest-aozora エラー (book_id=%s): %s", bid, e)
+                        err = _IngestResult()
+                        err.errors = 1
+                        err.error_details.append(IngestErrorDetail(
+                            category=IngestErrorCategory.METADATA_FETCH.value,
+                            target=bid,
+                            message=f"取り込み失敗: {e}",
+                        ))
+                        results.append(err)
         except (ValueError, TypeError) as e:
+            # fetcher 初期化など、ループ外の前提エラー
             if json_out:
                 _output_error(CliErrorCode.DEPENDENCY_UNAVAILABLE, str(e))
             logger.error("エラー: %s", e)
             sys.exit(1)
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(aozora): book_id={args.book_id}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
-        _print_ingest_result(ingest_result, pipeline_summary, context=f"作品ID: {args.book_id}", json_output=json_out)
+        ingest_result = _merge_ingest_results(results)
+
+        # 全件失敗（placed=0 and overwritten=0 and errors>0）は設定エラー疑いのため exit 1
+        # 仕様: docs/specs/rebuild-stats.md「CLI exit code 体系」
+        if (
+            ingest_result.placed == 0
+            and ingest_result.overwritten == 0
+            and ingest_result.errors > 0
+        ):
+            _print_ingest_result(ingest_result, None, context=context, json_output=json_out)
+            sys.exit(1)
+
+        if ingest_result.is_empty():
+            _print_ingest_result(ingest_result, None, context=context, json_output=json_out)
+            return
+
+        commit_message = f"ingest(aozora): {len(book_ids)} 件"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
+        _print_ingest_result(ingest_result, pipeline_summary, context=context, json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
@@ -3364,6 +3671,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
     from .pipeline.ingesters.aozora import AozoraIngester, create_aozora_fetcher
 
     json_out = _is_json_output(args)
+    no_pipeline = _is_no_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
 
@@ -3392,12 +3700,19 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
             logger.error("エラー: %s", e)
             sys.exit(1)
 
-        pipeline_summary = await controller.ingest_and_index(
-            f"ingest(aozora): person_id={args.person_id}",
-            progress_callback=progress_cb,
-        concurrency=settings.rag_embedding_concurrency,
-        )
+        commit_message = f"ingest(aozora): person_id={args.person_id}"
+        if no_pipeline:
+            _commit_for_no_pipeline(controller, commit_message)
+            pipeline_summary = None
+        else:
+            pipeline_summary = await controller.ingest_and_index(
+                commit_message,
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"著者ID: {args.person_id}", json_output=json_out)
+        if no_pipeline:
+            _print_no_pipeline_notice(json_out)
 
 
 if __name__ == "__main__":

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -358,13 +358,13 @@ def _add_output_option(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_no_pipeline_option(parser: argparse.ArgumentParser) -> None:
-    """サブコマンドパーサーに --no-pipeline オプションを追加する.
+def _add_skip_pipeline_option(parser: argparse.ArgumentParser) -> None:
+    """サブコマンドパーサーに --skip-pipeline オプションを追加する.
 
-    共通仕様は docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」を参照。
+    共通仕様は docs/specs/ingesters/common.md「`--skip-pipeline` フラグ共通仕様」を参照。
     """
     parser.add_argument(
-        "--no-pipeline",
+        "--skip-pipeline",
         action="store_true",
         default=False,
         help=(
@@ -375,41 +375,41 @@ def _add_no_pipeline_option(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _is_no_pipeline(args: argparse.Namespace) -> bool:
-    """args から --no-pipeline 指定の有無を取得する.
+def _is_skip_pipeline(args: argparse.Namespace) -> bool:
+    """args から --skip-pipeline 指定の有無を取得する.
 
-    `getattr` でデフォルトを偽として扱うため、--no-pipeline 未対応のサブコマンドが
+    `getattr` でデフォルトを偽として扱うため、--skip-pipeline 未対応のサブコマンドが
     呼ばれた場合でも安全に False を返す。
     """
-    return bool(getattr(args, "no_pipeline", False))
+    return bool(getattr(args, "skip_pipeline", False))
 
 
-def _print_no_pipeline_notice(json_out: bool) -> None:
-    """--no-pipeline 指定時に stdout へ案内文を出力する.
+def _print_skip_pipeline_notice(json_out: bool) -> None:
+    """--skip-pipeline 指定時に stdout へ案内文を出力する.
 
     `json_out=True` で呼ばれた場合は早期 return し何も出力しない（JSON 構造への反映は
     呼び出し側で `pipeline` フィールドの省略等で行う前提）。
-    共通仕様は docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」を参照。
+    共通仕様は docs/specs/ingesters/common.md「`--skip-pipeline` フラグ共通仕様」を参照。
     """
     if json_out:
         return
     print(
-        "パイプライン未実行（--no-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。",
+        "パイプライン未実行（--skip-pipeline 指定）。後で `uv run python -m rag.cli rebuild --mode incremental` を実行してください。",
     )
 
 
-def _commit_for_no_pipeline(
+def _commit_for_skip_pipeline(
     controller: "PipelineController",
     commit_message: str,
 ) -> None:
-    """`--no-pipeline` 経路の commit のみ実行（pipeline 処理はスキップ）.
+    """`--skip-pipeline` 経路の commit のみ実行（pipeline 処理はスキップ）.
 
     `controller.ingest_and_index()` 内では git commit + converter + indexer が一括実行されるが、
-    `--no-pipeline` 指定時は converter / indexer をスキップしつつ source_store の commit は
+    `--skip-pipeline` 指定時は converter / indexer をスキップしつつ source_store の commit は
     実行する必要がある（後段の `rebuild --mode incremental` が差分を検出できるようにするため）。
     本ヘルパーは commit のみ実行し pipeline は呼ばない。
 
-    仕様: docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」
+    仕様: docs/specs/ingesters/common.md「`--skip-pipeline` フラグ共通仕様」
     """
     controller.commit(commit_message)
 
@@ -766,7 +766,7 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     # delete サブコマンド
     delete_parser = subparsers.add_parser("delete", help="ソースをナレッジベースから論理削除")
     delete_parser.add_argument("source_id", nargs="+", help="削除するソース識別子（source_id、1 件以上）")
-    _add_no_pipeline_option(delete_parser)
+    _add_skip_pipeline_option(delete_parser)
     _add_output_option(delete_parser)
 
     # --- インジェスト系サブコマンド ---
@@ -774,14 +774,14 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     # ingest-youtube: YouTube 単一動画取り込み
     yt_parser = subparsers.add_parser("ingest-youtube", help="YouTube 動画を取り込み")
     yt_parser.add_argument("video_url", nargs="+", help="YouTube 動画 URL（1 件以上）")
-    _add_no_pipeline_option(yt_parser)
+    _add_skip_pipeline_option(yt_parser)
     _add_output_option(yt_parser)
 
     # ingest-youtube-playlist: YouTube プレイリスト一括取り込み
     ytpl_parser = subparsers.add_parser("ingest-youtube-playlist", help="YouTube プレイリストを一括取り込み")
     ytpl_parser.add_argument("playlist_url", help="YouTube プレイリスト URL")
     ytpl_parser.add_argument("--max-videos", type=int, default=None, help="取得する最大動画数")
-    _add_no_pipeline_option(ytpl_parser)
+    _add_skip_pipeline_option(ytpl_parser)
     _add_output_option(ytpl_parser)
 
     # crawl-bluesky: BlueSky 取り込み
@@ -797,13 +797,13 @@ def _build_parser() -> "_JsonAwareArgumentParser":
         help="リポストを含めるか（--no-include-reposts で除外）",
     )
     bs_parser.add_argument("--force", action="store_true", default=False, help="上書き再取得モード（既存ファイルを上書き + メディア再DL）")
-    _add_no_pipeline_option(bs_parser)
+    _add_skip_pipeline_option(bs_parser)
     _add_output_option(bs_parser)
 
     # ingest-bluesky: BlueSky 単一投稿取り込み
     rbs_parser = subparsers.add_parser("ingest-bluesky", help="BlueSky 投稿を URL 指定で取り込み")
     rbs_parser.add_argument("url", nargs="+", help="BlueSky 投稿の URL（1 件以上）")
-    _add_no_pipeline_option(rbs_parser)
+    _add_skip_pipeline_option(rbs_parser)
     _add_output_option(rbs_parser)
 
     # crawl-zenn: Zenn 取り込み
@@ -812,13 +812,13 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     zenn_parser.add_argument("--max-articles", type=int, default=None, help="取得する最大コンテンツ数")
     zenn_parser.add_argument("--content-type", choices=["articles", "scraps", "all"], default="all", help="取得対象")
     zenn_parser.add_argument("--force", action="store_true", default=False, help="既存ファイルを上書きする（デフォルト: スキップ）")
-    _add_no_pipeline_option(zenn_parser)
+    _add_skip_pipeline_option(zenn_parser)
     _add_output_option(zenn_parser)
 
     # ingest-zenn: Zenn 単一コンテンツ取り込み
     rzenn_parser = subparsers.add_parser("ingest-zenn", help="Zenn コンテンツを URL 指定で取り込み")
     rzenn_parser.add_argument("url", nargs="+", help="Zenn コンテンツの URL（1 件以上）")
-    _add_no_pipeline_option(rzenn_parser)
+    _add_skip_pipeline_option(rzenn_parser)
     _add_output_option(rzenn_parser)
 
     # add-document: 単一ドキュメント取り込み
@@ -836,7 +836,7 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     crawldoc_parser.add_argument("dir_path", help="取り込み対象ディレクトリのパス")
     crawldoc_parser.add_argument("--pattern", default="**/*", help="glob パターン")
     crawldoc_parser.add_argument("--upload-mode", choices=["fail", "replace"], default="fail", help="同名ファイル存在時の動作")
-    _add_no_pipeline_option(crawldoc_parser)
+    _add_skip_pipeline_option(crawldoc_parser)
     _add_output_option(crawldoc_parser)
 
     # site-ingest: Scrapy によるサイト一括取り込み
@@ -845,7 +845,7 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     siteingest_parser.add_argument("--url-pattern", default="", help="URL フィルタパターン（正規表現、クロールモードのみ）")
     siteingest_parser.add_argument("--max-pages", type=int, default=None, help="ページ数上限（クロールモードのみ）")
     siteingest_parser.add_argument("--force", action="store_true", help="JOBDIR を削除して再クロール（クロールモードのみ）")
-    _add_no_pipeline_option(siteingest_parser)
+    _add_skip_pipeline_option(siteingest_parser)
     _add_output_option(siteingest_parser)
 
     # update-aozora-catalog: 青空文庫カタログ更新
@@ -862,14 +862,14 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     # ingest-aozora: 青空文庫作品取り込み（バルク対応）
     ingest_aozora_parser = subparsers.add_parser("ingest-aozora", help="青空文庫の作品を取り込み")
     ingest_aozora_parser.add_argument("book_id", nargs="+", help="青空文庫の作品 ID（1 件以上）")
-    _add_no_pipeline_option(ingest_aozora_parser)
+    _add_skip_pipeline_option(ingest_aozora_parser)
     _add_output_option(ingest_aozora_parser)
 
     # ingest-aozora-author: 青空文庫著者一括取り込み
     ingest_aozora_author_parser = subparsers.add_parser("ingest-aozora-author", help="青空文庫の著者作品を一括取り込み")
     ingest_aozora_author_parser.add_argument("person_id", help="著者の人物 ID（search-aozora で確認）")
     ingest_aozora_author_parser.add_argument("--max-works", type=int, default=None, help="取得する最大作品数")
-    _add_no_pipeline_option(ingest_aozora_author_parser)
+    _add_skip_pipeline_option(ingest_aozora_author_parser)
     _add_output_option(ingest_aozora_author_parser)
 
     # add-journal: 単一ジャーナルエントリの登録
@@ -2291,14 +2291,14 @@ async def run_delete(args: argparse.Namespace) -> None:
 
     MCP ツール rag_delete と同等の削除を CLI で実行する。
     ファイルを物理削除し、パイプライン経由でインデックス・metadata.db を更新する。
-    `--no-pipeline` 指定時は pipeline をスキップし git commit のみ実行する。
+    `--skip-pipeline` 指定時は pipeline をスキップし git commit のみ実行する。
 
     Args:
         args: コマンドライン引数
     """
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
-    no_pipeline = _is_no_pipeline(args)
+    skip_pipeline = _is_skip_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
     source_ids: list[str] = list(args.source_id)
@@ -2336,7 +2336,7 @@ async def run_delete(args: argparse.Namespace) -> None:
             else f"delete: {len(deleted)} 件"
         )
         summary = None
-        if no_pipeline:
+        if skip_pipeline:
             controller.commit(commit_message)
         else:
             try:
@@ -2362,7 +2362,7 @@ async def run_delete(args: argparse.Namespace) -> None:
                 "deleted_count": len(deleted),
                 "not_found_ids": not_found,
             }
-            # 共通仕様: --no-pipeline 時は pipeline フィールドを省略する
+            # 共通仕様: --skip-pipeline 時は pipeline フィールドを省略する
             # （docs/specs/ingesters/common.md「stdout 案内文」セクション）
             if summary is not None:
                 data["pipeline"] = _summary_to_dict(summary)
@@ -2394,8 +2394,8 @@ async def run_delete(args: argparse.Namespace) -> None:
             print(f"削除しました: {len(deleted)}件")
             for sid in deleted:
                 print(f"  - {sid}")
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_add_journal(args: argparse.Namespace) -> None:
@@ -2686,7 +2686,7 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
 
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
-    no_pipeline = _is_no_pipeline(args)
+    skip_pipeline = _is_skip_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
 
@@ -2717,7 +2717,10 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
         for url in video_urls:
             try:
                 results.append(await youtube_ingester.ingest_video(url))
-            except (ValueError, TypeError) as e:
+            except Exception as e:
+                # bulk loop の partial result loss 防止のため、ループ内例外は per-item として
+                # IngestResult.errors に変換し処理継続。Exception 限定のため KeyboardInterrupt
+                # 等の BaseException 系（キャンセル）は捕捉せず正常に伝播する。
                 logger.error("ingest-youtube エラー (url=%s): %s", url, e)
                 err = _IngestResult()
                 err.errors = 1
@@ -2745,8 +2748,8 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
             return
 
         commit_message = f"ingest(youtube): {len(video_urls)} 件"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -2755,8 +2758,8 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=context, json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
@@ -2804,10 +2807,10 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context=f"プレイリスト: {args.playlist_url}", json_output=json_out)
             return
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = f"ingest(youtube-playlist): {args.playlist_url}"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -2816,8 +2819,8 @@ async def run_ingest_youtube_playlist(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"プレイリスト: {args.playlist_url}", json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 
@@ -2934,10 +2937,10 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             logger.error("エラー: %s", e)
             sys.exit(1)
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = f"ingest(bluesky): {args.handle}"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -2952,8 +2955,8 @@ async def run_crawl_bluesky(args: argparse.Namespace) -> None:
             url_stats=url_stats,
             context=f"ハンドル: {args.handle}",
         )
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_crawl_zenn(args: argparse.Namespace) -> None:
@@ -2999,10 +3002,10 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 print("（上書きするには --force を指定してください）")
             return
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = f"ingest(zenn): {args.username}"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3011,8 +3014,8 @@ async def run_crawl_zenn(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"ユーザー: {args.username}", json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_ingest_bluesky(args: argparse.Namespace) -> None:
@@ -3062,10 +3065,10 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context="BlueSky ingest", json_output=json_out)
             return
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = "ingest(bluesky/url)"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3080,8 +3083,8 @@ async def run_ingest_bluesky(args: argparse.Namespace) -> None:
             url_stats=url_stats,
             context="BlueSky ingest",
         )
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_ingest_zenn(args: argparse.Namespace) -> None:
@@ -3113,10 +3116,10 @@ async def run_ingest_zenn(args: argparse.Namespace) -> None:
             _print_ingest_result(ingest_result, None, context="Zenn ingest", json_output=json_out)
             return
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = "ingest(zenn/url)"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3125,8 +3128,8 @@ async def run_ingest_zenn(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context="Zenn ingest", json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_add_document(args: argparse.Namespace) -> None:
@@ -3302,10 +3305,10 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
             print(f"エラー: {first_detail}", file=sys.stderr)
             raise SystemExit(1)
 
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         commit_message = f"ingest(local): crawl {args.dir_path}"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3314,8 +3317,8 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"ディレクトリ: {args.dir_path}", json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_site_ingest(args: argparse.Namespace) -> None:
@@ -3412,17 +3415,17 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             return
 
         # パイプライン処理
-        no_pipeline = _is_no_pipeline(args)
+        skip_pipeline = _is_skip_pipeline(args)
         pipeline_summary = None
         has_changes = (execution.ingest.placed + execution.ingest.overwritten) > 0
-        if has_changes and not no_pipeline:
+        if has_changes and not skip_pipeline:
             pipeline_summary = await controller.ingest_and_index(
                 f"ingest(web): site-ingest {display_url}",
                 progress_callback=progress_cb,
                 concurrency=settings.rag_embedding_concurrency,
             )
-        elif has_changes and no_pipeline:
-            controller.commit(f"ingest(web): site-ingest {display_url} (no_pipeline)")
+        elif has_changes and skip_pipeline:
+            controller.commit(f"ingest(web): site-ingest {display_url} (skip_pipeline)")
 
         # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
         if execution.scrapy_success and execution.crawl_result is not None:
@@ -3436,7 +3439,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 execution.ingest, pipeline_summary,
             )
             data["elapsed"] = round(elapsed, 1)
-            data["no_pipeline"] = no_pipeline
+            data["skip_pipeline"] = skip_pipeline
             if not execution.scrapy_success:
                 data["scrapy_exit_code"] = execution.scrapy_exit_code
             _output_result(data)
@@ -3448,8 +3451,8 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 json_output=False,
             )
             print(f"所要時間: {elapsed:.1f}秒")
-            if no_pipeline:
-                _print_no_pipeline_notice(json_out=False)
+            if skip_pipeline:
+                _print_skip_pipeline_notice(json_out=False)
             if not execution.scrapy_success:
                 print(
                     f"Scrapy exit_code={execution.scrapy_exit_code}（部分的な結果）",
@@ -3570,7 +3573,7 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
 
     json_out = _is_json_output(args)
     progress_cb = _output_progress if json_out else None
-    no_pipeline = _is_no_pipeline(args)
+    skip_pipeline = _is_skip_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
 
@@ -3618,7 +3621,10 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
                 for bid in book_ids:
                     try:
                         results.append(await aozora_ingester.add_work(bid))
-                    except (ValueError, TypeError) as e:
+                    except Exception as e:
+                        # bulk loop の partial result loss 防止のため、ループ内例外は per-item として
+                        # IngestResult.errors に変換し処理継続。Exception 限定のため KeyboardInterrupt
+                        # 等の BaseException 系（キャンセル）は捕捉せず正常に伝播する。
                         logger.error("ingest-aozora エラー (book_id=%s): %s", bid, e)
                         err = _IngestResult()
                         err.errors = 1
@@ -3652,8 +3658,8 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
             return
 
         commit_message = f"ingest(aozora): {len(book_ids)} 件"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3662,8 +3668,8 @@ async def run_ingest_aozora(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=context, json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
@@ -3671,7 +3677,7 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
     from .pipeline.ingesters.aozora import AozoraIngester, create_aozora_fetcher
 
     json_out = _is_json_output(args)
-    no_pipeline = _is_no_pipeline(args)
+    skip_pipeline = _is_skip_pipeline(args)
 
     controller, settings = _build_cli_pipeline_controller()
 
@@ -3701,8 +3707,8 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
             sys.exit(1)
 
         commit_message = f"ingest(aozora): person_id={args.person_id}"
-        if no_pipeline:
-            _commit_for_no_pipeline(controller, commit_message)
+        if skip_pipeline:
+            _commit_for_skip_pipeline(controller, commit_message)
             pipeline_summary = None
         else:
             pipeline_summary = await controller.ingest_and_index(
@@ -3711,8 +3717,8 @@ async def run_ingest_aozora_author(args: argparse.Namespace) -> None:
                 concurrency=settings.rag_embedding_concurrency,
             )
         _print_ingest_result(ingest_result, pipeline_summary, context=f"著者ID: {args.person_id}", json_output=json_out)
-        if no_pipeline:
-            _print_no_pipeline_notice(json_out)
+        if skip_pipeline:
+            _print_skip_pipeline_notice(json_out)
 
 
 if __name__ == "__main__":

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -360,7 +360,7 @@ class RAGSettings(BaseModel):
     hnsw_search_ef: int = Field(ge=10, le=2000)
 
     # サイト一括取り込み（Scrapy subprocess）
-    # download_only 指定時も source_store への git commit は実行される（後から rebuild で差分処理可能）
+    # --no-pipeline 指定時も source_store への git commit は実行される（後から rebuild で差分処理可能）
     site_ingest_delay_sec: float = Field(ge=0.05, le=60.0)
     site_ingest_max_pages: int = Field(ge=1, le=1000)
     site_ingest_download_timeout: int = Field(ge=1, le=300)

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -360,7 +360,7 @@ class RAGSettings(BaseModel):
     hnsw_search_ef: int = Field(ge=10, le=2000)
 
     # サイト一括取り込み（Scrapy subprocess）
-    # --no-pipeline 指定時も source_store への git commit は実行される（後から rebuild で差分処理可能）
+    # --skip-pipeline 指定時も source_store への git commit は実行される（後から rebuild で差分処理可能）
     site_ingest_delay_sec: float = Field(ge=0.05, le=60.0)
     site_ingest_max_pages: int = Field(ge=1, le=1000)
     site_ingest_download_timeout: int = Field(ge=1, le=300)

--- a/src/rag/server/tools/delete.py
+++ b/src/rag/server/tools/delete.py
@@ -14,7 +14,7 @@ from ...pipeline.models import format_pipeline_error as _format_pipeline_error
 @mcp.tool()
 async def rag_delete(
     source_ids: list[str],
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG delete - ソース識別子指定でナレッジから削除（bulk 対応）.
@@ -27,17 +27,21 @@ async def rag_delete(
 
     Args:
         source_ids: 削除するソース識別子のリスト（1 件以上）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価。bulk 削除時の高速化用
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価。bulk 削除時の高速化用
 
     Returns:
         削除結果のメッセージ
     """
     if not source_ids:
         return "エラー: source_ids が空です（1 件以上指定してください）"
-    cli_args: list[str] = list(source_ids)
-    if defer_indexing:
-        cli_args.append("--no-pipeline")
+    # オプション注入対策: ユーザー入力の positional 群（source_ids）は `--` 以降に置く。
+    # source_id が `-`/`--` で始まる場合に argparse がオプションとして誤解釈するのを防ぐ。
+    cli_args: list[str] = []
+    if skip_pipeline:
+        cli_args.append("--skip-pipeline")
+    cli_args.append("--")
+    cli_args.extend(source_ids)
     context = source_ids[0] if len(source_ids) == 1 else f"{len(source_ids)} 件"
     try:
         result = await cli_subprocess._run_cli_subprocess("delete", cli_args, ctx=ctx)

--- a/src/rag/server/tools/delete.py
+++ b/src/rag/server/tools/delete.py
@@ -12,25 +12,43 @@ from ...pipeline.models import format_pipeline_error as _format_pipeline_error
 
 
 @mcp.tool()
-async def rag_delete(source_id: str, ctx: MCPContext | None = None) -> str:
-    """[rag-knowledge] RAG delete - ソース識別子指定でナレッジから削除.
+async def rag_delete(
+    source_ids: list[str],
+    defer_indexing: bool = False,
+    ctx: MCPContext | None = None,
+) -> str:
+    """[rag-knowledge] RAG delete - ソース識別子指定でナレッジから削除（bulk 対応）.
 
-    knowledge base, remove source, delete document.
+    knowledge base, remove source, delete document, bulk.
     source_store からファイルを物理削除し、パイプライン経由で
     インデックス・metadata.db を更新する。
     git 管理下のため、削除後も git checkout で復旧可能。
+    複数 source_id を 1 リクエストで処理可能。末尾 1 回だけパイプラインが走る。
 
     Args:
-        source_id: 削除するソース識別子（source_id）
+        source_ids: 削除するソース識別子のリスト（1 件以上）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価。bulk 削除時の高速化用
 
     Returns:
         削除結果のメッセージ
     """
+    if not source_ids:
+        return "エラー: source_ids が空です（1 件以上指定してください）"
+    cli_args: list[str] = list(source_ids)
+    if defer_indexing:
+        cli_args.append("--no-pipeline")
+    context = source_ids[0] if len(source_ids) == 1 else f"{len(source_ids)} 件"
     try:
-        result = await cli_subprocess._run_cli_subprocess("delete", [source_id], ctx=ctx)
+        result = await cli_subprocess._run_cli_subprocess("delete", cli_args, ctx=ctx)
 
-        if result.get("not_found"):
-            return f"該当するソースが見つかりませんでした: {source_id}"
+        # 全件 not_found のケース（CLI 側で {"deleted": False, "not_found_ids": [...]} を返す）
+        if result.get("deleted") is False:
+            not_found_ids = result.get("not_found_ids", [])
+            return f"該当するソースが見つかりませんでした: {', '.join(not_found_ids) or context}"
+
+        deleted_count = result.get("deleted_count", 0)
+        not_found_ids = result.get("not_found_ids", []) or []
 
         pipeline_data = result.get("pipeline")
         if pipeline_data:
@@ -39,7 +57,11 @@ async def rag_delete(source_id: str, ctx: MCPContext | None = None) -> str:
                 errors_text = "; ".join(
                     _format_pipeline_error(e) for e in pipeline_summary.errors
                 )
-                return f"削除しましたが、パイプラインでエラーが発生しました: {source_id} ({errors_text})"
-        return f"削除しました: {source_id}"
+                return f"削除しましたが、パイプラインでエラーが発生しました: {context} ({errors_text})"
+
+        msg = f"削除しました: {deleted_count}件"
+        if not_found_ids:
+            msg += f"（見つからなかったソース: {len(not_found_ids)}件）"
+        return msg
     except CLISubprocessError as e:
-        return e.format_mcp_error(f"削除に失敗しました。source_id: {source_id}")
+        return e.format_mcp_error(f"削除に失敗しました。{context}")

--- a/src/rag/server/tools/ingest_aozora.py
+++ b/src/rag/server/tools/ingest_aozora.py
@@ -71,7 +71,7 @@ async def rag_search_aozora(
 @mcp.tool()
 async def rag_add_aozora(
     book_ids: list[str],
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add Aozora - 青空文庫の作品を取り込み.
@@ -82,8 +82,8 @@ async def rag_add_aozora(
 
     Args:
         book_ids: 青空文庫の作品 ID リスト（1 件以上、カタログ検索で取得）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -91,9 +91,13 @@ async def rag_add_aozora(
     label = _fake_mode_labels(_AOZORA_INGEST_FAKE_SOURCES)
     if not book_ids:
         return label + "エラー: book_ids が空です（1 件以上指定してください）"
-    cli_args: list[str] = list(book_ids)
-    if defer_indexing:
-        cli_args.append("--no-pipeline")
+    # オプション注入対策: ユーザー入力の positional 群（book_ids）は `--` 以降に置く。
+    # book_id が `-`/`--` で始まる場合に argparse がオプションとして誤解釈するのを防ぐ。
+    cli_args: list[str] = []
+    if skip_pipeline:
+        cli_args.append("--skip-pipeline")
+    cli_args.append("--")
+    cli_args.extend(book_ids)
     context = f"作品ID: {book_ids[0]}" if len(book_ids) == 1 else f"作品 {len(book_ids)} 件"
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-aozora", cli_args, ctx=ctx)
@@ -106,7 +110,7 @@ async def rag_add_aozora(
 async def rag_crawl_aozora(
     person_id: str,
     max_works: int | None = None,
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Aozora - 青空文庫の著者作品を一括取り込み.
@@ -117,8 +121,8 @@ async def rag_crawl_aozora(
     Args:
         person_id: 著者の人物 ID（rag_search_aozora で確認可能）
         max_works: 取得する最大作品数（未指定時は設定値を使用、許容範囲: 1〜500）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -126,8 +130,8 @@ async def rag_crawl_aozora(
     args: list[str] = [person_id]
     if max_works is not None:
         args.extend(["--max-works", str(max_works)])
-    if defer_indexing:
-        args.append("--no-pipeline")
+    if skip_pipeline:
+        args.append("--skip-pipeline")
 
     label = _fake_mode_labels(_AOZORA_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_aozora.py
+++ b/src/rag/server/tools/ingest_aozora.py
@@ -70,32 +70,43 @@ async def rag_search_aozora(
 
 @mcp.tool()
 async def rag_add_aozora(
-    book_id: str,
+    book_ids: list[str],
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add Aozora - 青空文庫の作品を取り込み.
 
-    knowledge base, Aozora, aozora bunko, ingest, book, work.
+    knowledge base, Aozora, aozora bunko, ingest, book, work, bulk.
     指定作品の XHTML を取得し、ナレッジベースに取り込む。著作権フリーの作品のみ対応。
+    複数 book_id を 1 リクエストで処理可能。zfill(6) 後の重複入力は自動排除される。
 
     Args:
-        book_id: 青空文庫の作品 ID（カタログ検索で取得）
+        book_ids: 青空文庫の作品 ID リスト（1 件以上、カタログ検索で取得）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
     """
     label = _fake_mode_labels(_AOZORA_INGEST_FAKE_SOURCES)
+    if not book_ids:
+        return label + "エラー: book_ids が空です（1 件以上指定してください）"
+    cli_args: list[str] = list(book_ids)
+    if defer_indexing:
+        cli_args.append("--no-pipeline")
+    context = f"作品ID: {book_ids[0]}" if len(book_ids) == 1 else f"作品 {len(book_ids)} 件"
     try:
-        result = await cli_subprocess._run_cli_subprocess("ingest-aozora", [book_id], ctx=ctx)
-        return label + cli_subprocess._format_cli_ingest_result(result, context=f"作品ID: {book_id}")
+        result = await cli_subprocess._run_cli_subprocess("ingest-aozora", cli_args, ctx=ctx)
+        return label + cli_subprocess._format_cli_ingest_result(result, context=context)
     except CLISubprocessError as e:
-        return label + e.format_mcp_error(f"青空文庫作品の取り込みに失敗しました（作品ID: {book_id}）")
+        return label + e.format_mcp_error(f"青空文庫作品の取り込みに失敗しました（{context}）")
 
 
 @mcp.tool()
 async def rag_crawl_aozora(
     person_id: str,
     max_works: int | None = None,
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Aozora - 青空文庫の著者作品を一括取り込み.
@@ -106,6 +117,8 @@ async def rag_crawl_aozora(
     Args:
         person_id: 著者の人物 ID（rag_search_aozora で確認可能）
         max_works: 取得する最大作品数（未指定時は設定値を使用、許容範囲: 1〜500）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -113,6 +126,8 @@ async def rag_crawl_aozora(
     args: list[str] = [person_id]
     if max_works is not None:
         args.extend(["--max-works", str(max_works)])
+    if defer_indexing:
+        args.append("--no-pipeline")
 
     label = _fake_mode_labels(_AOZORA_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_bluesky.py
+++ b/src/rag/server/tools/ingest_bluesky.py
@@ -17,7 +17,7 @@ async def rag_crawl_bluesky(
     max_posts: int | None = None,
     include_reposts: bool | None = None,
     force: bool = False,
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl BlueSky - BlueSky 投稿を AT Protocol API 経由で取得し一括取り込み.
@@ -31,8 +31,8 @@ async def rag_crawl_bluesky(
         max_posts: 取得する最大投稿数（タイムライン全体に適用、未指定時は設定値を使用、許容範囲: 1〜1000）
         include_reposts: タイムラインにリポストを含めるか（未指定時は設定値を使用）
         force: 上書き再取得モード。既存ファイルを上書きし、メディアDLと投稿内URL先の再取得も実行する
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -49,8 +49,8 @@ async def rag_crawl_bluesky(
         args.append("--no-include-reposts")
     if force:
         args.append("--force")
-    if defer_indexing:
-        args.append("--no-pipeline")
+    if skip_pipeline:
+        args.append("--skip-pipeline")
 
     label = _fake_mode_labels(_BLUESKY_INGEST_FAKE_SOURCES)
     try:
@@ -63,7 +63,7 @@ async def rag_crawl_bluesky(
 @mcp.tool()
 async def rag_add_bluesky(
     urls: list[str],
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add BlueSky - BlueSky 投稿を URL 指定で取り込み.
@@ -74,8 +74,8 @@ async def rag_add_bluesky(
 
     Args:
         urls: BlueSky 投稿の URL リスト（1 件以上、例: ["https://bsky.app/profile/user.bsky.social/post/abc123"]）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -83,9 +83,13 @@ async def rag_add_bluesky(
     label = _fake_mode_labels(_BLUESKY_INGEST_FAKE_SOURCES)
     if not urls:
         return label + "エラー: urls が空です（1 件以上指定してください）"
-    args: list[str] = list(urls)
-    if defer_indexing:
-        args.append("--no-pipeline")
+    # オプション注入対策: ユーザー入力の positional 群（urls）は `--` 以降に置く。
+    # URL が `-`/`--` で始まる場合に argparse がオプションとして誤解釈するのを防ぐ。
+    args: list[str] = []
+    if skip_pipeline:
+        args.append("--skip-pipeline")
+    args.append("--")
+    args.extend(urls)
 
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-bluesky", args, ctx=ctx)

--- a/src/rag/server/tools/ingest_bluesky.py
+++ b/src/rag/server/tools/ingest_bluesky.py
@@ -17,6 +17,7 @@ async def rag_crawl_bluesky(
     max_posts: int | None = None,
     include_reposts: bool | None = None,
     force: bool = False,
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl BlueSky - BlueSky 投稿を AT Protocol API 経由で取得し一括取り込み.
@@ -30,6 +31,8 @@ async def rag_crawl_bluesky(
         max_posts: 取得する最大投稿数（タイムライン全体に適用、未指定時は設定値を使用、許容範囲: 1〜1000）
         include_reposts: タイムラインにリポストを含めるか（未指定時は設定値を使用）
         force: 上書き再取得モード。既存ファイルを上書きし、メディアDLと投稿内URL先の再取得も実行する
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -46,6 +49,8 @@ async def rag_crawl_bluesky(
         args.append("--no-include-reposts")
     if force:
         args.append("--force")
+    if defer_indexing:
+        args.append("--no-pipeline")
 
     label = _fake_mode_labels(_BLUESKY_INGEST_FAKE_SOURCES)
     try:
@@ -58,23 +63,30 @@ async def rag_crawl_bluesky(
 @mcp.tool()
 async def rag_add_bluesky(
     urls: list[str],
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add BlueSky - BlueSky 投稿を URL 指定で取り込み.
 
-    knowledge base, BlueSky, add, ingest, single post.
+    knowledge base, BlueSky, add, ingest, single post, bulk.
     指定 URL の BlueSky 投稿を取得し、ナレッジベースに取り込む。
     メディア（画像・動画）も DL する。既存投稿は上書きする。複数 URL を一括指定可能。
 
     Args:
-        urls: BlueSky 投稿の URL リスト（例: ["https://bsky.app/profile/user.bsky.social/post/abc123"]）
+        urls: BlueSky 投稿の URL リスト（1 件以上、例: ["https://bsky.app/profile/user.bsky.social/post/abc123"]）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
     """
-    args: list[str] = list(urls)
-
     label = _fake_mode_labels(_BLUESKY_INGEST_FAKE_SOURCES)
+    if not urls:
+        return label + "エラー: urls が空です（1 件以上指定してください）"
+    args: list[str] = list(urls)
+    if defer_indexing:
+        args.append("--no-pipeline")
+
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-bluesky", args, ctx=ctx)
         return label + cli_subprocess._format_cli_ingest_result(result, context="BlueSky ingest")

--- a/src/rag/server/tools/ingest_local.py
+++ b/src/rag/server/tools/ingest_local.py
@@ -137,6 +137,7 @@ async def rag_crawl_documents(
     dir_path: str,
     pattern: str = "**/*",
     upload_mode: str = "fail",
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl documents - ディレクトリ内のドキュメントを一括取り込み.
@@ -151,6 +152,8 @@ async def rag_crawl_documents(
         dir_path: 取り込み対象ディレクトリのパス（絶対パスまたは相対パス）
         pattern: glob パターン（デフォルト: ``**/*`` で再帰的に全対応ファイルを検索）
         upload_mode: 同名ファイル存在時の動作。"fail"（スキップ、デフォルト）または "replace"（上書き）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -163,6 +166,8 @@ async def rag_crawl_documents(
         args.extend(["--pattern", pattern])
     if upload_mode != "fail":
         args.extend(["--upload-mode", upload_mode])
+    if defer_indexing:
+        args.append("--no-pipeline")
 
     label = _fake_mode_labels(_LOCAL_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_local.py
+++ b/src/rag/server/tools/ingest_local.py
@@ -137,7 +137,7 @@ async def rag_crawl_documents(
     dir_path: str,
     pattern: str = "**/*",
     upload_mode: str = "fail",
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl documents - ディレクトリ内のドキュメントを一括取り込み.
@@ -152,8 +152,8 @@ async def rag_crawl_documents(
         dir_path: 取り込み対象ディレクトリのパス（絶対パスまたは相対パス）
         pattern: glob パターン（デフォルト: ``**/*`` で再帰的に全対応ファイルを検索）
         upload_mode: 同名ファイル存在時の動作。"fail"（スキップ、デフォルト）または "replace"（上書き）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -166,8 +166,8 @@ async def rag_crawl_documents(
         args.extend(["--pattern", pattern])
     if upload_mode != "fail":
         args.extend(["--upload-mode", upload_mode])
-    if defer_indexing:
-        args.append("--no-pipeline")
+    if skip_pipeline:
+        args.append("--skip-pipeline")
 
     label = _fake_mode_labels(_LOCAL_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_site.py
+++ b/src/rag/server/tools/ingest_site.py
@@ -24,7 +24,7 @@ async def rag_site_ingest(
     url_pattern: str = "",
     max_pages: int | None = None,
     force: bool = False,
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG site ingest - Scrapy でサイトを一括取り込み.
@@ -43,10 +43,10 @@ async def rag_site_ingest(
         url_pattern: URL フィルタパターン（正規表現、クロールモードのみ）
         max_pages: ページ数上限（クロールモードのみ、未指定時は設定値を使用）
         force: True の場合、JOBDIR を削除して最初からクロール（クロールモードのみ）
-        defer_indexing: True の場合、Scrapy クロール + Bridge まで実行し、
+        skip_pipeline: True の場合、Scrapy クロール + Bridge まで実行し、
             パイプライン処理（コンバート・インデックス構築）をスキップする。
-            CLI の --no-pipeline フラグと等価。共通仕様は
-            docs/specs/ingesters/common.md「--no-pipeline フラグ共通仕様」を参照
+            CLI の --skip-pipeline フラグと等価。共通仕様は
+            docs/specs/ingesters/common.md「--skip-pipeline フラグ共通仕様」を参照
 
     Returns:
         取り込み結果のサマリー
@@ -95,7 +95,9 @@ async def rag_site_ingest(
             return label + f"エラー: URL安全性チェックに失敗しました: {e}"
 
     # CLI subprocess に委譲
-    cli_args: list[str] = list(validated_urls)
+    # オプション注入対策: ユーザー入力の positional 群（validated_urls）は `--` 以降に置く。
+    # validate_url + check_ssrf を通過済みだが、一貫性とフォールバック安全性のため separator を入れる。
+    cli_args: list[str] = []
     if not multi_url_mode:
         if url_pattern:
             import re
@@ -108,8 +110,10 @@ async def rag_site_ingest(
             cli_args.extend(["--max-pages", str(max_pages)])
         if force:
             cli_args.append("--force")
-    if defer_indexing:
-        cli_args.append("--no-pipeline")
+    if skip_pipeline:
+        cli_args.append("--skip-pipeline")
+    cli_args.append("--")
+    cli_args.extend(validated_urls)
 
     display_url = validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
 

--- a/src/rag/server/tools/ingest_site.py
+++ b/src/rag/server/tools/ingest_site.py
@@ -24,7 +24,7 @@ async def rag_site_ingest(
     url_pattern: str = "",
     max_pages: int | None = None,
     force: bool = False,
-    download_only: bool = False,
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG site ingest - Scrapy でサイトを一括取り込み.
@@ -43,8 +43,10 @@ async def rag_site_ingest(
         url_pattern: URL フィルタパターン（正規表現、クロールモードのみ）
         max_pages: ページ数上限（クロールモードのみ、未指定時は設定値を使用）
         force: True の場合、JOBDIR を削除して最初からクロール（クロールモードのみ）
-        download_only: True の場合、Scrapy クロール + Bridge まで実行し、
-            パイプライン処理（コンバート・インデックス構築）をスキップする
+        defer_indexing: True の場合、Scrapy クロール + Bridge まで実行し、
+            パイプライン処理（コンバート・インデックス構築）をスキップする。
+            CLI の --no-pipeline フラグと等価。共通仕様は
+            docs/specs/ingesters/common.md「--no-pipeline フラグ共通仕様」を参照
 
     Returns:
         取り込み結果のサマリー
@@ -106,8 +108,8 @@ async def rag_site_ingest(
             cli_args.extend(["--max-pages", str(max_pages)])
         if force:
             cli_args.append("--force")
-    if download_only:
-        cli_args.append("--download-only")
+    if defer_indexing:
+        cli_args.append("--no-pipeline")
 
     display_url = validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
 

--- a/src/rag/server/tools/ingest_youtube.py
+++ b/src/rag/server/tools/ingest_youtube.py
@@ -14,7 +14,7 @@ from ..fake_labels import _YOUTUBE_INGEST_FAKE_SOURCES, _fake_mode_labels
 @mcp.tool()
 async def rag_add_youtube(
     video_urls: list[str],
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add YouTube - YouTube 動画の字幕/文字起こしを取り込む.
@@ -25,10 +25,10 @@ async def rag_add_youtube(
 
     Args:
         video_urls: YouTube 動画 URL リスト（1 件以上、youtube.com/watch?v= または youtu.be/ 形式）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価。bulk 取り込み時の高速化用。
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価。bulk 取り込み時の高速化用。
             後で `rag_rebuild`（incremental）を呼ぶ必要がある。
-            共通仕様は docs/specs/ingesters/common.md「--no-pipeline フラグ共通仕様」を参照
+            共通仕様は docs/specs/ingesters/common.md「--skip-pipeline フラグ共通仕様」を参照
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -36,9 +36,13 @@ async def rag_add_youtube(
     label = _fake_mode_labels(_YOUTUBE_INGEST_FAKE_SOURCES)
     if not video_urls:
         return label + "エラー: video_urls が空です（1 件以上指定してください）"
-    cli_args: list[str] = list(video_urls)
-    if defer_indexing:
-        cli_args.append("--no-pipeline")
+    # オプション注入対策: ユーザー入力の positional 群（video_urls）は `--` 以降に置く。
+    # URL が `-`/`--` で始まる場合に argparse がオプションとして誤解釈するのを防ぐ。
+    cli_args: list[str] = []
+    if skip_pipeline:
+        cli_args.append("--skip-pipeline")
+    cli_args.append("--")
+    cli_args.extend(video_urls)
     context = f"動画: {video_urls[0]}" if len(video_urls) == 1 else f"動画 {len(video_urls)} 件"
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-youtube", cli_args, ctx=ctx)
@@ -51,7 +55,7 @@ async def rag_add_youtube(
 async def rag_crawl_youtube(
     playlist_url: str,
     max_videos: int | None = None,
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl YouTube playlist - YouTube プレイリストの動画を一括取り込み.
@@ -62,8 +66,8 @@ async def rag_crawl_youtube(
     Args:
         playlist_url: YouTube プレイリスト URL（youtube.com/playlist?list= 形式）
         max_videos: 取得する最大動画数（未指定時は設定値を使用、許容範囲: 1〜500）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -71,8 +75,8 @@ async def rag_crawl_youtube(
     args: list[str] = [playlist_url]
     if max_videos is not None:
         args.extend(["--max-videos", str(max_videos)])
-    if defer_indexing:
-        args.append("--no-pipeline")
+    if skip_pipeline:
+        args.append("--skip-pipeline")
 
     label = _fake_mode_labels(_YOUTUBE_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_youtube.py
+++ b/src/rag/server/tools/ingest_youtube.py
@@ -13,32 +13,45 @@ from ..fake_labels import _YOUTUBE_INGEST_FAKE_SOURCES, _fake_mode_labels
 
 @mcp.tool()
 async def rag_add_youtube(
-    video_url: str,
+    video_urls: list[str],
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add YouTube - YouTube 動画の字幕/文字起こしを取り込む.
 
-    knowledge base, YouTube, video, transcript, subtitle, ingest.
+    knowledge base, YouTube, video, transcript, subtitle, ingest, bulk.
     YouTube 動画の字幕または音声文字起こしを取得し、ナレッジベースに取り込む。
+    複数 URL を 1 リクエストで処理可能。末尾 1 回だけパイプライン処理が走る。
 
     Args:
-        video_url: YouTube 動画 URL（youtube.com/watch?v= または youtu.be/ 形式）
+        video_urls: YouTube 動画 URL リスト（1 件以上、youtube.com/watch?v= または youtu.be/ 形式）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価。bulk 取り込み時の高速化用。
+            後で `rag_rebuild`（incremental）を呼ぶ必要がある。
+            共通仕様は docs/specs/ingesters/common.md「--no-pipeline フラグ共通仕様」を参照
 
     Returns:
         取り込み結果のサマリーテキスト
     """
     label = _fake_mode_labels(_YOUTUBE_INGEST_FAKE_SOURCES)
+    if not video_urls:
+        return label + "エラー: video_urls が空です（1 件以上指定してください）"
+    cli_args: list[str] = list(video_urls)
+    if defer_indexing:
+        cli_args.append("--no-pipeline")
+    context = f"動画: {video_urls[0]}" if len(video_urls) == 1 else f"動画 {len(video_urls)} 件"
     try:
-        result = await cli_subprocess._run_cli_subprocess("ingest-youtube", [video_url], ctx=ctx)
-        return label + cli_subprocess._format_cli_ingest_result(result, context=f"動画: {video_url}")
+        result = await cli_subprocess._run_cli_subprocess("ingest-youtube", cli_args, ctx=ctx)
+        return label + cli_subprocess._format_cli_ingest_result(result, context=context)
     except CLISubprocessError as e:
-        return label + e.format_mcp_error(f"YouTube 動画の取り込みに失敗しました: {video_url}")
+        return label + e.format_mcp_error(f"YouTube 動画の取り込みに失敗しました: {context}")
 
 
 @mcp.tool()
 async def rag_crawl_youtube(
     playlist_url: str,
     max_videos: int | None = None,
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl YouTube playlist - YouTube プレイリストの動画を一括取り込み.
@@ -49,6 +62,8 @@ async def rag_crawl_youtube(
     Args:
         playlist_url: YouTube プレイリスト URL（youtube.com/playlist?list= 形式）
         max_videos: 取得する最大動画数（未指定時は設定値を使用、許容範囲: 1〜500）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -56,6 +71,8 @@ async def rag_crawl_youtube(
     args: list[str] = [playlist_url]
     if max_videos is not None:
         args.extend(["--max-videos", str(max_videos)])
+    if defer_indexing:
+        args.append("--no-pipeline")
 
     label = _fake_mode_labels(_YOUTUBE_INGEST_FAKE_SOURCES)
     try:

--- a/src/rag/server/tools/ingest_zenn.py
+++ b/src/rag/server/tools/ingest_zenn.py
@@ -17,6 +17,7 @@ async def rag_crawl_zenn(
     max_articles: int | None = None,
     content_type: str = "all",
     force: bool = False,
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Zenn - Zenn コンテンツを API 経由で取得し一括取り込み.
@@ -30,6 +31,8 @@ async def rag_crawl_zenn(
         max_articles: 取得する最大コンテンツ数（未指定時は設定値を使用、許容範囲: 1〜100）
         content_type: 取得対象（"articles": 記事のみ、"scraps": スクラップのみ、"all": 両方。デフォルト: "all"）
         force: 既存ファイルを上書きするか（デフォルト: false＝スキップモード）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -41,6 +44,8 @@ async def rag_crawl_zenn(
         args.extend(["--max-articles", str(max_articles)])
     if force:
         args.append("--force")
+    if defer_indexing:
+        args.append("--no-pipeline")
 
     label = _fake_mode_labels(_ZENN_INGEST_FAKE_SOURCES)
     try:
@@ -53,23 +58,30 @@ async def rag_crawl_zenn(
 @mcp.tool()
 async def rag_add_zenn(
     urls: list[str],
+    defer_indexing: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add Zenn - Zenn コンテンツを URL 指定で取り込み.
 
-    knowledge base, Zenn, add, ingest, single article, single scrap.
+    knowledge base, Zenn, add, ingest, single article, single scrap, bulk.
     指定 URL の Zenn 記事またはスクラップを取得し、ナレッジベースに取り込む。
     既存コンテンツは上書きする。複数 URL を一括指定可能。
 
     Args:
-        urls: Zenn コンテンツの URL リスト（例: ["https://zenn.dev/alice/articles/my-post"]）
+        urls: Zenn コンテンツの URL リスト（1 件以上、例: ["https://zenn.dev/alice/articles/my-post"]）
+        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--no-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
     """
-    args: list[str] = list(urls)
-
     label = _fake_mode_labels(_ZENN_INGEST_FAKE_SOURCES)
+    if not urls:
+        return label + "エラー: urls が空です（1 件以上指定してください）"
+    args: list[str] = list(urls)
+    if defer_indexing:
+        args.append("--no-pipeline")
+
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-zenn", args, ctx=ctx)
         return label + cli_subprocess._format_cli_ingest_result(result, context="Zenn ingest")

--- a/src/rag/server/tools/ingest_zenn.py
+++ b/src/rag/server/tools/ingest_zenn.py
@@ -17,7 +17,7 @@ async def rag_crawl_zenn(
     max_articles: int | None = None,
     content_type: str = "all",
     force: bool = False,
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG crawl Zenn - Zenn コンテンツを API 経由で取得し一括取り込み.
@@ -31,8 +31,8 @@ async def rag_crawl_zenn(
         max_articles: 取得する最大コンテンツ数（未指定時は設定値を使用、許容範囲: 1〜100）
         content_type: 取得対象（"articles": 記事のみ、"scraps": スクラップのみ、"all": 両方。デフォルト: "all"）
         force: 既存ファイルを上書きするか（デフォルト: false＝スキップモード）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -44,8 +44,8 @@ async def rag_crawl_zenn(
         args.extend(["--max-articles", str(max_articles)])
     if force:
         args.append("--force")
-    if defer_indexing:
-        args.append("--no-pipeline")
+    if skip_pipeline:
+        args.append("--skip-pipeline")
 
     label = _fake_mode_labels(_ZENN_INGEST_FAKE_SOURCES)
     try:
@@ -58,7 +58,7 @@ async def rag_crawl_zenn(
 @mcp.tool()
 async def rag_add_zenn(
     urls: list[str],
-    defer_indexing: bool = False,
+    skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
     """[rag-knowledge] RAG add Zenn - Zenn コンテンツを URL 指定で取り込み.
@@ -69,8 +69,8 @@ async def rag_add_zenn(
 
     Args:
         urls: Zenn コンテンツの URL リスト（1 件以上、例: ["https://zenn.dev/alice/articles/my-post"]）
-        defer_indexing: True の場合、後段のパイプライン処理（converter + indexer）を
-            スキップする。CLI の `--no-pipeline` と等価
+        skip_pipeline: True の場合、後段のパイプライン処理（converter + indexer）を
+            スキップする。CLI の `--skip-pipeline` と等価
 
     Returns:
         取り込み結果のサマリーテキスト
@@ -78,9 +78,13 @@ async def rag_add_zenn(
     label = _fake_mode_labels(_ZENN_INGEST_FAKE_SOURCES)
     if not urls:
         return label + "エラー: urls が空です（1 件以上指定してください）"
-    args: list[str] = list(urls)
-    if defer_indexing:
-        args.append("--no-pipeline")
+    # オプション注入対策: ユーザー入力の positional 群（urls）は `--` 以降に置く。
+    # URL が `-`/`--` で始まる場合に argparse がオプションとして誤解釈するのを防ぐ。
+    args: list[str] = []
+    if skip_pipeline:
+        args.append("--skip-pipeline")
+    args.append("--")
+    args.extend(urls)
 
     try:
         result = await cli_subprocess._run_cli_subprocess("ingest-zenn", args, ctx=ctx)

--- a/tests/e2e/test_ingest_mcp_aozora.py
+++ b/tests/e2e/test_ingest_mcp_aozora.py
@@ -48,7 +48,7 @@ class TestMcpAozoraIngest:
         add_response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_add_aozora",
-            {"book_id": _FAKE_BOOK_ID},
+            {"book_ids": [_FAKE_BOOK_ID]},
         )
         assert "完了" in add_response or "placed" in add_response.lower(), (
             f"作品取り込みが完了していない: {add_response[:500]}"

--- a/tests/e2e/test_ingest_mcp_youtube.py
+++ b/tests/e2e/test_ingest_mcp_youtube.py
@@ -55,7 +55,7 @@ class TestMcpYoutubeIngest:
         ingest_response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_add_youtube",
-            {"video_url": _FAKE_VIDEO_URL},
+            {"video_urls": [_FAKE_VIDEO_URL]},
         )
         assert "完了" in ingest_response or "placed" in ingest_response.lower(), (
             f"取り込み完了を示すテキストが応答に含まれていない: {ingest_response}"
@@ -85,7 +85,7 @@ class TestMcpYoutubeIngest:
         response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_add_youtube",
-            {"video_url": _FAKE_VIDEO_URL},
+            {"video_urls": [_FAKE_VIDEO_URL]},
         )
         assert "[FAKE MODE" in response, (
             f"fake モードラベルが応答に含まれていない: {response[:300]}"
@@ -108,7 +108,7 @@ class TestMcpYoutubeIngest:
         first = await call_mcp_tool(
             e2e_mcp_server,
             "rag_add_youtube",
-            {"video_url": _OVERWRITE_TEST_VIDEO_URL},
+            {"video_urls": [_OVERWRITE_TEST_VIDEO_URL]},
         )
         # 1 回目は新規取り込みのため「上書き」表記を含まないことを厳密に確認する。
         # （早期 return バグが「常に上書き 0 件」を返す挙動を 2 回目側で検出するため、
@@ -123,7 +123,7 @@ class TestMcpYoutubeIngest:
         second = await call_mcp_tool(
             e2e_mcp_server,
             "rag_add_youtube",
-            {"video_url": _OVERWRITE_TEST_VIDEO_URL},
+            {"video_urls": [_OVERWRITE_TEST_VIDEO_URL]},
         )
         # 2 回目は overwritten カウントが反映される（早期 return バグなら反映されない）
         assert "上書き" in second or "overwritten" in second.lower(), (

--- a/tests/test_cli_no_pipeline.py
+++ b/tests/test_cli_no_pipeline.py
@@ -1,0 +1,353 @@
+"""--no-pipeline フラグおよび bulk 受付の振る舞いテスト.
+
+Issue #757 / 仕様: docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」
+                   docs/specs/ingesters/aozora.md「ingest-aozora 複数 ID 入力時の重複検出」
+
+テスト方針:
+- 12 CLI コマンドに --no-pipeline が argparse で受理されること
+- --no-pipeline 指定時に controller.ingest_and_index が呼ばれないこと
+- --no-pipeline 未指定時は呼ばれること（既存挙動維持）
+- 4 コマンドの複数引数受付（nargs='+' / action='append'）
+- aozora zfill 重複検出による WARN ログ + 1 回のみ ingest
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestNoPipelineParserRegistration:
+    """全 12 サブコマンドに --no-pipeline が argparse 上で受理されること."""
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["ingest-youtube", "https://youtu.be/aaa", "--no-pipeline"],
+            ["ingest-youtube-playlist", "https://example.com/pl", "--no-pipeline"],
+            ["crawl-bluesky", "user.bsky.social", "--no-pipeline"],
+            ["crawl-zenn", "username", "--no-pipeline"],
+            ["ingest-bluesky", "https://example.com/post", "--no-pipeline"],
+            ["ingest-zenn", "https://zenn.dev/u/articles/x", "--no-pipeline"],
+            ["crawl-documents", "/tmp/docs", "--no-pipeline"],
+            ["site-ingest", "https://example.com/", "--no-pipeline"],
+            ["ingest-aozora", "12345", "--no-pipeline"],
+            ["ingest-aozora-author", "00001", "--no-pipeline"],
+            ["delete", "local/.upload/2026/05/10/x.md", "--no-pipeline"],
+        ],
+    )
+    def test_no_pipeline_flag_accepted(self, argv: list[str]) -> None:
+        """--no-pipeline が argparse で True にパースされること."""
+        from rag.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(argv)
+        assert args.no_pipeline is True
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["ingest-youtube", "https://youtu.be/aaa"],
+            ["ingest-aozora", "12345"],
+        ],
+    )
+    def test_no_pipeline_default_false(self, argv: list[str]) -> None:
+        """--no-pipeline 未指定時は False がデフォルト."""
+        from rag.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(argv)
+        assert args.no_pipeline is False
+
+
+class TestBulkInputRegistration:
+    """単一引数 → 複数受付化されたコマンドの argparse 検証."""
+
+    def test_ingest_youtube_accepts_multiple_urls(self) -> None:
+        from rag.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["ingest-youtube", "https://youtu.be/a", "https://youtu.be/b"],
+        )
+        assert args.video_url == ["https://youtu.be/a", "https://youtu.be/b"]
+
+    def test_ingest_aozora_accepts_multiple_book_ids(self) -> None:
+        from rag.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["ingest-aozora", "1234", "5678"])
+        assert args.book_id == ["1234", "5678"]
+
+    def test_delete_accepts_multiple_source_ids(self) -> None:
+        from rag.cli import _build_parser
+
+        parser = _build_parser()
+        args = parser.parse_args(["delete", "src/a.md", "src/b.md"])
+        assert args.source_id == ["src/a.md", "src/b.md"]
+
+
+class TestNoPipelineHandlerSkipsIngestAndIndex:
+    """--no-pipeline 指定時に controller.ingest_and_index が呼ばれないこと."""
+
+    def _make_ingest_result(
+        self,
+        *,
+        placed: int = 1,
+        errors: int = 0,
+    ):
+        from rag.pipeline.ingesters._common import IngestResult
+
+        result = IngestResult()
+        result.placed = placed
+        result.errors = errors
+        return result
+
+    @pytest.mark.asyncio
+    async def test_ingest_aozora_with_no_pipeline_skips_index(
+        self, tmp_path: Path,
+    ) -> None:
+        """ingest-aozora --no-pipeline で controller.ingest_and_index が呼ばれない."""
+        args = argparse.Namespace(
+            book_id=["00012345"],
+            no_pipeline=True,
+            output_format="text",
+        )
+
+        mock_ingester = MagicMock()
+        mock_ingester.add_work = AsyncMock(return_value=self._make_ingest_result())
+        # async context manager for fetcher
+        mock_fetcher_cm = MagicMock()
+        mock_fetcher_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_fetcher_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("rag.cli._build_cli_pipeline_controller") as mock_ctrl,
+            patch("rag.cli._write_lock_or_exit") as mock_lock_ctx,
+            patch(
+                "rag.pipeline.ingesters.aozora.create_aozora_fetcher",
+                return_value=mock_fetcher_cm,
+            ),
+            patch(
+                "rag.pipeline.ingesters.aozora.AozoraIngester",
+                return_value=mock_ingester,
+            ),
+        ):
+            from contextlib import nullcontext
+
+            mock_lock_ctx.return_value = nullcontext()
+
+            mock_controller = MagicMock()
+            mock_controller.source_store.root_dir = tmp_path
+            mock_controller.ingest_and_index = AsyncMock()
+            mock_settings = MagicMock()
+            mock_settings.rag_aozora_max_works = 100
+            mock_settings.rag_embedding_concurrency = 1
+            mock_ctrl.return_value = (mock_controller, mock_settings)
+
+            from rag.cli import run_ingest_aozora
+
+            await run_ingest_aozora(args)
+
+            mock_controller.ingest_and_index.assert_not_called()
+            # --no-pipeline 指定時も controller.commit() が呼ばれる必要がある
+            # (Critical #1: source_store の git commit は実行される)
+            mock_controller.commit.assert_called_once()
+            mock_ingester.add_work.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ingest_aozora_without_no_pipeline_invokes_index(
+        self, tmp_path: Path,
+    ) -> None:
+        """ingest-aozora（既定）で controller.ingest_and_index が呼ばれる."""
+        args = argparse.Namespace(
+            book_id=["00012345"],
+            no_pipeline=False,
+            output_format="text",
+        )
+
+        mock_ingester = MagicMock()
+        mock_ingester.add_work = AsyncMock(return_value=self._make_ingest_result())
+        mock_fetcher_cm = MagicMock()
+        mock_fetcher_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_fetcher_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("rag.cli._build_cli_pipeline_controller") as mock_ctrl,
+            patch("rag.cli._write_lock_or_exit") as mock_lock_ctx,
+            patch(
+                "rag.pipeline.ingesters.aozora.create_aozora_fetcher",
+                return_value=mock_fetcher_cm,
+            ),
+            patch(
+                "rag.pipeline.ingesters.aozora.AozoraIngester",
+                return_value=mock_ingester,
+            ),
+        ):
+            from contextlib import nullcontext
+
+            mock_lock_ctx.return_value = nullcontext()
+
+            mock_controller = MagicMock()
+            mock_controller.source_store.root_dir = tmp_path
+            mock_controller.ingest_and_index = AsyncMock(return_value=MagicMock())
+            mock_settings = MagicMock()
+            mock_settings.rag_aozora_max_works = 100
+            mock_settings.rag_embedding_concurrency = 1
+            mock_ctrl.return_value = (mock_controller, mock_settings)
+
+            from rag.cli import run_ingest_aozora
+
+            await run_ingest_aozora(args)
+
+            mock_controller.ingest_and_index.assert_called_once()
+
+
+class TestAozoraZfillDuplicateDetection:
+    """ingest-aozora bulk 入力での zfill 後重複検出."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_zfill_inputs_warned_and_deduped(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """`['1234', '001234']` は zfill(6) 後同一 → WARN + 1 回のみ ingest."""
+        from rag.pipeline.ingesters._common import IngestResult
+
+        # zfill(6) の正規化規則: '1234' → '001234'、'001234' → '001234'
+        args = argparse.Namespace(
+            book_id=["1234", "001234", "5678"],
+            no_pipeline=True,
+            output_format="text",
+        )
+
+        mock_ingester = MagicMock()
+        mock_ingester.add_work = AsyncMock(return_value=IngestResult(placed=1))
+        mock_fetcher_cm = MagicMock()
+        mock_fetcher_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_fetcher_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch("rag.cli._build_cli_pipeline_controller") as mock_ctrl,
+            patch("rag.cli._write_lock_or_exit") as mock_lock_ctx,
+            patch(
+                "rag.pipeline.ingesters.aozora.create_aozora_fetcher",
+                return_value=mock_fetcher_cm,
+            ),
+            patch(
+                "rag.pipeline.ingesters.aozora.AozoraIngester",
+                return_value=mock_ingester,
+            ),
+            caplog.at_level(logging.WARNING, logger="rag.cli"),
+        ):
+            from contextlib import nullcontext
+
+            mock_lock_ctx.return_value = nullcontext()
+
+            mock_controller = MagicMock()
+            mock_controller.source_store.root_dir = tmp_path
+            mock_controller.ingest_and_index = AsyncMock()
+            mock_settings = MagicMock()
+            mock_settings.rag_aozora_max_works = 100
+            mock_settings.rag_embedding_concurrency = 1
+            mock_ctrl.return_value = (mock_controller, mock_settings)
+
+            from rag.cli import run_ingest_aozora
+
+            await run_ingest_aozora(args)
+
+            # 重複検出 WARN
+            warn_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+            assert any("重複入力を検出" in m for m in warn_messages), warn_messages
+            # 重複排除されて 2 回のみ呼び出される (1234/001234 → 1, 5678 → 1)
+            assert mock_ingester.add_work.call_count == 2
+
+
+class TestNormalizeAozoraIdEdgeCases:
+    """_normalize_aozora_id のエッジケース."""
+
+    def test_pad_to_six_digits(self) -> None:
+        from rag.cli import _normalize_aozora_id
+
+        assert _normalize_aozora_id("1234") == "001234"
+
+    def test_already_six_digits(self) -> None:
+        from rag.cli import _normalize_aozora_id
+
+        assert _normalize_aozora_id("001234") == "001234"
+
+    def test_more_than_six_digits_no_pad(self) -> None:
+        from rag.cli import _normalize_aozora_id
+
+        assert _normalize_aozora_id("00001234") == "00001234"
+
+    def test_strip_whitespace(self) -> None:
+        from rag.cli import _normalize_aozora_id
+
+        assert _normalize_aozora_id("  1234  ") == "001234"
+
+    def test_empty_string_normalizes_to_six_zeros(self) -> None:
+        """空文字列は zfill(6) で '000000' になる（ingester 側ロジックと整合）."""
+        from rag.cli import _normalize_aozora_id
+
+        assert _normalize_aozora_id("") == "000000"
+        assert _normalize_aozora_id("   ") == "000000"
+
+
+class TestMergeIngestResults:
+    """_merge_ingest_results 単体テスト."""
+
+    def test_counters_sum(self) -> None:
+        from rag.cli import _merge_ingest_results
+        from rag.pipeline.ingesters._common import IngestResult
+
+        r1 = IngestResult(placed=1, skipped=2, overwritten=3, errors=4, partial_failures=5)
+        r2 = IngestResult(placed=10, skipped=20, overwritten=30, errors=40, partial_failures=50)
+        merged = _merge_ingest_results([r1, r2])
+
+        assert merged.placed == 11
+        assert merged.skipped == 22
+        assert merged.overwritten == 33
+        assert merged.errors == 44
+        assert merged.partial_failures == 55
+
+    def test_details_concatenated(self) -> None:
+        from rag.cli import _merge_ingest_results
+        from rag.pipeline.ingesters._common import (
+            IngestErrorCategory,
+            IngestErrorDetail,
+            IngestResult,
+        )
+
+        d1 = IngestErrorDetail(category=IngestErrorCategory.METADATA_FETCH.value, target="a")
+        d2 = IngestErrorDetail(category=IngestErrorCategory.MEDIA_DOWNLOAD.value, target="b")
+        r1 = IngestResult(error_details=[d1])
+        r2 = IngestResult(partial_failure_details=[d2])
+        merged = _merge_ingest_results([r1, r2])
+
+        assert merged.error_details == [d1]
+        assert merged.partial_failure_details == [d2]
+
+    def test_aborted_first_reason_preserved(self) -> None:
+        """最初の aborted=True の abort_reason が採用される."""
+        from rag.cli import _merge_ingest_results
+        from rag.pipeline.ingesters._common import IngestResult
+
+        r1 = IngestResult(placed=1)
+        r2 = IngestResult(aborted=True, abort_reason="first reason")
+        r3 = IngestResult(aborted=True, abort_reason="second reason")
+        merged = _merge_ingest_results([r1, r2, r3])
+
+        assert merged.aborted is True
+        assert merged.abort_reason == "first reason"
+
+    def test_empty_list_returns_zero_result(self) -> None:
+        from rag.cli import _merge_ingest_results
+
+        merged = _merge_ingest_results([])
+        assert merged.is_empty()

--- a/tests/test_cli_skip_pipeline.py
+++ b/tests/test_cli_skip_pipeline.py
@@ -1,12 +1,12 @@
-"""--no-pipeline フラグおよび bulk 受付の振る舞いテスト.
+"""--skip-pipeline フラグおよび bulk 受付の振る舞いテスト.
 
-Issue #757 / 仕様: docs/specs/ingesters/common.md「`--no-pipeline` フラグ共通仕様」
+Issue #757 / 仕様: docs/specs/ingesters/common.md「`--skip-pipeline` フラグ共通仕様」
                    docs/specs/ingesters/aozora.md「ingest-aozora 複数 ID 入力時の重複検出」
 
 テスト方針:
-- 12 CLI コマンドに --no-pipeline が argparse で受理されること
-- --no-pipeline 指定時に controller.ingest_and_index が呼ばれないこと
-- --no-pipeline 未指定時は呼ばれること（既存挙動維持）
+- 12 CLI コマンドに --skip-pipeline が argparse で受理されること
+- --skip-pipeline 指定時に controller.ingest_and_index が呼ばれないこと
+- --skip-pipeline 未指定時は呼ばれること（既存挙動維持）
 - 4 コマンドの複数引数受付（nargs='+' / action='append'）
 - aozora zfill 重複検出による WARN ログ + 1 回のみ ingest
 """
@@ -22,31 +22,31 @@ import pytest
 
 
 class TestNoPipelineParserRegistration:
-    """全 12 サブコマンドに --no-pipeline が argparse 上で受理されること."""
+    """全 12 サブコマンドに --skip-pipeline が argparse 上で受理されること."""
 
     @pytest.mark.parametrize(
         "argv",
         [
-            ["ingest-youtube", "https://youtu.be/aaa", "--no-pipeline"],
-            ["ingest-youtube-playlist", "https://example.com/pl", "--no-pipeline"],
-            ["crawl-bluesky", "user.bsky.social", "--no-pipeline"],
-            ["crawl-zenn", "username", "--no-pipeline"],
-            ["ingest-bluesky", "https://example.com/post", "--no-pipeline"],
-            ["ingest-zenn", "https://zenn.dev/u/articles/x", "--no-pipeline"],
-            ["crawl-documents", "/tmp/docs", "--no-pipeline"],
-            ["site-ingest", "https://example.com/", "--no-pipeline"],
-            ["ingest-aozora", "12345", "--no-pipeline"],
-            ["ingest-aozora-author", "00001", "--no-pipeline"],
-            ["delete", "local/.upload/2026/05/10/x.md", "--no-pipeline"],
+            ["ingest-youtube", "https://youtu.be/aaa", "--skip-pipeline"],
+            ["ingest-youtube-playlist", "https://example.com/pl", "--skip-pipeline"],
+            ["crawl-bluesky", "user.bsky.social", "--skip-pipeline"],
+            ["crawl-zenn", "username", "--skip-pipeline"],
+            ["ingest-bluesky", "https://example.com/post", "--skip-pipeline"],
+            ["ingest-zenn", "https://zenn.dev/u/articles/x", "--skip-pipeline"],
+            ["crawl-documents", "/tmp/docs", "--skip-pipeline"],
+            ["site-ingest", "https://example.com/", "--skip-pipeline"],
+            ["ingest-aozora", "12345", "--skip-pipeline"],
+            ["ingest-aozora-author", "00001", "--skip-pipeline"],
+            ["delete", "local/.upload/2026/05/10/x.md", "--skip-pipeline"],
         ],
     )
-    def test_no_pipeline_flag_accepted(self, argv: list[str]) -> None:
-        """--no-pipeline が argparse で True にパースされること."""
+    def test_skip_pipeline_flag_accepted(self, argv: list[str]) -> None:
+        """--skip-pipeline が argparse で True にパースされること."""
         from rag.cli import _build_parser
 
         parser = _build_parser()
         args = parser.parse_args(argv)
-        assert args.no_pipeline is True
+        assert args.skip_pipeline is True
 
     @pytest.mark.parametrize(
         "argv",
@@ -55,13 +55,13 @@ class TestNoPipelineParserRegistration:
             ["ingest-aozora", "12345"],
         ],
     )
-    def test_no_pipeline_default_false(self, argv: list[str]) -> None:
-        """--no-pipeline 未指定時は False がデフォルト."""
+    def test_skip_pipeline_default_false(self, argv: list[str]) -> None:
+        """--skip-pipeline 未指定時は False がデフォルト."""
         from rag.cli import _build_parser
 
         parser = _build_parser()
         args = parser.parse_args(argv)
-        assert args.no_pipeline is False
+        assert args.skip_pipeline is False
 
 
 class TestBulkInputRegistration:
@@ -92,7 +92,7 @@ class TestBulkInputRegistration:
 
 
 class TestNoPipelineHandlerSkipsIngestAndIndex:
-    """--no-pipeline 指定時に controller.ingest_and_index が呼ばれないこと."""
+    """--skip-pipeline 指定時に controller.ingest_and_index が呼ばれないこと."""
 
     def _make_ingest_result(
         self,
@@ -108,13 +108,13 @@ class TestNoPipelineHandlerSkipsIngestAndIndex:
         return result
 
     @pytest.mark.asyncio
-    async def test_ingest_aozora_with_no_pipeline_skips_index(
+    async def test_ingest_aozora_with_skip_pipeline_skips_index(
         self, tmp_path: Path,
     ) -> None:
-        """ingest-aozora --no-pipeline で controller.ingest_and_index が呼ばれない."""
+        """ingest-aozora --skip-pipeline で controller.ingest_and_index が呼ばれない."""
         args = argparse.Namespace(
             book_id=["00012345"],
-            no_pipeline=True,
+            skip_pipeline=True,
             output_format="text",
         )
 
@@ -154,19 +154,19 @@ class TestNoPipelineHandlerSkipsIngestAndIndex:
             await run_ingest_aozora(args)
 
             mock_controller.ingest_and_index.assert_not_called()
-            # --no-pipeline 指定時も controller.commit() が呼ばれる必要がある
+            # --skip-pipeline 指定時も controller.commit() が呼ばれる必要がある
             # (Critical #1: source_store の git commit は実行される)
             mock_controller.commit.assert_called_once()
             mock_ingester.add_work.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_ingest_aozora_without_no_pipeline_invokes_index(
+    async def test_ingest_aozora_without_skip_pipeline_invokes_index(
         self, tmp_path: Path,
     ) -> None:
         """ingest-aozora（既定）で controller.ingest_and_index が呼ばれる."""
         args = argparse.Namespace(
             book_id=["00012345"],
-            no_pipeline=False,
+            skip_pipeline=False,
             output_format="text",
         )
 
@@ -222,7 +222,7 @@ class TestAozoraZfillDuplicateDetection:
         # zfill(6) の正規化規則: '1234' → '001234'、'001234' → '001234'
         args = argparse.Namespace(
             book_id=["1234", "001234", "5678"],
-            no_pipeline=True,
+            skip_pipeline=True,
             output_format="text",
         )
 

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -906,7 +906,8 @@ class TestRagDeleteTool:
         ) as mock_cli:
             result = await mod.rag_delete(["https://example.com/page"])
 
-        mock_cli.assert_called_once_with("delete", ["https://example.com/page"], ctx=None)
+        # `--` separator で positional 群を分離（オプション注入対策）
+        mock_cli.assert_called_once_with("delete", ["--", "https://example.com/page"], ctx=None)
         assert "削除しました" in result
 
     @pytest.mark.asyncio
@@ -939,8 +940,8 @@ class TestRagDeleteTool:
         assert "ロックを保持しています" in result
 
     @pytest.mark.asyncio
-    async def test_bulk_delete_with_defer_indexing(self) -> None:
-        """bulk 削除 + defer_indexing で CLI に複数 source_id + --no-pipeline が渡る."""
+    async def test_bulk_delete_with_skip_pipeline(self) -> None:
+        """bulk 削除 + skip_pipeline で CLI に複数 source_id + --skip-pipeline が渡る."""
         mod = import_module("rag.server")
         mock_result = {
             "deleted": True,
@@ -953,12 +954,12 @@ class TestRagDeleteTool:
             "rag.server.cli_subprocess._run_cli_subprocess",
             new_callable=AsyncMock, return_value=mock_result,
         ) as mock_cli:
-            await mod.rag_delete(["src/a.md", "src/b.md"], defer_indexing=True)
+            await mod.rag_delete(["src/a.md", "src/b.md"], skip_pipeline=True)
 
         cli_args = mock_cli.call_args[0][1]
         assert "src/a.md" in cli_args
         assert "src/b.md" in cli_args
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_empty_source_ids_returns_error(self) -> None:

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -893,12 +893,18 @@ class TestRagDeleteTool:
     async def test_success(self) -> None:
         """正常系: 削除成功メッセージが返ること."""
         mod = import_module("rag.server")
-        mock_result = {"deleted": True, "pipeline": None}
+        mock_result = {
+            "deleted": True,
+            "deleted_count": 1,
+            "deleted_ids": ["https://example.com/page"],
+            "not_found_ids": [],
+            "pipeline": None,
+        }
         with patch(
             "rag.server.cli_subprocess._run_cli_subprocess",
             new_callable=AsyncMock, return_value=mock_result,
         ) as mock_cli:
-            result = await mod.rag_delete("https://example.com/page")
+            result = await mod.rag_delete(["https://example.com/page"])
 
         mock_cli.assert_called_once_with("delete", ["https://example.com/page"], ctx=None)
         assert "削除しました" in result
@@ -907,12 +913,15 @@ class TestRagDeleteTool:
     async def test_not_found(self) -> None:
         """ソースが見つからない場合のメッセージが返ること."""
         mod = import_module("rag.server")
-        mock_result = {"not_found": True}
+        mock_result = {
+            "deleted": False,
+            "not_found_ids": ["https://example.com/missing"],
+        }
         with patch(
             "rag.server.cli_subprocess._run_cli_subprocess",
             new_callable=AsyncMock, return_value=mock_result,
         ):
-            result = await mod.rag_delete("https://example.com/missing")
+            result = await mod.rag_delete(["https://example.com/missing"])
 
         assert "見つかりませんでした" in result
 
@@ -925,9 +934,38 @@ class TestRagDeleteTool:
             new_callable=AsyncMock,
             side_effect=mod.CLISubprocessError("排他制御エラー", code="LOCK_CONFLICT"),
         ):
-            result = await mod.rag_delete("https://example.com/page")
+            result = await mod.rag_delete(["https://example.com/page"])
 
         assert "ロックを保持しています" in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_delete_with_defer_indexing(self) -> None:
+        """bulk 削除 + defer_indexing で CLI に複数 source_id + --no-pipeline が渡る."""
+        mod = import_module("rag.server")
+        mock_result = {
+            "deleted": True,
+            "deleted_count": 2,
+            "deleted_ids": ["src/a.md", "src/b.md"],
+            "not_found_ids": [],
+            "pipeline": None,
+        }
+        with patch(
+            "rag.server.cli_subprocess._run_cli_subprocess",
+            new_callable=AsyncMock, return_value=mock_result,
+        ) as mock_cli:
+            await mod.rag_delete(["src/a.md", "src/b.md"], defer_indexing=True)
+
+        cli_args = mock_cli.call_args[0][1]
+        assert "src/a.md" in cli_args
+        assert "src/b.md" in cli_args
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_empty_source_ids_returns_error(self) -> None:
+        """空 list でエラーメッセージが返る."""
+        mod = import_module("rag.server")
+        result = await mod.rag_delete([])
+        assert "エラー" in result
 
 
 class TestRagRebuildTool:

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -214,8 +214,8 @@ class TestMcpSiteIngestCliDelegation:
             assert "--force" not in cli_args
 
     @pytest.mark.asyncio
-    async def test_defer_indexing_flag_passed(self) -> None:
-        """defer_indexing フラグが CLI 引数に --no-pipeline として含まれること."""
+    async def test_skip_pipeline_flag_passed(self) -> None:
+        """skip_pipeline フラグが CLI 引数に --skip-pipeline として含まれること."""
         mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
 
         mod = import_module("rag.server")
@@ -226,10 +226,10 @@ class TestMcpSiteIngestCliDelegation:
         ):
             await mod.rag_site_ingest(
                 url="https://example.com",
-                defer_indexing=True,
+                skip_pipeline=True,
             )
             cli_args = mock_cli.call_args[0][1]
-            assert "--no-pipeline" in cli_args
+            assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_cli_subprocess_error_returns_error_message(self) -> None:
@@ -279,7 +279,7 @@ class TestCliSiteIngestValidation:
         """空 URL で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=[""], url_pattern="", max_pages=None, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=[""], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -289,7 +289,7 @@ class TestCliSiteIngestValidation:
         """不正スキームで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["ftp://example.com"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["ftp://example.com"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -299,7 +299,7 @@ class TestCliSiteIngestValidation:
         """プライベート IP で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["http://10.0.0.1/page"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["http://10.0.0.1/page"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -309,7 +309,7 @@ class TestCliSiteIngestValidation:
         """不正な正規表現パターンで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="[bad(", max_pages=None, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="[bad(", max_pages=None, force=False, skip_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -349,7 +349,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=-1, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=-1, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -373,7 +373,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=999999, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=999999, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -400,7 +400,7 @@ class TestCliSiteIngestMaxPagesClamp:
         mock_settings = _make_cli_mock_settings()
         mock_settings.site_ingest_max_pages = 800
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -428,7 +428,7 @@ class TestCliSiteIngestFlow:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -477,7 +477,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -549,7 +549,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -606,7 +606,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -214,8 +214,8 @@ class TestMcpSiteIngestCliDelegation:
             assert "--force" not in cli_args
 
     @pytest.mark.asyncio
-    async def test_download_only_flag_passed(self) -> None:
-        """download_only フラグが CLI 引数に含まれること."""
+    async def test_defer_indexing_flag_passed(self) -> None:
+        """defer_indexing フラグが CLI 引数に --no-pipeline として含まれること."""
         mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
 
         mod = import_module("rag.server")
@@ -226,10 +226,10 @@ class TestMcpSiteIngestCliDelegation:
         ):
             await mod.rag_site_ingest(
                 url="https://example.com",
-                download_only=True,
+                defer_indexing=True,
             )
             cli_args = mock_cli.call_args[0][1]
-            assert "--download-only" in cli_args
+            assert "--no-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_cli_subprocess_error_returns_error_message(self) -> None:
@@ -279,7 +279,7 @@ class TestCliSiteIngestValidation:
         """空 URL で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=[""], url_pattern="", max_pages=None, force=False, download_only=False)
+        args = argparse.Namespace(url=[""], url_pattern="", max_pages=None, force=False, no_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -289,7 +289,7 @@ class TestCliSiteIngestValidation:
         """不正スキームで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["ftp://example.com"], url_pattern="", max_pages=None, force=False, download_only=False)
+        args = argparse.Namespace(url=["ftp://example.com"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -299,7 +299,7 @@ class TestCliSiteIngestValidation:
         """プライベート IP で sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["http://10.0.0.1/page"], url_pattern="", max_pages=None, force=False, download_only=False)
+        args = argparse.Namespace(url=["http://10.0.0.1/page"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -309,7 +309,7 @@ class TestCliSiteIngestValidation:
         """不正な正規表現パターンで sys.exit(1) すること."""
         from rag.cli import run_site_ingest
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="[bad(", max_pages=None, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="[bad(", max_pages=None, force=False, no_pipeline=False)
         with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
         assert exc_info.value.code == 1
@@ -349,7 +349,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=-1, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=-1, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -373,7 +373,7 @@ class TestCliSiteIngestMaxPagesClamp:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=999999, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=999999, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -400,7 +400,7 @@ class TestCliSiteIngestMaxPagesClamp:
         mock_settings = _make_cli_mock_settings()
         mock_settings.site_ingest_max_pages = 800
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=None, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=None, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
@@ -428,7 +428,7 @@ class TestCliSiteIngestFlow:
             success=True,
         )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -477,7 +477,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -549,7 +549,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
@@ -606,7 +606,7 @@ class TestCliSiteIngestFlow:
         mock_controller.source_store = MagicMock()
         mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, download_only=False)
+        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, no_pipeline=False)
 
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),

--- a/tests/test_server_tools_no_pipeline.py
+++ b/tests/test_server_tools_no_pipeline.py
@@ -1,0 +1,188 @@
+"""MCP tool への defer_indexing パラメータ + bulk 受付の振る舞いテスト.
+
+Issue #757 / 仕様: docs/specs/rag-knowledge.md 各 rag_* tool セクション
+                   docs/specs/ingesters/common.md 「`--no-pipeline` フラグ共通仕様」
+
+検証観点:
+- 全 rag_add_* / rag_crawl_* / rag_crawl_documents で defer_indexing=True 時に
+  CLI subprocess の引数に `--no-pipeline` が含まれること
+- bulk 化対象 (rag_add_youtube/aozora/bluesky/zenn) で list[str] 受付が動作
+- bulk 化対象で空 list がエラーメッセージを返すこと
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+_MOCK_RESULT = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
+
+
+@pytest.fixture
+def _patch_cli_subprocess():
+    """各 MCP tool で _run_cli_subprocess を mock 化する fixture."""
+    with (
+        patch(
+            "rag.server.cli_subprocess._run_cli_subprocess",
+            new_callable=AsyncMock,
+            return_value=_MOCK_RESULT,
+        ) as mock_cli,
+        patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
+    ):
+        yield mock_cli
+
+
+class TestDeferIndexingFlag:
+    """全 add-/crawl- tool で defer_indexing=True が --no-pipeline に変換されること."""
+
+    @pytest.mark.asyncio
+    async def test_rag_add_youtube_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_youtube(
+            video_urls=["https://youtu.be/aaa"], defer_indexing=True,
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_youtube_default_no_flag(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_youtube(video_urls=["https://youtu.be/aaa"])
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" not in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_crawl_youtube_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_crawl_youtube(
+            playlist_url="https://example.com/pl", defer_indexing=True,
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_aozora_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_aozora(book_ids=["12345"], defer_indexing=True)
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_crawl_aozora_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_crawl_aozora(person_id="00001", defer_indexing=True)
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_bluesky_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_bluesky(
+            urls=["https://bsky.app/profile/u/post/x"], defer_indexing=True,
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_crawl_bluesky_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_crawl_bluesky(handle="u.bsky.social", defer_indexing=True)
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_zenn_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_zenn(
+            urls=["https://zenn.dev/u/articles/x"], defer_indexing=True,
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_crawl_zenn_defer(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_crawl_zenn(username="u", defer_indexing=True)
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "--no-pipeline" in cli_args
+
+
+class TestBulkListExpansion:
+    """bulk 化対象で list[str] が CLI 引数として展開されること."""
+
+    @pytest.mark.asyncio
+    async def test_rag_add_youtube_multiple_urls(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_youtube(
+            video_urls=["https://youtu.be/a", "https://youtu.be/b", "https://youtu.be/c"],
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        for u in ["https://youtu.be/a", "https://youtu.be/b", "https://youtu.be/c"]:
+            assert u in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_aozora_multiple_book_ids(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_aozora(book_ids=["1234", "5678"])
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "1234" in cli_args
+        assert "5678" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_bluesky_multiple_urls(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_bluesky(
+            urls=[
+                "https://bsky.app/profile/u/post/a",
+                "https://bsky.app/profile/u/post/b",
+            ],
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "https://bsky.app/profile/u/post/a" in cli_args
+        assert "https://bsky.app/profile/u/post/b" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_rag_add_zenn_multiple_urls(self, _patch_cli_subprocess) -> None:
+        mod = import_module("rag.server")
+        await mod.rag_add_zenn(
+            urls=[
+                "https://zenn.dev/u/articles/x",
+                "https://zenn.dev/u/articles/y",
+            ],
+        )
+        cli_args = _patch_cli_subprocess.call_args[0][1]
+        assert "https://zenn.dev/u/articles/x" in cli_args
+        assert "https://zenn.dev/u/articles/y" in cli_args
+
+
+class TestBulkEmptyInputError:
+    """bulk 化対象で空 list を渡すとエラーメッセージが返ること."""
+
+    @pytest.mark.asyncio
+    async def test_rag_add_youtube_empty_list(self) -> None:
+        mod = import_module("rag.server")
+        result = await mod.rag_add_youtube(video_urls=[])
+        assert "エラー" in result
+        assert "video_urls" in result
+
+    @pytest.mark.asyncio
+    async def test_rag_add_aozora_empty_list(self) -> None:
+        mod = import_module("rag.server")
+        result = await mod.rag_add_aozora(book_ids=[])
+        assert "エラー" in result
+        assert "book_ids" in result
+
+    @pytest.mark.asyncio
+    async def test_rag_add_bluesky_empty_list(self) -> None:
+        mod = import_module("rag.server")
+        result = await mod.rag_add_bluesky(urls=[])
+        assert "エラー" in result
+
+    @pytest.mark.asyncio
+    async def test_rag_add_zenn_empty_list(self) -> None:
+        mod = import_module("rag.server")
+        result = await mod.rag_add_zenn(urls=[])
+        assert "エラー" in result

--- a/tests/test_server_tools_skip_pipeline.py
+++ b/tests/test_server_tools_skip_pipeline.py
@@ -1,11 +1,11 @@
-"""MCP tool への defer_indexing パラメータ + bulk 受付の振る舞いテスト.
+"""MCP tool への skip_pipeline パラメータ + bulk 受付の振る舞いテスト.
 
 Issue #757 / 仕様: docs/specs/rag-knowledge.md 各 rag_* tool セクション
-                   docs/specs/ingesters/common.md 「`--no-pipeline` フラグ共通仕様」
+                   docs/specs/ingesters/common.md 「`--skip-pipeline` フラグ共通仕様」
 
 検証観点:
-- 全 rag_add_* / rag_crawl_* / rag_crawl_documents で defer_indexing=True 時に
-  CLI subprocess の引数に `--no-pipeline` が含まれること
+- 全 rag_add_* / rag_crawl_* / rag_crawl_documents で skip_pipeline=True 時に
+  CLI subprocess の引数に `--skip-pipeline` が含まれること
 - bulk 化対象 (rag_add_youtube/aozora/bluesky/zenn) で list[str] 受付が動作
 - bulk 化対象で空 list がエラーメッセージを返すこと
 """
@@ -36,78 +36,78 @@ def _patch_cli_subprocess():
 
 
 class TestDeferIndexingFlag:
-    """全 add-/crawl- tool で defer_indexing=True が --no-pipeline に変換されること."""
+    """全 add-/crawl- tool で skip_pipeline=True が --skip-pipeline に変換されること."""
 
     @pytest.mark.asyncio
     async def test_rag_add_youtube_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
         await mod.rag_add_youtube(
-            video_urls=["https://youtu.be/aaa"], defer_indexing=True,
+            video_urls=["https://youtu.be/aaa"], skip_pipeline=True,
         )
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_add_youtube_default_no_flag(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
         await mod.rag_add_youtube(video_urls=["https://youtu.be/aaa"])
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" not in cli_args
+        assert "--skip-pipeline" not in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_crawl_youtube_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
         await mod.rag_crawl_youtube(
-            playlist_url="https://example.com/pl", defer_indexing=True,
+            playlist_url="https://example.com/pl", skip_pipeline=True,
         )
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_add_aozora_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
-        await mod.rag_add_aozora(book_ids=["12345"], defer_indexing=True)
+        await mod.rag_add_aozora(book_ids=["12345"], skip_pipeline=True)
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_crawl_aozora_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
-        await mod.rag_crawl_aozora(person_id="00001", defer_indexing=True)
+        await mod.rag_crawl_aozora(person_id="00001", skip_pipeline=True)
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_add_bluesky_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
         await mod.rag_add_bluesky(
-            urls=["https://bsky.app/profile/u/post/x"], defer_indexing=True,
+            urls=["https://bsky.app/profile/u/post/x"], skip_pipeline=True,
         )
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_crawl_bluesky_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
-        await mod.rag_crawl_bluesky(handle="u.bsky.social", defer_indexing=True)
+        await mod.rag_crawl_bluesky(handle="u.bsky.social", skip_pipeline=True)
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_add_zenn_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
         await mod.rag_add_zenn(
-            urls=["https://zenn.dev/u/articles/x"], defer_indexing=True,
+            urls=["https://zenn.dev/u/articles/x"], skip_pipeline=True,
         )
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
     @pytest.mark.asyncio
     async def test_rag_crawl_zenn_defer(self, _patch_cli_subprocess) -> None:
         mod = import_module("rag.server")
-        await mod.rag_crawl_zenn(username="u", defer_indexing=True)
+        await mod.rag_crawl_zenn(username="u", skip_pipeline=True)
         cli_args = _patch_cli_subprocess.call_args[0][1]
-        assert "--no-pipeline" in cli_args
+        assert "--skip-pipeline" in cli_args
 
 
 class TestBulkListExpansion:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

> 破壊的変更を含む。詳細は本 PR body 末尾「破壊的変更」セクションおよび `docs/specs/ingesters/common.md`「\`--no-pipeline\` フラグ共通仕様」を参照。

## Summary

- **CLI 12 コマンドに \`--no-pipeline\` フラグ追加**: `ingest-youtube` / `ingest-youtube-playlist` / `crawl-bluesky` / `crawl-zenn` / `ingest-bluesky` / `ingest-zenn` / `crawl-documents` / `site-ingest` / `ingest-aozora` / `ingest-aozora-author` / `delete`（+ 既存 `add-document` / `add-journal` は対象外）。共通ヘルパー `_add_no_pipeline_option` / `_commit_for_no_pipeline` / `_print_no_pipeline_notice` 経由で実装統一
- **CLI 3 コマンドの bulk 受付化**: `ingest-youtube` / `ingest-aozora` の `nargs='+'`、`delete` の `nargs='+'`
- **aozora bulk 入力での zfill 重複検出**: 同一作品の複数表記 (`['1234', '001234']`) を検出して WARN ログ出力 + 重複排除
- **MCP add-\* / delete の bulk 化（破壊的変更）**: `rag_add_youtube` (`video_url: str` → `video_urls: list[str]`)、`rag_add_aozora` (`book_id: str` → `book_ids: list[str]`)、`rag_add_bluesky` / `rag_add_zenn` の `urls: list[str]` 化、`rag_delete` (`source_id: str` → `source_ids: list[str]`)
- **全 MCP add-\* / crawl-\* に `defer_indexing` パラメータ追加**: CLI の `--no-pipeline` と等価（`add_document` / `add_journal` を除く）
- **\`--download-only\` / \`download_only\` の完全削除（破壊的変更）**: site-ingest / `rag_site_ingest` から `--download-only` / `download_only` を削除し、`--no-pipeline` / `defer_indexing` に統一
- **bulk loop の partial result loss 防止 + 全件失敗時 exit 1**: youtube/aozora/delete handler でループ内例外を per-iteration の try/except で捕捉、`IngestResult.errors=1` を蓄積。集約後 `placed=0 and overwritten=0 and errors>0` なら exit 1（catalog 未ダウンロード等の設定エラー検知用）
- **`--no-pipeline` 経路で `controller.commit()` を確実に呼ぶ**: 11 handler 全てに `_commit_for_no_pipeline()` を導入し、後続の `rebuild --mode incremental` が差分検出可能な状態を保証
- **仕様書 10 件以上を同時更新**: `ingesters/common.md`（共通仕様 SSoT）/ `ingesters/{youtube,bluesky,zenn,aozora,local,journal}.md` / `site-ingest.md` / `rag-knowledge.md` / `infrastructure/content-upload.md` / `README.md`
- **Unit 3 (CLI 起動時遅延ロード化) はスコープ外確定**: 実測の `--help` 起動時間 1.1 秒で NFR 目標 < 1 秒にほぼ到達済み + 重い初期化は既に handler 内で lazy import 済みのため

## 破壊的変更

- CLI: `site-ingest --download-only` → `--no-pipeline`（フラグ削除）
- MCP `rag_site_ingest`: `download_only: bool` → `defer_indexing: bool`（パラメータ rename）
- MCP `rag_add_youtube(video_url: str)` → `rag_add_youtube(video_urls: list[str])`
- MCP `rag_add_aozora(book_id: str)` → `rag_add_aozora(book_ids: list[str])`
- MCP `rag_delete(source_id: str)` → `rag_delete(source_ids: list[str])`

既存の MCP クライアント・運用スクリプトで上記旧パラメータを使用している場合は、本 PR 取り込み後に動作不能になります。

## Test plan

- [x] L1 Unit Test: 2093 件全パス
- [x] L2 Mock E2E: 22 件全パス
- [x] ruff check: All checks passed
- [x] mypy (132 source files): no issues
- [x] 新規テスト追加: `test_cli_no_pipeline.py` (29 件), `test_server_tools_no_pipeline.py` (19 件), `test_rag_mcp_server.py` rag_delete bulk テスト追加
- [x] `download_only` / `--download-only` の参照が src / docs / tests から 0 件（README の破壊的変更注記のみ意図的に保持）

## Related issues

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)