### PR TITLE
feat(aozora): crawl_author の不正 person_id 時の挙動を add_work と対称化 (#760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,13 @@ uv run python -m rag.cli rebuild --mode incremental
 >   （`--skip-pipeline` / `skip_pipeline` に置き換え、同等の振る舞い）
 > - MCP `rag_add_youtube` / `rag_add_aozora` / `rag_delete` のパラメータは複数受付に変更
 >   （`video_url: str` → `video_urls: list[str]` / `book_id: str` → `book_ids: list[str]` / `source_id: str` → `source_ids: list[str]`）
+>
+> **破壊的変更（Issue #760）**:
+>
+> - MCP `rag_crawl_aozora` / CLI `ingest-aozora-author` で `person_id` がカタログに存在しない場合の挙動を変更
+>   （従来: 0 件配置の `IngestResult` を返す → 変更後: `ValueError`「人物 ID '...' がカタログに見つかりません」を送出）
+> - `add_work` 側（`rag_add_aozora` / `ingest-aozora`）の `book_id` 不一致時挙動と対称化。
+>   `person_id` がカタログに存在し取り込み可能作品が 0 件の場合（全作品が著作権あり等）は従来通り 0 件 `IngestResult` を返す
 
 ## Journal CLI
 

--- a/docs/specs/ingesters/aozora.md
+++ b/docs/specs/ingesters/aozora.md
@@ -235,10 +235,11 @@ CSV の URL: https://www.aozora.gr.jp/cards/{person_id}/files/{book_id}_{file_id
 これにより青空文庫公式ページ（カード URL `/cards/000148/card773.html` 等）から抽出した ID（`773` 等のゼロ埋めなし表現）をそのまま渡せる。
 `person_id` 側の正規化も API の対称性を保つために `book_id` と同等の挙動とする（外部から取得した `35` のような短桁 ID をそのまま `crawl_author` に渡せる）。
 6 桁未満はゼロ埋め、6 桁以上はそのまま検索に使う（数値検証や桁数上限チェックは行わない）。
-不正入力時の挙動は API ごとに異なる:
+不正入力時の挙動は `add_work` と `crawl_author` で対称化されている:
 
 - `add_work`: `book_id` がカタログ CSV の「作品ID」と一致しない場合、`ValueError`「作品 ID '...' がカタログに見つかりません」を送出する
-- `crawl_author`: `person_id` がカタログ CSV の「人物ID」と一致しない場合、例外を送出せず 0 件配置の `IngestResult` を返す（一括処理で「該当作品なし」と「不正な ID」を区別しない既存仕様）
+- `crawl_author`: `person_id` がカタログ CSV の「人物ID」と一致しない場合、`ValueError`「人物 ID '...' がカタログに見つかりません」を送出する（`add_work` と対称）
+- `crawl_author`: `person_id` はカタログに存在するが取り込み可能作品が 0 件の場合（全作品が著作権ありでフィルタされた等）は例外を送出せず 0 件配置の `IngestResult` を返す（「ID 不正」と「ID は正しいが対象作品なし」を区別する）
 
 ### .meta サイドカーファイル
 
@@ -436,7 +437,6 @@ flowchart TD
 | 作品 ID がカタログに存在しない | エラーメッセージを返す |
 | 著作権フラグが「なし」以外の作品を取り込み | エラーメッセージを返す（著作権ありの作品は取り込み不可） |
 | 著者名で検索して 0 件 | 0 件の結果を返す |
-| 著者の作品が 0 件（全て著作権あり） | 著作権フリー作品がない旨をメッセージで返す |
 | CSV の XHTML URL が欠落 | 該当作品をスキップし、エラーログを出力する |
 | GitHub Raw URL からの 404 / その他 HTTP エラー | 該当作品をスキップし、`errors` に `metadata_fetch` カテゴリで計上する（HTTP ステータス・URL を `status` / `url` に記録）。エラーログを出力して処理を続行する |
 | XHTML DL の連続失敗がサーキットブレーカー閾値を超えた場合 | 以降の作品取り込みを中断し、`aborted=True` / `abort_reason="consecutive failures"` を設定する。取得済みデータは配置する（閾値はコード SSoT: `src/rag/pipeline/ingesters/aozora.py`） |
@@ -453,7 +453,8 @@ flowchart TD
 | `book_id` / `person_id` に 7 桁以上の数字文字列を指定 | zfill 効果なしでそのままカタログ検索する（数値検証・桁数上限チェックなし） |
 | `book_id` / `person_id` に非数字文字（例: `abc`）を指定 | バリデーションは行わず、そのままカタログ検索する |
 | `add_work` で `book_id` がカタログに見つからない | `ValueError`「作品 ID '...' がカタログに見つかりません」を送出する |
-| `crawl_author` で `person_id` がカタログに見つからない | 例外を送出せず、0 件配置の `IngestResult` を返す（一括処理の既存仕様） |
+| `crawl_author` で `person_id` がカタログに見つからない | `ValueError`「人物 ID '...' がカタログに見つかりません」を送出する（`add_work` と対称） |
+| `crawl_author` で `person_id` は存在するが取り込み可能作品が 0 件 | 例外を送出せず、0 件配置の `IngestResult` を返す（「ID 不正」と「ID は正しいが対象作品なし」を区別） |
 | カタログ ZIP のダウンロードに失敗 | エラーメッセージを返す |
 | カタログ ZIP の展開に失敗（破損等） | エラーメッセージを返す |
 | .meta ファイルの書き込みに失敗した場合 | ファイル物理削除禁止制約により、配置済みデータファイルのロールバックは行わない。エラーログを出力して処理を続行する |

--- a/src/rag/pipeline/ingesters/aozora/_facade.py
+++ b/src/rag/pipeline/ingesters/aozora/_facade.py
@@ -293,16 +293,26 @@ class AozoraIngester(BaseIngester):
             max_works if max_works is not None else self._max_works,
         )
 
