### PR TITLE
fix(search-response,readme): rag_get_document の 64KiB 超対応 + CPU 環境向け UV_NO_GROUP 案内 (#777, #780)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,35 @@ MinerU + PyTorch を除外する。PDF 抽出は pymupdf4llm にフォールバ�
 uv sync --no-group with-mineru
 ```
 
+**CPU/AMD GPU 環境では `UV_NO_GROUP=with-mineru` の永続化が必須**:
+`uv sync --no-group with-mineru` 単発では除外できるが、その後の `uv run` が
+内部で `uv sync` を再実行する際に `pyproject.toml` の
+`tool.uv.default-groups = ["dev", "with-mineru"]` が再適用され、torch + MinerU が
+再インストールされる。これを構造的に防ぐため、OS ユーザー環境変数に
+`UV_NO_GROUP=with-mineru` を設定する。
+
+##### Windows
+
+```powershell
+setx UV_NO_GROUP with-mineru
+```
+
+設定後はターミナル・IDE を再起動して反映する。確認:
+
+```powershell
+echo $env:UV_NO_GROUP  # → with-mineru
+```
+
+##### Unix（macOS / Linux）
+
+shell の rc ファイル（`~/.bashrc` / `~/.zshrc` 等）に追記:
+
+```bash
+export UV_NO_GROUP=with-mineru
+```
+
+設定後はシェルを再起動するか `source ~/.bashrc` で反映する。
+
 ### 2. 環境設定
 
 ```bash

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -875,6 +875,7 @@ flowchart LR
 | `OPENAI_API_KEY` が未登録 | オンライン Embedding プロバイダーの初期化に失敗し、エラーを返す |
 | `GOOGLE_SAFE_BROWSING_API_KEY` が未登録・空・不正 | 設定エラー（`SafeBrowsingConfigError`）として即時中断する |
 | rag_get_document レスポンスサイズ超過 | MCP 経由で `rag_max_response_chars` 超過時はトランケーションし、末尾に CLI `--output-file` オプションでの全文取得を案内する。CLI の `--output-file` 指定時はトランケーションなし |
+| rag_get_document で極端に大きいドキュメント（subprocess 行バッファ 10MiB 超過） | MCP 経由で CLI subprocess の stdout 1 行が `asyncio.StreamReader` 行バッファ上限を超えると `CLISubprocessError` として明示エラーを返す。CLI 直接実行（`--output-file` 指定）では適用されない |
 | バジェット上限到達 | 取得済みデータを返し、上限到達の旨をログ出力する |
 | サーキットブレーカー発動 | 操作を中断し、取得済みデータを返す。エラーの詳細をログ出力する |
 | 操作全体タイムアウト | 操作を中断し、取得済みデータを返す |

--- a/docs/specs/search-response.md
+++ b/docs/specs/search-response.md
@@ -30,7 +30,10 @@ rag_search のレスポンスをチャンク単位の返却に変更し、全文
 - **レスポンス形式**: MCP ツールのレスポンスはプレーンテキスト形式を維持する（JSON 等の構造化形式には変更しない）
 - **全文取得の論理削除対応**: `status` が `deleted` のソースも全文取得可能とする（[source-store.md](source-store.md) の「ファイル取得」インターフェースの設計意図を踏襲）
 - **MCP + CLI 両提供**: rag_get_document は MCP ツールと CLI サブコマンドの両方で提供する。内部ロジックは共通関数とする
-- **レスポンスサイズ制御**: rag_get_document は大規模ドキュメントに対して `rag_max_response_chars`（既存設定項目を継続利用）でトランケーションを行う。上限超過時は末尾にトランケート通知（CLI の `--output` オプションでの全文取得を案内）を付記し、CLI の `--output` オプションによるファイル出力ではトランケーションを適用しない（全文出力）
+- **レスポンスサイズ制御**: rag_get_document は 2 段階の上限が適用される。
+  (1) **subprocess 行バッファ上限（10MiB）**: MCP 経由の場合、CLI subprocess の stdout 1 行（result JSON 行）が `asyncio.StreamReader` の行バッファ上限（10MiB）を超えると `CLISubprocessError` として明示エラーを返す。トランケーションは行わない。
+  (2) **アプリ層トランケーション（`rag_max_response_chars`）**: 上記 (1) を通過した応答に対し、MCP 経由で `rag_max_response_chars`（既存設定項目を継続利用）が設定されている場合は超過分をトランケーションし、末尾にトランケート通知（CLI の `--output-file` オプションでの全文取得を案内）を付記する。
+  CLI 直接実行（`--output-file` 指定）ではいずれの上限も適用せず全文出力する
 
 本コンポーネントは外部 API 通信を行わないため、想定プロファイル・安全制約セクションは省略する。
 
@@ -227,8 +230,9 @@ uv run python -m rag.cli get-document <source_id> [--format text|original] [--ou
 | rag_get_document で converted_store にファイルが存在しない場合（format=text） | エラーメッセージを返す。source_store にオリジナルが存在する旨を通知し、`format=original` での取得を提案する |
 | rag_search で `total_chunks` が未設定または 0 のチャンク（レガシーデータ等） | Chunk 位置を `{chunk_index+1}/?` と表示する（現在位置は既知のため保持し、総数のみ不明とする） |
 | rag_get_document で format=original 指定時にバイナリファイル（PDF 等）の場合 | ファイルの MIME タイプとファイルサイズを返し、テキスト形式での取得（format=text）を提案する。バイナリデータ自体は返さない |
-| rag_get_document で大規模ドキュメントの場合（MCP 経由） | `rag_max_response_chars` でトランケーションし、末尾に「トランケートされました。CLI の `--output` オプションで全文取得できます」と付記する |
-| rag_get_document で大規模ドキュメントの場合（CLI `--output` 指定） | トランケーションを適用せず全文をファイルに出力する |
+| rag_get_document で大規模ドキュメントの場合（MCP 経由、`rag_max_response_chars` 超過） | `rag_max_response_chars` でトランケーションし、末尾に「トランケートされました。CLI の `--output-file` オプションで全文取得できます」と付記する |
+| rag_get_document で極端に大きいドキュメントの場合（MCP 経由、subprocess 行バッファ 10MiB 超過） | CLI subprocess 通信レイヤーで `CLISubprocessError` として明示エラーを返す。トランケーションは行わない。CLI の `--output-file` オプションでの全文取得を案内する |
+| rag_get_document で大規模ドキュメントの場合（CLI `--output-file` 指定） | 上記いずれの上限も適用せず全文をファイルに出力する |
 
 ## コンポーネント構成
 

--- a/src/rag/server/cli_subprocess.py
+++ b/src/rag/server/cli_subprocess.py
@@ -41,6 +41,12 @@ logger = logging.getLogger("rag.server")
 # Unix: SIGSEGV=11, shell: 128+11=139
 _SEGFAULT_EXIT_CODES: frozenset[int] = frozenset({-1073741819, 3221225477, -11, 139})
 
+# asyncio StreamReader の行バッファ上限。
+# デフォルト 64KiB では rag_get_document が 64KB 超のドキュメントで
+# `Separator is found, but chunk is longer than limit` で失敗するため、
+# 1 行あたり 10MiB まで許容する。
+_STDOUT_LINE_BUFFER_LIMIT = 10 * 1024 * 1024
+
 
 class CLISubprocessError(Exception):
     """CLI サブプロセスの実行エラー."""
@@ -127,6 +133,7 @@ async def _run_cli_subprocess(
         stdin=stdin_mode,
         stderr=asyncio.subprocess.PIPE,
         env=env,
+        limit=_STDOUT_LINE_BUFFER_LIMIT,
     )
 
     # stdin にデータを書き込んでクローズする

--- a/src/rag/server/cli_subprocess.py
+++ b/src/rag/server/cli_subprocess.py
@@ -42,10 +42,10 @@ logger = logging.getLogger("rag.server")
 _SEGFAULT_EXIT_CODES: frozenset[int] = frozenset({-1073741819, 3221225477, -11, 139})
 
 # asyncio StreamReader の行バッファ上限。
-# デフォルト 64KiB では rag_get_document が 64KB 超のドキュメントで
+# デフォルト 64KiB では rag_get_document が 64KiB 超のドキュメントで
 # `Separator is found, but chunk is longer than limit` で失敗するため、
 # 1 行あたり 10MiB まで許容する。
-_STDOUT_LINE_BUFFER_LIMIT = 10 * 1024 * 1024
+_STDOUT_LINE_BUFFER_LIMIT: int = 10 * 1024 * 1024
 
 
 class CLISubprocessError(Exception):
@@ -152,7 +152,18 @@ async def _run_cli_subprocess(
         _error_line = ""
         assert process.stdout is not None  # noqa: S101
         while True:
-            raw = await process.stdout.readline()
+            try:
+                raw = await process.stdout.readline()
+            except ValueError as exc:
+                # _STDOUT_LINE_BUFFER_LIMIT を超える 1 行は asyncio.StreamReader が
+                # `Separator is found, but chunk is longer than limit` で
+                # ValueError を投げる。MCP ツール側で扱えるよう CLISubprocessError
+                # にラップする（仕様: docs/specs/search-response.md, rag-knowledge.md）。
+                limit_mib = _STDOUT_LINE_BUFFER_LIMIT // (1024 * 1024)
+                raise CLISubprocessError(
+                    f"応答が上限 ({limit_mib}MiB) を超えました。"
+                    f"CLI の get-document コマンド（--output-file オプション）で全文取得できます",
+                ) from exc
             if not raw:
                 break
             line = raw.decode("utf-8").strip()

--- a/src/rag/server/cli_subprocess.py
+++ b/src/rag/server/cli_subprocess.py
@@ -211,6 +211,16 @@ async def _run_cli_subprocess(
             with contextlib.suppress(asyncio.CancelledError):
                 await process.wait()
         raise
+    except CLISubprocessError:
+        # _read_stdout が ValueError をラップした CLISubprocessError を送出した場合、
+        # 子プロセスが残留・ゾンビ化しないよう kill()+wait() で後始末する
+        # （CancelledError 経路と同じパターン）。
+        if process.returncode is None:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            with contextlib.suppress(asyncio.CancelledError):
+                await process.wait()
+        raise
 
     await process.wait()
 

--- a/src/rag/server/tools/search.py
+++ b/src/rag/server/tools/search.py
@@ -87,8 +87,10 @@ async def rag_get_document(
 
     Returns:
         メタデータヘッダー + ドキュメント全文。
-        大規模ドキュメントはトランケーションされる場合がある。
-        その場合は CLI の --output オプションで全文取得可能。
+        2 段階の上限が適用される:
+        (1) CLI subprocess の 1 行 stdout バッファ上限（10MiB）を超えた場合は明示エラー
+        (2) `rag_max_response_chars` 設定時は超過分をトランケートし末尾に通知を付記（未設定時は全文返却）
+        上限を超える場合は CLI の get-document コマンド（--output-file オプション）で全文取得可能。
     """
     if format not in _VALID_DOCUMENT_FORMATS:
         valid = ", ".join(sorted(_VALID_DOCUMENT_FORMATS))

--- a/tests/test_cli_subprocess_parse.py
+++ b/tests/test_cli_subprocess_parse.py
@@ -192,9 +192,12 @@ class TestCLISubprocessStdoutReadLimit:
         `Separator is found, but chunk is longer than limit` の ValueError を投げる。
         MCP ツール側のエラー整形経路に乗せるため、CLISubprocessError へラップし、
         CLI `--output-file` での全文取得を案内するメッセージにする。
+
+        例外経路でも子プロセスを kill()+wait() で確実に後始末することも検証する
+        （ゾンビ化防止）。
         """
         mock_proc = MagicMock()
-        mock_proc.returncode = 0
+        mock_proc.returncode = None  # 未終了状態 → kill()+wait() 経路を通る
 
         async def _readline_raises() -> bytes:
             raise ValueError(
@@ -210,7 +213,11 @@ class TestCLISubprocessStdoutReadLimit:
         mock_proc.stderr = MagicMock()
         mock_proc.stderr.read = _stderr_read
 
+        wait_called = False
+
         async def _wait() -> int:
+            nonlocal wait_called
+            wait_called = True
             return 0
 
         mock_proc.wait = _wait
@@ -224,9 +231,15 @@ class TestCLISubprocessStdoutReadLimit:
             with pytest.raises(CLISubprocessError) as exc_info:
                 await _run_cli_subprocess("get-document", ["some-id"])
 
+        # 期待メッセージは定数から算出して将来の上限変更に追従する
+        expected_mib = _STDOUT_LINE_BUFFER_LIMIT // (1024 * 1024)
         message = str(exc_info.value)
-        assert "10MiB" in message
+        assert f"{expected_mib}MiB" in message
         assert "--output-file" in message
+
+        # 子プロセスの後始末（ゾンビ化防止）が行われたこと
+        mock_proc.kill.assert_called_once()
+        assert wait_called is True
 
 
 class TestCLISubprocessErrorFormatMcpError:

--- a/tests/test_cli_subprocess_parse.py
+++ b/tests/test_cli_subprocess_parse.py
@@ -20,7 +20,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rag.server.cli_subprocess import CLISubprocessError, _run_cli_subprocess
+from rag.server.cli_subprocess import (
+    _STDOUT_LINE_BUFFER_LIMIT,
+    CLISubprocessError,
+    _run_cli_subprocess,
+)
 
 
 def _make_mock_process(stdout_lines: list[str], exit_code: int = 1) -> MagicMock:
@@ -152,6 +156,34 @@ class TestCLISubprocessParseLockType:
             with pytest.raises(CLISubprocessError) as exc_info:
                 await _run_cli_subprocess("add-journal", [])
         assert exc_info.value.lock_type is None
+
+
+@pytest.mark.asyncio
+class TestCLISubprocessStdoutReadLimit:
+    """_run_cli_subprocess が asyncio StreamReader の行バッファ上限を引き上げるテスト.
+
+    rag_get_document が 64KiB 超のドキュメントで asyncio のデフォルト
+    `_DEFAULT_LIMIT` (65536) を超え `ValueError: Separator is found, but chunk
+    is longer than limit` で失敗する問題 (Issue #777) の回避を保証する。
+    """
+
+    async def test_stdout_read_limit_is_at_least_10_mib(self) -> None:
+        """`_STDOUT_LINE_BUFFER_LIMIT` 定数が 10 MiB 以上に設定されている."""
+        assert _STDOUT_LINE_BUFFER_LIMIT >= 10 * 1024 * 1024
+
+    async def test_passes_stdout_read_limit_to_subprocess_exec(self) -> None:
+        """`create_subprocess_exec` に `limit=_STDOUT_LINE_BUFFER_LIMIT` を渡している."""
+        result_line = json.dumps({"type": "result", "placed": 0})
+        mock_proc = _make_mock_process([result_line], exit_code=0)
+        with patch(
+            "asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ) as mock_exec:
+            await _run_cli_subprocess("get-document", ["some-id"])
+        assert mock_exec.await_count == 1
+        assert mock_exec.await_args is not None
+        assert mock_exec.await_args.kwargs.get("limit") == _STDOUT_LINE_BUFFER_LIMIT
 
 
 class TestCLISubprocessErrorFormatMcpError:

--- a/tests/test_cli_subprocess_parse.py
+++ b/tests/test_cli_subprocess_parse.py
@@ -185,6 +185,49 @@ class TestCLISubprocessStdoutReadLimit:
         assert mock_exec.await_args is not None
         assert mock_exec.await_args.kwargs.get("limit") == _STDOUT_LINE_BUFFER_LIMIT
 
+    async def test_wraps_readline_value_error_as_cli_subprocess_error(self) -> None:
+        """readline() の ValueError（行バッファ上限超過）を CLISubprocessError にラップする.
+
+        asyncio.StreamReader.readline() は 1 行が limit を超えると
+        `Separator is found, but chunk is longer than limit` の ValueError を投げる。
+        MCP ツール側のエラー整形経路に乗せるため、CLISubprocessError へラップし、
+        CLI `--output-file` での全文取得を案内するメッセージにする。
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+
+        async def _readline_raises() -> bytes:
+            raise ValueError(
+                "Separator is found, but chunk is longer than limit",
+            )
+
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.readline = _readline_raises
+
+        async def _stderr_read() -> bytes:
+            return b""
+
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.read = _stderr_read
+
+        async def _wait() -> int:
+            return 0
+
+        mock_proc.wait = _wait
+        mock_proc.stdin = None
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_proc,
+        ):
+            with pytest.raises(CLISubprocessError) as exc_info:
+                await _run_cli_subprocess("get-document", ["some-id"])
+
+        message = str(exc_info.value)
+        assert "10MiB" in message
+        assert "--output-file" in message
+
 
 class TestCLISubprocessErrorFormatMcpError:
     """CLISubprocessError.format_mcp_error の lock_type 別メッセージテスト."""


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正
- [x] docs: ドキュメント更新

## Summary

- **#777 (fix)**: `_run_cli_subprocess` の `asyncio.create_subprocess_exec` に `limit=10 MiB`（`_STDOUT_LINE_BUFFER_LIMIT`）を渡し、asyncio StreamReader の行バッファ上限を 64 KiB → 10 MiB に引き上げて `rag_get_document` の 64 KiB 超ドキュメント取得を可能にする
- **#777 (docs)**: `tools/search.py` の docstring を 2 段階上限（subprocess 10 MiB + アプリ層 `rag_max_response_chars`）に正確化。仕様書 `search-response.md` / `rag-knowledge.md` のエッジケースに 10 MiB 上限を明示。既存 typo `--output` を `--output-file` に修正
- **#777 (test)**: `tests/test_cli_subprocess_parse.py` に limit 引数検証テスト 2 件追加（`_STDOUT_LINE_BUFFER_LIMIT >= 10 MiB` 検証 + `create_subprocess_exec` 呼び出し時の `limit` kwarg 伝達検証）
- **#780 (docs)**: README の「CPU 環境（GPU なし / AMD GPU）」セクションに `UV_NO_GROUP=with-mineru` の Windows / Unix 永続化手順を追記。`uv run` が `pyproject.toml` の `default-groups` を再適用する構造的問題への対処として説明

## Test plan

- [x] L1 Unit Test: `tests/test_cli_subprocess_parse.py` 全件 pass（新規 2 件含む 10 passed）
- [x] ruff check / mypy / markdownlint すべて pass
- [x] L3 焦点 QA: worktree で MCP HTTP サーバー起動 → 105 KB 級ドキュメント取り込み → `rag_get_document` 経由で 107,189 bytes 全文取得確認（修正前は `Separator is found, but chunk is longer than limit` で失敗）
- [x] L3 焦点 QA: `rag_search` で 4,558 bytes 正常返却（リグレッションなし）

## Related issues

Closes #777
Closes #780