### PR TITLE
feat(youtube): Whisper モデルデフォルトを medium に変更 + ライフサイクル機構を追加 (#753)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ RAG_DEBUG_LOG_ENABLED=false
 # RAG_LOG_DIR=./logs
 
 # YouTube インジェスター（Whisper）
-RAG_YOUTUBE_WHISPER_MODEL=base
+RAG_YOUTUBE_WHISPER_MODEL=medium
 RAG_YOUTUBE_WHISPER_DEVICE=cuda
 
 # YouTube Fake モード（テスト・QA で実 YouTube アクセスを排除する）

--- a/docs/specs/infrastructure/fake-adapters/youtube.md
+++ b/docs/specs/infrastructure/fake-adapters/youtube.md
@@ -35,14 +35,17 @@ Fake モード基盤の制約（[Fake モード基盤](../fake-mode.md)）はす
 
 YouTube インジェスターの外部アクセス処理を以下のメソッドに抽象化する:
 
-| メソッド | 引数 | 戻り値 | 振る舞い |
-|---|---|---|---|
-| `fetch_metadata` | `video_id: str`、`request_timeout: int` | `dict[str, Any]`（yt-dlp `extract_info` の info_dict 形式） | 動画メタデータ取得 |
-| `fetch_subtitle` | `video_id: str`、`languages: list[str]` | `tuple[list[dict[str, Any]], str]`（snippets, language） | 字幕取得 |
-| `transcribe_audio` | `video_id: str`、`languages: list[str]`、`whisper_model: str`、`whisper_device: str`、`request_timeout: int` | `tuple[list[dict[str, Any]], str]`（snippets, language） | 音声 DL + Whisper 文字起こし |
-| `expand_playlist` | `playlist_url: str`、`max_videos: int`、`request_timeout: int` | `list[dict[str, Any]]`（entries） | プレイリスト展開 |
+| メソッド | 同期/非同期 | 引数 | 戻り値 | 振る舞い |
+|---|---|---|---|---|
+| `fetch_metadata` | async | `video_id: str`、`request_timeout: int` | `dict[str, Any]`（yt-dlp `extract_info` の info_dict 形式） | 動画メタデータ取得 |
+| `fetch_subtitle` | async | `video_id: str`、`languages: list[str]` | `tuple[list[dict[str, Any]], str]`（snippets, language） | 字幕取得 |
+| `transcribe_audio` | async | `video_id: str`、`languages: list[str]`、`whisper_model: str`、`whisper_device: str`、`request_timeout: int` | `tuple[list[dict[str, Any]], str]`（snippets, language） | 音声 DL + Whisper 文字起こし |
+| `expand_playlist` | async | `playlist_url: str`、`max_videos: int`、`request_timeout: int` | `list[dict[str, Any]]`（entries） | プレイリスト展開 |
+| `unload_whisper` | sync | `None` | `None` | 保持している Whisper モデルインスタンスを破棄し VRAM を解放する。Real は GPU メモリを解放し、Fake は no-op |
 
-すべて `async` メソッド。Real / Fake で同じシグネチャを実装する。
+`unload_whisper` のみ同期メソッド（GPU メモリ解放を確実に同期実行するため）。Real / Fake で同じシグネチャを実装する。
+
+Whisper モデルライフサイクルの設計意図は [YouTube インジェスター仕様](../../ingesters/youtube.md) の「Whisper モデルライフサイクル」セクションを参照。
 
 戻り値の dict 構造の詳細フィールドは [YouTube インジェスター](../../ingesters/youtube.md) の「保存形式」セクション・既存実装の `_make_metadata()` テストヘルパーを参照（コード SSoT）。
 

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -167,7 +167,7 @@ YouTube インジェスターは以下の URL パターンを単一動画とし�
 | `rag_youtube_max_videos` | 共通設定値 | プレイリスト取得時の最大動画数。API 負荷を抑制 |
 | `rag_youtube_request_interval` | 共通設定値 | リクエスト間の最大待機時間（ランダムジッター付き）。固定間隔によるボット検知・IP ブロック回避 |
 | `rag_youtube_request_timeout` | 共通設定値 | リクエストタイムアウト |
-| `rag_youtube_whisper_model` | 環境依存値 | faster-whisper のモデル名。GPU メモリに応じて選択 |
+| `rag_youtube_whisper_model` | 環境依存値 | faster-whisper のモデル名。転写品質と VRAM 消費・モデルロード時間のトレードオフ。GPU メモリに応じて選択 |
 | `rag_youtube_whisper_device` | 環境依存値 | faster-whisper のデバイス。GPU 有無で切替 |
 | `rag_youtube_transcript_languages` | 共通設定値 | 字幕取得の優先言語 |
 | `rag_youtube_max_duration` | 共通設定値 | 動画長上限。長時間動画の処理負荷を制限 |
@@ -371,6 +371,42 @@ flowchart TD
     ABORT --> NOTIFY
     NOTIFY --> RESULT
 ```
+
+### Whisper モデルライフサイクル
+
+#### 動機
+
+Whisper モデルは VRAM を大きく占有する。サブプロセス（CLI / MCP サブプロセス）内で Whisper を一度でも使用するとサブプロセス終了まで VRAM を保持し続けるため、Embedding モデル等の他リソースと競合しないよう、取り込み境界でアンロードする運用とする。
+
+#### 振る舞い
+
+- ロード: 初回 transcribe 時に遅延初期化する
+- アンロード: 取り込み境界で明示的に解放する
+- 境界: 単発取り込み・bulk 取り込み（複数 URL / プレイリスト）・BlueSky 経由取り込み（投稿内 YouTube URL の自動取り込み）のいずれでも、取り込み処理終了時に必ず VRAM を解放する。bulk 取り込みではロードは bulk 全体で 1 回のみ発生し、末尾で 1 回アンロードする
+- 例外時の保証: 取り込み途中の例外発生時も VRAM 解放を保証する
+- 並行呼び出し制約: アンロードは transcribe 実行中に呼び出されてはならない。並行発火した場合は警告ログを出力してアンロードを見送る
+
+#### Protocol 拡張
+
+`YoutubeFetcher` Protocol に Whisper モデルアンロード用のメソッドを追加する。外部 caller（CLI / MCP / 他インジェスター）から取り込み境界で呼び出される。詳細な契約は [Fake Adapter 仕様](../infrastructure/fake-adapters/youtube.md) を参照。
+
+他インジェスター（BlueSky 等）からの delegation 経由のアンロード呼び出し用に、`YoutubeDelegator` Protocol にも同等のメソッドを追加する。`YoutubeDelegator` の `ingest_video` が `async` であるのに対し、アンロード用メソッドは sync で呼び出す。
+
+#### VRAM 占有期間
+
+| 状態 | VRAM 占有 |
+|------|-----------|
+| 取り込み未実行 | なし |
+| YouTube 取り込み実行中（字幕のみで完結） | なし |
+| YouTube 取り込み実行中（Whisper 経路発火） | あり |
+| YouTube 取り込み完了直後 | なし |
+| BlueSky 経由取り込み実行中（投稿内 YouTube URL が字幕のみで完結） | なし |
+| BlueSky 経由取り込み実行中（投稿内 YouTube URL で Whisper 経路発火） | あり |
+| BlueSky 取り込み完了直後 | なし |
+
+#### ロードオーバーヘッド
+
+ロードはモデルキャッシュからの VRAM 転送のため、モデルサイズに比例した時間を要する。bulk 取り込みでは先頭 1 回のみ発生するため、N 本連続取り込みでもオーバーヘッドはモデルロード 1 回分。
 
 ## エッジケース
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -2710,26 +2710,10 @@ async def run_ingest_youtube(args: argparse.Namespace) -> None:
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
-        from .pipeline.ingesters._common import IngestErrorCategory, IngestErrorDetail
-        from .pipeline.ingesters._common import IngestResult as _IngestResult
-
-        results: "list[IngestResult]" = []
-        for url in video_urls:
-            try:
-                results.append(await youtube_ingester.ingest_video(url))
-            except Exception as e:
-                # bulk loop の partial result loss 防止のため、ループ内例外は per-item として
-                # IngestResult.errors に変換し処理継続。Exception 限定のため KeyboardInterrupt
-                # 等の BaseException 系（キャンセル）は捕捉せず正常に伝播する。
-                logger.error("ingest-youtube エラー (url=%s): %s", url, e)
-                err = _IngestResult()
-                err.errors = 1
-                err.error_details.append(IngestErrorDetail(
-                    category=IngestErrorCategory.METADATA_FETCH.value,
-                    target=url,
-                    message=f"取り込み失敗: {e}",
-                ))
-                results.append(err)
+        # ingest_videos は bulk 末尾で Whisper モデルを必ずアンロードし、
+        # 個別 URL の例外は per-item の IngestResult.errors に変換して処理継続する
+        # （`KeyboardInterrupt` 等の `BaseException` 系は伝播）。
+        results: "list[IngestResult]" = await youtube_ingester.ingest_videos(video_urls)
 
         ingest_result = _merge_ingest_results(results)
 

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -87,7 +87,7 @@ class _EnvLoader(BaseSettings):
     rag_log_dir: str | None = None
 
     # YouTube インジェスター（Whisper）— GPU 有無で選択が変わるため .env 管理
-    rag_youtube_whisper_model: str = "base"
+    rag_youtube_whisper_model: str = "medium"
     rag_youtube_whisper_device: Literal["cuda", "cpu"] = "cuda"
 
     # YouTube Fake モード — テスト・QA で実 YouTube アクセスを排除する。デフォルトは安全側（fake 有効）

--- a/src/rag/pipeline/ingesters/_fake/youtube/__init__.py
+++ b/src/rag/pipeline/ingesters/_fake/youtube/__init__.py
@@ -139,3 +139,7 @@ class FakeYoutubeFetcher:
             return list(self._custom_playlist_entries)[:max_videos]
         entries: list[dict[str, Any]] = self._load_json("playlist_happy.json")
         return entries[:max_videos]
+
+    def unload_whisper(self) -> None:
+        """Fake は Whisper モデルを保持しないため no-op."""
+        return

--- a/src/rag/pipeline/ingesters/bluesky/delegations.py
+++ b/src/rag/pipeline/ingesters/bluesky/delegations.py
@@ -113,29 +113,38 @@ async def follow_urls(
         youtube_urls = target_youtube_urls
 
     if youtube_urls:
-        for i, url in enumerate(youtube_urls):
+        # bluesky 投稿内 YouTube URL の bulk 取り込み境界。
+        # 末尾で必ず Whisper モデルをアンロードして VRAM を解放する
+        # （仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」）。
+        # youtube_urls が空 / youtube_delegator が None の場合は本ブロックに入らず、
+        # Whisper モデルがロードされないため unload_whisper は不要。
+        try:
+            for i, url in enumerate(youtube_urls):
+                if youtube_delegator is not None:
+                    try:
+                        yt_result = await youtube_delegator.ingest_video(url)
+                        stats["youtube_placed"] += yt_result.placed
+                        if yt_result.errors > 0:
+                            stats["errors"] += yt_result.errors
+                    except Exception as exc:
+                        logger.exception("YouTube URL の取り込みに失敗: %s", url)
+                        stats["errors"] += 1
+                        if result is not None:
+                            result.errors += 1
+                            result.error_details.append(IngestErrorDetail(
+                                category=IngestErrorCategory.DELEGATION.value,
+                                target=url,
+                                url=url,
+                                message=f"youtube delegation failed: {exc}",
+                            ))
+                    if i < len(youtube_urls) - 1:
+                        await asyncio.sleep(youtube_request_interval)
+                else:
+                    logger.warning("YouTube インジェスターが未指定: %s", url)
+                    stats["skipped"] += 1
+        finally:
             if youtube_delegator is not None:
-                try:
-                    yt_result = await youtube_delegator.ingest_video(url)
-                    stats["youtube_placed"] += yt_result.placed
-                    if yt_result.errors > 0:
-                        stats["errors"] += yt_result.errors
-                except Exception as exc:
-                    logger.exception("YouTube URL の取り込みに失敗: %s", url)
-                    stats["errors"] += 1
-                    if result is not None:
-                        result.errors += 1
-                        result.error_details.append(IngestErrorDetail(
-                            category=IngestErrorCategory.DELEGATION.value,
-                            target=url,
-                            url=url,
-                            message=f"youtube delegation failed: {exc}",
-                        ))
-                if i < len(youtube_urls) - 1:
-                    await asyncio.sleep(youtube_request_interval)
-            else:
-                logger.warning("YouTube インジェスターが未指定: %s", url)
-                stats["skipped"] += 1
+                youtube_delegator.unload_whisper()
 
     logger.info(
         "URL 取り込み完了: web=%d, youtube=%d, skipped=%d, errors=%d",

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -355,6 +355,51 @@ class YoutubeIngester(BaseIngester):
         )
         return result
 
+    async def ingest_videos(
+        self, video_urls: list[str],
+    ) -> list[IngestResult]:
+        """複数 URL を順次取り込む bulk メソッド.
+
+        Whisper モデルは bulk 全体で 1 度だけロード（先頭の Whisper 経路動画で遅延初期化）し、
+        bulk 末尾で `try/finally` を経て必ずアンロードする。
+        個別動画の例外は per-item の ``IngestResult.errors`` に変換し、bulk 全体は継続する
+        （`KeyboardInterrupt` 等の `BaseException` 系は伝播）。
+
+        Args:
+            video_urls: YouTube 動画 URL のリスト
+
+        Returns:
+            URL ごとの取り込み結果リスト（順序保証）
+        """
+        results: list[IngestResult] = []
+        try:
+            for url in video_urls:
+                try:
+                    results.append(await self.ingest_video(url))
+                except Exception as e:
+                    logger.error("ingest_videos エラー (url=%s): %s", url, e)
+                    err = IngestResult()
+                    err.errors = 1
+                    err.error_details.append(IngestErrorDetail(
+                        category=IngestErrorCategory.METADATA_FETCH.value,
+                        target=url,
+                        message=f"取り込み失敗: {e}",
+                    ))
+                    results.append(err)
+        finally:
+            self._fetcher.unload_whisper()
+        return results
+
+    def unload_whisper(self) -> None:
+        """fetcher の Whisper モデルをアンロードする.
+
+        bulk 取り込みの外部 caller（CLI / MCP / 他インジェスター）が
+        取り込み境界で明示呼び出しする用途。``ingest_videos`` / ``crawl_playlist``
+        は内部で `try/finally` から呼び出すため、それらの利用時は本メソッドの
+        二重呼び出しは不要（no-op として安全）。
+        """
+        self._fetcher.unload_whisper()
+
     async def crawl_playlist(
         self,
         playlist_url: str,
@@ -377,6 +422,23 @@ class YoutubeIngester(BaseIngester):
             playlist_url,
             max_videos if max_videos is not None else self._max_videos,
         )
+        try:
+            return await self._crawl_playlist_impl(
+                playlist_url,
+                max_videos=max_videos,
+                progress_callback=progress_callback,
+            )
+        finally:
+            self._fetcher.unload_whisper()
+
+    async def _crawl_playlist_impl(
+        self,
+        playlist_url: str,
+        *,
+        max_videos: int | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ) -> IngestResult:
+        """``crawl_playlist`` の本体実装. Whisper アンロードは呼び出し側で `try/finally` 配置."""
         result = IngestResult()
 
         playlist_id = extract_playlist_id(playlist_url)

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -377,6 +377,9 @@ class YoutubeIngester(BaseIngester):
                 try:
                     results.append(await self.ingest_video(url))
                 except Exception as e:
+                    # プログラミングエラーは伝播させる（ingest_video 内部の設計と整合）
+                    if isinstance(e, (TypeError, AttributeError, ImportError)):
+                        raise
                     logger.error("ingest_videos エラー (url=%s): %s", url, e)
                     err = IngestResult()
                     err.errors = 1

--- a/src/rag/pipeline/ingesters/youtube_fetcher.py
+++ b/src/rag/pipeline/ingesters/youtube_fetcher.py
@@ -96,6 +96,10 @@ class YoutubeFetcher(Protocol):
         """プレイリストを展開する."""
         ...
 
+    def unload_whisper(self) -> None:
+        """保持している Whisper モデルインスタンスを破棄し VRAM を解放する."""
+        ...
+
 
 class RealYoutubeFetcher:
     """yt-dlp / youtube-transcript-api / faster-whisper を使う実 Fetcher 実装.
@@ -108,6 +112,22 @@ class RealYoutubeFetcher:
         # threading.Lock で worker スレッド内の transcribe 全体を直列化（faster-whisper はスレッドセーフでないため）
         self._whisper_model_instance: Any = None
         self._whisper_lock = threading.Lock()
+        # CUDA 可用性は起動時に 1 度判定してキャッシュする。
+        # torch は optional 依存（uv sync --no-group with-mineru で除外可能）のため、
+        # 未導入環境では CPU フォールバックとして cuda_available=False を返す。
+        self._cuda_available = self._detect_cuda()
+
+    @staticmethod
+    def _detect_cuda() -> bool:
+        """torch.cuda.is_available() を 1 度だけ呼び出す静的判定.
+
+        torch 未導入の CPU 環境では ImportError をキャッチして False を返す。
+        """
+        try:
+            import torch  # safety:allowed
+        except ImportError:
+            return False
+        return bool(torch.cuda.is_available())
 
     async def fetch_metadata(
         self, video_id: str, request_timeout: int
@@ -233,6 +253,39 @@ class RealYoutubeFetcher:
                 return entries
 
         return await loop.run_in_executor(None, _expand)
+
+    def unload_whisper(self) -> None:
+        """保持している Whisper モデルインスタンスを破棄し VRAM を解放する.
+
+        取り込み境界（単発・bulk）で `YoutubeIngester` が `try/finally` から呼び出す前提。
+        Whisper モデルがロードされていない場合は no-op。
+
+        `transcribe_audio` 実行中の並行発火は VRAM 解放を中断するリスクがあるため、
+        ロックを非ブロッキング acquire し、取得失敗時は警告ログを出してアンロードを見送る。
+        """
+        import gc
+
+        acquired = self._whisper_lock.acquire(blocking=False)
+        if not acquired:
+            logger.warning(
+                "Whisper モデルアンロードを見送り: transcribe 実行中の並行発火を検出。"
+                "VRAM は解放されていません。次の取り込み境界で再試行されます。"
+                "取り込み境界で `try/finally` から呼ぶこと",
+            )
+            return
+        try:
+            if self._whisper_model_instance is None:
+                return
+            # 参照を切って GC 対象にし、CUDA 環境では VRAM キャッシュを解放する
+            self._whisper_model_instance = None
+            gc.collect()
+            if self._cuda_available:
+                import torch  # safety:allowed
+
+                torch.cuda.empty_cache()
+            logger.info("Whisper モデルをアンロードしました")
+        finally:
+            self._whisper_lock.release()
 
     async def _download_audio(
         self, video_id: str, tmpdir: str, request_timeout: int

--- a/src/rag/pipeline/ingesters/youtube_protocols.py
+++ b/src/rag/pipeline/ingesters/youtube_protocols.py
@@ -73,6 +73,18 @@ class YoutubeDelegator(Protocol):
         """
         ...
 
+    def unload_whisper(self) -> None:
+        """委譲先 YouTube インジェスターの Whisper モデルをアンロードする.
+
+        ※ 同期メソッド（GPU メモリ解放を確実に同期実行するため）。
+        `ingest_video` が `async` であるのに対し、本メソッドは sync で呼び出すこと。
+
+        BlueSky 等の他インジェスターが bulk 取り込み完了時に呼び出し、
+        delegation 経由で保持された Whisper モデルの VRAM を解放する。
+        Whisper モデル未ロード時は no-op（実装は委譲先側で判定）。
+        """
+        ...
+
 
 class RealYoutubeClassifier:
     """既存 ``rag.pipeline.ingesters.youtube.classify_youtube_url`` をラップする実装.
@@ -110,6 +122,9 @@ class RealYoutubeDelegator:
         return await self._ingester.ingest_video(
             video_url, playlist_id=playlist_id,
         )
+
+    def unload_whisper(self) -> None:
+        self._ingester.unload_whisper()
 
 
 def create_youtube_classifier() -> YoutubeClassifier:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -165,7 +165,7 @@ def e2e_subprocess_env(
         # デバッグ・ログ
         "RAG_DEBUG_LOG_ENABLED": "false",
         # YouTube インジェスター（Whisper は Fake Fetcher 経由のため値は使われない）
-        "RAG_YOUTUBE_WHISPER_MODEL": "base",
+        "RAG_YOUTUBE_WHISPER_MODEL": "medium",
         "RAG_YOUTUBE_WHISPER_DEVICE": "cpu",
         # Fake Adapter 一括有効化
         "RAG_YOUTUBE_FAKE_MODE": "true",

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -414,7 +414,7 @@ def make_youtube_ingester(source_store: Any, **overrides: Any) -> Any:
         "max_videos": 100,
         "request_interval": 0.1,
         "request_timeout": 30,
-        "whisper_model": "base",
+        "whisper_model": "medium",
         "whisper_device": "cuda",
         "transcript_languages": None,
         "max_duration": 14400,

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -65,7 +65,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_bluesky_include_reposts": True,
     "rag_bluesky_force_youtube_reingest": False,
     # YouTube インジェスター
-    "rag_youtube_whisper_model": "base",
+    "rag_youtube_whisper_model": "medium",
     "rag_youtube_whisper_device": "cpu",
     # YouTube Fake モード（テストでは fake デフォルト）
     "rag_youtube_fake_mode": True,

--- a/tests/test_pipeline_ingesters_bluesky_delegations.py
+++ b/tests/test_pipeline_ingesters_bluesky_delegations.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -159,6 +159,7 @@ class TestFollowUrlsYoutubeDelegation:
     @pytest.mark.asyncio
     async def test_youtube_url_calls_delegator(self) -> None:
         delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
         delegator.ingest_video = AsyncMock(return_value=yt_result)
@@ -193,6 +194,7 @@ class TestFollowUrlsYoutubeDelegation:
     @pytest.mark.asyncio
     async def test_suppressed_youtube_skipped_when_force_false(self) -> None:
         delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
         runner = AsyncMock()
         runner.run_for_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(
@@ -212,6 +214,7 @@ class TestFollowUrlsYoutubeDelegation:
     @pytest.mark.asyncio
     async def test_suppressed_youtube_taken_when_force_true(self) -> None:
         delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
         delegator.ingest_video = AsyncMock(return_value=yt_result)
@@ -233,6 +236,7 @@ class TestFollowUrlsYoutubeDelegation:
     @pytest.mark.asyncio
     async def test_youtube_delegator_failure_recorded(self) -> None:
         delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
         delegator.ingest_video = AsyncMock(
             side_effect=RuntimeError("yt failed"),
         )
@@ -255,11 +259,57 @@ class TestFollowUrlsYoutubeDelegation:
         )
 
     @pytest.mark.asyncio
+    async def test_youtube_delegator_unload_whisper_called(self) -> None:
+        """BlueSky 経由 YouTube 取り込み完了時に unload_whisper が呼ばれることを検証する.
+
+        仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
+        """
+        delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
+        yt_result = IngestResult()
+        yt_result.placed = 1
+        delegator.ingest_video = AsyncMock(return_value=yt_result)
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        items = [_item_with_urls([
+            "https://youtu.be/abcdEFG1234",
+            "https://youtu.be/abcdEFG5678",
+        ])]
+        await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=delegator,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+        # bulk 末尾で 1 回だけアンロード
+        delegator.unload_whisper.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_youtube_delegator_unload_whisper_called_on_exception(self) -> None:
+        """BlueSky 経由 YouTube 取り込みの途中で例外が発生しても unload_whisper が呼ばれることを検証する."""
+        delegator = AsyncMock()
+        delegator.ingest_video = AsyncMock(side_effect=RuntimeError("yt failed"))
+        delegator.unload_whisper = MagicMock()
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
+        await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=delegator,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+        delegator.unload_whisper.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_dedup_across_suppress_and_unsuppress_safer_side(
         self,
     ) -> None:
         # 同一 URL が「抑制対象」と「抑制対象外」両方に存在 → 安全側で取り込み
         delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
         delegator.ingest_video = AsyncMock(return_value=yt_result)

--- a/tests/test_pipeline_ingesters_bluesky_fetcher.py
+++ b/tests/test_pipeline_ingesters_bluesky_fetcher.py
@@ -72,13 +72,15 @@ class TestProtocolDefinitions:
         }
         assert names == {"classify"}
 
-    def test_youtube_delegator_protocol_has_ingest_video(self) -> None:
+    def test_youtube_delegator_protocol_has_expected_methods(self) -> None:
         names = {
             name
             for name, member in inspect.getmembers(YoutubeDelegator)
             if not name.startswith("_") and inspect.isfunction(member)
         }
-        assert names == {"ingest_video"}
+        # unload_whisper は Whisper モデルアンロード用の同期メソッド
+        # 仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
+        assert names == {"ingest_video", "unload_whisper"}
 
     def test_web_delegator_protocol_has_run_for_urls(self) -> None:
         names = {

--- a/tests/test_pipeline_ingesters_youtube.py
+++ b/tests/test_pipeline_ingesters_youtube.py
@@ -375,7 +375,7 @@ class TestIngestVideo:
         # no_subtitle で Whisper フォールバックを発動 → カスタム snippets を whisper でも返す
         fetcher = _fake(scenario="no_subtitle", metadata=metadata, snippets=snippets, language="ja")
         ingester = make_youtube_ingester(
-            source_store, fetcher=fetcher, whisper_model="base",
+            source_store, fetcher=fetcher, whisper_model="medium",
         )
 
         result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
@@ -384,7 +384,7 @@ class TestIngestVideo:
         call_kwargs = source_store.place_file.call_args
         data = json.loads(call_kwargs.kwargs["data"].decode("utf-8"))
         assert data["transcript_source"] == "whisper"
-        assert data["whisper_model"] == "base"
+        assert data["whisper_model"] == "medium"
 
     @pytest.mark.asyncio()
     async def test_overwritten_count_on_reingest(self, source_store: Any) -> None:
@@ -660,3 +660,139 @@ class TestCrawlPlaylist:
         assert detail["category"] == "metadata_fetch"
         assert detail["target"] == "entry_0"
         assert "video_id missing" in detail["message"]
+
+
+class TestWhisperLifecycle:
+    """Whisper モデルの遅延ロード/明示アンロード機構を検証する.
+
+    仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
+    """
+
+    @pytest.mark.asyncio()
+    async def test_ingest_videos_unloads_whisper_once(self, source_store: Any) -> None:
+        """ingest_videos の bulk 取り込み完了時に unload_whisper が 1 度だけ呼ばれることを検証する."""
+        fetcher = _fake()
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(
+            source_store, fetcher=fetcher, max_duration=14400,
+        )
+
+        single_result = IngestResult(placed=1)
+        with patch.object(
+            ingester,
+            "ingest_video",
+            new_callable=AsyncMock,
+            return_value=single_result,
+        ):
+            results = await ingester.ingest_videos([
+                "https://www.youtube.com/watch?v=TestVideo01",
+                "https://www.youtube.com/watch?v=TestVideo02",
+                "https://www.youtube.com/watch?v=TestVideo03",
+            ])
+
+        assert len(results) == 3
+        assert all(r.placed == 1 for r in results)
+        assert fetcher.unload_whisper.call_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_ingest_videos_unloads_on_exception(self, source_store: Any) -> None:
+        """ingest_videos の途中で例外が発生しても unload_whisper が呼ばれることを検証する."""
+        fetcher = _fake()
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(
+            source_store, fetcher=fetcher, max_duration=14400,
+        )
+
+        # 2 本目で例外、3 本目は per-item エラーに変換されて継続する。
+        # AsyncMock の side_effect は Exception インスタンスを自動的に raise する。
+        with patch.object(
+            ingester,
+            "ingest_video",
+            new_callable=AsyncMock,
+            side_effect=[
+                IngestResult(placed=1),
+                RuntimeError("boom"),
+                IngestResult(placed=1),
+            ],
+        ):
+            results = await ingester.ingest_videos([
+                "https://www.youtube.com/watch?v=TestVideo01",
+                "https://www.youtube.com/watch?v=TestVideo02",
+                "https://www.youtube.com/watch?v=TestVideo03",
+            ])
+
+        assert len(results) == 3
+        assert results[0].placed == 1
+        assert results[1].errors == 1
+        assert "boom" in results[1].error_details[0]["message"]
+        assert results[2].placed == 1
+        assert fetcher.unload_whisper.call_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_crawl_playlist_unloads_whisper(self, source_store: Any) -> None:
+        """crawl_playlist 完了時に unload_whisper が呼ばれることを検証する."""
+        entries = [
+            {"id": "video_id_01", "url": "video_id_01"},
+            {"id": "video_id_02", "url": "video_id_02"},
+        ]
+        fetcher = _fake(playlist_entries=entries)
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(
+            source_store, fetcher=fetcher, max_videos=3, request_interval=0.1,
+        )
+
+        single_result = IngestResult(placed=1)
+        with patch.object(
+            ingester,
+            "ingest_video",
+            new_callable=AsyncMock,
+            return_value=single_result,
+        ):
+            await ingester.crawl_playlist(
+                "https://www.youtube.com/playlist?list=PLtest123"
+            )
+
+        assert fetcher.unload_whisper.call_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_crawl_playlist_unloads_on_expand_error(self, source_store: Any) -> None:
+        """crawl_playlist の playlist 展開失敗時も unload_whisper が呼ばれることを検証する."""
+        fetcher = _fake(scenario="playlist_expand_error")
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(source_store, fetcher=fetcher)
+
+        result = await ingester.crawl_playlist(
+            "https://www.youtube.com/playlist?list=PLtest123"
+        )
+
+        assert result.errors == 1
+        assert fetcher.unload_whisper.call_count == 1
+
+    def test_fake_unload_whisper_is_noop(self) -> None:
+        """FakeYoutubeFetcher の unload_whisper が例外を出さないことを検証する."""
+        fetcher = _fake()
+        # 2 回呼んでも安全（no-op）
+        fetcher.unload_whisper()
+        fetcher.unload_whisper()
+
+    def test_real_unload_whisper_is_idempotent(self) -> None:
+        """RealYoutubeFetcher の unload_whisper が未ロード状態でも安全に呼べることを検証する."""
+        from rag.pipeline.ingesters.youtube_fetcher import RealYoutubeFetcher
+
+        fetcher = RealYoutubeFetcher()
+        # _whisper_model_instance is None の状態で 2 回連続呼んでも例外なし
+        fetcher.unload_whisper()
+        fetcher.unload_whisper()
+        assert fetcher._whisper_model_instance is None
+
+    @pytest.mark.asyncio()
+    async def test_crawl_playlist_unloads_on_invalid_url(self, source_store: Any) -> None:
+        """crawl_playlist が不正 URL で ValueError を raise しても unload_whisper が呼ばれることを検証する."""
+        fetcher = _fake()
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(source_store, fetcher=fetcher)
+
+        with pytest.raises(ValueError, match="不正な YouTube プレイリスト URL"):
+            await ingester.crawl_playlist("https://example.com/playlist?list=test")
+
+        assert fetcher.unload_whisper.call_count == 1

--- a/tests/test_pipeline_ingesters_youtube.py
+++ b/tests/test_pipeline_ingesters_youtube.py
@@ -729,6 +729,33 @@ class TestWhisperLifecycle:
         assert fetcher.unload_whisper.call_count == 1
 
     @pytest.mark.asyncio()
+    async def test_ingest_videos_propagates_programming_errors(self, source_store: Any) -> None:
+        """ingest_videos がプログラミングエラー（TypeError/AttributeError/ImportError）を per-item 変換せず伝播することを検証する.
+
+        ingest_video 内部の「プログラミングエラーは伝播させる」設計と整合させ、
+        バグをサイレントに成功扱いにしないことを保証する。
+        """
+        fetcher = _fake()
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(
+            source_store, fetcher=fetcher, max_duration=14400,
+        )
+
+        with patch.object(
+            ingester,
+            "ingest_video",
+            new_callable=AsyncMock,
+            side_effect=TypeError("programming error"),
+        ):
+            with pytest.raises(TypeError, match="programming error"):
+                await ingester.ingest_videos([
+                    "https://www.youtube.com/watch?v=TestVideo01",
+                ])
+
+        # 例外伝播時も bulk 末尾の unload_whisper は呼ばれる（try/finally 配置）
+        assert fetcher.unload_whisper.call_count == 1
+
+    @pytest.mark.asyncio()
     async def test_crawl_playlist_unloads_whisper(self, source_store: Any) -> None:
         """crawl_playlist 完了時に unload_whisper が呼ばれることを検証する."""
         entries = [

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -444,7 +444,7 @@ key = "test-vision-model"
             "RAG_HTTP_PORT": "8081",
             "RAG_DNS_REBINDING_PROTECTION": "true",
             "RAG_DEBUG_LOG_ENABLED": "false",
-            "RAG_YOUTUBE_WHISPER_MODEL": "base",
+            "RAG_YOUTUBE_WHISPER_MODEL": "medium",
             "RAG_YOUTUBE_WHISPER_DEVICE": "cpu",
             "SITE_INGEST_TEMP_DIR": ".tmp/site_ingest",
         }


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★

## Summary

- pydantic Field default を `base` → `medium` に変更（`.env.example` + テスト 5 ファイルを同期）
- `YoutubeFetcher` Protocol に `unload_whisper()` を追加（Real / Fake 両実装）
- `YoutubeIngester.ingest_videos(urls)` を新設し `try/finally` で unload を保証（CLI からも本メソッド経由に切替）
- `crawl_playlist` も最外側 `try/finally` で unload を保証
- `YoutubeDelegator` Protocol にも `unload_whisper()` を追加し、BlueSky 経由 YouTube 取り込みでも bulk 末尾で unload
- `try_lock`（非ブロッキング）で transcribe 並行発火時はアンロード見送り（警告ログ）
- CUDA 可用性は `__init__` で 1 度判定してキャッシュ（torch 未導入 CPU 環境は `cuda_available=False` で動作）
- 仕様書 `docs/specs/ingesters/youtube.md` に「Whisper モデルライフサイクル」セクション追加（振る舞いベース記述、内部属性・API 列挙・観測数値を排除）
- 仕様書 `docs/specs/infrastructure/fake-adapters/youtube.md` の Protocol テーブルに `unload_whisper` 行 + 同期/非同期列を追加

## 評価結果サマリ

`97S45-HQLwM`（桜井政博「ステージをじっくり見てみよう」、17:36）を base/small/medium の 3 モデルで転写比較した結果、11 箇所の認識精度比較で **base 0/11 → small 7/11 → medium 8/11**。medium 採用 + ライフサイクル機構（VRAM 解放）をセットで提供することで、検索ヒット率改善という Issue 目的と VRAM 5GB 常時占有の懸念を同時に解消する。

詳細: <https://github.com/becky3/rag-knowledge/issues/753#issuecomment-4416524703>

## Test plan

- [x] L1 unit test: 2102 件全パス（新規テスト 7 件追加: bulk 1 回 unload / 例外時 unload / playlist 不正 URL unload / Real idempotent / Fake no-op / BlueSky 経由 unload / BlueSky 経由 例外時 unload）
- [x] L2 mock e2e test: 22 件全パス
- [x] ruff check: clean
- [x] mypy: clean (132 source files)
- [x] code-reviewer / doc-reviewer 2 巡実施 + triage で全指摘対応済（要修正 7 件対応、現状維持 5 件、Issue 起票 1 件）
- 本番相当 (L3) QA: 別 Issue #771 で対応

## Related issues

Closes #753

関連起票:
- #770: chore(tests): テスト用設定値の多重定義整理（本作業中に発見、別 Issue 化）
- #771: QA: Issue #753 本番相当 (L3) 検証（既存 QA Issue #763/#764/#767 と合わせて一括対応）