### PR TITLE
fix(youtube): YoutubeIngester.ingest_video() 単独呼び出しでの Whisper VRAM 未解放を構造的に解消 (#773)

### DIFF
--- a/docs/specs/infrastructure/fake-adapters/youtube.md
+++ b/docs/specs/infrastructure/fake-adapters/youtube.md
@@ -147,7 +147,7 @@ JSON のフィールド構造は対応する Real Fetcher の戻り値と同じ�
 `YoutubeIngester.__init__` に `fetcher: YoutubeFetcher` パラメータを追加する。
 
 - 必須（required）: コーディング規約のフォールバック禁止に従い、デフォルト値を持たない
-- インジェスター本体（`ingest_video` / `crawl_playlist`）は `_fetch_metadata` 等の private メソッドを廃止し、Fetcher Protocol 経由で呼び出す
+- インジェスター本体（`ingest_videos` / `crawl_playlist`）は `_fetch_metadata` 等の private メソッドを廃止し、Fetcher Protocol 経由で呼び出す
 - 既存の `_fetch_metadata` / `_fetch_transcript` / `_fetch_subtitle` / `_transcribe_with_whisper` / `_download_audio` / `_expand_playlist` メソッドは `RealYoutubeFetcher` に移植する（既存ロジックの単純な再配置）
 - **ハードリミット定数の所属**: 既存の `MAX_VIDEOS_HARD_LIMIT` / `MIN_REQUEST_INTERVAL` / `MAX_AUDIO_FILE_SIZE_MB` / `JITTER_MIN_RATIO` / `CIRCUIT_BREAKER_THRESHOLD` 等の定数は、
   本プロジェクトの既存慣例（モジュールトップレベル定数 + `# ハードリミット` コメント）に従い、インジェスター本体モジュール（`youtube.py`）のトップレベルに残す。
@@ -179,7 +179,7 @@ CLI / MCP のインジェスター生成箇所（`src/rag/cli.py` / `src/rag/ser
 ```mermaid
 flowchart TB
     subgraph Ingester["YoutubeIngester (本体)"]
-        ING["ingest_video / crawl_playlist"]
+        ING["ingest_videos / crawl_playlist"]
     end
 
     subgraph Protocol["YoutubeFetcher Protocol"]

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -606,7 +606,7 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 
 | URL パターン | 委譲先 | 備考 |
 |-------------|--------|------|
-| YouTube 動画 URL（対応する具体パターンは [youtube.md](youtube.md) を参照） | YoutubeIngester.ingest_video | YouTube 動画の字幕・文字起こしを取り込む |
+| YouTube 動画 URL（対応する具体パターンは [youtube.md](youtube.md) を参照） | YoutubeDelegator.ingest_videos | YouTube 動画の字幕・文字起こしを取り込む |
 | 不正な YouTube 動画 URL（パターンには該当するが video_id 形式が不正） | エラー扱いでスキップ | site_ingest に流すと無駄な HTTP アクセスが発生し、リスクもあるため取り込まない。`errors` カウンタを増やし、`error_details` に記録する |
 | `bsky.app/profile/` | スキップ | BlueSky 投稿は既にインジェスト対象 |
 | 上記以外の HTTP/HTTPS URL | site_ingest（複数 URL モード） | Web ページをバッチ取得する。YouTube チャンネル URL（`/@handle`, `/c/`, `/channel/`）・プレイリスト URL（`/playlist?list=`）はこの分類に含まれる |
@@ -635,6 +635,8 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
    - 上書き投稿由来の YouTube URL は、呼び出し元から受け取った再取り込み許可フラグが `true` の場合のみ取得する
    - `rag_add_bluesky` 経由では全投稿が YouTube 抑制対象外として渡されるため、上記判定の結果として YouTube URL は常に取得対象となる
 6. YouTube インジェスターで動画を取り込む（個別処理、URL 間に `rag_youtube_request_interval` に基づくスリープを挿入）
+   - per-URL レート制限を維持するため、`YoutubeDelegator.ingest_videos` を URL ごとに長さ 1 のリストで呼び出す
+   - Whisper モデルのロード/アンロードは URL ごとに発生する（複数の字幕無効動画が含まれる投稿では bulk 効率は失われるが、安全性優先の判断）
 7. 全 URL の処理が完了した後、パイプライン制御に取り込み完了を通知する
 
 #### エラーハンドリング

--- a/docs/specs/ingesters/youtube.md
+++ b/docs/specs/ingesters/youtube.md
@@ -381,16 +381,21 @@ Whisper モデルは VRAM を大きく占有する。サブプロセス（CLI / 
 #### 振る舞い
 
 - ロード: 初回 transcribe 時に遅延初期化する
-- アンロード: 取り込み境界で明示的に解放する
-- 境界: 単発取り込み・bulk 取り込み（複数 URL / プレイリスト）・BlueSky 経由取り込み（投稿内 YouTube URL の自動取り込み）のいずれでも、取り込み処理終了時に必ず VRAM を解放する。bulk 取り込みではロードは bulk 全体で 1 回のみ発生し、末尾で 1 回アンロードする
+- 境界: 公開 API である `ingest_videos`（単発 URL の場合は長さ 1 のリスト、bulk の場合は複数）と `crawl_playlist` のいずれでも、取り込み処理終了時に必ず VRAM を解放する。
+  - BlueSky 経由取り込み（投稿内 YouTube URL の自動取り込み）も `YoutubeDelegator.ingest_videos` 経由でこの保証を継承する
+  - bulk 取り込みではロードは bulk 全体で 1 回のみ発生し、末尾で 1 回アンロードする
+- 内部 helper: 単一動画取り込みの内部 helper（実装側で private 化済み）は VRAM 解放を保証しない。外部から直接呼び出してはならない
 - 例外時の保証: 取り込み途中の例外発生時も VRAM 解放を保証する
 - 並行呼び出し制約: アンロードは transcribe 実行中に呼び出されてはならない。並行発火した場合は警告ログを出力してアンロードを見送る
 
 #### Protocol 拡張
 
-`YoutubeFetcher` Protocol に Whisper モデルアンロード用のメソッドを追加する。外部 caller（CLI / MCP / 他インジェスター）から取り込み境界で呼び出される。詳細な契約は [Fake Adapter 仕様](../infrastructure/fake-adapters/youtube.md) を参照。
+`YoutubeFetcher` Protocol に Whisper モデルアンロード用のメソッドを追加する。`YoutubeIngester.ingest_videos` / `crawl_playlist` の `try/finally` 内部から呼び出される。
+詳細な契約は [Fake Adapter 仕様](../infrastructure/fake-adapters/youtube.md) を参照。
 
-他インジェスター（BlueSky 等）からの delegation 経由のアンロード呼び出し用に、`YoutubeDelegator` Protocol にも同等のメソッドを追加する。`YoutubeDelegator` の `ingest_video` が `async` であるのに対し、アンロード用メソッドは sync で呼び出す。
+他インジェスター（BlueSky 等）からの delegation 経由の取り込み用に、`YoutubeDelegator` Protocol は `ingest_videos(urls)` を公開する。これは内部で VRAM 解放を保証する公開 API であり、外部 caller は `unload_whisper` を明示呼び出しする必要はない。
+
+`YoutubeDelegator.unload_whisper` も保険的な明示呼び出し用として残すが、通常は使わない。
 
 #### VRAM 占有期間
 

--- a/src/rag/pipeline/ingesters/bluesky/delegations.py
+++ b/src/rag/pipeline/ingesters/bluesky/delegations.py
@@ -45,7 +45,7 @@ async def follow_urls(
     """配置済み投稿から URL を抽出し、Web/YouTube 委譲先に取り込ませる.
 
     Web URL は ``WebDelegator.run_for_urls`` でバッチ取得（subprocess 直起動を
-    回避するため Python API 経由）。YouTube URL は ``YoutubeDelegator.ingest_video``
+    回避するため Python API 経由）。YouTube URL は ``YoutubeDelegator.ingest_videos``
     で個別取り込み（URL 間にレート制限スリープ）。
 
     各 placed_item の ``_suppress_youtube_reingest`` フラグにより YouTube 抑制対象
@@ -113,38 +113,35 @@ async def follow_urls(
         youtube_urls = target_youtube_urls
 
     if youtube_urls:
-        # bluesky 投稿内 YouTube URL の bulk 取り込み境界。
-        # 末尾で必ず Whisper モデルをアンロードして VRAM を解放する
-        # （仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」）。
-        # youtube_urls が空 / youtube_delegator が None の場合は本ブロックに入らず、
-        # Whisper モデルがロードされないため unload_whisper は不要。
-        try:
-            for i, url in enumerate(youtube_urls):
-                if youtube_delegator is not None:
-                    try:
-                        yt_result = await youtube_delegator.ingest_video(url)
-                        stats["youtube_placed"] += yt_result.placed
-                        if yt_result.errors > 0:
-                            stats["errors"] += yt_result.errors
-                    except Exception as exc:
-                        logger.exception("YouTube URL の取り込みに失敗: %s", url)
-                        stats["errors"] += 1
-                        if result is not None:
-                            result.errors += 1
-                            result.error_details.append(IngestErrorDetail(
-                                category=IngestErrorCategory.DELEGATION.value,
-                                target=url,
-                                url=url,
-                                message=f"youtube delegation failed: {exc}",
-                            ))
-                    if i < len(youtube_urls) - 1:
-                        await asyncio.sleep(youtube_request_interval)
-                else:
-                    logger.warning("YouTube インジェスターが未指定: %s", url)
-                    stats["skipped"] += 1
-        finally:
+        # bluesky 投稿内 YouTube URL の取り込み。
+        # 各 URL を ingest_videos([url]) で呼ぶことで、公開 API 内部の try/finally に
+        # よって Whisper モデルの VRAM 解放が保証される。
+        # （仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」）
+        # per-URL レート制限を維持するため bulk 一括ではなく URL ごとに呼び出す。
+        for i, url in enumerate(youtube_urls):
             if youtube_delegator is not None:
-                youtube_delegator.unload_whisper()
+                try:
+                    yt_results = await youtube_delegator.ingest_videos([url])
+                    yt_result = yt_results[0]
+                    stats["youtube_placed"] += yt_result.placed
+                    if yt_result.errors > 0:
+                        stats["errors"] += yt_result.errors
+                except Exception as exc:
+                    logger.exception("YouTube URL の取り込みに失敗: %s", url)
+                    stats["errors"] += 1
+                    if result is not None:
+                        result.errors += 1
+                        result.error_details.append(IngestErrorDetail(
+                            category=IngestErrorCategory.DELEGATION.value,
+                            target=url,
+                            url=url,
+                            message=f"youtube delegation failed: {exc}",
+                        ))
+                if i < len(youtube_urls) - 1:
+                    await asyncio.sleep(youtube_request_interval)
+            else:
+                logger.warning("YouTube インジェスターが未指定: %s", url)
+                stats["skipped"] += 1
 
     logger.info(
         "URL 取り込み完了: web=%d, youtube=%d, skipped=%d, errors=%d",

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -197,13 +197,17 @@ class YoutubeIngester(BaseIngester):
         """リクエスト間隔（秒）."""
         return self._request_interval
 
-    async def ingest_video(
+    async def _ingest_one(
         self,
         video_url: str,
         *,
         playlist_id: str | None = None,
     ) -> IngestResult:
-        """単一 YouTube 動画を取得し source_store に配置する.
+        """単一 YouTube 動画を取得し source_store に配置する内部 helper.
+
+        ※ private メソッド。VRAM 解放を保証しないため外部から直接呼ばないこと。
+        公開 API は `ingest_videos(urls)` / `crawl_playlist(url)` を使う。
+        本メソッドはそれら公開 API の内部から `try/finally` の保護下でのみ呼ばれる。
 
         Args:
             video_url: YouTube 動画 URL
@@ -375,9 +379,9 @@ class YoutubeIngester(BaseIngester):
         try:
             for url in video_urls:
                 try:
-                    results.append(await self.ingest_video(url))
+                    results.append(await self._ingest_one(url))
                 except Exception as e:
-                    # プログラミングエラーは伝播させる（ingest_video 内部の設計と整合）
+                    # プログラミングエラーは伝播させる（_ingest_one 内部の設計と整合）
                     if isinstance(e, (TypeError, AttributeError, ImportError)):
                         raise
                     logger.error("ingest_videos エラー (url=%s): %s", url, e)
@@ -498,7 +502,7 @@ class YoutubeIngester(BaseIngester):
             video_url = f"https://www.youtube.com/watch?v={video_id}"
 
             try:
-                single_result = await self.ingest_video(
+                single_result = await self._ingest_one(
                     video_url, playlist_id=playlist_id
                 )
                 result.placed += single_result.placed

--- a/src/rag/pipeline/ingesters/youtube.py
+++ b/src/rag/pipeline/ingesters/youtube.py
@@ -207,7 +207,7 @@ class YoutubeIngester(BaseIngester):
 
         ※ private メソッド。VRAM 解放を保証しないため外部から直接呼ばないこと。
         公開 API は `ingest_videos(urls)` / `crawl_playlist(url)` を使う。
-        本メソッドはそれら公開 API の内部から `try/finally` の保護下でのみ呼ばれる。
+        本メソッドは原則として、それら公開 API の内部から `try/finally` の保護下で呼ばれる想定。
 
         Args:
             video_url: YouTube 動画 URL

--- a/src/rag/pipeline/ingesters/youtube_protocols.py
+++ b/src/rag/pipeline/ingesters/youtube_protocols.py
@@ -63,10 +63,10 @@ class YoutubeDelegator(Protocol):
         内部で `try/finally` を配置し、bulk 末尾で `unload_whisper` を呼び出す。
 
         Args:
-            video_urls: YouTube 動画 URL のリスト（長さ 1 以上）
+            video_urls: YouTube 動画 URL のリスト。空リストの場合は no-op で空リストを返す
 
         Returns:
-            URL ごとの配置結果リスト（順序保証）。委譲先での失敗は各要素の
+            URL ごとの配置結果リスト（順序保証、入力と同じ長さ）。委譲先での失敗は各要素の
             ``errors`` / ``error_details`` に計上される。
         """
         ...

--- a/src/rag/pipeline/ingesters/youtube_protocols.py
+++ b/src/rag/pipeline/ingesters/youtube_protocols.py
@@ -10,10 +10,8 @@ Protocol 経由で利用するための型を集約する。
   ``rag.pipeline.ingesters.youtube.classify_youtube_url`` 関数を SSoT として
   ラップする）
 - ``YoutubeDelegator``: 動画取り込みの抽象化（既存
-  ``YoutubeIngester.ingest_video`` メソッドを SSoT としてラップする）
-
-本ファイルは U1 で Protocol のみを公開する。Real 実装（``RealYoutubeClassifier``
-/ ``RealYoutubeDelegator``）と factory 関数は U2 で追加される。
+  ``YoutubeIngester.ingest_videos`` メソッドを SSoT としてラップする。
+  bulk 取り込み境界で Whisper モデルの VRAM 解放を保証する公開 API）
 """
 
 from __future__ import annotations
@@ -52,24 +50,24 @@ class YoutubeDelegator(Protocol):
 
     呼び出し側（bluesky 等）は本 Protocol 経由でのみ YouTube インジェスターを
     利用する。実装は ``rag.pipeline.ingesters.youtube.YoutubeIngester`` を
-    ラップする ``RealYoutubeDelegator``（U2）または各テスト・QA 用の Fake。
+    ラップする ``RealYoutubeDelegator`` または各テスト・QA 用の Fake。
     """
 
-    async def ingest_video(
+    async def ingest_videos(
         self,
-        video_url: str,
-        *,
-        playlist_id: str | None = None,
-    ) -> IngestResult:
-        """単一 YouTube 動画を取り込む.
+        video_urls: list[str],
+    ) -> list[IngestResult]:
+        """YouTube 動画を bulk 取り込みする（単発取り込みは長さ 1 のリストで呼ぶ）.
+
+        本メソッドは取り込み境界として Whisper モデルの VRAM 解放を保証する公開 API。
+        内部で `try/finally` を配置し、bulk 末尾で `unload_whisper` を呼び出す。
 
         Args:
-            video_url: YouTube 動画 URL
-            playlist_id: プレイリスト経由の場合のプレイリスト ID
+            video_urls: YouTube 動画 URL のリスト（長さ 1 以上）
 
         Returns:
-            配置結果（``IngestResult``）。委譲先での失敗は ``errors`` /
-            ``error_details`` に計上される。
+            URL ごとの配置結果リスト（順序保証）。委譲先での失敗は各要素の
+            ``errors`` / ``error_details`` に計上される。
         """
         ...
 
@@ -77,10 +75,10 @@ class YoutubeDelegator(Protocol):
         """委譲先 YouTube インジェスターの Whisper モデルをアンロードする.
 
         ※ 同期メソッド（GPU メモリ解放を確実に同期実行するため）。
-        `ingest_video` が `async` であるのに対し、本メソッドは sync で呼び出すこと。
+        `ingest_videos` が `async` であるのに対し、本メソッドは sync で呼び出すこと。
 
-        BlueSky 等の他インジェスターが bulk 取り込み完了時に呼び出し、
-        delegation 経由で保持された Whisper モデルの VRAM を解放する。
+        通常は `ingest_videos` 内部の `try/finally` で自動的にアンロードされるため、
+        外部から明示呼び出しする必要はない。プロセス終了前の保険的な明示呼び出しのために残す。
         Whisper モデル未ロード時は no-op（実装は委譲先側で判定）。
         """
         ...
@@ -104,7 +102,7 @@ class RealYoutubeClassifier:
 
 
 class RealYoutubeDelegator:
-    """``YoutubeIngester.ingest_video`` をラップする実装.
+    """``YoutubeIngester.ingest_videos`` をラップする実装.
 
     bluesky の URL 自動取り込みなど、他インジェスターから YouTube への
     委譲を Protocol 経由に統一するための薄いブリッジ。
@@ -113,15 +111,11 @@ class RealYoutubeDelegator:
     def __init__(self, ingester: YoutubeIngester) -> None:
         self._ingester = ingester
 
-    async def ingest_video(
+    async def ingest_videos(
         self,
-        video_url: str,
-        *,
-        playlist_id: str | None = None,
-    ) -> IngestResult:
-        return await self._ingester.ingest_video(
-            video_url, playlist_id=playlist_id,
-        )
+        video_urls: list[str],
+    ) -> list[IngestResult]:
+        return await self._ingester.ingest_videos(video_urls)
 
     def unload_whisper(self) -> None:
         self._ingester.unload_whisper()

--- a/tests/test_pipeline_ingesters_bluesky_delegations.py
+++ b/tests/test_pipeline_ingesters_bluesky_delegations.py
@@ -162,7 +162,7 @@ class TestFollowUrlsYoutubeDelegation:
         delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
-        delegator.ingest_video = AsyncMock(return_value=yt_result)
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
         runner.run_for_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
@@ -174,7 +174,7 @@ class TestFollowUrlsYoutubeDelegation:
             youtube_request_interval=0.0,
         )
         assert stats["youtube_placed"] == 1
-        delegator.ingest_video.assert_awaited_once_with("https://youtu.be/abcdEFG1234")
+        delegator.ingest_videos.assert_awaited_once_with(["https://youtu.be/abcdEFG1234"])
 
     @pytest.mark.asyncio
     async def test_youtube_skipped_when_delegator_none(self) -> None:
@@ -208,7 +208,7 @@ class TestFollowUrlsYoutubeDelegation:
             youtube_request_interval=0.0,
             force_youtube_reingest=False,
         )
-        delegator.ingest_video.assert_not_called()
+        delegator.ingest_videos.assert_not_called()
         assert stats["skipped"] >= 1
 
     @pytest.mark.asyncio
@@ -217,7 +217,7 @@ class TestFollowUrlsYoutubeDelegation:
         delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
-        delegator.ingest_video = AsyncMock(return_value=yt_result)
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
         runner.run_for_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(
@@ -237,7 +237,7 @@ class TestFollowUrlsYoutubeDelegation:
     async def test_youtube_delegator_failure_recorded(self) -> None:
         delegator = AsyncMock()
         delegator.unload_whisper = MagicMock()
-        delegator.ingest_video = AsyncMock(
+        delegator.ingest_videos = AsyncMock(
             side_effect=RuntimeError("yt failed"),
         )
         runner = AsyncMock()
@@ -259,16 +259,19 @@ class TestFollowUrlsYoutubeDelegation:
         )
 
     @pytest.mark.asyncio
-    async def test_youtube_delegator_unload_whisper_called(self) -> None:
-        """BlueSky 経由 YouTube 取り込み完了時に unload_whisper が呼ばれることを検証する.
+    async def test_youtube_urls_call_ingest_videos_per_url(self) -> None:
+        """BlueSky 経由で各 YouTube URL ごとに ingest_videos([url]) が呼ばれることを検証する.
 
+        Whisper モデルのアンロードは ingest_videos 内部の try/finally で保証されるため、
+        BlueSky 側で外部 unload_whisper を呼ぶ必要はない。本テストでは「per-URL で
+        ingest_videos が呼ばれる」契約を検証することで、unload 保証経路が成立することを担保する。
         仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
         """
         delegator = AsyncMock()
         delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
-        delegator.ingest_video = AsyncMock(return_value=yt_result)
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
         runner.run_for_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls([
@@ -282,26 +285,10 @@ class TestFollowUrlsYoutubeDelegation:
             web_delegator=runner,
             youtube_request_interval=0.0,
         )
-        # bulk 末尾で 1 回だけアンロード
-        delegator.unload_whisper.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_youtube_delegator_unload_whisper_called_on_exception(self) -> None:
-        """BlueSky 経由 YouTube 取り込みの途中で例外が発生しても unload_whisper が呼ばれることを検証する."""
-        delegator = AsyncMock()
-        delegator.ingest_video = AsyncMock(side_effect=RuntimeError("yt failed"))
-        delegator.unload_whisper = MagicMock()
-        runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
-        items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
-        await follow_urls(
-            items,
-            classifier=RealYoutubeClassifier(),
-            youtube_delegator=delegator,
-            web_delegator=runner,
-            youtube_request_interval=0.0,
-        )
-        delegator.unload_whisper.assert_called_once()
+        # URL ごとに ingest_videos([url]) が呼ばれる
+        assert delegator.ingest_videos.await_count == 2
+        delegator.ingest_videos.assert_any_await(["https://youtu.be/abcdEFG1234"])
+        delegator.ingest_videos.assert_any_await(["https://youtu.be/abcdEFG5678"])
 
     @pytest.mark.asyncio
     async def test_dedup_across_suppress_and_unsuppress_safer_side(
@@ -312,7 +299,7 @@ class TestFollowUrlsYoutubeDelegation:
         delegator.unload_whisper = MagicMock()
         yt_result = IngestResult()
         yt_result.placed = 1
-        delegator.ingest_video = AsyncMock(return_value=yt_result)
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
         runner.run_for_urls = AsyncMock(return_value=_make_execution())
         items = [
@@ -328,7 +315,7 @@ class TestFollowUrlsYoutubeDelegation:
             force_youtube_reingest=False,
         )
         # 1 回呼ばれる（安全側で suppress=False と扱われる）
-        delegator.ingest_video.assert_awaited_once()
+        delegator.ingest_videos.assert_awaited_once()
 
 
 class TestFollowUrlsEmpty:

--- a/tests/test_pipeline_ingesters_bluesky_fetcher.py
+++ b/tests/test_pipeline_ingesters_bluesky_fetcher.py
@@ -78,9 +78,9 @@ class TestProtocolDefinitions:
             for name, member in inspect.getmembers(YoutubeDelegator)
             if not name.startswith("_") and inspect.isfunction(member)
         }
-        # unload_whisper は Whisper モデルアンロード用の同期メソッド
+        # ingest_videos が VRAM 解放保証を含む公開 API、unload_whisper は保険的な明示呼び出し用
         # 仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
-        assert names == {"ingest_video", "unload_whisper"}
+        assert names == {"ingest_videos", "unload_whisper"}
 
     def test_web_delegator_protocol_has_run_for_urls(self) -> None:
         names = {

--- a/tests/test_pipeline_ingesters_youtube.py
+++ b/tests/test_pipeline_ingesters_youtube.py
@@ -305,7 +305,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata, snippets=snippets, language="ja")
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.placed == 1
         assert result.errors == 0
@@ -331,7 +331,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=60)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.placed == 0
         assert result.skipped == 1
@@ -342,7 +342,7 @@ class TestIngestVideo:
         fetcher = _fake(scenario="metadata_error")
         ingester = make_youtube_ingester(source_store, fetcher=fetcher)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.errors == 1
         detail = result.error_details[0]
@@ -358,7 +358,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.placed == 0
         assert result.errors == 1
@@ -378,7 +378,7 @@ class TestIngestVideo:
             source_store, fetcher=fetcher, whisper_model="medium",
         )
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.placed == 1
         call_kwargs = source_store.place_file.call_args
@@ -398,7 +398,7 @@ class TestIngestVideo:
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
         # 1 回目: dest.exists() が False → placed=1, overwritten=0
-        result1 = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result1 = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
         assert result1.placed == 1
         assert result1.overwritten == 0
 
@@ -407,7 +407,7 @@ class TestIngestVideo:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text("{}", encoding="utf-8")
 
-        result2 = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result2 = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
         # 排他計上: 既存ファイル上書き時は placed=0, overwritten=1
         assert result2.placed == 0
         assert result2.overwritten == 1
@@ -424,7 +424,7 @@ class TestIngestVideo:
         fetcher = _fake(scenario="ip_blocked", metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         # Whisper フォールバックされず、エラーとして処理される
         assert result.errors == 1
@@ -444,7 +444,7 @@ class TestIngestVideo:
         )
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
+        result = (await ingester.ingest_videos(["https://www.youtube.com/watch?v=TestVideo01"]))[0]
 
         assert result.placed == 1
         assert result.errors == 0

--- a/tests/test_pipeline_ingesters_youtube.py
+++ b/tests/test_pipeline_ingesters_youtube.py
@@ -305,7 +305,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata, snippets=snippets, language="ja")
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         assert result.errors == 0
@@ -331,7 +331,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=60)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 0
         assert result.skipped == 1
