### PR TITLE
feat(converter): business.4gamer.net 用 site_rule を追加

### DIFF
--- a/site_rules.toml
+++ b/site_rules.toml
@@ -63,3 +63,13 @@ content_selectors = [
     ".maintxt",
 ]
 remove_selectors = []
+
+# 4Gamer Business: <article class="main_contents"> 配下に
+# `<div class="article_news">`（ヘッダ）+ `<div class="maintxt">`（本文）+
+# `<aside class="article_related">`（関連記事ノイズ）が並ぶ構造。
+# 本文 div `.maintxt` を直接指定する。
+[hosts."business.4gamer.net"]
+content_selectors = [
+    ".maintxt",
+]
+remove_selectors = []


### PR DESCRIPTION
## Summary

- site_rules.toml の  セクションを新規追加
- content_selectors に  を指定

## Test plan

- [x] business.4gamer.net 既存記事の converter 出力検証済み
- [x] 4Gamer CEDEC 関連 832/834 件取り込み成功