### PR TITLE
feat(converter,rag-knowledge): HTML サイト別抽出ルール機構を導入 (#786)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ API キー（`UPLOAD_API_KEY`）の事前登録が必要（上記「API キー�
 |---|--------|---------|---------|
 | シークレット | OS セキュアストレージ (keyring) | 管理外 | 漏洩時に直接被害が発生する値（API キー、トークン、パスワード） |
 | 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値（接続先 URL、ストレージパス、ネットワーク設定、デバッグフラグ） |
-| 共通設定値 | `config.toml` / `lmstudio.toml` | **管理する** | プロジェクトとして統一管理する値（チューニングパラメータ、ポリシー設定、モデル名、機能フラグ）。`lmstudio.toml` は LM Studio で読み込むモデル key の SSoT |
+| 共通設定値 | `config.toml` / `lmstudio.toml` / `site_rules.toml` | **管理する** | プロジェクトとして統一管理する値（チューニングパラメータ、ポリシー設定、モデル名、機能フラグ、カスタムルール）。`lmstudio.toml` は LM Studio で読み込むモデル key の SSoT。`site_rules.toml` は HTML 抽出ルール（コンテンツ領域 selector・除去 class トークン・サイト別追加 selector）の SSoT |
 
 新しい設定値を追加する際は、上記の判断基準に従って適切な層に配置すること。詳細は [設定管理仕様](docs/specs/rag-knowledge.md#設定管理) を参照。
 

--- a/config.toml
+++ b/config.toml
@@ -64,19 +64,9 @@ rag_upload_max_file_size_mb = 500
 rag_upload_retry_after_write_sec = 30
 rag_upload_retry_after_rebuild_sec = 300
 
-# HTML → Markdown 変換時に除去する class トークン（完全一致、大文字小文字無視）
-rag_html_remove_class_tokens = [
-    "breadcrumb",   # パンくずリスト
-    "breadcrumbs",  # パンくずリスト（複数形: Foundation, Docusaurus 等）
-    "topic-path",   # パンくずリスト（日本語サイト）
-    "nextprev",     # ページ送りナビゲーション
-    "pagination",   # ページネーション
-    "toolbar",      # ツールバー
-    "footer-wrapper", # サイトフッター（ラッパー要素）
-    "footer",       # サイトフッター
-    "scrollToFeedback", # フィードバックリンク
-    "suggest",      # 変更提案フォーム
-]
+# HTML 抽出ルール（content_id_patterns / content_class_patterns / remove_class_tokens /
+# サイト別 content_selectors / remove_selectors）は site_rules.toml（プロジェクトルート直下）が SSoT。
+# 仕様: docs/specs/converter.md「サイト別抽出ルール設定ファイル」
 
 # PDF バックエンド (auto / mineru / pymupdf4llm)
 rag_pdf_backend = "auto"

--- a/docs/specs/converter.md
+++ b/docs/specs/converter.md
@@ -213,53 +213,45 @@ markdownify ベースの変換。RAG 用途に最適化したカスタマイズ�
 
 #### コンテンツ領域の特定
 
-HTML からナビゲーション・サイドバー・フッター等のボイラープレートを除外し、本文コンテンツを含む領域を特定する。以下の優先順で探索し、最初にヒットした要素をコンテンツ領域とする。
+HTML からナビゲーション・サイドバー・フッター等のボイラープレートを除外し、本文コンテンツを含む領域を特定する。サイト別抽出ルール（`site_rules.toml`）の有無で挙動が分岐する。
+
+##### サイト別ルールが定義されているホストの場合
+
+source_store のパス（`web/{scheme}/{host}/...`、scheme は `https` または `http`）から抽出した `host` が
+`site_rules.toml` の `[hosts."<host>"]` セクションに完全一致する場合、当該セクションの `content_selectors`
+（CSS selector のリスト）を先頭から順に `BeautifulSoup.select_one()` で試行する。
+最初にヒットした要素をコンテンツ領域として採用する。
+ヒットした要素のテキストが空の場合は次の selector を試行する。
+全 selector がミスした場合は下記「共通フォールバック」に降りる。
+
+CSS selector は標準の BS4 `select_one()` で評価する。タグ・id・class・属性・子孫指定が利用できる
+（例: `"article.post-body"`、`"div[data-role='main']"`）。
+
+selector の構文が不正な場合（`soupsieve.SelectorSyntaxError` 等）は当該 selector をスキップして次の
+selector を試行する。警告ログを出力する。
+
+##### 共通フォールバック（サイト別ルール未定義 or 全 selector ミス）
+
+`site_rules.toml` の `[default]` セクションを参照し、以下の優先順で探索する。最初にヒットした要素をコンテンツ領域とする。
 
 | 優先度 | 探索対象 | 根拠 |
 |--------|---------|------|
 | 1 | `<article>` タグ | HTML5 セマンティックタグ |
 | 2 | `<main>` タグ | HTML5 セマンティックタグ |
 | 3 | `role="main"` 属性を持つ要素 | WAI-ARIA ランドマーク |
-| 4 | id 属性がコンテンツパターンに一致する要素 | 慣習的な命名パターン |
-| 5 | class 属性がコンテンツパターンに一致する要素 | 慣習的な命名パターン |
+| 4 | id 属性が `[default].content_id_patterns` のいずれかに部分一致する要素 | 慣習的な命名パターン |
+| 5 | class 属性が `[default].content_class_patterns` のいずれかに部分一致する要素 | 慣習的な命名パターン |
 | 6 | `<body>` 直下でテキスト量が最大の子要素 | テキスト密度フォールバック |
 | 7 | `<body>` タグ | 最終フォールバック |
 
 id/class パターンの一致判定:
 
 - 部分一致（大文字小文字を区別しない）で判定する
-- id パターンは長いパターンから順に試行する（具体的なパターンを優先）
+- パターンは `site_rules.toml` の配列順（長いパターンから順に並べる前提）で試行する。具体的なパターンを優先するため、短いパターン（例: `content`）は配列末尾に置く
 - テキストが空の要素はスキップし、次の候補を試行する（空の `<div id="contents">` 等による誤検出を防止）
+- ハイフンとアンダースコアは正規表現上別文字として扱われるため、両方の変種を個別エントリとして登録する
 
-id パターン一覧（試行順）:
-
-部分一致判定のため、短いパターンが先に試行されると、より具体的な id を持つ要素が短いパターンで先にマッチしてしまう。これを防ぐため長いパターンから順に試行する。ハイフンとアンダースコアは正規表現上別文字として扱われるため、両方の変種を個別パターンとして登録する。
-
-| パターン | マッチ例 |
-|---------|---------|
-| `main-content` | `id="main-content"` |
-| `main_content` | `id="main_content"` |
-| `content-wrap` | `id="content-wrap"` |
-| `content_wrap` | `id="content_wrap"` |
-| `page-container` | `id="page-container"` |
-| `page_container` | `id="page_container"` |
-| `main-body` | `id="main-body"` |
-| `main_body` | `id="main_body"` |
-| `content` | `id="content"`, `id="content-area"` |
-| `main` | `id="main"` |
-
-class パターン一覧（試行順）:
-
-| パターン | マッチ例 |
-|---------|---------|
-| `main-content` | `class="main-content"` |
-| `main_content` | `class="main_content"` |
-| `main_text` | `class="main_text"`（青空文庫 XHTML 等） |
-| `main-text` | `class="main-text"` |
-| `content-wrap` | `class="content-wrap"` |
-| `content_wrap` | `class="content_wrap"` |
-| `page-container` | `class="page-container"` |
-| `page_container` | `class="page_container"` |
+パターン値の SSoT は `site_rules.toml` の `[default]` セクション。仕様書には具体値を転記しない。
 
 テキスト密度フォールバック:
 
@@ -268,6 +260,14 @@ class パターン一覧（試行順）:
   - 子 Tag を持たない末端要素（`<p>`, `<h1>` 等）を除外する（コンテンツラッパーではないため）
 - 残った候補のうち `get_text(strip=True)` のテキスト量が最大の要素を選択する
 - コンテンツ領域の外にある要素（サイドバー、ヘッダー、フッター等）は、多くのケースでテキスト密度の条件により候補から外れるが、ページ構造によっては選択される可能性もある
+
+##### サイト別ルールの設計意図
+
+特定サイトの HTML 構造ではページ全体ラッパー（記事本文 + サイドバー + 新着一覧）が共通の id/class パターンに
+偶然マッチし、本文と無関係なリスト情報が大量に混入することがある。
+共通の id/class パターンに対象サイト固有値を追加するグローバル変更は他サイトへの副作用が読めないため、
+サイト別ルール機構によりホスト単位で `content_selectors` を最優先試行する。
+ルール書きミス時の挙動破綻を避けるため、全 selector がミスした場合は共通フォールバックに降りる二段構えとする。
 
 #### コンテンツ領域内の非コンテンツ除去
 
@@ -284,9 +284,49 @@ class パターン一覧（試行順）:
 
 class トークン完全一致の除去（大文字小文字を区別しない）:
 
-除去対象の class トークンは `config.toml` の `rag_html_remove_class_tokens` で設定する。BS4 は各クラストークンに対して `regex.search()` を実行するため、`^(?:トークン1|トークン2|...)$` の正規表現で完全トークン一致を実現する。部分一致（`suggest` が `suggested-reading` にマッチする等）による誤除去を防ぐ。
+除去対象の class トークンは `site_rules.toml` の `[default].remove_class_tokens` で設定する。
+BS4 は各クラストークンに対して `regex.search()` を実行するため、
+`^(?:トークン1|トークン2|...)$` の正規表現で完全トークン一致を実現する。
+部分一致（`suggest` が `suggested-reading` にマッチする等）による誤除去を防ぐ。
+
+サイト別追加除去:
+
+`site_rules.toml` の `[hosts."<host>"]` セクションに `remove_selectors`（CSS selector のリスト）が定義されている場合、共通の class トークン除去に加えて当該 selector にマッチする要素も除去する。サイト固有の構造（広告ブロック・関連記事ブロック等）を狙い撃ちで除去するために使用する。
 
 `<nav>`, `<header>`, `<footer>`, `<aside>` タグはコンテンツ領域の特定により自動的に除外されるケースが多いため、コンテンツ領域内では一律除去しない。これにより、コンテンツ領域内の `<header>` タグ（インタビュータイトル等）が誤って除去される問題を回避する。
+
+#### サイト別抽出ルール設定ファイル
+
+`site_rules.toml`（プロジェクトルート直下）が HTML 抽出ルールの SSoT。`config.toml` とは別ファイルとして管理する（共通設定値ではなくカスタムルールの性質を持つため）。
+
+ファイル構造:
+
+```toml
+[default]
+content_id_patterns = ["main-content", "main_content", "...", "content", "main"]
+content_class_patterns = ["main-content", "main_content", "..."]
+remove_class_tokens = ["sidebar", "related-articles", "..."]
+
+[hosts."www.example.com"]
+content_selectors = ["#article-body", ".post-content"]
+remove_selectors = [".related-articles"]
+```
+
+| セクション | 必須 | 内容 |
+|---|---|---|
+| `[default]` | 必須 | 共通フォールバックで使用する id パターン・class パターン・除去 class トークン |
+| `[hosts."<host>"]` | 任意（複数可） | ホスト単位の抽出ルール。`<host>` はパスから抽出した文字列との完全一致 |
+
+設計意図:
+
+- ホスト識別は **完全一致のみ**（サブドメイン違いは別ルール扱い）。
+  サブドメイン暗黙継承による誤適用を防ぐ。
+  複数ホストで同じルールを共有したい場合はセクションを複数定義する
+- 設定変更後の既存 converted_store への反映は **手動** `rebuild --mode full` で行う
+  （自動再変換は対象外）。ルール変更は頻繁ではない前提
+- `[default]` への HTML 抽出ルール一式の集約（旧ハードコード id/class パターン + 旧
+  `rag_html_remove_class_tokens` を含む）により、HTML 抽出ロジックに関わる設定が 1 ファイルに揃い、
+  `config.toml` とロールが分離される。共通パターンの追加・調整がコード改修なしで可能になる
 
 #### Markdown 変換ルール
 
@@ -504,6 +544,9 @@ source_type が `local` のメディアファイル（画像・動画）は、�
 
 ### 設定項目
 
+本表は PDF / YouTube 等の他カテゴリの設定項目を列挙する。HTML 抽出ルールは
+<<#### サイト別抽出ルール設定ファイル@self>> を参照（SSoT は `site_rules.toml`）。
+
 | 設定項目 | 層 | 設計意図 |
 |---------|-----|---------|
 | `rag_pdf_backend` | 共通設定値 | PDF バックエンド選択。環境のGPU有無やPDF特性に応じて切り替える |
@@ -515,7 +558,6 @@ source_type が `local` のメディアファイル（画像・動画）は、�
 | `rag_pdf_quality_sample_pages` | 共通設定値 | 品質サンプリングページ数。判定の精度とコストのバランス |
 | `rag_youtube_merge_gap_sec` | 共通設定値 | YouTube スニペット結合の間隔閾値。段落分割の粒度を制御する |
 | `rag_youtube_merge_max_chars` | 共通設定値 | YouTube スニペット結合の最大文字数。段落サイズの上限 |
-| `rag_html_remove_class_tokens` | 共通設定値 | HTML 変換時のボイラープレート除去。完全トークン一致でサイト UI 要素を除外する |
 
 `CONVERTED_STORE_DIR` は [pipeline-controller.md](pipeline-controller.md) の設定項目で定義済み。
 
@@ -539,6 +581,8 @@ source_type が `local` のメディアファイル（画像・動画）は、�
 | メディア解析モジュールが利用不可（LM Studio 停止中） | メディアファイルの変換をスキップし、警告ログを出力する。BlueSky 投稿はテキストのみで変換する |
 | BlueSky 投稿に対応する media ディレクトリが存在しない | メディア解析テキストなしで変換する（`<image:N>` / `<video:N>` タグを出力しない） |
 | ffmpeg が未インストールの環境で動画ファイルを変換 | 動画解析をスキップし、警告ログを出力する |
+| site rule の `content_selectors` 内の selector が CSS 構文として不正な場合 | 当該 selector をスキップして次の selector を試行する。警告ログを出力する |
+| site rule の `remove_selectors` 内の selector が CSS 構文として不正な場合 | 当該 selector をスキップして除去をスキップする。警告ログを出力する |
 
 ## 関連ドキュメント
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -32,7 +32,7 @@ MCP サーバーとして独立動作し、ナレッジ操作用の MCP ツー�
 |---|--------|---------|---------|
 | シークレット | OS セキュアストレージ (keyring) | 管理外 | 漏洩時に直接被害が発生する値。py-common-lib の `get_secret` で取得 |
 | 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値 |
-| 共通設定値 | `config.toml` / `lmstudio.toml` | **管理する** | プロジェクトとして統一管理する値（`lmstudio.toml` は LM Studio で読み込むモデル key の SSoT） |
+| 共通設定値 | `config.toml` / `lmstudio.toml` / `site_rules.toml` | **管理する** | プロジェクトとして統一管理する値（`lmstudio.toml` は LM Studio モデル key の SSoT、`site_rules.toml` は HTML 抽出ルールの SSoT） |
 
 #### `.env`（環境依存値）
 
@@ -81,6 +81,17 @@ MCP サーバーとして独立動作し、ナレッジ操作用の MCP ツー�
 
 - [infrastructure/lmstudio-reference.md](infrastructure/lmstudio-reference.md) — CLI 仕様参照
 - [infrastructure/lmstudio-operation.md](infrastructure/lmstudio-operation.md) — 運用手順
+
+#### `site_rules.toml`（HTML 抽出ルール）
+
+HTML → Markdown 変換時のコンテンツ領域 selector・除去 class トークン・サイト別追加 selector の SSoT。`config.toml` とは別ファイルで管理する（カスタムルールの性質を持つため）。詳細は [converter.md](converter.md)「サイト別抽出ルール設定ファイル」を参照。
+
+| セクション | 役割 |
+|---|---|
+| `[default]` | 共通フォールバックで使用する id/class パターン・除去 class トークン |
+| `[hosts."<host>"]` | ホスト単位の抽出ルール（`content_selectors` / `remove_selectors`） |
+
+#### 設定管理の補足事項
 
 - `hnsw_m` と `hnsw_construction_ef` はコレクション作成時のみ適用される（不変）。既存コレクションへの反映には `rebuild --mode full`（コレクション削除 → 再作成）が必要。`hnsw_search_ef` は起動時に `collection.modify()` で既存コレクションにも自動適用される
 - Embedding モデルを変更した場合、既存データとの類似度計算が不正確になるため、コレクション再構築が必要

--- a/site_rules.toml
+++ b/site_rules.toml
@@ -1,0 +1,65 @@
+# HTML 抽出ルール設定ファイル
+#
+# 仕様: docs/specs/converter.md「サイト別抽出ルール設定ファイル」
+#
+# - [default] は共通フォールバックで使用するパターン群（SSoT）
+# - [hosts."<host>"] はホスト単位の抽出ルール（`web/https/{host}/...` の host と完全一致）
+# - ホスト識別は完全一致のみ。サブドメインの暗黙継承は行わない
+# - 設定変更後の既存 converted_store への反映は手動 `rebuild --mode full` で実施
+#
+# content_selectors の試行は BS4 `select_one()` で評価し、最初にヒットした要素を採用する。
+# 全 selector がミスした場合は [default] の優先順（<article> → <main> → role → id → class → ...）に
+# フォールバックする。
+
+[default]
+# id 部分一致（大文字小文字無視）。長いパターンを先に置き、短いパターン（content, main 等）は末尾。
+# ハイフン版とアンダースコア版を両方登録する（正規表現上別文字として扱われるため）。
+content_id_patterns = [
+    "main-content",
+    "main_content",
+    "content-wrap",
+    "content_wrap",
+    "page-container",
+    "page_container",
+    "main-body",
+    "main_body",
+    "content",
+    "main",
+]
+
+# class 部分一致（大文字小文字無視）
+content_class_patterns = [
+    "main-content",
+    "main_content",
+    "main_text",
+    "main-text",
+    "content-wrap",
+    "content_wrap",
+    "page-container",
+    "page_container",
+]
+
+# class トークン完全一致除去（大文字小文字無視）
+remove_class_tokens = [
+    "breadcrumb",        # パンくずリスト
+    "breadcrumbs",       # パンくずリスト（複数形: Foundation, Docusaurus 等）
+    "topic-path",        # パンくずリスト（日本語サイト）
+    "nextprev",          # ページ送りナビゲーション
+    "pagination",        # ページネーション
+    "toolbar",           # ツールバー
+    "footer-wrapper",    # サイトフッター（ラッパー要素）
+    "footer",            # サイトフッター
+    "scrollToFeedback",  # フィードバックリンク
+    "suggest",           # 変更提案フォーム
+]
+
+# 4Gamer: <div class="main_contents"> がページ全体ラッパー（本文+サイドバー+新着一覧）であり、
+# 共通 class パターン `main_content` の部分一致で誤マッチする。真の本文は
+# `<div class="maintxt">` 内の `<div class="entry-content">` にあるため、
+# site rule で優先指定する。
+[hosts."www.4gamer.net"]
+content_selectors = [
+    ".maintxt .entry-content",
+    ".maintxt",
+]
+remove_selectors = []

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -23,7 +23,7 @@ import os
 import sys
 import tomllib
 from pathlib import Path
-from typing import Annotated, Any, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -280,11 +280,6 @@ class RAGSettings(BaseModel):
     rag_zenn_max_articles: int = Field(ge=1, le=100)
     rag_zenn_request_timeout: int = Field(ge=1, le=120)
     rag_zenn_request_interval: float = Field(ge=0.1, le=60.0)
-
-    # HTML → Markdown 変換時に除去する class トークン（完全一致）
-    rag_html_remove_class_tokens: list[Annotated[str, Field(min_length=1)]] = Field(
-        min_length=1,
-    )
 
     # ドキュメントインジェスター
     rag_document_supported_extensions: str

--- a/src/rag/converter/converter.py
+++ b/src/rag/converter/converter.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from rag.media.analyzer import MediaAnalyzer
 
 from rag.converter.handlers import (
-    compile_remove_class_re,
     convert_html,
     convert_json_bluesky,
     convert_json_youtube,
@@ -31,6 +30,7 @@ from rag.converter.handlers import (
 )
 from rag.converter.normalize import normalize_text
 from rag.converter.pdf_extractor import PdfBackendConfig, extract_pdf
+from rag.converter.site_rules import CompiledSiteRules, extract_web_host
 from rag.store.meta import read_meta
 from rag.store.models import SourceType
 from rag.store.source_store import detect_source_type
@@ -106,7 +106,7 @@ class Converter:
         youtube_merge_gap_sec: float,
         youtube_merge_max_chars: int,
         media_analyzer: MediaAnalyzer | None,
-        html_remove_class_tokens: list[str],
+        site_rules: CompiledSiteRules,
     ) -> None:
         """Converter を初期化する.
 
@@ -116,14 +116,14 @@ class Converter:
             youtube_merge_gap_sec: YouTube スニペット結合の間隔閾値（秒）
             youtube_merge_max_chars: YouTube スニペット結合の最大文字数
             media_analyzer: メディア解析モジュール（None の場合メディア解析スキップ）
-            html_remove_class_tokens: HTML 変換時に除去する class トークン
+            site_rules: HTML 抽出ルール（site_rules.toml をコンパイル済みのオブジェクト）
         """
         self._regen_option = regen_option
         self._pdf_config = pdf_config
         self._youtube_merge_gap_sec = youtube_merge_gap_sec
         self._youtube_merge_max_chars = youtube_merge_max_chars
         self._media_analyzer = media_analyzer
-        self._html_remove_class_re = compile_remove_class_re(html_remove_class_tokens)
+        self._site_rules = site_rules
 
     # --- ConverterProtocol 実装 ---
 
@@ -399,8 +399,9 @@ class Converter:
         if ext in (".html", ".htm"):
             return convert_html(
                 source_path,
-                self._html_remove_class_re,
+                self._site_rules,
                 source_type=detect_source_type(file_path),
+                host=extract_web_host(file_path),
             )
 
         if ext == ".pdf":

--- a/src/rag/converter/handlers.py
+++ b/src/rag/converter/handlers.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 from bs4 import BeautifulSoup, Tag
 from charset_normalizer import from_bytes
 
+from rag.converter.site_rules import CompiledSiteRules
 from rag.markdown import RagMarkdownConverter
 
 logger = logging.getLogger(__name__)
@@ -68,32 +69,6 @@ def _fix_void_elements(soup: BeautifulSoup) -> None:
 # セマンティックタグ（優先順）
 _SEMANTIC_CONTENT_TAGS = ("article", "main")
 
-# id パターン（長いものから試行 = 具体的なパターン優先）
-_CONTENT_ID_PATTERNS = (
-    "main-content",
-    "main_content",
-    "content-wrap",
-    "content_wrap",
-    "page-container",
-    "page_container",
-    "main-body",
-    "main_body",
-    "content",
-    "main",
-)
-
-# class パターン
-_CONTENT_CLASS_PATTERNS = (
-    "main-content",
-    "main_content",
-    "main_text",
-    "main-text",
-    "content-wrap",
-    "content_wrap",
-    "page-container",
-    "page_container",
-)
-
 # --- コンテンツ領域内の非コンテンツ除去 ---
 
 # タグ名ベースの除去
@@ -103,30 +78,6 @@ _REMOVE_TAGS = ("script", "style", "noscript", "form")
 _TEXT_DENSITY_SKIP_TAGS = frozenset(
     ("script", "style", "nav", "noscript", "link"),
 )
-
-# 事前コンパイル済み正規表現
-_COMPILED_ID_PATTERNS = tuple(
-    re.compile(re.escape(p), re.IGNORECASE) for p in _CONTENT_ID_PATTERNS
-)
-_COMPILED_CLASS_PATTERNS = tuple(
-    re.compile(re.escape(p), re.IGNORECASE) for p in _CONTENT_CLASS_PATTERNS
-)
-
-
-def compile_remove_class_re(tokens: list[str]) -> re.Pattern[str]:
-    """class トークン除去用の正規表現をコンパイルする.
-
-    BS4 は各クラストークンに regex.search() するため ^...$ で完全一致にする。
-    空文字列トークンは除外される。
-    """
-    valid = [t.strip() for t in tokens if t.strip()]
-    if not valid:
-        msg = "rag_html_remove_class_tokens に有効なトークンがありません"
-        raise ValueError(msg)
-    return re.compile(
-        "^(?:" + "|".join(re.escape(t) for t in valid) + ")$",
-        re.IGNORECASE,
-    )
 
 
 def _create_md_converter() -> RagMarkdownConverter:
@@ -139,44 +90,65 @@ def _create_md_converter() -> RagMarkdownConverter:
     )
 
 
-def _find_content_area(soup: BeautifulSoup) -> Tag | BeautifulSoup:
+def _find_content_area(
+    soup: BeautifulSoup,
+    site_rules: CompiledSiteRules,
+    host: str | None,
+) -> Tag | BeautifulSoup:
     """HTML からコンテンツ領域を特定する.
 
     仕様: docs/specs/converter.md「コンテンツ領域の特定」
 
-    優先順（仕様書と同一）:
-    1. <article> タグ
-    2. <main> タグ
-    3. role="main" 属性
-    4. id パターンマッチ
-    5. class パターンマッチ
-    6. テキスト密度フォールバック（body 直下で最大テキスト量のコンテナ要素）
-    7. <body> タグ（最終フォールバック。body もなければ soup を返す）
+    優先順:
+    1. サイト別ルールの content_selectors（host にルールがある場合）
+    2. <article> タグ
+    3. <main> タグ
+    4. role="main" 属性
+    5. id パターンマッチ（site_rules.default.content_id_patterns）
+    6. class パターンマッチ（site_rules.default.content_class_patterns）
+    7. テキスト密度フォールバック（body 直下で最大テキスト量のコンテナ要素）
+    8. <body> タグ（最終フォールバック。body もなければ soup を返す）
     """
-    # 1. セマンティックタグ
+    # 1. サイト別ルールの content_selectors
+    host_rule = site_rules.get_host_rule(host)
+    if host_rule is not None:
+        for selector in host_rule.content_selectors:
+            try:
+                found = soup.select_one(selector)
+            except Exception:  # noqa: BLE001 — soupsieve.SelectorSyntaxError 等を含む
+                # SoupSieve が解釈不能な selector を渡された場合のフォールバック
+                logger.warning(
+                    "Invalid CSS selector for host=%s: %r", host, selector,
+                )
+                continue
+            if isinstance(found, Tag) and found.get_text(strip=True):
+                return found
+        # 全 selector がミスした場合は共通フォールバックに降りる
+
+    # 2. セマンティックタグ
     for tag_name in _SEMANTIC_CONTENT_TAGS:
         found = soup.find(tag_name)
         if isinstance(found, Tag):
             return found
 
-    # 2. role="main"
+    # 3. role="main"
     found = soup.find(attrs={"role": "main"})
     if isinstance(found, Tag):
         return found
 
-    # 3. id パターンマッチ（長いパターンから = 具体的なパターン優先）
-    for regex in _COMPILED_ID_PATTERNS:
+    # 4. id パターンマッチ（長いパターンから = 具体的なパターン優先）
+    for regex in site_rules.default_id_patterns:
         found = soup.find(id=regex)
         if isinstance(found, Tag) and found.get_text(strip=True):
             return found
 
-    # 4. class パターンマッチ
-    for regex in _COMPILED_CLASS_PATTERNS:
+    # 5. class パターンマッチ
+    for regex in site_rules.default_class_patterns:
         found = soup.find(class_=regex)
         if isinstance(found, Tag) and found.get_text(strip=True):
             return found
 
-    # 5-6. テキスト密度フォールバック → body 最終フォールバック
+    # 6-7. テキスト密度フォールバック → body 最終フォールバック
     body = soup.find("body")
     if isinstance(body, Tag):
         # body 直下の子要素のうち、子 Tag を持つコンテナ要素に限定して
@@ -204,7 +176,8 @@ def _find_content_area(soup: BeautifulSoup) -> Tag | BeautifulSoup:
 
 def _clean_content_area(
     content: Tag | BeautifulSoup,
-    remove_class_re: re.Pattern[str],
+    site_rules: CompiledSiteRules,
+    host: str | None,
 ) -> None:
     """コンテンツ領域内の非コンテンツ要素を除去する.
 
@@ -216,8 +189,23 @@ def _clean_content_area(
             tag.decompose()
 
     # class トークン完全一致の除去（1つの結合済み正規表現で1パス走査）
-    for tag in content.find_all(class_=remove_class_re):
+    for tag in content.find_all(class_=site_rules.default_remove_class_re):
         tag.decompose()
+
+    # サイト別追加除去 selector
+    host_rule = site_rules.get_host_rule(host)
+    if host_rule is not None:
+        for selector in host_rule.remove_selectors:
+            try:
+                matched = content.select(selector)
+            except Exception:  # noqa: BLE001 — soupsieve.SelectorSyntaxError 等を含む
+                logger.warning(
+                    "Invalid CSS selector in remove_selectors for host=%s: %r",
+                    host, selector,
+                )
+                continue
+            for tag in matched:
+                tag.decompose()
 
 
 def _detect_aozora_encoding(raw_bytes: bytes) -> str:
@@ -246,8 +234,9 @@ def _detect_aozora_encoding(raw_bytes: bytes) -> str:
 
 def convert_html(
     source_path: Path,
-    remove_class_re: re.Pattern[str],
+    site_rules: CompiledSiteRules,
     source_type: SourceType | None = None,
+    host: str | None = None,
 ) -> str | None:
     """HTML ファイルを Markdown に変換する.
 
@@ -255,12 +244,14 @@ def convert_html(
 
     Args:
         source_path: HTML ファイルの絶対パス
-        remove_class_re: 除去対象 class トークンのコンパイル済み正規表現
+        site_rules: 事前コンパイル済みのサイトルール（共通フォールバックパターン + ホスト別ルール）
         source_type: source_store のトップレベルディレクトリから判定された source_type。
             "aozora" の場合は charset_normalizer 自動推定をスキップし、
             XML 宣言 / meta タグから charset を抽出する経路を通る（旧字旧仮名・特殊文字を
             多く含む作品で charset_normalizer が誤検出するため）。
             None の場合は従来どおり charset_normalizer で自動推定する。
+        host: source_store のパスから抽出した web ホスト（web 以外は None）。
+            site_rules の [hosts."<host>"] セクションを引くキーになる。
 
     Returns:
         Markdown テキスト、または変換失敗時は None
@@ -298,10 +289,10 @@ def convert_html(
     _fix_void_elements(soup)
 
     # コンテンツ領域の特定
-    content_area = _find_content_area(soup)
+    content_area = _find_content_area(soup, site_rules, host)
 
     # コンテンツ領域内の非コンテンツ除去
-    _clean_content_area(content_area, remove_class_re)
+    _clean_content_area(content_area, site_rules, host)
 
     # HTML → Markdown 変換
     md_converter = _create_md_converter()

--- a/src/rag/converter/site_rules.py
+++ b/src/rag/converter/site_rules.py
@@ -15,7 +15,30 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    ValidationError,
+)
+
+
+def _validate_non_blank(value: str) -> str:
+    """文字列が空白のみでないことを検証する.
+
+    `Field(min_length=1)` だけでは "  " 等の空白のみ文字列が通り、意図せず
+    マッチしない・除去できない設定ミスを招くため、strip 後の長さでチェックする。
+    """
+    if not isinstance(value, str) or not value.strip():
+        msg = "空白のみの文字列は許容されません"
+        raise ValueError(msg)
+    return value
+
+
+NonBlankStr = Annotated[
+    str, Field(min_length=1), BeforeValidator(_validate_non_blank),
+]
 
 
 class DefaultRules(BaseModel):
@@ -23,15 +46,9 @@ class DefaultRules(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    content_id_patterns: list[Annotated[str, Field(min_length=1)]] = Field(
-        min_length=1,
-    )
-    content_class_patterns: list[Annotated[str, Field(min_length=1)]] = Field(
-        min_length=1,
-    )
-    remove_class_tokens: list[Annotated[str, Field(min_length=1)]] = Field(
-        min_length=1,
-    )
+    content_id_patterns: list[NonBlankStr] = Field(min_length=1)
+    content_class_patterns: list[NonBlankStr] = Field(min_length=1)
+    remove_class_tokens: list[NonBlankStr] = Field(min_length=1)
 
 
 class HostRule(BaseModel):
@@ -39,12 +56,8 @@ class HostRule(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    content_selectors: list[Annotated[str, Field(min_length=1)]] = Field(
-        default_factory=list,
-    )
-    remove_selectors: list[Annotated[str, Field(min_length=1)]] = Field(
-        default_factory=list,
-    )
+    content_selectors: list[NonBlankStr] = Field(default_factory=list)
+    remove_selectors: list[NonBlankStr] = Field(default_factory=list)
 
 
 class SiteRulesConfig(BaseModel):

--- a/src/rag/converter/site_rules.py
+++ b/src/rag/converter/site_rules.py
@@ -1,0 +1,164 @@
+"""HTML サイト別抽出ルール (site_rules.toml) のローダーとデータモデル.
+
+仕様: docs/specs/converter.md「サイト別抽出ルール設定ファイル」
+
+site_rules.toml が SSoT。共通フォールバック用パターン群（[default] セクション）と
+ホスト単位の抽出ルール（[hosts."<host>"] セクション）を pydantic で検証し、
+正規表現の事前コンパイル済みインスタンスを converter に渡す。
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class DefaultRules(BaseModel):
+    """共通フォールバックで使用するパターン群."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    content_id_patterns: list[Annotated[str, Field(min_length=1)]] = Field(
+        min_length=1,
+    )
+    content_class_patterns: list[Annotated[str, Field(min_length=1)]] = Field(
+        min_length=1,
+    )
+    remove_class_tokens: list[Annotated[str, Field(min_length=1)]] = Field(
+        min_length=1,
+    )
+
+
+class HostRule(BaseModel):
+    """ホスト単位の抽出ルール."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    content_selectors: list[Annotated[str, Field(min_length=1)]] = Field(
+        default_factory=list,
+    )
+    remove_selectors: list[Annotated[str, Field(min_length=1)]] = Field(
+        default_factory=list,
+    )
+
+
+class SiteRulesConfig(BaseModel):
+    """site_rules.toml の構造."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    default: DefaultRules
+    hosts: dict[str, HostRule] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CompiledSiteRules:
+    """事前コンパイル済みのサイトルール.
+
+    converter から繰り返し参照されるため、正規表現は構築時に 1 度だけコンパイルする。
+    """
+
+    raw: SiteRulesConfig
+    default_id_patterns: tuple[re.Pattern[str], ...]
+    default_class_patterns: tuple[re.Pattern[str], ...]
+    default_remove_class_re: re.Pattern[str]
+
+    def get_host_rule(self, host: str | None) -> HostRule | None:
+        """ホスト名に完全一致するルールを返す.
+
+        Args:
+            host: ホスト名（None なら None を返す）
+
+        Returns:
+            HostRule または None（ホストにルールが定義されていない場合）
+        """
+        if host is None:
+            return None
+        return self.raw.hosts.get(host)
+
+
+def compile_site_rules(raw: SiteRulesConfig) -> CompiledSiteRules:
+    """SiteRulesConfig から CompiledSiteRules を構築する."""
+    id_patterns = tuple(
+        re.compile(re.escape(p), re.IGNORECASE)
+        for p in raw.default.content_id_patterns
+    )
+    class_patterns = tuple(
+        re.compile(re.escape(p), re.IGNORECASE)
+        for p in raw.default.content_class_patterns
+    )
+    remove_re = _compile_remove_class_re(raw.default.remove_class_tokens)
+    return CompiledSiteRules(
+        raw=raw,
+        default_id_patterns=id_patterns,
+        default_class_patterns=class_patterns,
+        default_remove_class_re=remove_re,
+    )
+
+
+def _compile_remove_class_re(tokens: list[str]) -> re.Pattern[str]:
+    """class トークン除去用の正規表現をコンパイルする.
+
+    BS4 は各クラストークンに regex.search() するため ^...$ で完全一致にする。
+    """
+    return re.compile(
+        "^(?:" + "|".join(re.escape(t) for t in tokens) + ")$",
+        re.IGNORECASE,
+    )
+
+
+def load_site_rules(path: Path) -> CompiledSiteRules:
+    """site_rules.toml を読み込んで CompiledSiteRules を返す.
+
+    Args:
+        path: site_rules.toml の絶対パス
+
+    Raises:
+        FileNotFoundError: ファイルが存在しない場合
+        ValueError: TOML 構文エラー or pydantic バリデーションに失敗した場合
+            （ファイルパス・原因を含むメッセージを送出）
+    """
+    if not path.exists():
+        msg = f"site_rules.toml が見つかりません: {path}"
+        raise FileNotFoundError(msg)
+    with open(path, "rb") as f:
+        try:
+            data = tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            msg = f"site_rules.toml の TOML 解析に失敗しました ({path}): {e}"
+            raise ValueError(msg) from e
+    try:
+        raw = SiteRulesConfig.model_validate(data)
+    except ValidationError as e:
+        msg = f"site_rules.toml の検証に失敗しました ({path}): {e}"
+        raise ValueError(msg) from e
+    return compile_site_rules(raw)
+
+
+def extract_web_host(file_path: str) -> str | None:
+    """source_store の相対パスから web の host 部分を抽出する.
+
+    web/{scheme}/{host}/... 形式（scheme は https / http）のパスのみ host を返す。
+    aozora / bluesky / youtube 等の web 以外のパスは None を返す。
+    host 部分が空文字列の場合（不正パス）も None を返す。
+
+    Args:
+        file_path: source_store ルート基準の相対パス（POSIX / Windows 両形式可）
+
+    Returns:
+        host 文字列、または web パスでなければ None
+    """
+    parts = file_path.replace("\\", "/").split("/")
+    if (
+        len(parts) >= 3
+        and parts[0] == "web"
+        and parts[1] in ("https", "http")
+        and parts[2]
+    ):
+        return parts[2]
+    return None

--- a/src/rag/pipeline/factory.py
+++ b/src/rag/pipeline/factory.py
@@ -10,9 +10,10 @@ import io
 from pathlib import Path
 
 from rag.bm25_index import BM25Index
-from rag.config import RAGSettings, get_settings
+from rag.config import PROJECT_ROOT, RAGSettings, get_settings
 from rag.converter import Converter
 from rag.converter.pdf_extractor import PdfBackendConfig
+from rag.converter.site_rules import load_site_rules
 from rag.embedding.factory import get_embedding_provider
 from rag.indexer import Indexer
 from rag.media.analyzer import MediaAnalyzer
@@ -59,13 +60,14 @@ def build_pipeline_controller(
         max_tokens=settings.rag_vision_max_tokens,
         api_timeout=settings.rag_vision_api_timeout,
     )
+    site_rules = load_site_rules(PROJECT_ROOT / "site_rules.toml")
     converter = Converter(
         regen_option="force",
         pdf_config=pdf_config,
         youtube_merge_gap_sec=settings.rag_youtube_merge_gap_sec,
         youtube_merge_max_chars=settings.rag_youtube_merge_max_chars,
         media_analyzer=media_analyzer,
-        html_remove_class_tokens=settings.rag_html_remove_class_tokens,
+        site_rules=site_rules,
     )
 
     embedding_provider = get_embedding_provider(settings, settings.embedding_provider)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -249,17 +249,37 @@ def make_scrapy_runner_args(**overrides: Any) -> dict[str, Any]:
 def make_converter_args(**overrides: Any) -> dict[str, Any]:
     """Converter のデフォルト引数を返す."""
     from rag.converter.pdf_extractor import PdfBackendConfig
+    from rag.converter.site_rules import (
+        DefaultRules,
+        SiteRulesConfig,
+        compile_site_rules,
+    )
 
+    site_rules = compile_site_rules(SiteRulesConfig(
+        default=DefaultRules(
+            content_id_patterns=[
+                "main-content", "main_content", "content-wrap", "content_wrap",
+                "page-container", "page_container", "main-body", "main_body",
+                "content", "main",
+            ],
+            content_class_patterns=[
+                "main-content", "main_content", "main_text", "main-text",
+                "content-wrap", "content_wrap", "page-container", "page_container",
+            ],
+            remove_class_tokens=[
+                "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
+                "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
+            ],
+        ),
+        hosts={},
+    ))
     defaults: dict[str, Any] = {
         "regen_option": "skip",
         "pdf_config": PdfBackendConfig(),
         "youtube_merge_gap_sec": 2.0,
         "youtube_merge_max_chars": 300,
         "media_analyzer": None,
-        "html_remove_class_tokens": [
-            "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
-            "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
-        ],
+        "site_rules": site_rules,
     }
     defaults.update(overrides)
     return defaults

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -48,10 +48,6 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_zenn_max_articles": 50,
     "rag_zenn_request_timeout": 30,
     "rag_zenn_request_interval": 1.0,
-    "rag_html_remove_class_tokens": [
-        "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
-        "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
-    ],
     "rag_document_supported_extensions": ".md,.txt,.pdf,.adoc,.jpg,.jpeg,.png,.webp,.mp4,.ts",
     "rag_document_http_mode_enabled": False,
     "rag_document_allowed_dirs": "",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -27,7 +27,6 @@ from rag.converter.handlers import (
     _AOZORA_HEAD_SCAN_BYTES,
     _detect_aozora_encoding,
     _fix_void_elements,
-    compile_remove_class_re,
     convert_html,
     convert_json_bluesky,
     convert_json_zenn_article,
@@ -35,11 +34,30 @@ from rag.converter.handlers import (
     passthrough_copy,
 )
 from rag.converter.normalize import normalize_text
+from rag.converter.site_rules import (
+    DefaultRules,
+    SiteRulesConfig,
+    compile_site_rules,
+)
 
-_TEST_REMOVE_CLASS_RE = compile_remove_class_re([
-    "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
-    "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
-])
+_TEST_SITE_RULES = compile_site_rules(SiteRulesConfig(
+    default=DefaultRules(
+        content_id_patterns=[
+            "main-content", "main_content", "content-wrap", "content_wrap",
+            "page-container", "page_container", "main-body", "main_body",
+            "content", "main",
+        ],
+        content_class_patterns=[
+            "main-content", "main_content", "main_text", "main-text",
+            "content-wrap", "content_wrap", "page-container", "page_container",
+        ],
+        remove_class_tokens=[
+            "breadcrumb", "breadcrumbs", "topic-path", "nextprev", "pagination",
+            "toolbar", "footer-wrapper", "footer", "scrollToFeedback", "suggest",
+        ],
+    ),
+    hosts={},
+))
 
 
 # ============================================================
@@ -90,7 +108,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Title" in result
         assert "Content here." in result
@@ -106,7 +124,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Article body." in result
         assert "Navigation" not in result
@@ -122,7 +140,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main body." in result
         assert "Navigation" not in result
@@ -143,7 +161,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Content" in result
         assert "alert" not in result
@@ -164,7 +182,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main body." in result
         assert "Header Noise" not in result
@@ -182,7 +200,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Content body." in result
         assert "Sidebar" not in result
@@ -199,7 +217,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main body." in result
         assert "Sidebar Noise" not in result
@@ -219,7 +237,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Interview Title" in result
         assert "Interview body." in result
@@ -236,7 +254,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main content." in result
         assert "Nav" not in result
@@ -254,7 +272,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Article Title" in result
         assert "Article body." in result
@@ -275,7 +293,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Long content paragraph" in result
         assert "Nav Link" not in result
@@ -294,7 +312,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Content here." in result
         assert "Home > Page" not in result
@@ -315,7 +333,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main content." in result
         assert "Copyright" not in result
@@ -336,7 +354,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "API description." in result
         assert "Leave feedback" not in result
@@ -356,7 +374,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Main content." in result
         assert "Copyright" not in result
@@ -378,7 +396,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Recommended articles." in result
         assert "User reviews here." in result
@@ -405,7 +423,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "AnimationClip" in result
         assert "Provides an asset." in result
@@ -427,7 +445,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "FAQ Question" in result
         assert "FAQ Answer" in result
@@ -443,7 +461,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Article content." in result
         assert "Main div content." not in result
@@ -453,7 +471,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "# H1" in result
         assert "## H2" in result
@@ -464,7 +482,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Link Text" in result
         assert "https://example.com" not in result
@@ -474,7 +492,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Photo description" in result
         assert "img.png" not in result
@@ -484,7 +502,7 @@ class TestConvertHtml:
         html_file = tmp_path / "test.html"
         html_file.write_bytes(html.encode("shift_jis"))
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "日本語テスト" in result
 
@@ -501,7 +519,7 @@ class TestConvertHtml:
         html_file.write_bytes(html.encode("shift_jis"))
 
         result = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert result is not None
         assert "旧字旧仮名の作品本文" in result
@@ -514,7 +532,7 @@ class TestConvertHtml:
         html_file.write_bytes(html.encode("shift_jis"))
 
         result = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert result is not None
         assert "メタタグなしの作品本文" in result
@@ -530,7 +548,7 @@ class TestConvertHtml:
         html_file.write_bytes(html.encode("shift_jis"))
 
         result = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert result is not None
         assert "不正 charset の作品本文" in result
@@ -550,7 +568,7 @@ class TestConvertHtml:
         html_file.write_bytes(html.encode("utf-8"))
 
         result = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert result is not None
         assert "UTF-8 配信の作品本文" in result
@@ -561,7 +579,7 @@ class TestConvertHtml:
         html_file = tmp_path / "web.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "UTF-8 default content." in result
 
@@ -620,7 +638,7 @@ class TestAozoraConversionIntegrity:
         ground_truth = self._extract_plain_from_html(raw_bytes, encoding="shift_jis")
 
         markdown = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert markdown is not None
         converted_plain = self._extract_plain_from_markdown(markdown)
@@ -655,7 +673,7 @@ class TestAozoraConversionIntegrity:
         ground_truth = self._extract_plain_from_html(raw_bytes, encoding="shift_jis")
 
         markdown = convert_html(
-            html_file, _TEST_REMOVE_CLASS_RE, source_type="aozora",
+            html_file, _TEST_SITE_RULES, source_type="aozora",
         )
         assert markdown is not None
 
@@ -710,7 +728,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Name" in result
         assert "Value" in result
@@ -741,7 +759,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "First paragraph" in result
         assert "Second paragraph" in result
@@ -758,7 +776,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Before break." in result
         assert "After break." in result
@@ -774,7 +792,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "Content after self-closed img." in result
 
@@ -788,7 +806,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "吾輩" in result
         assert "(わがはい)" in result
@@ -804,7 +822,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "漢字" in result
         assert "(かんじ)" in result
@@ -822,7 +840,7 @@ class TestDetectAozoraEncoding:
         html_file = tmp_path / "test.html"
         html_file.write_text(html, encoding="utf-8")
 
-        result = convert_html(html_file, _TEST_REMOVE_CLASS_RE)
+        result = convert_html(html_file, _TEST_SITE_RULES)
         assert result is not None
         assert "青空" in result
         assert "文庫" in result

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -368,7 +368,6 @@ rag_log_file_max_bytes = 10485760
 rag_zenn_max_articles = 50
 rag_zenn_request_timeout = 30
 rag_zenn_request_interval = 1.0
-rag_html_remove_class_tokens = ["breadcrumb", "toolbar"]
 rag_document_supported_extensions = ".md,.txt,.pdf,.adoc,.jpg,.jpeg,.png,.webp,.mp4,.ts"
 rag_document_http_mode_enabled = false
 rag_document_allowed_dirs = ""

--- a/tests/test_site_rules.py
+++ b/tests/test_site_rules.py
@@ -118,6 +118,34 @@ class TestSiteRulesConfigValidation:
                 "unknown_section": {"foo": "bar"},
             })
 
+    def test_blank_string_in_pattern_rejected(self) -> None:
+        """空白のみの文字列は早期にバリデーションエラーで弾かれる."""
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": ["main", "   "],
+                    "content_class_patterns": ["main"],
+                    "remove_class_tokens": ["sidebar"],
+                },
+            })
+
+    def test_blank_string_in_host_rule_rejected(self) -> None:
+        """ホストルールの selector も空白のみ文字列を弾く."""
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": ["main"],
+                    "content_class_patterns": ["main"],
+                    "remove_class_tokens": ["sidebar"],
+                },
+                "hosts": {
+                    "example.com": {
+                        "content_selectors": ["\t  "],
+                        "remove_selectors": [],
+                    },
+                },
+            })
+
     def test_unknown_host_field_rejected(self) -> None:
         with pytest.raises(ValidationError):
             SiteRulesConfig.model_validate({

--- a/tests/test_site_rules.py
+++ b/tests/test_site_rules.py
@@ -1,0 +1,389 @@
+"""site_rules.py のテスト.
+
+仕様: docs/specs/converter.md「サイト別抽出ルール設定ファイル」
+計画: aidlc-docs/plan-work/issue-786.md
+
+テスト方針:
+- L1 Unit Test。host マッチング・selector 試行順・フォールバック・共通除去合成の各観点を検証する
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+from pydantic import ValidationError
+
+from rag.converter.handlers import _clean_content_area, _find_content_area
+from rag.converter.site_rules import (
+    CompiledSiteRules,
+    SiteRulesConfig,
+    compile_site_rules,
+    extract_web_host,
+    load_site_rules,
+)
+
+
+def _make_site_rules(
+    *,
+    content_id_patterns: list[str] | None = None,
+    content_class_patterns: list[str] | None = None,
+    remove_class_tokens: list[str] | None = None,
+    hosts: dict[str, dict[str, list[str]]] | None = None,
+) -> CompiledSiteRules:
+    """テスト用に CompiledSiteRules を構築する."""
+    raw = SiteRulesConfig.model_validate({
+        "default": {
+            "content_id_patterns": content_id_patterns or ["main-content", "content"],
+            "content_class_patterns": content_class_patterns or ["main-content"],
+            "remove_class_tokens": remove_class_tokens or ["sidebar"],
+        },
+        "hosts": hosts or {},
+    })
+    return compile_site_rules(raw)
+
+
+# ============================================================
+# extract_web_host
+# ============================================================
+
+
+class TestExtractWebHost:
+    """extract_web_host のテスト."""
+
+    def test_web_https_path_returns_host(self) -> None:
+        assert extract_web_host("web/https/example.com/foo.html") == "example.com"
+
+    def test_web_http_path_returns_host(self) -> None:
+        assert extract_web_host("web/http/example.com/foo.html") == "example.com"
+
+    def test_aozora_path_returns_none(self) -> None:
+        assert extract_web_host("aozora/000035/001567.html") is None
+
+    def test_bluesky_path_returns_none(self) -> None:
+        assert extract_web_host("bluesky/did:plc:xxx/2026/03/rkey.json") is None
+
+    def test_backslash_path_normalized(self) -> None:
+        assert (
+            extract_web_host("web\\https\\example.com\\foo.html") == "example.com"
+        )
+
+    def test_too_short_path_returns_none(self) -> None:
+        assert extract_web_host("web") is None
+        assert extract_web_host("web/https") is None
+
+    def test_empty_host_returns_none(self) -> None:
+        """host 部分が空文字列のパス（不正形式）は None を返す."""
+        assert extract_web_host("web/https//foo.html") is None
+
+
+# ============================================================
+# SiteRulesConfig validation
+# ============================================================
+
+
+class TestSiteRulesConfigValidation:
+    """pydantic バリデーションのテスト."""
+
+    def test_default_requires_all_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": ["main"],
+                    # content_class_patterns missing
+                    "remove_class_tokens": ["sidebar"],
+                },
+            })
+
+    def test_default_rejects_empty_pattern_list(self) -> None:
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": [],
+                    "content_class_patterns": ["main"],
+                    "remove_class_tokens": ["sidebar"],
+                },
+            })
+
+    def test_unknown_section_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": ["main"],
+                    "content_class_patterns": ["main"],
+                    "remove_class_tokens": ["sidebar"],
+                },
+                "unknown_section": {"foo": "bar"},
+            })
+
+    def test_unknown_host_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SiteRulesConfig.model_validate({
+                "default": {
+                    "content_id_patterns": ["main"],
+                    "content_class_patterns": ["main"],
+                    "remove_class_tokens": ["sidebar"],
+                },
+                "hosts": {
+                    "example.com": {
+                        "content_selectors": ["#main"],
+                        "unknown_field": "x",
+                    },
+                },
+            })
+
+
+# ============================================================
+# load_site_rules
+# ============================================================
+
+
+class TestLoadSiteRules:
+    """load_site_rules のテスト."""
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.toml"
+        with pytest.raises(FileNotFoundError):
+            load_site_rules(missing)
+
+    def test_valid_toml_loads(self, tmp_path: Path) -> None:
+        toml_path = tmp_path / "site_rules.toml"
+        toml_path.write_text(
+            """
+[default]
+content_id_patterns = ["main"]
+content_class_patterns = ["main"]
+remove_class_tokens = ["sidebar"]
+
+[hosts."www.example.com"]
+content_selectors = ["#main"]
+""",
+            encoding="utf-8",
+        )
+        compiled = load_site_rules(toml_path)
+        assert compiled.raw.default.content_id_patterns == ["main"]
+        host_rule = compiled.get_host_rule("www.example.com")
+        assert host_rule is not None
+        assert host_rule.content_selectors == ["#main"]
+
+    def test_invalid_toml_syntax_raises_valueerror_with_path(
+        self, tmp_path: Path,
+    ) -> None:
+        """TOML 構文不正時にファイルパスを含む ValueError を送出する."""
+        toml_path = tmp_path / "site_rules.toml"
+        toml_path.write_text("not = valid = toml", encoding="utf-8")
+        with pytest.raises(ValueError, match=re.escape(str(toml_path))):
+            load_site_rules(toml_path)
+
+    def test_validation_error_raises_valueerror_with_path(
+        self, tmp_path: Path,
+    ) -> None:
+        """pydantic バリデーション失敗時にファイルパスを含む ValueError を送出する."""
+        toml_path = tmp_path / "site_rules.toml"
+        toml_path.write_text(
+            """
+[default]
+content_id_patterns = ["main"]
+# content_class_patterns と remove_class_tokens が欠落
+""",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=re.escape(str(toml_path))):
+            load_site_rules(toml_path)
+
+
+# ============================================================
+# _find_content_area: host rule precedence + fallback
+# ============================================================
+
+
+class TestFindContentArea:
+    """_find_content_area の host ルール優先 + 共通フォールバックの統合テスト."""
+
+    def test_host_selector_hits_overrides_common(self) -> None:
+        """host の content_selectors にヒットした要素を共通優先順より優先する."""
+        html = """
+        <html><body>
+          <article>本来 article が優先される</article>
+          <div id="maintxt"><div class="entry-content">これが真の本文</div></div>
+        </body></html>
+        """
+        rules = _make_site_rules(
+            hosts={"www.4gamer.net": {
+                "content_selectors": ["#maintxt .entry-content"],
+                "remove_selectors": [],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        result = _find_content_area(soup, rules, host="www.4gamer.net")
+        assert result.get_text(strip=True) == "これが真の本文"
+
+    def test_host_selector_all_miss_falls_back_to_common(self) -> None:
+        """host の content_selectors が全ミスした場合、共通優先順にフォールバックする."""
+        html = """
+        <html><body>
+          <article>article fallback</article>
+          <div id="other">not used</div>
+        </body></html>
+        """
+        rules = _make_site_rules(
+            hosts={"www.4gamer.net": {
+                "content_selectors": ["#maintxt"],
+                "remove_selectors": [],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        result = _find_content_area(soup, rules, host="www.4gamer.net")
+        assert result.name == "article"
+
+    def test_host_without_rule_uses_common(self) -> None:
+        """ルール未定義ホストは共通優先順のみで判定する."""
+        html = """
+        <html><body>
+          <div class="main-content">common class match</div>
+        </body></html>
+        """
+        rules = _make_site_rules(
+            content_class_patterns=["main-content"],
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        result = _find_content_area(soup, rules, host="other.example.com")
+        assert "common class match" in result.get_text()
+
+    def test_none_host_uses_common(self) -> None:
+        """host=None でも共通優先順で動作する."""
+        html = "<html><body><main>main tag</main></body></html>"
+        rules = _make_site_rules()
+        soup = BeautifulSoup(html, "html.parser")
+        result = _find_content_area(soup, rules, host=None)
+        assert result.name == "main"
+
+    def test_invalid_selector_skipped(self) -> None:
+        """不正な CSS selector はスキップして次の selector を試行する."""
+        html = """
+        <html><body>
+          <article>fallback</article>
+          <div id="real-content">real</div>
+        </body></html>
+        """
+        # 1 つ目は不正（":::invalid:::"）、2 つ目は有効
+        rules = _make_site_rules(
+            hosts={"example.com": {
+                "content_selectors": [":::invalid:::", "#real-content"],
+                "remove_selectors": [],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        result = _find_content_area(soup, rules, host="example.com")
+        assert result.get_text(strip=True) == "real"
+
+    def test_host_exact_match_only(self) -> None:
+        """完全一致のみ。サブドメイン違いはルール適用されない."""
+        html = """
+        <html><body>
+          <article>common fallback</article>
+          <div id="maintxt">site rule target</div>
+        </body></html>
+        """
+        rules = _make_site_rules(
+            hosts={"www.4gamer.net": {
+                "content_selectors": ["#maintxt"],
+                "remove_selectors": [],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        # news.4gamer.net は別ホストとして扱われ、site rule が適用されない
+        result = _find_content_area(soup, rules, host="news.4gamer.net")
+        assert result.name == "article"
+
+
+# ============================================================
+# _clean_content_area: site-specific remove_selectors
+# ============================================================
+
+
+class TestCleanContentArea:
+    """_clean_content_area の共通除去 + サイト別追加除去の合成テスト."""
+
+    def test_common_remove_class_tokens_applied(self) -> None:
+        html = """
+        <div>
+          <p>keep me</p>
+          <div class="sidebar">remove</div>
+        </div>
+        """
+        rules = _make_site_rules(remove_class_tokens=["sidebar"])
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.find("div")
+        _clean_content_area(content, rules, host=None)
+        assert "remove" not in content.get_text()
+        assert "keep me" in content.get_text()
+
+    def test_site_remove_selectors_added_to_common(self) -> None:
+        """site rule の remove_selectors は共通除去に追加適用される."""
+        html = """
+        <div>
+          <p>keep</p>
+          <div class="sidebar">common remove</div>
+          <div data-role="ad">site remove</div>
+        </div>
+        """
+        rules = _make_site_rules(
+            remove_class_tokens=["sidebar"],
+            hosts={"example.com": {
+                "content_selectors": [],
+                "remove_selectors": ['[data-role="ad"]'],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.find("div")
+        _clean_content_area(content, rules, host="example.com")
+        text = content.get_text()
+        assert "keep" in text
+        assert "common remove" not in text
+        assert "site remove" not in text
+
+    def test_invalid_remove_selector_skipped(self) -> None:
+        """site rule の remove_selectors 内の不正 CSS selector はスキップして続行する."""
+        html = """
+        <div>
+          <p>keep</p>
+          <div class="sidebar">common remove</div>
+          <div data-role="ad">site remove</div>
+        </div>
+        """
+        # 1 つ目は不正、2 つ目は有効
+        rules = _make_site_rules(
+            remove_class_tokens=["sidebar"],
+            hosts={"example.com": {
+                "content_selectors": [],
+                "remove_selectors": [":::invalid:::", '[data-role="ad"]'],
+            }},
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.find("div")
+        _clean_content_area(content, rules, host="example.com")
+        text = content.get_text()
+        assert "keep" in text
+        assert "common remove" not in text  # 共通除去は適用される
+        assert "site remove" not in text  # 有効な selector は適用される
+
+    def test_no_host_rule_only_common_removal(self) -> None:
+        """ホストにルールがない場合は共通除去のみ適用される."""
+        html = """
+        <div>
+          <p>keep</p>
+          <div class="sidebar">remove</div>
+          <div data-role="ad">stays (no host rule)</div>
+        </div>
+        """
+        rules = _make_site_rules(remove_class_tokens=["sidebar"])
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.find("div")
+        _clean_content_area(content, rules, host="unknown.com")
+        text = content.get_text()
+        assert "keep" in text
+        assert "remove" not in text
+        assert "stays" in text


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- `site_rules.toml` をプロジェクトルート直下に新設し、HTML 抽出ルール（コンテンツ領域 selector・除去 class トークン・サイト別追加 selector）の SSoT を集約
- `[default]` セクションに共通フォールバックパターン、`[hosts."<host>"]` セクションにホスト単位ルールを定義（host 完全一致のみ）
- site rule の `content_selectors` を最優先試行 → 全ミス時に共通フォールバック（`<article>` → `<main>` → role → id → class → テキスト密度）に降りる二段構え
- `_clean_content_area` に site rule の `remove_selectors` を共通除去に追加適用するロジックを追加
- **破壊的変更**: `config.toml` の `rag_html_remove_class_tokens` を `site_rules.toml` の `[default].remove_class_tokens` に移管
- **破壊的変更**: `Converter.__init__` の引数を `html_remove_class_tokens` → `site_rules: CompiledSiteRules` に変更
- ハードコード定数 `_CONTENT_ID_PATTERNS` / `_CONTENT_CLASS_PATTERNS` を削除し `[default]` セクションから読み込む形に変更
- `docs/specs/converter.md` / `docs/specs/rag-knowledge.md` / `README.md` の設定管理表を更新

## Test plan

- [x] `tests/test_site_rules.py` を新設（25 件: host マッチング・selector 試行順・フォールバック・除去合成・TOML 構文不正・pydantic 失敗・不正 CSS selector スキップ）
- [x] 既存テスト（`tests/test_converter.py` / `tests/factories.py` / `tests/settings_defaults.py` / `tests/test_rag_config.py`）を新 API に追従
- [x] `uv run pytest` 2159 passed
- [x] `uv run ruff check src/ tests/` All checks passed
- [x] `uv run mypy src` Success
- [x] markdownlint 0 errors
- [x] 4Gamer スモーク 3 件で converter 出力を目視確認し、サイドバー文字列（週刊プロゲーマーファイル / 新着連載 / 新着レビュー / Steam Controller 等）が完全消失することを確認

## Related issues

Closes #786