@@ -342,7 +342,7 @@ class TestIngestVideo:
         fetcher = _fake(scenario="metadata_error")
         ingester = make_youtube_ingester(source_store, fetcher=fetcher)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.errors == 1
         detail = result.error_details[0]
@@ -358,7 +358,7 @@ class TestIngestVideo:
         fetcher = _fake(metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 0
         assert result.errors == 1
@@ -378,7 +378,7 @@ class TestIngestVideo:
             source_store, fetcher=fetcher, whisper_model="medium",
         )
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         call_kwargs = source_store.place_file.call_args
@@ -398,7 +398,7 @@ class TestIngestVideo:
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
         # 1 回目: dest.exists() が False → placed=1, overwritten=0
-        result1 = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result1 = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
         assert result1.placed == 1
         assert result1.overwritten == 0
 
@@ -407,7 +407,7 @@ class TestIngestVideo:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text("{}", encoding="utf-8")
 
-        result2 = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result2 = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
         # 排他計上: 既存ファイル上書き時は placed=0, overwritten=1
         assert result2.placed == 0
         assert result2.overwritten == 1
@@ -424,7 +424,7 @@ class TestIngestVideo:
         fetcher = _fake(scenario="ip_blocked", metadata=metadata)
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         # Whisper フォールバックされず、エラーとして処理される
         assert result.errors == 1