-        effective_max = self._validate_max_works(
-            max_works if max_works is not None else self._max_works
-        )
-
+        # カタログ操作系のエラー（未ダウンロード / person_id 不一致）を
+        # max_works バリデーションより先に伝える（利用者の直感に合わせる）
         records = self._load_catalog()
         if records is None:
             raise ValueError(
                 "カタログが未ダウンロードです。"
                 "先に rag_update_aozora_catalog でカタログを更新してください"
             )
+
+        # person_id がカタログに存在するか検証（add_work と対称化）
+        if not any(
+            record.get(COL_PERSON_ID, "") == person_id for record in records
+        ):
+            raise ValueError(
+                f"人物 ID '{person_id}' がカタログに見つかりません"
+            )
+
+        effective_max = self._validate_max_works(
+            max_works if max_works is not None else self._max_works
+        )
 
         # 人物 ID で検索 + 著作権フリーフィルタ
         targets: list[dict[str, str]] = []

--- a/tests/test_pipeline_ingesters_aozora.py
+++ b/tests/test_pipeline_ingesters_aozora.py
@@ -354,6 +354,78 @@ class TestCatalogNotFound:
             await ingester.crawl_author("000035")
 
 
+# === ID 不一致テスト（add_work / crawl_author の対称性） ===
+
+
+class TestIdNotFoundInCatalog:
+    """ID 不一致時の ValueError 送出（add_work / crawl_author の対称性）.
+
+    本クラスは Issue #760 で対称化された API ペアの挙動を 1 箇所に集約する。
+    `add_work` 側の不一致挙動は元々存在する仕様だが、対称化の宣言として併置する。
+    """
+
+    @pytest.mark.asyncio()
+    async def test_add_work_book_id_not_in_catalog(
+        self, source_store: SourceStore
+    ) -> None:
+        """add_work で book_id がカタログに存在しない場合 ValueError."""
+        _write_catalog(source_store, [_make_record(book_id="001567")])
+        fetcher = StubAozoraFetcher(xhtml_default=b"<html><body>test</body></html>")
+        ingester = make_aozora_ingester(source_store, fetcher=fetcher)
+        with pytest.raises(ValueError, match="作品 ID '999999' がカタログに見つかりません"):
+            await ingester.add_work("999999")
+
+    @pytest.mark.asyncio()
+    async def test_crawl_author_person_id_not_in_catalog(
+        self, source_store: SourceStore
+    ) -> None:
+        """crawl_author で person_id がカタログに存在しない場合 ValueError（add_work と対称）."""
+        _write_catalog(source_store, [_make_record(person_id="000035")])
+        fetcher = StubAozoraFetcher(xhtml_default=b"<html><body>test</body></html>")
+        ingester = make_aozora_ingester(source_store, fetcher=fetcher)
+        with pytest.raises(ValueError, match="人物 ID '999999' がカタログに見つかりません"):
+            await ingester.crawl_author("999999")
+
+    @pytest.mark.asyncio()
+    async def test_crawl_author_person_id_zfill_then_not_in_catalog(
+        self, source_store: SourceStore
+    ) -> None:
+        """zfill 後の person_id がカタログに存在しない場合、正規化後の値でエラーメッセージを返す."""
+        _write_catalog(source_store, [_make_record(person_id="000035")])
+        fetcher = StubAozoraFetcher(xhtml_default=b"<html><body>test</body></html>")
+        ingester = make_aozora_ingester(source_store, fetcher=fetcher)
+        with pytest.raises(ValueError, match="人物 ID '000999' がカタログに見つかりません"):
+            await ingester.crawl_author("999")
+
+
+# === バリデーション順序テスト（カタログ操作 > max_works 検証） ===
+
+
+class TestCrawlAuthorValidationOrder:
+    """crawl_author のバリデーション順序: カタログ操作系のエラーを max_works 検証より先に伝える."""
+
+    @pytest.mark.asyncio()
+    async def test_no_catalog_takes_priority_over_invalid_max_works(
+        self, source_store: SourceStore
+    ) -> None:
+        """カタログ未ダウンロード + max_works 不正が同時に発生した場合、カタログエラーが先に出る."""
+        fetcher = StubAozoraFetcher(xhtml_default=b"<html><body>test</body></html>")
+        ingester = make_aozora_ingester(source_store, fetcher=fetcher)
+        with pytest.raises(ValueError, match="カタログが未ダウンロード"):
+            await ingester.crawl_author("000035", max_works=0)
+
+    @pytest.mark.asyncio()
+    async def test_person_id_not_found_takes_priority_over_invalid_max_works(
+        self, source_store: SourceStore
+    ) -> None:
+        """person_id 不一致 + max_works 不正が同時に発生した場合、person_id エラーが先に出る."""
+        _write_catalog(source_store, [_make_record(person_id="000035")])
+        fetcher = StubAozoraFetcher(xhtml_default=b"<html><body>test</body></html>")
+        ingester = make_aozora_ingester(source_store, fetcher=fetcher)
+        with pytest.raises(ValueError, match="人物 ID '999999' がカタログに見つかりません"):
+            await ingester.crawl_author("999999", max_works=0)
+
+
 # === 重複スキップテスト ===
 
 


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★（破壊的変更を含む API 対称化）
- [x] docs: ドキュメント更新

