### PR TITLE
fix(content-upload): CLI 連続実行時の LOCK_CONFLICT 解消（write helper にリトライ追加） (#755)

### DIFF
--- a/docs/specs/infrastructure/content-upload.md
+++ b/docs/specs/infrastructure/content-upload.md
@@ -59,10 +59,21 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
   ロック取得処理の実施主体は CLI とし、MCP サーバー（`src/rag/server/`）からの書き込みも CLI サブプロセスを起動して同一のロック取得処理を利用する。
   サーバー側自身はロックファイルを直接操作しない
 - **ロックファイル**: source_store ディレクトリ直下に配置する。`write_lock`（書き込みロック、ファイル名 `.write.lock`）と `rebuild_lock`（再構築ロック、ファイル名 `.rebuild.lock`）でそれぞれ別のロックファイルを使用する
-- **ノンブロッキング**: CLI はロック取得を試み（`LOCK_NB` / `LK_NBLCK`）、取得できない場合は待機せず即座にエラーを返却する。
-  CLI はロック競合時に JSON Lines の error メッセージ（`type: "error"`）にロック競合コード（`LOCK_CONFLICT`）とロック種別（`write` / `rebuild`）を含め、exit code 1 で終了する。
-  サーバー側（`src/rag/server/cli_subprocess.py`）は CLI サブプロセスの error メッセージからロック競合を判定し、Upload HTTP API ではロック種別に応じた HTTP 応答（`write` 競合 = 429、`rebuild` 競合 = 503）+ `Retry-After` ヘッダ、MCP ツールではロック種別に応じたエラーメッセージとして返却する。
-  CLI 直接実行では標準エラー出力 + exit code 1 を返す
+- **ノンブロッキング primitive + helper レベルの短時間リトライ**:
+  低レベル `FileLock` / `PipelineLock` は常にノンブロッキング（`LOCK_NB` / `LK_NBLCK`）で動作する。
+  書き込み系 CLI helper (`_write_lock_or_exit`) は `kind="write"` の競合に限り短時間の指数バックオフでリトライし
+  （CLI 連続実行時の OS ロック解放遅延を吸収する目的）、
+  リトライ全失敗または `kind="rebuild"` の場合は即座にエラーを返却する。
+  rebuild コマンド側の lock helper（`rebuild_lock` を取得する処理）はリトライしない
+  （rebuild は秒〜分単位の長時間処理のため短時間リトライの意味が薄い）。
+  CLI はロック競合時に JSON Lines の error メッセージ（`type: "error"`）に
+  ロック競合コード（`LOCK_CONFLICT`）とロック種別（`write` / `rebuild`）を含め、exit code 1 で終了する。
+  サーバー側（`src/rag/server/cli_subprocess.py`）は CLI サブプロセスの error メッセージから
+  ロック競合を判定し、Upload HTTP API ではロック種別に応じた HTTP 応答
+  （`write` 競合 = 429、`rebuild` 競合 = 503）+ `Retry-After` ヘッダ、
+  MCP ツールではロック種別に応じたエラーメッセージとして返却する。
+  CLI 直接実行では標準エラー出力 + exit code 1 を返す。
+  リトライ間隔・回数の具体値は `src/rag/cli.py` の `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を SSoT とする。
 - **ロック種別の伝搬**: CLI のロック競合エラーには種別識別子（`write` または `rebuild`）を含める。この識別子は Upload HTTP API の HTTP ステータスコード・`Retry-After` 値の選択と、MCP ツールのエラーメッセージの切替に使用する。識別子の意味は「取得失敗したロック」であり、外部プロセスの保持状態を示す
 - **lock_type 不明時のフォールバック**: CLI エラー応答に `details.lock_type` が含まれない
   （低レベル `FileLock` 直接利用で `kind=None` の場合、または旧バージョン CLI との後方互換）、

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -184,6 +184,14 @@ def _output_error(
     sys.exit(1)
 
 
+# write_lock 取得失敗（kind=write）時の指数バックオフ間隔（秒）。
+# CLI 連続実行時の OS ファイルロック解放遅延を吸収する目的。
+# 4 回再試行 = 初回 + 4 回 = 最大 5 回試行。合計待機時間 ~1.85s。
+# kind=rebuild は秒〜分単位の処理が走っているケースのため対象外（即失敗）。
+# Issue #755
+_WRITE_LOCK_RETRY_BACKOFFS_SEC: tuple[float, ...] = (0.1, 0.25, 0.5, 1.0)
+
+
 @contextlib.contextmanager
 def _write_lock_or_exit(
     source_store_root: Path,
@@ -195,6 +203,10 @@ def _write_lock_or_exit(
     ロック取得に失敗した場合はロック種別に応じたメッセージで _output_error 経由で
     exit する。with 文を抜ける際にロックは自動解放される。
 
+    kind=write の競合に対しては短時間の指数バックオフでリトライする
+    （CLI 連続実行時の OS ロック解放遅延を吸収するため）。kind=rebuild の
+    競合はリトライせず即失敗する。
+
     仕様: docs/specs/infrastructure/content-upload.md の「rebuild との相互排他」
 
     使い方::
@@ -203,23 +215,39 @@ def _write_lock_or_exit(
             # ロック保持下の処理
             ...
     """
+    import time
+
     from .infrastructure.file_lock import LockAcquisitionError, write_lock
 
     lock = write_lock(source_store_root)
-    try:
-        lock.acquire()
-    except LockAcquisitionError as e:
-        if e.kind == "rebuild":
+    last_error: LockAcquisitionError | None = None
+    for backoff in (None, *_WRITE_LOCK_RETRY_BACKOFFS_SEC):
+        if backoff is not None:
+            time.sleep(backoff)
+        try:
+            lock.acquire()
+        except LockAcquisitionError as e:
+            last_error = e
+            # kind=rebuild はリトライ対象外（即失敗）。kind=write はループ継続
+            if e.kind == "rebuild":
+                break
+        else:
+            # 取得成功
+            last_error = None
+            break
+
+    if last_error is not None:
+        if last_error.kind == "rebuild":
             msg = "別の再構築が実行中です（ロック競合）"
         else:
             msg = "別の取り込みが実行中です（ロック競合）"
         if json_out:
             _output_error(
-                CliErrorCode.LOCK_CONFLICT, msg, lock_type=e.kind,
+                CliErrorCode.LOCK_CONFLICT, msg, lock_type=last_error.kind,
             )
         else:
             print(f"エラー: {msg}", file=sys.stderr)
-        raise SystemExit(1) from e
+        raise SystemExit(1) from last_error
     try:
         yield
     finally:

--- a/tests/test_cli_lock_conflict.py
+++ b/tests/test_cli_lock_conflict.py
@@ -12,6 +12,9 @@ details.lock_type に `e.kind` を正しく詰めることを検証する。サ�
   2 kind（rebuild / write）= 6 ケース
 - 既存の run_rebuild は rebuild_lock（別ロック）のためスコープ外
 - write_lock をモックして LockAcquisitionError を送出させる
+- kind=write はリトライ対象（Issue #755）のため、リトライ実時間を消費しないよう
+  `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を空タプルに上書きする
+  `_disable_lock_retry_backoff` fixture をクラス単位で適用
 """
 
 from __future__ import annotations
@@ -20,12 +23,25 @@ import argparse
 import asyncio
 import io
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rag.infrastructure.file_lock import LockAcquisitionError, LockKind
+
+
+@pytest.fixture
+def _disable_lock_retry_backoff() -> Iterator[None]:
+    """write_lock リトライのバックオフを無効化する fixture.
+
+    Issue #755 で導入した `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を空タプルに置き換え、
+    既存テストの実時間消費（最大 ~1.85s × ケース数）を回避する。
+    リトライ動作自体の検証は `TestWriteLockRetryBehavior` で別途実施する。
+    """
+    with patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", ()):
+        yield
 
 
 def _make_lock_mock(kind: LockKind) -> MagicMock:
@@ -44,6 +60,7 @@ def _parse_error_json(captured_out: str) -> dict[str, object]:
     return parsed
 
 
+@pytest.mark.usefixtures("_disable_lock_retry_backoff")
 class TestAddJournalLockConflict:
     """run_add_journal のロック競合 → lock_type 伝搬テスト."""
 
@@ -152,11 +169,14 @@ class TestAddJournalLockConflict:
         assert "取り込み" in str(parsed["message"])
 
 
+@pytest.mark.usefixtures("_disable_lock_retry_backoff")
 class TestIngestZennLockConflict:
     """run_ingest_zenn（ヘルパー経由）のロック競合 → lock_type 伝搬テスト.
 
-    ヘルパー `_write_lock_or_exit` を経由する代表関数として、
-    個別 try/except を使う add_journal / add_document とは別のパスを検証する。
+    ヘルパー `_write_lock_or_exit` 経由パスの代表として `run_ingest_zenn` で
+    検証する。書き込み系 CLI 関数は `_write_lock_or_exit` 経由に統一されており
+    （add_journal / add_document / ingest_zenn 等）、本テストはその統一パスの
+    回帰検出を担う。
     """
 
     @pytest.mark.parametrize("kind", ["rebuild", "write"])
@@ -251,3 +271,120 @@ class TestWriteLockOrExitHelper:
         details = parsed.get("details")
         assert isinstance(details, dict)
         assert details["lock_type"] == "rebuild"
+
+
+class TestWriteLockRetryBehavior:
+    """_write_lock_or_exit の write 競合時リトライ挙動テスト（Issue #755）.
+
+    CLI 連続実行時の OS ロック解放遅延を吸収するため、kind=write の
+    LockAcquisitionError に対してのみ短時間リトライする設計を検証する。
+
+    各テストは `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を `(0.0, 0.0, 0.0, 0.0)` に
+    再 patch しつつ `time.sleep` を mock することで、リトライの実時間消費を回避し
+    試行回数のみを検証する。
+    """
+
+    def test_retry_succeeds_after_initial_failure(self) -> None:
+        """初回失敗 → リトライで成功するケース（kind=write）."""
+        mock_lock = MagicMock()
+        # 1 回目失敗 → 2 回目成功
+        mock_lock.acquire.side_effect = [
+            LockAcquisitionError(
+                Path("/tmp/test/.write.lock"), kind="write",
+            ),
+            None,  # 成功
+        ]
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", (0.0, 0.0, 0.0, 0.0)),
+            patch("time.sleep") as mock_sleep,
+        ):
+            from rag.cli import _write_lock_or_exit
+            with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
+                pass
+        # acquire は 2 回呼ばれる（初回失敗 + 再試行成功）
+        assert mock_lock.acquire.call_count == 2
+        mock_lock.release.assert_called_once()
+        # backoff の sleep は 1 回呼ばれる（初回失敗後の 1 回目バックオフ）
+        assert mock_sleep.call_count == 1
+
+    def test_retry_exhausted_then_exits_with_lock_conflict(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """全リトライ失敗後に LOCK_CONFLICT で exit 1（kind=write）."""
+        mock_lock = MagicMock()
+        # 全試行で失敗
+        mock_lock.acquire.side_effect = LockAcquisitionError(
+            Path("/tmp/test/.write.lock"), kind="write",
+        )
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", (0.0, 0.0, 0.0, 0.0)),
+            patch("time.sleep"),
+        ):
+            from rag.cli import _write_lock_or_exit
+            with pytest.raises(SystemExit) as exc_info:
+                with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
+                    pytest.fail("body should not execute when retries exhausted")
+            assert exc_info.value.code == 1
+        # 初回 + 4 回再試行 = 5 回試行
+        assert mock_lock.acquire.call_count == 5
+        mock_lock.release.assert_not_called()
+
+        captured = capsys.readouterr()
+        parsed = _parse_error_json(captured.out)
+        assert parsed["code"] == "LOCK_CONFLICT"
+        details = parsed.get("details")
+        assert isinstance(details, dict)
+        assert details["lock_type"] == "write"
+
+    def test_rebuild_kind_does_not_retry(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """kind=rebuild はリトライ対象外で初回失敗で即 exit."""
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = LockAcquisitionError(
+            Path("/tmp/test/.rebuild.lock"), kind="rebuild",
+        )
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", (0.0, 0.0, 0.0, 0.0)),
+            patch("time.sleep") as mock_sleep,
+        ):
+            from rag.cli import _write_lock_or_exit
+            with pytest.raises(SystemExit) as exc_info:
+                with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
+                    pytest.fail("body should not execute when acquire fails")
+            assert exc_info.value.code == 1
+        # 初回試行 1 回のみ（リトライしない）
+        assert mock_lock.acquire.call_count == 1
+        # sleep も呼ばれない
+        mock_sleep.assert_not_called()
+        mock_lock.release.assert_not_called()
+
+        captured = capsys.readouterr()
+        parsed = _parse_error_json(captured.out)
+        assert parsed["code"] == "LOCK_CONFLICT"
+        details = parsed.get("details")
+        assert isinstance(details, dict)
+        assert details["lock_type"] == "rebuild"
+
+    def test_default_backoffs_match_spec(self) -> None:
+        """`_WRITE_LOCK_RETRY_BACKOFFS_SEC` の値変更時に意図的でない改変を検知する.
+
+        コード側 `_WRITE_LOCK_RETRY_BACKOFFS_SEC` が SSoT（仕様書 content-upload.md
+        は SSoT 方針により具体値を記載しない）。本テストはコード側 SSoT のうっかり
+        改変検知用として、現行値をハードコードで検証する。値変更時は本テストと
+        計画ファイル / PR description の合計待機時間記述を併せて更新すること。
+        """
+        from rag.cli import _WRITE_LOCK_RETRY_BACKOFFS_SEC
+        assert _WRITE_LOCK_RETRY_BACKOFFS_SEC == (0.1, 0.25, 0.5, 1.0)


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新

## Summary

CLI 連続実行時の `LOCK_CONFLICT (kind=write)` を解消するため、`_write_lock_or_exit` に短時間の指数バックオフリトライを導入。

- `src/rag/cli.py`: 新定数 `_WRITE_LOCK_RETRY_BACKOFFS_SEC = (0.1, 0.25, 0.5, 1.0)` を SSoT として追加。`_write_lock_or_exit` を try/except/else 構造で書き換え、`kind="write"` の競合に限り 100/250/500/1000ms の指数バックオフでリトライ（初回 + 4 回再試行 = 最大 5 回試行、合計待機 ~1.85s）。`kind="rebuild"` は従来どおり即失敗
- `tests/test_cli_lock_conflict.py`: opt-in fixture `_disable_lock_retry_backoff` を追加し既存テストの実時間消費を回避。新クラス `TestWriteLockRetryBehavior` で 4 ケース（リトライ後成功 / 全失敗で exit 1 / kind=rebuild 即失敗 / SSoT 値検証）を新規追加
- `docs/specs/infrastructure/content-upload.md`: 「ノンブロッキング」項を「primitive はノンブロッキング + helper レベル短時間リトライ」に書き換え。SSoT は `_WRITE_LOCK_RETRY_BACKOFFS_SEC` と明示

## Test plan

- [x] `uv run pytest`（2097 passed）
- [x] `uv run ruff check src tests`（pass）
- [x] `uv run mypy src`（132 files pass）
- [x] `markdownlint-cli2`（0 errors）
- [x] 新規テスト 4 ケース pass（リトライ動作の振る舞い検証）
- [ ] L3 本番相当 QA（実 OS ファイルロックでの解放遅延吸収確認）→ Issue #767 で別途実施

## Related issues

Closes #755
Refs #767 (L3 QA)