@@ -444,7 +444,7 @@ class TestIngestVideo:
         )
         ingester = make_youtube_ingester(source_store, fetcher=fetcher, max_duration=14400)
 
-        result = await ingester.ingest_video("https://www.youtube.com/watch?v=TestVideo01")
+        result = await ingester._ingest_one("https://www.youtube.com/watch?v=TestVideo01")
 
         assert result.placed == 1
         assert result.errors == 0
@@ -490,11 +490,11 @@ class TestCrawlPlaylist:
             source_store, fetcher=fetcher, max_videos=3, request_interval=0.1,
         )
 
-        # ingest_video は public method なので patch.object 可（Fetcher 経由ではない）
+        # _ingest_one は private 内部 helper だが patch.object 可（Fetcher 経由ではない）
         single_result = IngestResult(placed=1)
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             return_value=single_result,
         ):
@@ -525,7 +525,7 @@ class TestCrawlPlaylist:
         with (
             patch.object(
                 ingester,
-                "ingest_video",
+                "_ingest_one",
                 new_callable=AsyncMock,
                 return_value=single_result,
             ),
@@ -566,7 +566,7 @@ class TestCrawlPlaylist:
         with (
             patch.object(
                 ingester,
-                "ingest_video",
+                "_ingest_one",
                 new_callable=AsyncMock,
                 return_value=single_result,
             ),
@@ -601,7 +601,7 @@ class TestCrawlPlaylist:
 
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             side_effect=lambda *args, **kwargs: _make_error_result(),
         ):
@@ -669,6 +669,34 @@ class TestWhisperLifecycle:
     """
 
     @pytest.mark.asyncio()
+    async def test_ingest_videos_single_url_unloads_whisper(self, source_store: Any) -> None:
+        """ingest_videos([url]) を 1 URL のみで呼び出した場合も末尾で unload_whisper が呼ばれることを検証する.
+
+        Issue #773 で対応: 単発取り込み経路でも VRAM 解放を構造的に保証する。
+        """
+        fetcher = _fake()
+        fetcher.unload_whisper = MagicMock()  # type: ignore[method-assign]
+        ingester = make_youtube_ingester(
+            source_store, fetcher=fetcher, max_duration=14400,
+        )
+
+        single_result = IngestResult(placed=1)
+        with patch.object(
+            ingester,
+            "_ingest_one",
+            new_callable=AsyncMock,
+            return_value=single_result,
+        ):
+            results = await ingester.ingest_videos([
+                "https://www.youtube.com/watch?v=TestVideo01",
+            ])
+
+        assert len(results) == 1
+        assert results[0].placed == 1
+        # 単発でも末尾で 1 回だけ unload される
+        assert fetcher.unload_whisper.call_count == 1
+
+    @pytest.mark.asyncio()
     async def test_ingest_videos_unloads_whisper_once(self, source_store: Any) -> None:
         """ingest_videos の bulk 取り込み完了時に unload_whisper が 1 度だけ呼ばれることを検証する."""
         fetcher = _fake()
@@ -680,7 +708,7 @@ class TestWhisperLifecycle:
         single_result = IngestResult(placed=1)
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             return_value=single_result,
         ):
@@ -707,7 +735,7 @@ class TestWhisperLifecycle:
         # AsyncMock の side_effect は Exception インスタンスを自動的に raise する。
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             side_effect=[
                 IngestResult(placed=1),
@@ -732,7 +760,7 @@ class TestWhisperLifecycle:
     async def test_ingest_videos_propagates_programming_errors(self, source_store: Any) -> None:
         """ingest_videos がプログラミングエラー（TypeError/AttributeError/ImportError）を per-item 変換せず伝播することを検証する.
 
-        ingest_video 内部の「プログラミングエラーは伝播させる」設計と整合させ、
+        _ingest_one 内部の「プログラミングエラーは伝播させる」設計と整合させ、
         バグをサイレントに成功扱いにしないことを保証する。
         """
         fetcher = _fake()
@@ -743,7 +771,7 @@ class TestWhisperLifecycle:
 
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             side_effect=TypeError("programming error"),
         ):
@@ -771,7 +799,7 @@ class TestWhisperLifecycle:
         single_result = IngestResult(placed=1)
         with patch.object(
             ingester,
-            "ingest_video",
+            "_ingest_one",
             new_callable=AsyncMock,
             return_value=single_result,
         ):

--- a/tests/test_pipeline_ingesters_youtube_protocols.py
+++ b/tests/test_pipeline_ingesters_youtube_protocols.py
@@ -44,32 +44,36 @@ class TestRealYoutubeClassifier:
 
 class TestRealYoutubeDelegator:
     @pytest.mark.asyncio
-    async def test_ingest_video_delegates_to_ingester(self) -> None:
+    async def test_ingest_videos_delegates_to_ingester(self) -> None:
         ingester = AsyncMock()
-        expected = IngestResult()
-        ingester.ingest_video.return_value = expected
+        expected = [IngestResult()]
+        ingester.ingest_videos.return_value = expected
         delegator = RealYoutubeDelegator(ingester)
 
-        result = await delegator.ingest_video(
-            "https://youtu.be/test", playlist_id="PLtest",
-        )
+        result = await delegator.ingest_videos(["https://youtu.be/test"])
 
         assert result is expected
-        ingester.ingest_video.assert_awaited_once_with(
-            "https://youtu.be/test", playlist_id="PLtest",
+        ingester.ingest_videos.assert_awaited_once_with(
+            ["https://youtu.be/test"],
         )
 
     @pytest.mark.asyncio
-    async def test_ingest_video_default_playlist_id_is_none(self) -> None:
+    async def test_ingest_videos_supports_bulk_urls(self) -> None:
         ingester = AsyncMock()
-        ingester.ingest_video.return_value = IngestResult()
+        expected = [IngestResult(), IngestResult()]
+        ingester.ingest_videos.return_value = expected
         delegator = RealYoutubeDelegator(ingester)
 
-        await delegator.ingest_video("https://youtu.be/test")
+        result = await delegator.ingest_videos([
+            "https://youtu.be/test1",
+            "https://youtu.be/test2",
+        ])
 
-        ingester.ingest_video.assert_awaited_once_with(
-            "https://youtu.be/test", playlist_id=None,
-        )
+        assert result is expected
+        ingester.ingest_videos.assert_awaited_once_with([
+            "https://youtu.be/test1",
+            "https://youtu.be/test2",
+        ])
 
 
 class TestFactories:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

PR #772（Issue #753、Whisper モデルライフサイクル機構の追加）に実装欠陥があり、`YoutubeIngester.ingest_video()` を単独で公開メソッドとして呼び出すと VRAM が解放されない経路が存在した。本 PR で構造的に解消する。

主な変更:

- `YoutubeIngester.ingest_video()` を `_ingest_one()` に private リネーム（VRAM 解放を保証しない内部 helper 化）
- `YoutubeDelegator` Protocol の `ingest_video(url)` を `ingest_videos(urls: list[str])` に変更
- `RealYoutubeDelegator` は `YoutubeIngester.ingest_videos()` に委譲
- `bluesky/delegations.py` を `youtube_delegator.ingest_videos([url])` 経由に変更し、外部 `unload_whisper` 呼び出しを削除（公開 API 内部の保証に一本化）
- 関連テスト群を新 API に追従、`test_ingest_videos_single_url_unloads_whisper`（単発呼び出しの VRAM 解放保証）を追加
- 仕様書 `docs/specs/ingesters/youtube.md`「Whisper モデルライフサイクル」を公開 API での保証に整合化
- 仕様書 `docs/specs/ingesters/bluesky.md` に YouTube 委譲経路の per-URL 呼び出し制約を注記
- 仕様書 `docs/specs/infrastructure/fake-adapters/youtube.md` の古い識別子 `ingest_video` を `ingest_videos` に追従

これにより「VRAM 解放されない呼び出し経路」が構造的に存在しなくなる。

## Test plan

- [x] L1 unit test: 2123 件全パス（新規テスト 1 件 `test_ingest_videos_single_url_unloads_whisper` 追加 + 既存テスト追従）
- [x] L2 mock e2e test: 22 件全パス
- [x] ruff check: clean
- [x] mypy: clean (132 source files)
- [x] markdownlint: clean
- [x] code-reviewer / doc-reviewer 2 巡実施 + triage で全指摘対応済（要修正 8 件対応、要相談 6 件は triage 確定）
- 本番相当 (L3) QA: 既存 QA Issue #771 にて #753 と合わせて実施予定

## 互換性に関する注意（破壊的変更）

- `YoutubeDelegator` Protocol の `ingest_video` → `ingest_videos` への置換は **公開 Protocol の破壊的変更**。本リポジトリ内では `RealYoutubeDelegator` のみが実装しているため内部完結する
- `YoutubeIngester.ingest_video` → `_ingest_one()` は内部 helper への private 化。外部直接呼び出しがあれば破壊的変更となるが、リポジトリ内で外部直接呼び出しはなし

## Related issues

Closes #773

関連:
- PR #772 / Issue #753: feat(youtube): Whisper モデルサイズの再検討（base → medium） + ライフサイクル機構（本 PR で実装欠陥を解消）