## Summary

- `crawl_author(person_id)` で person_id がカタログに存在しない場合、`ValueError`「人物 ID '...' がカタログに見つかりません」を送出する（`add_work` と対称化）
  - 従来: 0 件配置の `IngestResult` を返す（破壊的変更）
  - `person_id` がカタログに存在し取り込み可能作品が 0 件の場合（全作品が著作権あり等）は従来通り 0 件 `IngestResult` を返す
- バリデーション順序を変更: カタログ操作系エラー（未ダウンロード / person_id 不一致）を `max_works` 検証より先に伝える
- `docs/specs/ingesters/aozora.md`: URL 変換規則とエッジケース表を更新（一貫性のため箇条書き分割、重複行削除）
- `README.md`: 「破壊的変更（Issue #760）」セクションを追加（PR #761 のフォーマットに準拠）
- テスト: `TestIdNotFoundInCatalog`（4 件）+ `TestCrawlAuthorValidationOrder`（2 件）追加。重複していた既存テスト `test_crawl_author_person_id_found_but_no_eligible_works` を削除

## Test plan

- [x] `uv run pytest -n0 tests/test_pipeline_ingesters_aozora.py` 全 42 件パス
- [x] `uv run ruff check` / `uv run mypy src/rag/pipeline/ingesters/aozora/` クリア
- [x] `npx markdownlint-cli2` 0 error
- [x] L3 本番相当 QA は別 Issue #763 で実施

## Related issues

Closes #760
Related: #763 (L3 本番相当 QA タスク)