### PR TITLE
fix(bluesky,content-upload): URL 取り込みログ集計内訳化 + rebuild shutdown lock retry (#778, #779)

### DIFF
--- a/docs/specs/infrastructure/content-upload.md
+++ b/docs/specs/infrastructure/content-upload.md
@@ -61,11 +61,18 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
 - **ロックファイル**: source_store ディレクトリ直下に配置する。`write_lock`（書き込みロック、ファイル名 `.write.lock`）と `rebuild_lock`（再構築ロック、ファイル名 `.rebuild.lock`）でそれぞれ別のロックファイルを使用する
 - **ノンブロッキング primitive + helper レベルの短時間リトライ**:
   低レベル `FileLock` / `PipelineLock` は常にノンブロッキング（`LOCK_NB` / `LK_NBLCK`）で動作する。
-  書き込み系 CLI helper (`_write_lock_or_exit`) は `kind="write"` の競合に限り短時間の指数バックオフでリトライし
-  （CLI 連続実行時の OS ロック解放遅延を吸収する目的）、
-  リトライ全失敗または `kind="rebuild"` の場合は即座にエラーを返却する。
-  rebuild コマンド側の lock helper（`rebuild_lock` を取得する処理）はリトライしない
-  （rebuild は秒〜分単位の長時間処理のため短時間リトライの意味が薄い）。
+  リトライ責務は helper 種別ごとに分離する:
+  - **書き込み系 CLI helper（`_write_lock_or_exit`）**:
+    - `kind="write"` 競合（他の書き込み操作との競合）: 短時間の指数バックオフでリトライする
+      （CLI 連続実行時の OS ロック解放遅延を吸収する目的）
+    - `kind="rebuild"` 競合（rebuild との競合）: 短時間の指数バックオフでリトライする。
+      ただし「rebuild の本体処理を待つ」のではなく、「visible log 完了後も続く python interpreter
+      shutdown 期間（chroma client teardown / GC / file flush 等）の数〜十数秒の lock 保持を
+      吸収する」目的に限定される（Issue #779）
+    - いずれの kind もリトライ全失敗時はエラーを返却する
+  - **rebuild コマンド自身の lock helper（`rebuild_lock` を取得する処理）**:
+    - リトライしない（rebuild は秒〜分単位の長時間処理のため短時間リトライの意味が薄い）
+
   CLI はロック競合時に JSON Lines の error メッセージ（`type: "error"`）に
   ロック競合コード（`LOCK_CONFLICT`）とロック種別（`write` / `rebuild`）を含め、exit code 1 で終了する。
   サーバー側（`src/rag/server/cli_subprocess.py`）は CLI サブプロセスの error メッセージから
@@ -73,14 +80,20 @@ MCP は JSON ベースのテキストプロトコルであるため、ツール�
   （`write` 競合 = 429、`rebuild` 競合 = 503）+ `Retry-After` ヘッダ、
   MCP ツールではロック種別に応じたエラーメッセージとして返却する。
   CLI 直接実行では標準エラー出力 + exit code 1 を返す。
-  リトライ間隔・回数の具体値は `src/rag/cli.py` の `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を SSoT とする。
+  リトライ間隔・回数の具体値は `src/rag/cli.py` の `_WRITE_LOCK_RETRY_BACKOFFS_SEC`（kind=write）と
+  `_REBUILD_PROBE_RETRY_BACKOFFS_SEC`（kind=rebuild）を SSoT とする。
 - **ロック種別の伝搬**: CLI のロック競合エラーには種別識別子（`write` または `rebuild`）を含める。この識別子は Upload HTTP API の HTTP ステータスコード・`Retry-After` 値の選択と、MCP ツールのエラーメッセージの切替に使用する。識別子の意味は「取得失敗したロック」であり、外部プロセスの保持状態を示す
 - **lock_type 不明時のフォールバック**: CLI エラー応答に `details.lock_type` が含まれない
   （低レベル `FileLock` 直接利用で `kind=None` の場合、または旧バージョン CLI との後方互換）、
   もしくは不正値（`write`/`rebuild` 以外）の場合、Upload HTTP API は `write` 相当として
   HTTP 429 + `rag_upload_retry_after_write_sec` を返す。
   短めの Retry-After を返すことで安全側に倒す（長時間待機を誤って強いるリスクを避ける）
-- **ステールロック対策**: OS ファイルロックはプロセス終了時（SEGFAULT 含む異常終了を含む）に OS が自動解放するため、明示的なステールロック対策は不要。OS クラッシュ・電源断の場合もロックはカーネルメモリ上のみに存在し、再起動後にクリーンな状態になる
+- **ステールロック対策**: OS ファイルロックはプロセス終了時（SEGFAULT 含む異常終了を含む）に OS が自動解放するため、明示的なステールロック対策は不要。
+  OS クラッシュ・電源断の場合もロックはカーネルメモリ上のみに存在し、再起動後にクリーンな状態になる
+  - **shutdown 期間の lock 保持**: 「プロセス終了時の自動解放」は OS の handle close 契機であり、python interpreter から見た
+    「visible log 出力完了」と「プロセス終了」の間には shutdown 処理（chroma client teardown / GC / file flush 等）の
+    数秒〜十数秒の差がある。この期間中は lock がまだ保持されているため、書き込み helper 側で
+    `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` による短時間リトライで吸収する（Issue #779）
 - **Advisory lock の制約**: OS ファイルロックは advisory lock（協調ロック）であり、ロック取得のコードを経由しないアクセスは防げない。本システムでは全書き込み操作が CLI 経由（MCP サブプロセス + CLI 直接実行）のため問題ない
 - **rebuild との相互排他（非対称設計 + プリチェック）**: 書き込み操作（ingest / delete 等）と
   rebuild 操作は相互排他で動作する。ロック保持戦略は非対称で、書き込み系 CLI は `write_lock`

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -628,7 +628,11 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 4. Web URL を全てバッチ収集し、site-ingest（複数 URL モード）の Python API を直接呼び出して取り込む。
    - 子 CLI subprocess として起動しない理由: BlueSky 取り込みの呼び出し元 CLI が既に source_store の write_lock を保持しており、子プロセス側での再取得がロック競合で失敗するため
    - site-ingest 内部の Scrapy subprocess 起動は維持される（reactor 制約のため）
-   - bridge 結果の配置件数（新規配置と上書きの合算）とエラーを BlueSky 側の集計に反映する
+   - bridge 結果は新規配置（`placed`）と上書き（`overwritten`）を **内訳として分離** して BlueSky 側の集計に反映する（合算ではなく排他カウントを別キーで保持）
+     - 内部 logger（`rag.pipeline.ingesters.bluesky.delegations`）の完了ログは `URL 取り込み完了: web=N (placed=X, overwritten=Y), youtube=N (placed=X, overwritten=Y), skipped=N, errors=N` 形式で出力する
+     - ユーザー向け CLI/MCP 応答テキストは「`Web N件 (新規 X, 上書き Y), YouTube N件 (新規 X, 上書き Y)`」形式で内訳を表示する
+     - 上書き再取り込み時に「0 件」と誤表示される問題（Issue #778）を防ぐための分離設計
+     - YouTube 側も同じ規約で内訳を保持・表示する
    - 後続のインデックス処理は BlueSky 側で一括実行する
 5. YouTube URL の取得対象判定:
    - 新規投稿由来の YouTube URL は常に取得する

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -187,9 +187,17 @@ def _output_error(
 # write_lock 取得失敗（kind=write）時の指数バックオフ間隔（秒）。
 # CLI 連続実行時の OS ファイルロック解放遅延を吸収する目的。
 # 4 回再試行 = 初回 + 4 回 = 最大 5 回試行。合計待機時間 ~1.85s。
-# kind=rebuild は秒〜分単位の処理が走っているケースのため対象外（即失敗）。
 # Issue #755
 _WRITE_LOCK_RETRY_BACKOFFS_SEC: tuple[float, ...] = (0.1, 0.25, 0.5, 1.0)
+
+# write 操作の rebuild_lock プリチェック失敗（kind=rebuild）時の指数バックオフ間隔（秒）。
+# rebuild プロセスの visible log 完了後も python interpreter shutdown 処理
+# （chroma client teardown / GC / file flush 等）の間は OS ファイルロックが
+# 保持され続け、その期間 write 操作が即失敗する事象（QA で 10〜15 秒観察）を
+# 吸収する目的。rebuild 本体処理の長時間 retry は意図しないが、shutdown 期間の
+# 短時間 retry は安全に吸収できる（Issue #779）。
+# 5 回再試行 = 初回 + 5 回 = 最大 6 回試行。合計待機時間 ~15.5s。
+_REBUILD_PROBE_RETRY_BACKOFFS_SEC: tuple[float, ...] = (0.5, 1.0, 2.0, 4.0, 8.0)
 
 
 @contextlib.contextmanager
@@ -203,9 +211,12 @@ def _write_lock_or_exit(
     ロック取得に失敗した場合はロック種別に応じたメッセージで _output_error 経由で
     exit する。with 文を抜ける際にロックは自動解放される。
 
-    kind=write の競合に対しては短時間の指数バックオフでリトライする
-    （CLI 連続実行時の OS ロック解放遅延を吸収するため）。kind=rebuild の
-    競合はリトライせず即失敗する。
+    kind=write の競合に対しては ``_WRITE_LOCK_RETRY_BACKOFFS_SEC`` の指数バック
+    オフでリトライする（CLI 連続実行時の OS ロック解放遅延を吸収するため）。
+    kind=rebuild の競合に対しては ``_REBUILD_PROBE_RETRY_BACKOFFS_SEC`` の
+    短時間バックオフでリトライする（rebuild プロセスの visible log 完了後も
+    続く python interpreter shutdown 期間の lock 保持を吸収するため）。
+    両者ともリトライ全失敗時は exit する。
 
     仕様: docs/specs/infrastructure/content-upload.md の「rebuild との相互排他」
 
@@ -221,18 +232,23 @@ def _write_lock_or_exit(
 
     lock = write_lock(source_store_root)
     last_error: LockAcquisitionError | None = None
-    for backoff in (None, *_WRITE_LOCK_RETRY_BACKOFFS_SEC):
-        if backoff is not None:
-            time.sleep(backoff)
+    write_iter = iter(_WRITE_LOCK_RETRY_BACKOFFS_SEC)
+    rebuild_iter = iter(_REBUILD_PROBE_RETRY_BACKOFFS_SEC)
+    next_backoff: float | None = None
+    while True:
+        if next_backoff is not None:
+            time.sleep(next_backoff)
         try:
             lock.acquire()
         except LockAcquisitionError as e:
             last_error = e
-            # kind=rebuild はリトライ対象外（即失敗）。kind=write はループ継続
             if e.kind == "rebuild":
+                next_backoff = next(rebuild_iter, None)
+            else:
+                next_backoff = next(write_iter, None)
+            if next_backoff is None:
                 break
         else:
-            # 取得成功
             last_error = None
             break
 
@@ -2686,7 +2702,9 @@ def _emit_bluesky_result(
         if url_stats:
             data["url_follow"] = {
                 "web_placed": url_stats.get("web_placed", 0),
+                "web_overwritten": url_stats.get("web_overwritten", 0),
                 "youtube_placed": url_stats.get("youtube_placed", 0),
+                "youtube_overwritten": url_stats.get("youtube_overwritten", 0),
                 "errors": url_stats.get("errors", 0),
             }
         _output_result(data)
@@ -2695,14 +2713,21 @@ def _emit_bluesky_result(
     _print_ingest_result(ingest_result, pipeline_summary, context=context)
     if not url_stats:
         return
-    if not any(url_stats.get(k, 0) > 0 for k in ("web_placed", "youtube_placed", "errors")):
+    web_placed = url_stats.get("web_placed", 0)
+    web_overwritten = url_stats.get("web_overwritten", 0)
+    yt_placed = url_stats.get("youtube_placed", 0)
+    yt_overwritten = url_stats.get("youtube_overwritten", 0)
+    err_n = url_stats.get("errors", 0)
+    web_total = web_placed + web_overwritten
+    yt_total = yt_placed + yt_overwritten
+    if web_total == 0 and yt_total == 0 and err_n == 0:
         return
     parts = ["URL 自動取り込み:"]
-    web_n = url_stats.get("web_placed", 0)
-    yt_n = url_stats.get("youtube_placed", 0)
-    err_n = url_stats.get("errors", 0)
-    if web_n > 0 or yt_n > 0:
-        parts.append(f"Web {web_n}件, YouTube {yt_n}件")
+    if web_total > 0 or yt_total > 0:
+        parts.append(
+            f"Web {web_total}件 (新規 {web_placed}, 上書き {web_overwritten}),"
+            f" YouTube {yt_total}件 (新規 {yt_placed}, 上書き {yt_overwritten})",
+        )
     if err_n > 0:
         parts.append(f"エラー {err_n}件")
     print(" ".join(parts))

--- a/src/rag/pipeline/ingesters/bluesky/_facade.py
+++ b/src/rag/pipeline/ingesters/bluesky/_facade.py
@@ -333,7 +333,8 @@ class BlueskyIngester(BaseIngester):
             result: 委譲失敗の計上先 IngestResult（指定時は errors + delegation を計上）
 
         Returns:
-            ``{"web_placed": N, "youtube_placed": N, "skipped": N, "errors": N}``
+            ``{"web_placed": N, "web_overwritten": N, "youtube_placed": N,
+            "youtube_overwritten": N, "skipped": N, "errors": N}``
         """
         return await _follow_urls(
             placed_items,

--- a/src/rag/pipeline/ingesters/bluesky/delegations.py
+++ b/src/rag/pipeline/ingesters/bluesky/delegations.py
@@ -63,11 +63,16 @@ async def follow_urls(
             を追加する（従来の stats 返却は互換維持）
 
     Returns:
-        ``{"web_placed": N, "youtube_placed": N, "skipped": N, "errors": N}``
+        ``{"web_placed": N, "web_overwritten": N, "youtube_placed": N,
+        "youtube_overwritten": N, "skipped": N, "errors": N}``.
+        ``placed`` と ``overwritten`` は排他関係（``IngestResult`` 仕様）であり、
+        実際の取り込み件数を表示するときは両者を加算する。
     """
     stats: dict[str, int] = {
         "web_placed": 0,
+        "web_overwritten": 0,
         "youtube_placed": 0,
+        "youtube_overwritten": 0,
         "skipped": 0,
         "errors": 0,
     }
@@ -87,11 +92,14 @@ async def follow_urls(
     logger.info("投稿内から %d 件の URL を抽出しました", all_url_count)
 
     if web_urls:
-        web_placed, web_errors, web_error_details = await _fetch_web_urls(
-            web_urls,
-            web_delegator=web_delegator,
+        web_placed, web_overwritten, web_errors, web_error_details = (
+            await _fetch_web_urls(
+                web_urls,
+                web_delegator=web_delegator,
+            )
         )
         stats["web_placed"] = web_placed
+        stats["web_overwritten"] = web_overwritten
         stats["errors"] += web_errors
         if result is not None and web_error_details:
             result.errors += len(web_error_details)
@@ -124,6 +132,7 @@ async def follow_urls(
                     yt_results = await youtube_delegator.ingest_videos([url])
                     yt_result = yt_results[0]
                     stats["youtube_placed"] += yt_result.placed
+                    stats["youtube_overwritten"] += yt_result.overwritten
                     if yt_result.errors > 0:
                         stats["errors"] += yt_result.errors
                 except Exception as exc:
@@ -143,10 +152,17 @@ async def follow_urls(
                 logger.warning("YouTube インジェスターが未指定: %s", url)
                 stats["skipped"] += 1
 
+    web_total = stats["web_placed"] + stats["web_overwritten"]
+    youtube_total = stats["youtube_placed"] + stats["youtube_overwritten"]
     logger.info(
-        "URL 取り込み完了: web=%d, youtube=%d, skipped=%d, errors=%d",
+        "URL 取り込み完了: web=%d (placed=%d, overwritten=%d), "
+        "youtube=%d (placed=%d, overwritten=%d), skipped=%d, errors=%d",
+        web_total,
         stats["web_placed"],
+        stats["web_overwritten"],
+        youtube_total,
         stats["youtube_placed"],
+        stats["youtube_overwritten"],
         stats["skipped"],
         stats["errors"],
     )
@@ -211,7 +227,7 @@ async def _fetch_web_urls(
     urls: list[str],
     *,
     web_delegator: WebDelegator,
-) -> tuple[int, int, list[IngestErrorDetail]]:
+) -> tuple[int, int, int, list[IngestErrorDetail]]:
     """Web URL を WebDelegator（複数 URL モード）の Python API で取得する.
 
     親プロセスが既に write_lock を保持している前提で、subprocess を介さず同一
@@ -224,7 +240,9 @@ async def _fetch_web_urls(
     チェックは引き続き有効）。
 
     Returns:
-        (配置されたファイル数の合計, エラー件数, errors の dict リスト)。
+        (新規配置件数, 上書き件数, エラー件数, errors の dict リスト)。
+        ``placed`` と ``overwritten`` は排他関係（``IngestResult`` 仕様）であり、
+        完了ログ等で総件数を表示する場合は呼び出し側で両者を加算する。
         ``error_details`` の件数とエラー件数は常に一致する。
     """
     from rag.utils.url import check_ssrf, validate_url
@@ -252,7 +270,7 @@ async def _fetch_web_urls(
         validated_urls.append(validated)
 
     if not validated_urls:
-        return 0, len(validation_errors), validation_errors
+        return 0, 0, len(validation_errors), validation_errors
 
     try:
         execution = await web_delegator.run_for_urls(validated_urls)
@@ -268,9 +286,10 @@ async def _fetch_web_urls(
             for url in validated_urls
         ]
         all_errors = validation_errors + execute_errors
-        return 0, len(all_errors), all_errors
+        return 0, 0, len(all_errors), all_errors
 
-    placed = execution.ingest.placed + execution.ingest.overwritten
+    placed = execution.ingest.placed
+    overwritten = execution.ingest.overwritten
     error_details: list[IngestErrorDetail] = list(execution.ingest.error_details)
     if execution.parse_errors > 0:
         error_details.append(IngestErrorDetail(
@@ -284,9 +303,9 @@ async def _fetch_web_urls(
     all_error_details = validation_errors + error_details
     total_errors = len(all_error_details)
     logger.info(
-        "web 取り込み完了: 合計 %d 件配置, %d 件エラー",
-        placed, total_errors,
+        "web 取り込み完了: 配置 %d 件, 上書き %d 件, エラー %d 件",
+        placed, overwritten, total_errors,
     )
     if execution.scrapy_success and execution.crawl_result is not None:
         execution.crawl_result.cleanup()
-    return placed, total_errors, all_error_details
+    return placed, overwritten, total_errors, all_error_details

--- a/src/rag/server/cli_subprocess.py
+++ b/src/rag/server/cli_subprocess.py
@@ -299,11 +299,20 @@ def _format_ingest_response(
             )
             parts.append(f"パイプラインエラー: {len(pipeline_summary.errors)}件 ({details})")
     if url_follow:
-        web_n = url_follow.get("web_placed", 0)
-        yt_n = url_follow.get("youtube_placed", 0)
+        web_placed = url_follow.get("web_placed", 0)
+        web_overwritten = url_follow.get("web_overwritten", 0)
+        yt_placed = url_follow.get("youtube_placed", 0)
+        yt_overwritten = url_follow.get("youtube_overwritten", 0)
         err_n = url_follow.get("errors", 0)
-        if web_n > 0 or yt_n > 0 or err_n > 0:
-            seg = [f"URL 自動取り込み: Web {web_n}件, YouTube {yt_n}件"]
+        web_total = web_placed + web_overwritten
+        yt_total = yt_placed + yt_overwritten
+        if web_total > 0 or yt_total > 0 or err_n > 0:
+            seg = [
+                f"URL 自動取り込み: Web {web_total}件"
+                f" (新規 {web_placed}, 上書き {web_overwritten}),"
+                f" YouTube {yt_total}件"
+                f" (新規 {yt_placed}, 上書き {yt_overwritten})",
+            ]
             if err_n > 0:
                 seg.append(f"エラー {err_n}件")
             parts.append(" ".join(seg))
@@ -344,7 +353,11 @@ def _format_cli_ingest_result(
     if isinstance(url_follow_data, dict):
         url_follow = {
             "web_placed": int(url_follow_data.get("web_placed", 0)),
+            "web_overwritten": int(url_follow_data.get("web_overwritten", 0)),
             "youtube_placed": int(url_follow_data.get("youtube_placed", 0)),
+            "youtube_overwritten": int(
+                url_follow_data.get("youtube_overwritten", 0),
+            ),
             "errors": int(url_follow_data.get("errors", 0)),
         }
 

--- a/tests/test_cli_lock_conflict.py
+++ b/tests/test_cli_lock_conflict.py
@@ -12,8 +12,9 @@ details.lock_type に `e.kind` を正しく詰めることを検証する。サ�
   2 kind（rebuild / write）= 6 ケース
 - 既存の run_rebuild は rebuild_lock（別ロック）のためスコープ外
 - write_lock をモックして LockAcquisitionError を送出させる
-- kind=write はリトライ対象（Issue #755）のため、リトライ実時間を消費しないよう
-  `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を空タプルに上書きする
+- kind=write は Issue #755、kind=rebuild は Issue #779 でそれぞれリトライ対象。
+  リトライ実時間を消費しないよう `_WRITE_LOCK_RETRY_BACKOFFS_SEC` と
+  `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` を空タプルに上書きする
   `_disable_lock_retry_backoff` fixture をクラス単位で適用
 """
 
@@ -36,11 +37,15 @@ from rag.infrastructure.file_lock import LockAcquisitionError, LockKind
 def _disable_lock_retry_backoff() -> Iterator[None]:
     """write_lock リトライのバックオフを無効化する fixture.
 
-    Issue #755 で導入した `_WRITE_LOCK_RETRY_BACKOFFS_SEC` を空タプルに置き換え、
-    既存テストの実時間消費（最大 ~1.85s × ケース数）を回避する。
+    Issue #755 で導入した `_WRITE_LOCK_RETRY_BACKOFFS_SEC` および
+    Issue #779 で導入した `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` を空タプルに置き換え、
+    既存テストの実時間消費（最大 ~1.85s + ~15.5s × ケース数）を回避する。
     リトライ動作自体の検証は `TestWriteLockRetryBehavior` で別途実施する。
     """
-    with patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", ()):
+    with (
+        patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", ()),
+        patch("rag.cli._REBUILD_PROBE_RETRY_BACKOFFS_SEC", ()),
+    ):
         yield
 
 
@@ -248,13 +253,22 @@ class TestWriteLockOrExitHelper:
     def test_acquire_failure_exits_without_release(
         self, capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """取得失敗時は exit、release は呼ばれない（acquire 失敗のため）."""
+        """取得失敗時は exit、release は呼ばれない（acquire 失敗のため）.
+
+        リトライ動作自体は別クラスで検証するため、本テストでは
+        `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` を空タプルに上書きしてリトライを
+        無効化する。
+        """
         mock_lock = MagicMock()
         mock_lock.acquire.side_effect = LockAcquisitionError(
             Path("/tmp/test/.rebuild.lock"), kind="rebuild",
         )
-        with patch(
-            "rag.infrastructure.file_lock.write_lock", return_value=mock_lock,
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch("rag.cli._REBUILD_PROBE_RETRY_BACKOFFS_SEC", ()),
         ):
             from rag.cli import _write_lock_or_exit
             with pytest.raises(SystemExit) as exc_info:
@@ -344,10 +358,37 @@ class TestWriteLockRetryBehavior:
         assert isinstance(details, dict)
         assert details["lock_type"] == "write"
 
-    def test_rebuild_kind_does_not_retry(
+    def test_rebuild_retry_succeeds_after_initial_failure(self) -> None:
+        """kind=rebuild も短時間リトライ → 2 回目で成功（Issue #779）."""
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = [
+            LockAcquisitionError(
+                Path("/tmp/test/.rebuild.lock"), kind="rebuild",
+            ),
+            None,
+        ]
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch(
+                "rag.cli._REBUILD_PROBE_RETRY_BACKOFFS_SEC",
+                (0.0, 0.0, 0.0, 0.0, 0.0),
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            from rag.cli import _write_lock_or_exit
+            with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
+                pass
+        assert mock_lock.acquire.call_count == 2
+        mock_lock.release.assert_called_once()
+        assert mock_sleep.call_count == 1
+
+    def test_rebuild_retry_exhausted_then_exits(
         self, capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """kind=rebuild はリトライ対象外で初回失敗で即 exit."""
+        """kind=rebuild も全リトライ失敗後に LOCK_CONFLICT で exit 1（Issue #779）."""
         mock_lock = MagicMock()
         mock_lock.acquire.side_effect = LockAcquisitionError(
             Path("/tmp/test/.rebuild.lock"), kind="rebuild",
@@ -357,18 +398,19 @@ class TestWriteLockRetryBehavior:
                 "rag.infrastructure.file_lock.write_lock",
                 return_value=mock_lock,
             ),
-            patch("rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC", (0.0, 0.0, 0.0, 0.0)),
-            patch("time.sleep") as mock_sleep,
+            patch(
+                "rag.cli._REBUILD_PROBE_RETRY_BACKOFFS_SEC",
+                (0.0, 0.0, 0.0, 0.0, 0.0),
+            ),
+            patch("time.sleep"),
         ):
             from rag.cli import _write_lock_or_exit
             with pytest.raises(SystemExit) as exc_info:
                 with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
-                    pytest.fail("body should not execute when acquire fails")
+                    pytest.fail("body should not execute when retries exhausted")
             assert exc_info.value.code == 1
-        # 初回試行 1 回のみ（リトライしない）
-        assert mock_lock.acquire.call_count == 1
-        # sleep も呼ばれない
-        mock_sleep.assert_not_called()
+        # 初回 + 5 回再試行 = 6 回試行
+        assert mock_lock.acquire.call_count == 6
         mock_lock.release.assert_not_called()
 
         captured = capsys.readouterr()
@@ -378,13 +420,61 @@ class TestWriteLockRetryBehavior:
         assert isinstance(details, dict)
         assert details["lock_type"] == "rebuild"
 
-    def test_default_backoffs_match_spec(self) -> None:
-        """`_WRITE_LOCK_RETRY_BACKOFFS_SEC` の値変更時に意図的でない改変を検知する.
+    def test_write_and_rebuild_counters_independent(self) -> None:
+        """kind 別バックオフ列が独立に消費される（write/rebuild 混在時の堅牢性）.
 
-        コード側 `_WRITE_LOCK_RETRY_BACKOFFS_SEC` が SSoT（仕様書 content-upload.md
+        現実には rebuild 中の write 競合は同じ kind=rebuild を返し続けるため
+        混在は稀だが、ロック実装が kind を切り替える可能性を考慮し、各カウンタが
+        独立して進むこと（write 競合の度に write カウンタ、rebuild 競合の度に
+        rebuild カウンタ）を確認する。
+        """
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = [
+            LockAcquisitionError(
+                Path("/tmp/test/.write.lock"), kind="write",
+            ),
+            LockAcquisitionError(
+                Path("/tmp/test/.rebuild.lock"), kind="rebuild",
+            ),
+            LockAcquisitionError(
+                Path("/tmp/test/.write.lock"), kind="write",
+            ),
+            None,
+        ]
+        with (
+            patch(
+                "rag.infrastructure.file_lock.write_lock",
+                return_value=mock_lock,
+            ),
+            patch(
+                "rag.cli._WRITE_LOCK_RETRY_BACKOFFS_SEC",
+                (0.0, 0.0, 0.0, 0.0),
+            ),
+            patch(
+                "rag.cli._REBUILD_PROBE_RETRY_BACKOFFS_SEC",
+                (0.0, 0.0, 0.0, 0.0, 0.0),
+            ),
+            patch("time.sleep"),
+        ):
+            from rag.cli import _write_lock_or_exit
+            with _write_lock_or_exit(Path("/tmp/test"), json_out=True):
+                pass
+        # 4 回試行 = 初回 write 失敗 → rebuild 失敗 → write 失敗 → 成功
+        assert mock_lock.acquire.call_count == 4
+        mock_lock.release.assert_called_once()
+
+    def test_default_backoffs_match_spec(self) -> None:
+        """各リトライ定数のうっかり改変を検知する.
+
+        コード側 `_WRITE_LOCK_RETRY_BACKOFFS_SEC` と
+        `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` が SSoT（仕様書 content-upload.md
         は SSoT 方針により具体値を記載しない）。本テストはコード側 SSoT のうっかり
         改変検知用として、現行値をハードコードで検証する。値変更時は本テストと
         計画ファイル / PR description の合計待機時間記述を併せて更新すること。
         """
-        from rag.cli import _WRITE_LOCK_RETRY_BACKOFFS_SEC
+        from rag.cli import (
+            _REBUILD_PROBE_RETRY_BACKOFFS_SEC,
+            _WRITE_LOCK_RETRY_BACKOFFS_SEC,
+        )
         assert _WRITE_LOCK_RETRY_BACKOFFS_SEC == (0.1, 0.25, 0.5, 1.0)
+        assert _REBUILD_PROBE_RETRY_BACKOFFS_SEC == (0.5, 1.0, 2.0, 4.0, 8.0)

--- a/tests/test_pipeline_ingesters_bluesky_delegations.py
+++ b/tests/test_pipeline_ingesters_bluesky_delegations.py
@@ -39,13 +39,14 @@ def _item_with_urls(
 
 
 def _make_execution(
-    *, placed: int = 0, errors: int = 0,
+    *, placed: int = 0, overwritten: int = 0, errors: int = 0,
     error_details: list[dict[str, Any]] | None = None,
     parse_errors: int = 0,
 ) -> SiteIngestExecution:
     """WebIngester 実行結果オブジェクトを生成."""
     ingest = IngestResult()
     ingest.placed = placed
+    ingest.overwritten = overwritten
     ingest.errors = errors
     if error_details:
         ingest.error_details = list(error_details)
@@ -329,7 +330,9 @@ class TestFollowUrlsEmpty:
             youtube_request_interval=0.0,
         )
         assert stats == {
-            "web_placed": 0, "youtube_placed": 0, "skipped": 0, "errors": 0,
+            "web_placed": 0, "web_overwritten": 0,
+            "youtube_placed": 0, "youtube_overwritten": 0,
+            "skipped": 0, "errors": 0,
         }
 
     @pytest.mark.asyncio
@@ -342,5 +345,134 @@ class TestFollowUrlsEmpty:
             youtube_request_interval=0.0,
         )
         assert stats == {
-            "web_placed": 0, "youtube_placed": 0, "skipped": 0, "errors": 0,
+            "web_placed": 0, "web_overwritten": 0,
+            "youtube_placed": 0, "youtube_overwritten": 0,
+            "skipped": 0, "errors": 0,
         }
+
+
+class TestFollowUrlsOverwriteBreakdown:
+    """placed/overwritten 内訳の集計テスト（Issue #778）.
+
+    完了ログで上書き再取り込みが 0 件と誤認される問題を防ぐため、web/youtube
+    の両側で placed と overwritten を別カウントとして保持・出力することを検証する。
+    """
+
+    @pytest.mark.asyncio
+    async def test_web_overwritten_counted_separately(self) -> None:
+        """web の上書きのみのケースで web_overwritten が計上される."""
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(
+            return_value=_make_execution(placed=0, overwritten=1),
+        )
+        items = [_item_with_urls(["https://example.com/article"])]
+        stats = await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=None,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+        assert stats["web_placed"] == 0
+        assert stats["web_overwritten"] == 1
+
+    @pytest.mark.asyncio
+    async def test_youtube_overwritten_counted_separately(self) -> None:
+        """youtube の上書きのみのケースで youtube_overwritten が計上される.
+
+        Issue #778 のメイン回帰検出。BlueSky 経由で既存動画の URL を再取り込みする
+        と yt_result.placed=0 / yt_result.overwritten=1 となり、修正前は
+        youtube_placed=0 のみ集計されて完了ログが「youtube=0」と誤表示していた。
+        """
+        delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
+        yt_result = IngestResult()
+        yt_result.placed = 0
+        yt_result.overwritten = 1
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
+        stats = await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=delegator,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+        assert stats["youtube_placed"] == 0
+        assert stats["youtube_overwritten"] == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_placed_and_overwritten(self) -> None:
+        """web/youtube 混在ケースで両側の placed/overwritten が独立に集計される."""
+        delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
+        yt_a = IngestResult()
+        yt_a.placed = 1
+        yt_b = IngestResult()
+        yt_b.overwritten = 1
+        delegator.ingest_videos = AsyncMock(side_effect=[[yt_a], [yt_b]])
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(
+            return_value=_make_execution(placed=2, overwritten=1),
+        )
+        items = [_item_with_urls([
+            "https://example.com/a",
+            "https://example.com/b",
+            "https://example.com/c",
+            "https://youtu.be/abcdEFG1234",
+            "https://youtu.be/abcdEFG5678",
+        ])]
+        stats = await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=delegator,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+        assert stats["web_placed"] == 2
+        assert stats["web_overwritten"] == 1
+        assert stats["youtube_placed"] == 1
+        assert stats["youtube_overwritten"] == 1
+
+    @pytest.mark.asyncio
+    async def test_completion_log_shows_breakdown(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """完了ログ文字列に web/youtube 両側の placed/overwritten 内訳が含まれる."""
+        import logging
+
+        delegator = AsyncMock()
+        delegator.unload_whisper = MagicMock()
+        yt_result = IngestResult()
+        yt_result.overwritten = 1
+        delegator.ingest_videos = AsyncMock(return_value=[yt_result])
+        runner = AsyncMock()
+        runner.run_for_urls = AsyncMock(
+            return_value=_make_execution(placed=1, overwritten=2),
+        )
+        items = [_item_with_urls([
+            "https://example.com/x",
+            "https://youtu.be/abcdEFG1234",
+        ])]
+        with caplog.at_level(
+            logging.INFO,
+            logger="rag.pipeline.ingesters.bluesky.delegations",
+        ):
+            await follow_urls(
+                items,
+                classifier=RealYoutubeClassifier(),
+                youtube_delegator=delegator,
+                web_delegator=runner,
+                youtube_request_interval=0.0,
+            )
+        completion_logs = [
+            r.getMessage() for r in caplog.records
+            if r.getMessage().startswith("URL 取り込み完了:")
+        ]
+        assert len(completion_logs) == 1
+        log = completion_logs[0]
+        # web=3 (placed=1, overwritten=2) / youtube=1 (placed=0, overwritten=1)
+        assert "web=3 (placed=1, overwritten=2)" in log
+        assert "youtube=1 (placed=0, overwritten=1)" in log


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

Issue #778 + #779 を 1 PR で統合対応（QA セッションで起票された関連バグ）。

### #778: BlueSky URL 取り込み完了ログの集計内訳化

- BlueSky 経由で URL を上書き再取り込みした際、完了ログが `youtube=0` と誤表示する集計不整合を解消
- `delegations.py` の集計 dict に `web_overwritten` / `youtube_overwritten` を追加
- `_fetch_web_urls` の戻り値を `(placed, overwritten, errors, error_details)` に分離
- 完了ログを `URL 取り込み完了: web=N (placed=X, overwritten=Y), youtube=N (placed=X, overwritten=Y), skipped=N, errors=N` 形式に変更
- CLI / MCP の `url_follow` JSON 出力と人間可読サマリーにも内訳を反映
- `docs/specs/ingesters/bluesky.md` を内訳化に追従

### #779: rebuild shutdown 期間の lock 保持を吸収する write probe retry

- rebuild の visible log 完了後も python interpreter shutdown 処理（chroma client teardown / GC / file flush）の数〜十数秒の間 lock が保持され続け、その期間 `kind=rebuild` で write が即失敗する事象を解消
- `_REBUILD_PROBE_RETRY_BACKOFFS_SEC = (0.5, 1.0, 2.0, 4.0, 8.0)`（合計 15.5s）を新設
- `_write_lock_or_exit` を write/rebuild の kind 別バックオフ列を独立に消費するループに変更
- `docs/specs/infrastructure/content-upload.md` の short retry / SSoT 参照両定数化 / shutdown 期間 lock 保持 を明記

## Test plan

- [x] 新規テスト追加: `TestFollowUrlsOverwriteBreakdown`（web 上書きのみ / youtube 上書きのみ / 混在 / 完了ログフォーマット の 4 ケース）
- [x] 新規テスト追加: rebuild リトライ成功/枯渇/kind 別バックオフ独立性 の 3 ケース + 定数値検証
- [x] `_disable_lock_retry_backoff` fixture を `_REBUILD_PROBE_RETRY_BACKOFFS_SEC` 対応に拡張
- [x] pytest 全 2129 件 pass
- [x] ruff check / mypy / markdownlint 全パス

## Related issues

Closes #778
Closes #779