### PR TITLE
fix(aozora,converter): aozora HTML の charset 自動検出誤判定で文字化けする問題を修正 (#762)

### DIFF
--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -525,7 +525,7 @@ source_type が `local` のメディアファイル（画像・動画）は、�
 |--------|---------|
 | 未対応の拡張子のファイル | 変換をスキップし、警告ログを出力する。converted_store にはファイルを配置しない |
 | 0 バイトのファイル | 変換をスキップし、警告ログを出力する |
-| HTML ファイルの文字エンコーディングが UTF-8 以外 | charset_normalizer ベースのエンコーディング自動推定で元のエンコーディングを検出し、UTF-8 に変換する |
+| HTML ファイルの文字エンコーディングが UTF-8 以外 | charset_normalizer ベースのエンコーディング自動推定で元のエンコーディングを検出し、UTF-8 に変換する。ただし `source_type=aozora` の HTML は source_type 固有の前処理として XML 宣言 / meta タグの charset を優先採用し、抽出失敗時は `cp932` にフォールバックする（charset_normalizer の誤検出回避。詳細は [ingesters/aozora.md](ingesters/aozora.md) を参照） |
 | PDF のテキスト抽出結果が空 | 変換をスキップし、警告ログを出力する。converted_store にはファイルを配置しない |
 | MinerU が未インストールの環境で `rag_pdf_backend` が `auto` | auto 判定で MinerU が必要と判断された場合、pymupdf4llm にフォールバックし、警告ログを出力する |
 | MinerU が未インストールの環境で `rag_pdf_backend` が `mineru` | エラーログを出力し、当該ファイルの変換をスキップする |

--- a/docs/specs/ingesters/aozora.md
+++ b/docs/specs/ingesters/aozora.md
@@ -440,7 +440,7 @@ flowchart TD
 | CSV の XHTML URL が欠落 | 該当作品をスキップし、エラーログを出力する |
 | GitHub Raw URL からの 404 / その他 HTTP エラー | 該当作品をスキップし、`errors` に `metadata_fetch` カテゴリで計上する（HTTP ステータス・URL を `status` / `url` に記録）。エラーログを出力して処理を続行する |
 | XHTML DL の連続失敗がサーキットブレーカー閾値を超えた場合 | 以降の作品取り込みを中断し、`aborted=True` / `abort_reason="consecutive failures"` を設定する。取得済みデータは配置する（閾値はコード SSoT: `src/rag/pipeline/ingesters/aozora.py`） |
-| XHTML の文字コード（Shift_JIS） | 生データのまま source_store に保存。エンコーディング変換はコンバーターが charset_normalizer で自動検出して実施する |
+| XHTML の文字コード（Shift_JIS） | 生データのまま source_store に保存。エンコーディング変換はコンバーターが aozora 専用経路で実施する。XML 宣言または meta タグ（`http-equiv="Content-Type"`）の charset を優先採用し、抽出失敗・解釈不能な値の場合は `cp932`（Shift_JIS のスーパーセット）にフォールバックする。旧字旧仮名・特殊文字を多く含む作品で `charset_normalizer` の自動検出が誤った別エンコーディング（cp1252 等）を返し文字化けする問題への対応 |
 | 同一作品の再取り込み | source_id（= ファイルパス）に該当するファイルが存在する場合はスキップする |
 | バジェット上限到達 | 取得済みデータを配置し、上限到達の旨をログ出力する |
 | サーキットブレーカー発動 | 操作を中断し、取得済みデータを配置する。`aborted=True` を設定する。エラーの詳細をログ出力する |

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -397,7 +397,11 @@ class Converter:
             変換後テキスト、または失敗時は None
         """
         if ext in (".html", ".htm"):
-            return convert_html(source_path, self._html_remove_class_re)
+            return convert_html(
+                source_path,
+                self._html_remove_class_re,
+                source_type=detect_source_type(file_path),
+            )
 
         if ext == ".pdf":
             return extract_pdf(source_path, self._pdf_config)

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import codecs
 import logging
 import re
 import shutil
@@ -15,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from rag.media.analyzer import MediaAnalyzer
+    from rag.store.models import SourceType
 
 from bs4 import BeautifulSoup, Tag
 from charset_normalizer import from_bytes
@@ -22,6 +24,19 @@ from charset_normalizer import from_bytes
 from rag.markdown import RagMarkdownConverter
 
 logger = logging.getLogger(__name__)
+
+# aozora HTML の charset 抽出用（XML 宣言 / meta http-equiv の両方をカバー）
+_AOZORA_CHARSET_RE = re.compile(
+    rb'(?:<\?xml[^>]+encoding=|<meta[^>]+charset=)["\']?([\w\-]+)',
+    re.IGNORECASE,
+)
+# ハードリミット: aozora HTML の charset 抽出スキャン範囲（先頭バイト数）。
+# XML 宣言 + meta タグは HTML 先頭にあり、過剰なスキャンを防ぐ。
+_AOZORA_HEAD_SCAN_BYTES = 2048
+_AOZORA_FALLBACK_ENCODING = "cp932"
+_AOZORA_SHIFTJIS_ALIASES = frozenset({
+    "shift_jis", "shift-jis", "sjis", "x-sjis", "shift_jisx0213",
+})
 
 # --- HTML void 要素修正 ---
 
@@ -205,9 +220,34 @@ def _clean_content_area(
         tag.decompose()
 
 
+def _detect_aozora_encoding(raw_bytes: bytes) -> str:
+    """aozora HTML の charset を XML 宣言 / meta タグから抽出する.
+
+    aozora は GitHub aozorabunko リポジトリ由来で歴史的に Shift_JIS が標準だが、
+    将来別エンコーディングに切り替わる可能性に備えて meta タグを優先する。
+    抽出失敗・解釈不能な値の場合は cp932（Shift_JIS のスーパーセット）にフォールバックする。
+
+    Returns:
+        Python 標準の codec 名。aozora の Shift_JIS 系 alias または抽出失敗時は
+        ``"cp932"``。それ以外は ``codecs.lookup`` で正規化された codec 名を返す。
+    """
+    match = _AOZORA_CHARSET_RE.search(raw_bytes[:_AOZORA_HEAD_SCAN_BYTES])
+    if match is None:
+        return _AOZORA_FALLBACK_ENCODING
+    charset_raw = match.group(1).decode("ascii", errors="ignore").lower()
+    if charset_raw in _AOZORA_SHIFTJIS_ALIASES:
+        return _AOZORA_FALLBACK_ENCODING
+    try:
+        codec_info = codecs.lookup(charset_raw)
+    except LookupError:
+        return _AOZORA_FALLBACK_ENCODING
+    return codec_info.name
+
+
 def convert_html(
     source_path: Path,
     remove_class_re: re.Pattern[str],
+    source_type: SourceType | None = None,
 ) -> str | None:
     """HTML ファイルを Markdown に変換する.
 
@@ -216,6 +256,11 @@ def convert_html(
     Args:
         source_path: HTML ファイルの絶対パス
         remove_class_re: 除去対象 class トークンのコンパイル済み正規表現
+        source_type: source_store のトップレベルディレクトリから判定された source_type。
+            "aozora" の場合は charset_normalizer 自動推定をスキップし、
+            XML 宣言 / meta タグから charset を抽出する経路を通る（旧字旧仮名・特殊文字を
+            多く含む作品で charset_normalizer が誤検出するため）。
+            None の場合は従来どおり charset_normalizer で自動推定する。
 
     Returns:
         Markdown テキスト、または変換失敗時は None
@@ -226,12 +271,26 @@ def convert_html(
         logger.exception("Failed to read HTML file: %s", source_path)
         return None
 
-    # エンコーディング自動推定（charset_normalizer）
-    detection = from_bytes(raw_bytes).best()
-    if detection is None:
-        logger.warning("Failed to detect encoding: %s", source_path)
-        return None
-    html_text = str(detection)
+    if source_type == "aozora":
+        encoding = _detect_aozora_encoding(raw_bytes)
+        try:
+            html_text = raw_bytes.decode(encoding)
+        except UnicodeDecodeError:
+            # 検出 encoding で失敗した場合のフォールバック。
+            # encoding == cp932 で失敗するケース（破損データ等）でも errors="replace" で
+            # 部分的にでも本文を救済する（None 返却での全件破棄を避ける）。
+            logger.warning(
+                "Failed to decode aozora HTML with %s, retrying with %s and errors=replace: %s",
+                encoding, _AOZORA_FALLBACK_ENCODING, source_path,
+            )
+            html_text = raw_bytes.decode(_AOZORA_FALLBACK_ENCODING, errors="replace")
+    else:
+        # エンコーディング自動推定（charset_normalizer）
+        detection = from_bytes(raw_bytes).best()
+        if detection is None:
+            logger.warning("Failed to detect encoding: %s", source_path)
+            return None
+        html_text = str(detection)
 
     soup = BeautifulSoup(html_text, "html.parser")
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -23,6 +23,8 @@ from rag.converter.converter import (
     get_converted_rel_path,
 )
 from rag.converter.handlers import (
+    _AOZORA_HEAD_SCAN_BYTES,
+    _detect_aozora_encoding,
     _fix_void_elements,
     compile_remove_class_re,
     convert_html,
@@ -484,6 +486,114 @@ class TestConvertHtml:
         result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
         assert result is not None
         assert "日本語テスト" in result
+
+    def test_aozora_shift_jis_with_meta_tag(self, tmp_path: Path) -> None:
+        """aozora 経路: meta タグで charset=Shift_JIS、Shift_JIS bytes → 正しく decode."""
+        html = (
+            '<?xml version="1.0" encoding="Shift_JIS"?>'
+            '<html><head>'
+            '<meta http-equiv="Content-Type" content="text/html;charset=Shift_JIS" />'
+            '<title>谷崎潤一郎 少年</title>'
+            '</head><body><p>旧字旧仮名の作品本文。傳統的な日本語。</p></body></html>'
+        )
+        html_file = tmp_path / "001383.html"
+        html_file.write_bytes(html.encode("shift_jis"))
+
+        result = convert_html(
+            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+        )
+        assert result is not None
+        assert "旧字旧仮名の作品本文" in result
+        assert "傳統的な日本語" in result
+
+    def test_aozora_meta_tag_missing_fallback_cp932(self, tmp_path: Path) -> None:
+        """aozora 経路: meta タグなしの Shift_JIS bytes → cp932 fallback で正しく decode."""
+        html = "<html><body><p>メタタグなしの作品本文。</p></body></html>"
+        html_file = tmp_path / "no_meta.html"
+        html_file.write_bytes(html.encode("shift_jis"))
+
+        result = convert_html(
+            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+        )
+        assert result is not None
+        assert "メタタグなしの作品本文" in result
+
+    def test_aozora_invalid_charset_fallback_cp932(self, tmp_path: Path) -> None:
+        """aozora 経路: meta タグの charset 値が不正 → cp932 fallback."""
+        html = (
+            '<html><head>'
+            '<meta http-equiv="Content-Type" content="text/html;charset=invalid-encoding" />'
+            '</head><body><p>不正 charset の作品本文。</p></body></html>'
+        )
+        html_file = tmp_path / "invalid_charset.html"
+        html_file.write_bytes(html.encode("shift_jis"))
+
+        result = convert_html(
+            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+        )
+        assert result is not None
+        assert "不正 charset の作品本文" in result
+
+    def test_aozora_utf8_with_utf8_meta_tag(self, tmp_path: Path) -> None:
+        """aozora 経路: UTF-8 HTML + UTF-8 meta タグ → meta タグを尊重して UTF-8 decode.
+
+        将来 aozora が UTF-8 配信に切り替わるケースに備えた振る舞いの検証。
+        """
+        html = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<html><head>'
+            '<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />'
+            '</head><body><p>UTF-8 配信の作品本文。</p></body></html>'
+        )
+        html_file = tmp_path / "utf8.html"
+        html_file.write_bytes(html.encode("utf-8"))
+
+        result = convert_html(
+            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+        )
+        assert result is not None
+        assert "UTF-8 配信の作品本文" in result
+
+    def test_non_aozora_html_uses_charset_normalizer(self, tmp_path: Path) -> None:
+        """source_type=None の場合は従来どおり charset_normalizer 経路を通る (回帰確認)."""
+        html = "<html><body><p>UTF-8 default content.</p></body></html>"
+        html_file = tmp_path / "web.html"
+        html_file.write_text(html, encoding="utf-8")
+
+        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        assert result is not None
+        assert "UTF-8 default content." in result
+
+
+class TestDetectAozoraEncoding:
+    """_detect_aozora_encoding の境界条件テスト."""
+
+    def test_meta_tag_shift_jis_returns_cp932(self) -> None:
+        raw = b'<meta http-equiv="Content-Type" content="text/html;charset=Shift_JIS" />'
+        assert _detect_aozora_encoding(raw) == "cp932"
+
+    def test_xml_declaration_shift_jis_returns_cp932(self) -> None:
+        raw = b'<?xml version="1.0" encoding="Shift_JIS"?>'
+        assert _detect_aozora_encoding(raw) == "cp932"
+
+    def test_meta_tag_utf8_returns_normalized_codec_name(self) -> None:
+        raw = b'<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />'
+        # codecs.lookup で正規化された Python 標準の codec 名を返す
+        assert _detect_aozora_encoding(raw) == "utf-8"
+
+    def test_no_meta_tag_returns_cp932_fallback(self) -> None:
+        raw = b'<html><body><p>plain bytes</p></body></html>'
+        assert _detect_aozora_encoding(raw) == "cp932"
+
+    def test_invalid_charset_value_returns_cp932_fallback(self) -> None:
+        raw = b'<meta charset="not-a-real-encoding" />'
+        assert _detect_aozora_encoding(raw) == "cp932"
+
+    def test_charset_outside_head_scan_window_ignored(self) -> None:
+        # _AOZORA_HEAD_SCAN_BYTES を超えた位置の charset 宣言は無視される
+        padding = b" " * (_AOZORA_HEAD_SCAN_BYTES + 100)
+        raw = padding + b'<meta charset="UTF-8" />'
+        assert _detect_aozora_encoding(raw) == "cp932"
 
     def test_table_conversion(self, tmp_path: Path) -> None:
         html = (


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- charset_normalizer の自動検出が旧字旧仮名・特殊文字を多く含む aozora 作品で別エンコーディング（cp1252 等）を返し、UTF-8 変換結果が文字化けする問題に対応
- aozora 専用経路として XML 宣言 / meta タグの `charset` を優先採用し、抽出失敗・解釈不能な値の場合は `cp932`（Shift_JIS のスーパーセット）にフォールバック
- 他 source_type の HTML は従来の charset_normalizer 自動推定経路を維持（影響なし）
- L1 unit test 11 ケース追加（aozora 経路 5 ケース + `_detect_aozora_encoding` 6 ケース）
- 仕様書更新: `docs/specs/ingesters/aozora.md` line 443 を新方針で書き換え + `docs/specs/converter.md` のエッジケース表に最小補足を追加

## Test plan

- [x] L1 Unit Test: 2104 件 pass（`uv run pytest`）
- [x] L2 aozora E2E: 3 件 pass（`uv run pytest tests/e2e/test_ingest_mcp_aozora.py -m e2e -n0`）
- [x] ruff: All checks passed
- [x] mypy: Success: no issues found in 132 source files
- [x] code-reviewer / doc-reviewer 実施済み（要修正は対応・要相談は triage で全件確定）

既存 9 件の文字化けデータの再変換は本 PR スコープ外（QA Issue #764 でマージ後に実施）。

## Related issues

Closes #762