### PR TITLE
feat(content-listing): 指定日付範囲でソース取得する MCP ツール rag_list_by_date_range を追加 (#789)

### DIFF
--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -2,12 +2,13 @@
 
 ## 概要
 
-指定された `source_type` のソースを公開日時（`published_at`）順で一覧取得する機能を MCP ツールおよび CLI サブコマンドとして提供する。
+取り込み済みソースを一覧取得する機能を MCP ツールおよび CLI サブコマンドとして提供する。`rag_list_recent`（指定 `source_type` の `published_at` 順）と `rag_list_by_date_range`（`published_at` 日付範囲・`source_type` 任意で横断取得）の 2 ツールを提供する。
 
 スコープ:
 
 - ソース単位の一覧取得（MCP ツール + CLI サブコマンド）
-- `source_type` 指定による絞り込み
+- `source_type` 指定による絞り込み（`rag_list_recent` は必須、`rag_list_by_date_range` は任意）
+- `published_at` の日付範囲指定による絞り込み（`rag_list_by_date_range`）
 - メタデータフィルタ（`filters`）による絞り込み
 - `published_at` によるソート（降順/昇順切り替え可能）
 - 取得件数の制限
@@ -58,6 +59,7 @@
 | 操作 | 種別 | 提供方式 | 概要 |
 |------|------|---------|------|
 | rag_list_recent | 既存 | MCP ツール + CLI | 指定 source_type のソースを公開日時順で一覧取得する |
+| rag_list_by_date_range | 新規 | MCP ツール + CLI | 指定日付範囲のソースを横断取得する（`source_type` 任意） |
 
 ### MCP ツール
 
@@ -112,6 +114,79 @@ source_type: web（5件 / 全80件, 新しい順）
 - Source の値は source_store 内の相対パス（全 source_type 共通）
 - クエリコスト: 一覧取得 1 クエリ + 総件数 COUNT 1 クエリの最大 2 クエリで完結する。全データは MetadataDB から取得し、VectorStore への追加クエリは発行しない
 
+#### rag_list_by_date_range
+
+`published_at` の日付範囲で取り込み済みソースを横断取得する。`source_type` 未指定時は全種別を横断する。
+
+| 項目 | 内容 |
+|------|------|
+| ツール名 | `rag_list_by_date_range` |
+| 説明 | 指定日付範囲のソースを横断取得する（JST 解釈、両端 inclusive） |
+
+パラメータ:
+
+| パラメータ | 型 | 必須 | 内容 |
+|-----------|-----|------|------|
+| `date_from` | str | はい | 開始日（`YYYY-MM-DD` 形式、JST 起点で inclusive） |
+| `date_to` | str | はい | 終了日（`YYYY-MM-DD` 形式、JST 起点で inclusive） |
+| `source_type` | str | いいえ | ソース種別（値は [`_schema/enums.yml`](../../../_schema/enums.yml) の `source_type` を参照）。未指定時は全種別横断 |
+| `limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml の値を流用） |
+| `order` | str | いいえ | ソート順。`"desc"`（新しい順、デフォルト）または `"asc"`（古い順） |
+| `filters` | str | いいえ | メタデータフィルタ（`key=value` 形式、カンマ区切り）。`rag_list_recent` の `filters` と同一形式 |
+
+バリデーション:
+
+- `date_from` / `date_to` が `YYYY-MM-DD` 形式でない場合、エラーメッセージを返す
+- `date_from` が `date_to` より後の日付の場合、エラーメッセージを返す
+- `source_type` 指定時に有効値でない場合、エラーメッセージを返す
+- `limit` が許容範囲外の場合、エラーメッセージを返す。許容範囲は `src/rag/config.py` の pydantic Field 制約に従う
+- `order` が `"asc"` / `"desc"` 以外の場合、エラーメッセージを返す
+- `filters` のキー名が不正な場合、エラーメッセージを返す
+
+範囲解釈:
+
+- `date_from` / `date_to` は JST(`+09:00`) として解釈する
+- `published_at` カラムは初回 INSERT 時に **UTC マイクロ秒 6 桁固定の ISO 8601** に正規化される
+  （`MetadataDB.register_source` / `update_source` の入口で `normalize_published_at()` を適用）。
+  範囲境界も同書式に揃えて SQL の文字列比較で範囲フィルタする
+  - 例: `date_from=2026-01-15` → `2026-01-14T15:00:00.000000+00:00`
+  - 例: `date_to=2026-01-15` → `2026-01-15T14:59:59.999999+00:00`
+- 表記揺れ（マイクロ秒の有無、`Z` vs `+09:00` 等の TZ オフセット表記差）は書き込み入口で吸収されるため、辞書順比較が時系列順比較と一致する
+- 既存データは `uv run python -m rag.cli migrate` を 1 回実行することで一括正規化される（初回適用後は冪等）
+- 範囲の両端は inclusive（`>=` / `<=`）
+
+出力:
+
+プレーンテキスト形式。ヘッダー行に日付範囲・件数・ソート順・`source_type` フィルタ条件を表示し、各エントリに `Type: {source_type}` を付与したフラットリストを出力する。
+
+```
+date_range: 2026-01-15〜2026-01-15（all, 3件 / 全3件, 新しい順）
+
+1. セッション記録
+   Type: journal
+   Source: journal/example-repo/20260115-101500-list-by-date-range.md
+   Published: 2026-01-15T01:15:00.000000+00:00
+   Size: 4.2 KB
+
+2. 開発メモ投稿
+   Type: bluesky
+   Source: bluesky/example.bsky.social/3k...
+   Published: 2026-01-15T00:00:00.000000+00:00
+   Size: 0.5 KB
+
+3. RAG 解説記事
+   Type: zenn
+   Source: zenn/example-user/article-slug
+   Published: 2026-01-14T22:30:00.000000+00:00
+   Size: 12.3 KB
+```
+
+- ヘッダー行: `date_range: {date_from}〜{date_to}（{source_type or "all"}, {表示件数}件 / 全{該当総件数}件, {ソート順}）`
+  - 総件数: 同じ範囲・`source_type`・`filters` 条件の `COUNT(*)` で取得する
+- 各エントリ: 番号付きリスト。タイトル、`Type: {source_type}`、source_id、published_at、ファイルサイズを表示
+- 該当ソースが 0 件の場合: `date_range: {date_from}〜{date_to}（{source_type or "all"}, 0件 / 全0件）`（ソート順は省略）
+- クエリコスト: 一覧取得 1 クエリ + 総件数 COUNT 1 クエリの最大 2 クエリで完結する
+
 ### CLI サブコマンド
 
 #### list-recent コマンド
@@ -129,6 +204,23 @@ uv run python -m rag.cli list-recent --source-type <TYPE> [--limit <N>] [--order
 
 MCP ツール `rag_list_recent` と同じバリデーション・振る舞いを適用する。出力形式も同一。
 
+#### list-by-date-range コマンド
+
+```
+uv run python -m rag.cli list-by-date-range --date-from <YYYY-MM-DD> --date-to <YYYY-MM-DD> [--source-type <TYPE>] [--limit <N>] [--order asc|desc] [--filters <FILTERS>]
+```
+
+| オプション | 型 | 必須 | 内容 |
+|-----------|-----|------|------|
+| `--date-from` | str | はい | 開始日（`YYYY-MM-DD` 形式、JST 起点で inclusive） |
+| `--date-to` | str | はい | 終了日（`YYYY-MM-DD` 形式、JST 起点で inclusive） |
+| `--source-type` | str | いいえ | ソース種別。未指定で全種別横断 |
+| `--limit` | int | いいえ | 取得件数。デフォルト: `rag_list_recent_limit`（config.toml） |
+| `--order` | str | いいえ | ソート順。`asc`（古い順）/ `desc`（新しい順、デフォルト） |
+| `--filters` | str | いいえ | メタデータフィルタ（`key=value` 形式、カンマ区切り）。MCP ツールと同一形式 |
+
+MCP ツール `rag_list_by_date_range` と同じバリデーション・範囲解釈・出力形式を適用する。
+
 ### 設定項目
 
 | 設定項目 | 層 | 設計意図 |
@@ -139,25 +231,36 @@ MCP ツール `rag_list_recent` と同じバリデーション・振る舞いを
 
 ```mermaid
 flowchart TD
-    MCP["MCP rag_list_recent"]
-    CLI["CLI list-recent"]
+    MCP_RECENT["MCP rag_list_recent"]
+    MCP_RANGE["MCP rag_list_by_date_range"]
+    CLI_RECENT["CLI list-recent"]
+    CLI_RANGE["CLI list-by-date-range"]
     VALIDATE["パラメータ検証"]
-    SERVICE["StatsPort.list_recent / list_recent_sources"]
+    SERVICE_RECENT["StatsPort.list_recent / list_recent_sources"]
+    SERVICE_RANGE["StatsPort.list_by_date_range / list_sources_by_date_range"]
     METADB["MetadataDB"]
     FORMAT["テキストフォーマット"]
     RESPONSE["レスポンス返却"]
 
-    MCP --> VALIDATE
-    CLI --> VALIDATE
+    MCP_RECENT --> VALIDATE
+    CLI_RECENT --> VALIDATE
+    MCP_RANGE --> VALIDATE
+    CLI_RANGE --> VALIDATE
     VALIDATE -->|不正| ERROR["エラー返却"]
-    VALIDATE -->|正常| SERVICE
-    SERVICE --> METADB
-    METADB -->|"source_type + filters フィルタ + published_at ソート + COUNT"| SERVICE
-    SERVICE --> FORMAT
+    VALIDATE -->|"正常 (rag_list_recent)"| SERVICE_RECENT
+    VALIDATE -->|"正常 (rag_list_by_date_range)"| SERVICE_RANGE
+    SERVICE_RECENT --> METADB
+    SERVICE_RANGE --> METADB
+    METADB -->|"フィルタ条件 + ソート + COUNT"| SERVICE_RECENT
+    METADB -->|"範囲フィルタ + フィルタ条件 + ソート + COUNT"| SERVICE_RANGE
+    SERVICE_RECENT --> FORMAT
+    SERVICE_RANGE --> FORMAT
     FORMAT --> RESPONSE
 ```
 
 ### データ取得フロー
+
+#### rag_list_recent
 
 1. MCP ツールまたは CLI からパラメータを受け取る
 2. `source_type`、`limit`、`order`、`filters` のバリデーションを実行する
@@ -167,21 +270,35 @@ flowchart TD
    - 総件数取得: 同条件の `COUNT(*)` で該当 source_type の全件数を取得（`filters` 指定時は絞り込み後の件数）
 5. 結果をテキスト形式にフォーマットして返却する（file_size は人間が読みやすい単位に変換）
 
+#### rag_list_by_date_range
+
+1. MCP ツールまたは CLI からパラメータを受け取る
+2. `date_from` / `date_to` を `YYYY-MM-DD` 形式で検証し、`date_from <= date_to` を確認する
+3. `source_type`（指定時）、`limit`、`order`、`filters` のバリデーションを実行する
+4. 「範囲解釈」節に従い、`date_from` / `date_to` を UTC マイクロ秒 6 桁固定 ISO 8601 の境界文字列に変換する
+5. `StatsPort.list_by_date_range` Adapter メソッド（または `list_sources_by_date_range` 共通関数）を呼び出す
+6. `MetadataDB` から以下の 2 クエリを発行する:
+   - 一覧取得: `status = 'active'` + `published_at >= ?` + `published_at <= ?` + `source_type`（指定時） + `filters`（指定時）でフィルタし、`published_at` でソートして `limit` 件取得
+   - 総件数取得: 同条件の `COUNT(*)`
+7. 結果をテキスト形式にフォーマットして返却する（各エントリに `Type: {source_type}` を含める）
+
 ### 関連ファイル
 
 | ファイル | 役割 |
 |---------|------|
-| `src/rag/server/tools/listing.py` | MCP ツール定義（`rag_list_recent`, `rag_stats`）。パラメータ検証と共通関数呼び出し |
-| `src/rag/cli.py` | CLI サブコマンド定義。パラメータ検証と共通関数呼び出し |
-| `src/rag/admin/stats_port.py` | `StatsPort` Protocol + `RealStatsAdapter` + `list_recent_sources` 関数。MetadataDB へのクエリ |
+| `src/rag/server/tools/listing.py` | MCP ツール定義（`rag_list_recent`, `rag_list_by_date_range`, `rag_stats`）。パラメータ検証と共通関数呼び出し |
+| `src/rag/cli.py` | CLI サブコマンド定義（`list-recent`, `list-by-date-range` 等）。パラメータ検証と共通関数呼び出し |
+| `src/rag/admin/stats_port.py` | `StatsPort` Protocol + `RealStatsAdapter` + `list_recent_sources` / `list_sources_by_date_range` 関数。日付検証・JST 境界生成・MetadataDB へのクエリ |
 | `src/rag/admin/formatting.py` | `format_file_size` 等のフォーマット処理 |
 | `src/rag/filter_parser.py` | `parse_filters()` — `key=value` 文字列のパース（`rag_search` と共通） |
-| `src/rag/store/metadata_db.py` | MetadataDB。`source_type` + メタデータフィルタ + `published_at` ソートのクエリ |
+| `src/rag/store/metadata_db.py` | MetadataDB。`list_sources` / `list_sources_by_date_range` 等のクエリ |
 | `src/rag/store/resolve.py` | `resolve_published_at()` — source_type ごとの公開日時解決 |
-| `src/rag/config.py` | `rag_list_recent_limit` 設定の定義 |
+| `src/rag/config.py` | `rag_list_recent_limit` 設定の定義（`rag_list_by_date_range` でも流用） |
 | `config.toml` | `rag_list_recent_limit` のデフォルト値 |
 
 ## エッジケース
+
+### rag_list_recent
 
 | ケース | 振る舞い |
 |--------|---------|
@@ -196,6 +313,22 @@ flowchart TD
 | `filters` 指定で該当ソースが0件 | `source_type: {type}（0件 / 全0件）` を返す |
 | `filters` のキー名が不正 | エラーメッセージを返す |
 | `filters` 未指定 | 既存の動作（全件返却）を維持する |
+
+### rag_list_by_date_range
+
+| ケース | 振る舞い |
+|--------|---------|
+| 範囲内のソースが 0 件 | `date_range: {date_from}〜{date_to} ({source_type or "all"}, 0件 / 全0件)` を返す |
+| `date_from` / `date_to` が `YYYY-MM-DD` 形式でない | エラーメッセージを返す |
+| `date_from > date_to` | エラーメッセージを返す |
+| `source_type` 未指定 | 全 source_type を横断して取得する |
+| `source_type` 指定 | その source_type のみ取得する |
+| `published_at` が UTC（`Z` 終端）のソース | 書き込み入口で UTC マイクロ秒 6 桁固定 ISO 8601 に正規化済みのため、範囲境界との文字列比較が時系列順と一致する |
+| `published_at` が空文字列のソース | 書き込み入口で `collected_at` を fallback として適用するため通常は発生しない。万一空文字列が残った場合は範囲条件で除外される |
+| `published_at` が同一の複数ソース | ソート順序は不定 |
+| 同一 `source_id` の再取り込み | `register_source` の ON CONFLICT で `published_at` は **更新されない**（初回 INSERT 時の値が保持される）。再取り込みで `published_at` を更新したい場合は `update_source` で明示的に渡すか、`uv run python -m rag.cli migrate` を再実行する |
+| 論理削除済みソース | 一覧に含めない（`status = 'active'` のみ対象） |
+| `filters` のキー名が不正 | エラーメッセージを返す |
 
 ## 関連ドキュメント
 

--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -318,7 +318,7 @@ flowchart TD
 
 | ケース | 振る舞い |
 |--------|---------|
-| 範囲内のソースが 0 件 | `date_range: {date_from}〜{date_to} ({source_type or "all"}, 0件 / 全0件)` を返す |
+| 範囲内のソースが 0 件 | `date_range: {date_from}〜{date_to}（{source_type or "all"}, 0件 / 全0件）` を返す |
 | `date_from` / `date_to` が `YYYY-MM-DD` 形式でない | エラーメッセージを返す |
 | `date_from > date_to` | エラーメッセージを返す |
 | `source_type` 未指定 | 全 source_type を横断して取得する |

--- a/src/rag/admin/stats_port.py
+++ b/src/rag/admin/stats_port.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
+from datetime import UTC, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -18,6 +20,13 @@ if TYPE_CHECKING:
     from rag.vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
+
+# rag_list_by_date_range / list-by-date-range の日付パラメータは JST(+09:00) 起点で
+# inclusive 範囲を構築する。MetadataDB の published_at カラムは
+# `normalize_published_at()` により UTC マイクロ秒 6 桁固定 ISO 8601 で統一されているため、
+# 範囲境界も同書式（UTC マイクロ秒 6 桁固定）に揃えて文字列比較する。
+_JST_TZ = timezone(timedelta(hours=9))
+_YYYYMMDD_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 class StatsPort(Protocol):
@@ -35,6 +44,18 @@ class StatsPort(Protocol):
         filters: dict[str, str] | None = None,
     ) -> str:
         """指定 source_type のソースを公開日時順で一覧取得する."""
+        ...
+
+    def list_by_date_range(
+        self,
+        date_from: str,
+        date_to: str,
+        source_type: str | None,
+        limit: int,
+        ascending: bool = False,
+        filters: dict[str, str] | None = None,
+    ) -> str:
+        """published_at 範囲でソースを一覧取得する."""
         ...
 
     def close(self) -> None:
@@ -79,6 +100,31 @@ class RealStatsAdapter:
             )
         return list_recent_sources(
             source_store_dir=str(self._source_store_dir),
+            source_type=source_type,
+            limit=limit,
+            ascending=ascending,
+            filters=filters,
+        )
+
+    def list_by_date_range(
+        self,
+        date_from: str,
+        date_to: str,
+        source_type: str | None,
+        limit: int,
+        ascending: bool = False,
+        filters: dict[str, str] | None = None,
+    ) -> str:
+        """published_at 範囲でソースを一覧取得する."""
+        if self._source_store_dir is None:
+            raise RuntimeError(
+                "list_by_date_range requires source_store_dir; "
+                "RealStatsAdapter must be constructed with it",
+            )
+        return list_sources_by_date_range(
+            source_store_dir=str(self._source_store_dir),
+            date_from=date_from,
+            date_to=date_to,
             source_type=source_type,
             limit=limit,
             ascending=ascending,
@@ -151,4 +197,141 @@ def list_recent_sources(
         lines.append(f"   Published: {src.published_at}")
         lines.append(f"   Size: {format_file_size(src.file_size)}")
 
+    return "\n".join(lines)
+
+
+def validate_date_string(value: str, *, field_name: str) -> str:
+    """YYYY-MM-DD 形式の日付文字列を検証する.
+
+    Raises:
+        ValueError: 形式が不正な場合
+    """
+    if not _YYYYMMDD_RE.match(value):
+        msg = (
+            f"{field_name} は YYYY-MM-DD 形式で指定してください "
+            f"(指定値: {value!r})"
+        )
+        raise ValueError(msg)
+    # 月日の妥当性チェック（例: 2026-13-01 を弾く）
+    try:
+        datetime.strptime(value, "%Y-%m-%d")  # noqa: DTZ007
+    except ValueError as e:
+        msg = f"{field_name} の日付が不正です (指定値: {value!r}): {e}"
+        raise ValueError(msg) from None
+    return value
+
+
+def to_jst_range_iso(date_from: str, date_to: str) -> tuple[str, str]:
+    """YYYY-MM-DD 形式の date_from/date_to を、JST 起点 inclusive 範囲の UTC ISO 8601 に変換する.
+
+    MetadataDB の published_at は `normalize_published_at()` により UTC マイクロ秒 6 桁固定
+    ISO 8601 に統一されているため、範囲境界も同書式に揃える。
+
+    返り値: (date_from_iso, date_to_iso)
+    - date_from_iso: JST {date_from} 00:00:00.000000 を UTC に変換したマイクロ秒 6 桁固定 ISO 8601
+    - date_to_iso:   JST {date_to} 23:59:59.999999 を UTC に変換したマイクロ秒 6 桁固定 ISO 8601
+
+    Raises:
+        ValueError: いずれかが YYYY-MM-DD 形式でないか、date_from > date_to の場合
+    """
+    validate_date_string(date_from, field_name="date_from")
+    validate_date_string(date_to, field_name="date_to")
+    if date_from > date_to:
+        msg = (
+            f"date_from は date_to 以前の日付を指定してください "
+            f"(date_from={date_from!r}, date_to={date_to!r})"
+        )
+        raise ValueError(msg)
+    from_dt = datetime.combine(
+        datetime.strptime(date_from, "%Y-%m-%d").date(),  # noqa: DTZ007
+        time(0, 0, 0, 0),
+        tzinfo=_JST_TZ,
+    )
+    to_dt = datetime.combine(
+        datetime.strptime(date_to, "%Y-%m-%d").date(),  # noqa: DTZ007
+        time(23, 59, 59, 999_999),
+        tzinfo=_JST_TZ,
+    )
+    date_from_iso = from_dt.astimezone(UTC).isoformat(timespec="microseconds")
+    date_to_iso = to_dt.astimezone(UTC).isoformat(timespec="microseconds")
+    return date_from_iso, date_to_iso
+
+
+def list_sources_by_date_range(
+    source_store_dir: str,
+    date_from: str,
+    date_to: str,
+    source_type: str | None,
+    limit: int,
+    ascending: bool = False,
+    filters: dict[str, str] | None = None,
+) -> str:
+    """published_at 範囲でソースを取得して整形済みテキストを返す（MCP/CLI 共通ロジック）.
+
+    仕様: docs/specs/infrastructure/content-listing.md
+    """
+    from rag.store.metadata_db import MetadataDB
+    from rag.store.models import SourceType
+
+    try:
+        date_from_iso, date_to_iso = to_jst_range_iso(date_from, date_to)
+    except ValueError as e:
+        return f"エラー: {e}"
+
+    header_type = source_type if source_type else "all"
+
+    db_path = Path(source_store_dir) / "metadata.db"
+    if not db_path.exists():
+        return f"date_range: {date_from}〜{date_to}（{header_type}, 0件 / 全0件）"
+
+    db = MetadataDB(db_path)
+    try:
+        db.initialize()
+        st = cast(SourceType, source_type) if source_type else None
+        try:
+            sources = db.list_sources_by_date_range(
+                date_from_iso=date_from_iso,
+                date_to_iso=date_to_iso,
+                source_type=st,
+                limit=limit,
+                ascending=ascending,
+                filters=filters,
+            )
+            total = db.count_sources_by_date_range(
+                date_from_iso=date_from_iso,
+                date_to_iso=date_to_iso,
+                source_type=st,
+                filters=filters,
+            )
+        except ValueError as e:
+            return f"エラー: {e}"
+    finally:
+        db.close()
+
+    logger.info(
+        "list-by-date-range: date_from=%s, date_to=%s, source_type=%s,"
+        " total=%d, returned=%d",
+        date_from, date_to, header_type, total, len(sources),
+    )
+    for i, src in enumerate(sources, 1):
+        logger.info(
+            "list-by-date-range result %d: source_id=%s, title=%r",
+            i, src.source_id, src.title,
+        )
+
+    if not sources:
+        return f"date_range: {date_from}〜{date_to}（{header_type}, 0件 / 全0件）"
+
+    order_label = "古い順" if ascending else "新しい順"
+    lines: list[str] = [
+        f"date_range: {date_from}〜{date_to}"
+        f"（{header_type}, {len(sources)}件 / 全{total}件, {order_label}）",
+    ]
+    for i, src in enumerate(sources, 1):
+        lines.append("")
+        lines.append(f"{i}. {src.title}")
+        lines.append(f"   Type: {src.source_type}")
+        lines.append(f"   Source: {src.source_id}")
+        lines.append(f"   Published: {src.published_at}")
+        lines.append(f"   Size: {format_file_size(src.file_size)}")
     return "\n".join(lines)

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -18,7 +18,7 @@ import sys
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 from urllib.parse import urldefrag
 
 from .errors import CliErrorCode
@@ -779,6 +779,46 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     )
     _add_output_option(list_recent_parser)
 
+    # list-by-date-range サブコマンド
+    list_by_date_range_parser = subparsers.add_parser(
+        "list-by-date-range",
+        help="指定日付範囲（published_at, JST 解釈, 両端 inclusive）でソースを取得",
+    )
+    list_by_date_range_parser.add_argument(
+        "--date-from",
+        required=True,
+        help="開始日（YYYY-MM-DD、JST 起点で inclusive）",
+    )
+    list_by_date_range_parser.add_argument(
+        "--date-to",
+        required=True,
+        help="終了日（YYYY-MM-DD、JST 起点で inclusive）",
+    )
+    list_by_date_range_parser.add_argument(
+        "--source-type",
+        default=None,
+        choices=["web", "bluesky", "zenn", "youtube", "aozora", "local", "journal"],
+        help="ソース種別（任意、未指定で全種別横断）",
+    )
+    list_by_date_range_parser.add_argument(
+        "--limit",
+        type=_validate_list_recent_limit,
+        default=None,
+        help="取得件数（1〜100、未指定時は設定値を使用）",
+    )
+    list_by_date_range_parser.add_argument(
+        "--order",
+        choices=["asc", "desc"],
+        default="desc",
+        help="ソート順（asc: 古い順, desc: 新しい順。デフォルト: desc）",
+    )
+    list_by_date_range_parser.add_argument(
+        "--filters",
+        default=None,
+        help="メタデータフィルタ（key=value 形式、例: 'repository=rag-knowledge'）",
+    )
+    _add_output_option(list_by_date_range_parser)
+
     # search サブコマンド
     search_parser = subparsers.add_parser("search", help="ナレッジベースを検索")
     search_parser.add_argument("--query", required=True, help="検索クエリ")
@@ -980,6 +1020,7 @@ def main() -> None:
         "get-document": run_get_document,
         "stats": run_stats,
         "list-recent": run_list_recent,
+        "list-by-date-range": run_list_by_date_range,
         "search": run_search,
         "search-aozora": run_search_aozora,
         "migrate-journal": run_migrate_journal,
@@ -2226,6 +2267,143 @@ def run_list_recent(args: argparse.Namespace) -> None:
         from .admin.stats_port import list_recent_sources
         print(list_recent_sources(
             settings.source_store_dir, args.source_type, limit, ascending=ascending,
+            filters=parsed_filters,
+        ))
+
+
+def run_list_by_date_range(args: argparse.Namespace) -> None:
+    """published_at の日付範囲でソースを一覧取得する.
+
+    MCP ツール rag_list_by_date_range と同等の一覧取得を CLI で実行する。
+    """
+    from .admin.stats_port import to_jst_range_iso
+    from .config import get_settings
+
+    json_out = _is_json_output(args)
+    settings = get_settings()
+    limit: int = args.limit if args.limit is not None else settings.rag_list_recent_limit
+    ascending = args.order == "asc"
+
+    parsed_filters: dict[str, str] | None = None
+    if args.filters is not None:
+        try:
+            parsed_filters = parse_filters(args.filters)
+        except ValueError as e:
+            if json_out:
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
+                return
+            logger.error("エラー: %s", e)
+            sys.exit(1)
+
+    try:
+        date_from_iso, date_to_iso = to_jst_range_iso(args.date_from, args.date_to)
+    except ValueError as e:
+        if json_out:
+            _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
+            return
+        logger.error("エラー: %s", e)
+        sys.exit(1)
+
+    source_type = args.source_type  # None で全種別
+
+    if json_out:
+        from .store.metadata_db import MetadataDB
+        from .store.models import SourceType
+
+        if not settings.source_store_dir:
+            _output_result({
+                "date_from": args.date_from,
+                "date_to": args.date_to,
+                "source_type": source_type,
+                "sources": [],
+                "count": 0,
+                "total": 0,
+                "order": args.order,
+            })
+            return
+        db_path = Path(settings.source_store_dir) / "metadata.db"
+        if not db_path.exists():
+            _output_result({
+                "date_from": args.date_from,
+                "date_to": args.date_to,
+                "source_type": source_type,
+                "sources": [],
+                "count": 0,
+                "total": 0,
+                "order": args.order,
+            })
+            return
+        db = MetadataDB(db_path)
+        try:
+            db.initialize()
+            st = cast(SourceType, source_type) if source_type else None
+            try:
+                sources = db.list_sources_by_date_range(
+                    date_from_iso=date_from_iso,
+                    date_to_iso=date_to_iso,
+                    source_type=st,
+                    limit=limit,
+                    ascending=ascending,
+                    filters=parsed_filters,
+                )
+                total = db.count_sources_by_date_range(
+                    date_from_iso=date_from_iso,
+                    date_to_iso=date_to_iso,
+                    source_type=st,
+                    filters=parsed_filters,
+                )
+            except ValueError as e:
+                _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
+                return
+        finally:
+            db.close()
+        for i, s in enumerate(sources, 1):
+            logger.info(
+                "list-by-date-range result %d: source_id=%s, title=%r",
+                i, s.source_id, s.title,
+            )
+        _output_result_logged(
+            {
+                "date_from": args.date_from,
+                "date_to": args.date_to,
+                "source_type": source_type,
+                "sources": [
+                    {
+                        "source_id": s.source_id,
+                        "source_type": s.source_type,
+                        "title": s.title,
+                        "published_at": s.published_at,
+                        "file_size": s.file_size,
+                    }
+                    for s in sources
+                ],
+                "count": len(sources),
+                "total": total,
+                "order": args.order,
+            },
+            "list-by-date-range: date_from=%s, date_to=%s, source_type=%s,"
+            " total=%d, returned=%d",
+            args.date_from,
+            args.date_to,
+            source_type or "all",
+            total,
+            len(sources),
+        )
+    else:
+        from .admin.stats_port import list_sources_by_date_range
+        if not settings.source_store_dir:
+            print(
+                f"date_range: {args.date_from}〜{args.date_to}"
+                f"（{source_type or 'all'}, 0件 / 全0件）"
+            )
+            return
+        print(list_sources_by_date_range(
+            settings.source_store_dir,
+            args.date_from,
+            args.date_to,
+            source_type,
+            limit,
+            ascending=ascending,
             filters=parsed_filters,
         ))
 

--- a/src/rag/server/__init__.py
+++ b/src/rag/server/__init__.py
@@ -90,7 +90,11 @@ from .tools.ingest_aozora import (  # noqa: E402, F401
 from .tools.ingest_site import rag_site_ingest  # noqa: E402, F401
 from .tools.delete import rag_delete  # noqa: E402, F401
 from .tools.rebuild import rag_rebuild  # noqa: E402, F401
-from .tools.listing import rag_list_recent, rag_stats  # noqa: E402, F401
+from .tools.listing import (  # noqa: E402, F401
+    rag_list_by_date_range,
+    rag_list_recent,
+    rag_stats,
+)
 
 
 def __getattr__(name: str):  # type: ignore[no-untyped-def]

--- a/src/rag/server/tools/listing.py
+++ b/src/rag/server/tools/listing.py
@@ -68,6 +68,64 @@ async def rag_list_recent(
 
 
 @mcp.tool()
+async def rag_list_by_date_range(
+    date_from: str,
+    date_to: str,
+    source_type: str | None = None,
+    limit: int | None = None,
+    order: str = "desc",
+    filters: str | None = None,
+) -> str:
+    """[rag-knowledge] List sources by date range - 指定日付範囲のソースを横断取得する.
+
+    content listing, date range, published_at filter, cross source_type.
+    `published_at` の日付範囲（JST 解釈、両端 inclusive）で取り込み済みソースを
+    取得する。`source_type` 未指定時は全種別を横断する。特定日の作業内容を
+    journal / bluesky / zenn 等から一括取得するユースケースに使用する。
+
+    Args:
+        date_from: 開始日（YYYY-MM-DD、JST 起点で inclusive）
+        date_to: 終了日（YYYY-MM-DD、JST 起点で inclusive）
+        source_type: ソース種別（任意）。
+            指定時はそのタイプのみ。値は "web", "bluesky", "zenn", "youtube",
+            "aozora", "local", "journal"。未指定で全種別横断
+        limit: 取得件数（1〜100、未指定時は設定値を使用）
+        order: ソート順（"desc": 新しい順（デフォルト）, "asc": 古い順）
+        filters: メタデータフィルタ（key=value 形式、カンマ区切りで複数指定可）。
+            完全一致。未指定時はフィルタなし。
+
+    Returns:
+        ソース一覧テキスト（日付範囲ヘッダー + 各エントリに source_type を含む）
+    """
+    if source_type is not None and source_type not in _VALID_LISTING_SOURCE_TYPES:
+        valid = ", ".join(sorted(_VALID_LISTING_SOURCE_TYPES))
+        return f"無効な source_type: {source_type!r}（有効値: {valid}）"
+
+    if limit is not None and (limit < 1 or limit > 100):
+        return "エラー: limit は 1〜100 の範囲で指定してください"
+
+    if order not in ("asc", "desc"):
+        return f"エラー: order は 'asc' または 'desc' を指定してください（指定値: {order!r}）"
+
+    args: list[str] = ["--date-from", date_from, "--date-to", date_to]
+    if source_type is not None:
+        args.extend(["--source-type", source_type])
+    if limit is not None:
+        args.extend(["--limit", str(limit)])
+    args.extend(["--order", order])
+    if filters is not None:
+        args.extend(["--filters", filters])
+
+    try:
+        result = await cli_subprocess._run_cli_subprocess(
+            "list-by-date-range", args,
+        )
+        return _format_cli_list_by_date_range_result(result)
+    except CLISubprocessError as e:
+        return e.format_mcp_error("ソース一覧の取得に失敗しました")
+
+
+@mcp.tool()
 async def rag_stats() -> str:
     """[rag-knowledge] RAG stats - ナレッジベースの統計情報と蓄積データ概要を表示.
 
@@ -117,6 +175,46 @@ def _format_cli_list_recent_result(result: dict[str, Any]) -> str:
         lines.append(line)
         lines.append(f"  {source_id}")
 
+    return "\n".join(lines)
+
+
+def _format_cli_list_by_date_range_result(result: dict[str, Any]) -> str:
+    """CLI list-by-date-range の JSON 結果を MCP レスポンス文字列に変換する."""
+    sources = result.get("sources", [])
+    date_from = result.get("date_from", "")
+    date_to = result.get("date_to", "")
+    source_type = result.get("source_type") or "all"
+    count = result.get("count", len(sources))
+    total = result.get("total", count)
+    order = result.get("order", "desc")
+    order_label = "古い順" if order == "asc" else "新しい順"
+
+    if not sources:
+        return (
+            f"date_range: {date_from}〜{date_to}"
+            f"（{source_type}, 0件 / 全0件）"
+        )
+
+    lines = [
+        f"date_range: {date_from}〜{date_to}"
+        f"（{source_type}, {count}件 / 全{total}件, {order_label}）",
+    ]
+    for i, s in enumerate(sources, 1):
+        title = s.get("title", "(無題)")
+        s_type = s.get("source_type", "")
+        source_id = s.get("source_id", "")
+        published_at = s.get("published_at", "")
+        file_size = s.get("file_size", 0)
+        size_str = format_file_size(file_size) if file_size else ""
+        lines.append("")
+        lines.append(f"{i}. {title}")
+        if s_type:
+            lines.append(f"   Type: {s_type}")
+        lines.append(f"   Source: {source_id}")
+        if published_at:
+            lines.append(f"   Published: {published_at}")
+        if size_str:
+            lines.append(f"   Size: {size_str}")
     return "\n".join(lines)
 
 

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 import sqlite3
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,38 @@ logger = logging.getLogger(__name__)
 
 # json_extract の JSON パスに埋め込むキー名の許容パターン
 _VALID_FILTER_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+# naive datetime（TZ 情報なし）の published_at は JST として解釈する。
+# YouTube の upload_date 由来など、TZ 不在の値が混在することを想定。
+_JST_TZ = timezone(timedelta(hours=9))
+
+
+def normalize_published_at(value: str) -> str:
+    """published_at を UTC マイクロ秒 6 桁固定の ISO 8601 文字列に正規化する.
+
+    範囲フィルタを文字列比較で実装するため、表記揺れを吸収する。
+    冪等: 正規化済み出力（UTC マイクロ秒 6 桁固定）を再入力しても同じ値を返す。
+
+    入力例 → 出力例:
+        ""                                  → ""（空文字はそのまま）
+        "2026-01-15T00:00:00+09:00"         → "2026-01-14T15:00:00.000000+00:00"
+        "2026-01-15T00:00:00Z"              → "2026-01-15T00:00:00.000000+00:00"
+        "2026-01-15T00:00:00.123Z"          → "2026-01-15T00:00:00.123000+00:00"
+        "2026-01-15T00:00:00"               → "2026-01-14T15:00:00.000000+00:00"
+                                              （naive は JST 解釈）
+        "2026-01-14T15:00:00.000000+00:00"  → "2026-01-14T15:00:00.000000+00:00"
+                                              （正規化済み入力の冪等性）
+
+    Raises:
+        ValueError: ISO 8601 として解析できない場合
+    """
+    if not value:
+        return value
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_JST_TZ)
+    return dt.astimezone(UTC).isoformat(timespec="microseconds")
+
 
 # SQL 内の status リテラルは SourceStatus Enum の value から導出する。
 # 値定義の SSoT は _schema/enums.yml の source_status カテゴリ。
@@ -211,7 +244,71 @@ class MetadataDB:
                 "sources に meta 列を追加しました（%d 件充填）", filled,
             )
 
+        # published_at を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する。
+        # rag_list_by_date_range の範囲フィルタが文字列比較で時系列順と
+        # 一致するようにするため、書き込み入口（register_source/update_source）
+        # と既存データの書式を揃える。冪等性は「正規化後と一致する行はスキップ」
+        # で確保する（migrate を再実行しても二重書き込みは発生しない）。
+        normalized_count, skipped_count, error_count = self._normalize_published_at_column()
+        if normalized_count > 0:
+            applied.append(
+                f"sources の published_at を UTC マイクロ秒 6 桁固定 ISO 8601"
+                f" に正規化（{normalized_count} 件更新, {skipped_count} 件スキップ,"
+                f" {error_count} 件パース失敗）"
+            )
+        elif error_count > 0:
+            # 更新は発生しなかったがパース失敗があった場合も applied に残す
+            # （冪等な再実行で失敗が握り潰されないようにするため）
+            applied.append(
+                f"sources の published_at 正規化中にパース失敗 {error_count} 件"
+                "（詳細はログ参照、対象行は元値のまま）"
+            )
+
         return applied
+
+    def _normalize_published_at_column(self) -> tuple[int, int, int]:
+        """sources.published_at を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する.
+
+        既に正規化済み（normalize_published_at の出力と一致）の行は UPDATE しない。
+        パース不能な値はログ警告のみで UPDATE せず、`error_count` でカウントする。
+
+        Returns:
+            (更新件数, 既に正規化済みでスキップした件数, パース失敗でスキップした件数)
+        """
+        rows = self._connection.execute(
+            "SELECT source_id, published_at FROM sources"
+            " WHERE published_at != ''"
+        ).fetchall()
+        normalized_count = 0
+        skipped_count = 0
+        error_count = 0
+        for row in rows:
+            src_id = row["source_id"]
+            raw = row["published_at"]
+            try:
+                normalized = normalize_published_at(raw)
+            except ValueError as e:
+                logger.warning(
+                    "published_at 正規化失敗: source_id=%s, value=%r, error=%s",
+                    src_id, raw, e,
+                )
+                error_count += 1
+                continue
+            if normalized == raw:
+                skipped_count += 1
+                continue
+            self._connection.execute(
+                "UPDATE sources SET published_at = ? WHERE source_id = ?",
+                (normalized, src_id),
+            )
+            normalized_count += 1
+        if normalized_count > 0:
+            self._connection.commit()
+            logger.info(
+                "published_at を正規化しました: 更新=%d, スキップ=%d, 失敗=%d",
+                normalized_count, skipped_count, error_count,
+            )
+        return normalized_count, skipped_count, error_count
 
     def _fill_meta_from_files(
         self, source_store_dir: Path | None,
@@ -302,6 +399,19 @@ class MetadataDB:
         if not published_at:
             published_at = collected_at
 
+        # published_at を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する。
+        # 範囲フィルタ（list_sources_by_date_range）の文字列比較で表記揺れを吸収するため。
+        # 不正値は migrate 側と挙動を揃えてログ警告のみ（元値そのまま保持）とし、
+        # rebuild ループの途中で 1 件の不正値が残り全ソースの処理を止めないようにする。
+        try:
+            published_at = normalize_published_at(published_at)
+        except ValueError as e:
+            logger.warning(
+                "register_source: published_at の正規化に失敗（元値のまま保存）"
+                ": source_id=%s, value=%r, error=%s",
+                source_id, published_at, e,
+            )
+
         self._connection.execute(
             """\
             INSERT INTO sources
@@ -363,6 +473,20 @@ class MetadataDB:
         if invalid:
             msg = f"不正なフィールド: {invalid}"
             raise ValueError(msg)
+
+        # published_at は書き込み入口で UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する
+        # （範囲フィルタの文字列比較で表記揺れを吸収するため）。不正値は migrate 側と
+        # 挙動を揃えてログ警告のみ（元値そのまま保持）とし、書き込み入口の fail-fast
+        # で連鎖停止しないようにする。
+        if "published_at" in fields:
+            try:
+                fields["published_at"] = normalize_published_at(fields["published_at"])
+            except ValueError as e:
+                logger.warning(
+                    "update_source: published_at の正規化に失敗（元値のまま保存）"
+                    ": source_id=%s, value=%r, error=%s",
+                    source_id, fields["published_at"], e,
+                )
 
         set_clause = ", ".join(f"{k} = ?" for k in fields)
         values = list(fields.values())
@@ -671,6 +795,90 @@ class MetadataDB:
         if filters:
             self._build_meta_filter_conditions(filters, conditions, params)
 
+        where = " AND ".join(conditions)
+        row = self._connection.execute(
+            f"SELECT COUNT(*) as cnt FROM sources WHERE {where}",  # noqa: S608
+            params,
+        ).fetchone()
+        return int(row["cnt"]) if row else 0
+
+    def _build_date_range_conditions(
+        self,
+        *,
+        date_from_iso: str,
+        date_to_iso: str,
+        source_type: SourceType | None,
+        filters: dict[str, str] | None,
+    ) -> tuple[list[str], list[Any]]:
+        """published_at 範囲 + 任意の source_type + filters の WHERE 条件を構築する."""
+        conditions = ["status = ?", "published_at >= ?", "published_at <= ?"]
+        params: list[Any] = [_STATUS_ACTIVE, date_from_iso, date_to_iso]
+        if source_type is not None:
+            conditions.append("source_type = ?")
+            params.append(source_type)
+        if filters:
+            self._build_meta_filter_conditions(filters, conditions, params)
+        return conditions, params
+
+    def list_sources_by_date_range(
+        self,
+        *,
+        date_from_iso: str,
+        date_to_iso: str,
+        source_type: SourceType | None = None,
+        limit: int,
+        ascending: bool = False,
+        filters: dict[str, str] | None = None,
+    ) -> list[SourceRecord]:
+        """published_at 範囲で active ソースを取得する.
+
+        Args:
+            date_from_iso: 範囲下端の ISO 8601 文字列（inclusive）
+            date_to_iso: 範囲上端の ISO 8601 文字列（inclusive）
+            source_type: ソース種別（None で全種別横断）
+            limit: 取得件数
+            ascending: True で古い順、False で新しい順
+            filters: メタデータフィルタ（key=value 形式）
+
+        Raises:
+            ValueError: filters のキー名に不正な文字が含まれる場合
+        """
+        direction = "ASC" if ascending else "DESC"
+        conditions, params = self._build_date_range_conditions(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            source_type=source_type,
+            filters=filters,
+        )
+        where = " AND ".join(conditions)
+        params.append(limit)
+        rows = self._connection.execute(
+            f"SELECT * FROM sources WHERE {where}"  # noqa: S608
+            f" ORDER BY published_at {direction}"
+            " LIMIT ?",
+            params,
+        ).fetchall()
+        return [_row_to_source_record(r) for r in rows]
+
+    def count_sources_by_date_range(
+        self,
+        *,
+        date_from_iso: str,
+        date_to_iso: str,
+        source_type: SourceType | None = None,
+        filters: dict[str, str] | None = None,
+    ) -> int:
+        """published_at 範囲の active ソース件数を返す.
+
+        Raises:
+            ValueError: filters のキー名に不正な文字が含まれる場合
+        """
+        conditions, params = self._build_date_range_conditions(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            source_type=source_type,
+            filters=filters,
+        )
         where = " AND ".join(conditions)
         row = self._connection.execute(
             f"SELECT COUNT(*) as cnt FROM sources WHERE {where}",  # noqa: S608

--- a/tests/expected_tools.py
+++ b/tests/expected_tools.py
@@ -15,5 +15,5 @@ EXPECTED_MCP_TOOL_NAMES: frozenset[str] = frozenset({
     "rag_update_aozora_catalog", "rag_search_aozora",
     "rag_add_aozora", "rag_crawl_aozora",
     "rag_delete", "rag_rebuild", "rag_stats",
-    "rag_list_recent",
+    "rag_list_recent", "rag_list_by_date_range",
 })

--- a/tests/test_list_by_date_range.py
+++ b/tests/test_list_by_date_range.py
@@ -1,0 +1,403 @@
+"""rag_list_by_date_range / list-by-date-range のテスト.
+
+仕様: docs/specs/infrastructure/content-listing.md
+
+テスト方針 (計画ファイル: aidlc-docs/plan-work/issue-789.md):
+- MetadataDB.list_sources_by_date_range / count_sources_by_date_range の単体テスト
+- 範囲フィルタの JST 境界（date_from T00:00:00+09:00 〜 date_to T23:59:59.999999+09:00）
+- UTC 表記の published_at（`Z` 終端）が JST 解釈で正しく振り分けられること
+- source_type 指定有無（None で全種別横断）
+- filters・order・limit・0 件・論理削除除外
+- stats_port.list_sources_by_date_range 共通関数のフォーマット検証
+- バリデーション（YYYY-MM-DD 形式・date_from > date_to）
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rag.admin.stats_port import (
+    list_sources_by_date_range,
+    to_jst_range_iso,
+    validate_date_string,
+)
+from rag.store.metadata_db import MetadataDB
+from rag.store.models import SourceStatus
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> MetadataDB:
+    """テスト用 MetadataDB インスタンス."""
+    mdb = MetadataDB(tmp_path / "metadata.db")
+    mdb.initialize()
+    return mdb
+
+
+def _register(
+    db: MetadataDB,
+    source_id: str,
+    source_type: str = "web",
+    title: str = "Test",
+    collected_at: str = "2026-01-01T00:00:00Z",
+    published_at: str = "",
+    file_size: int = 1024,
+    status: str = "active",
+    meta: str = "{}",
+) -> None:
+    """テスト用ソース登録ヘルパー."""
+    db.register_source(
+        source_id=source_id,
+        source_type=source_type,
+        title=title,
+        content_hash="hash",
+        file_size=file_size,
+        collected_at=collected_at,
+        updated_at=collected_at,
+        published_at=published_at,
+        meta=meta,
+    )
+    if status == "deleted":
+        db.set_status(source_id, SourceStatus.DELETED)
+
+
+class TestValidateDateString:
+    """validate_date_string のテスト."""
+
+    def test_valid_date(self) -> None:
+        assert validate_date_string("2026-01-15", field_name="date_from") == "2026-01-15"
+
+    @pytest.mark.parametrize("value", [
+        "2026/01/15",
+        "20260115",
+        "2026-1-15",
+        "2026-01-15T00:00:00",
+        "",
+        "abc",
+    ])
+    def test_invalid_format(self, value: str) -> None:
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            validate_date_string(value, field_name="date_from")
+
+    def test_invalid_calendar(self) -> None:
+        with pytest.raises(ValueError, match="不正"):
+            validate_date_string("2026-13-01", field_name="date_from")
+
+
+class TestToJstRangeIso:
+    """to_jst_range_iso のテスト.
+
+    境界文字列は MetadataDB.published_at の正規化書式（UTC マイクロ秒 6 桁固定 ISO 8601）
+    に揃える。JST 2026-01-15 00:00:00.000000 → UTC 2026-01-14 15:00:00.000000、
+    JST 2026-01-15 23:59:59.999999 → UTC 2026-01-15 14:59:59.999999。
+    """
+
+    def test_basic_range(self) -> None:
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        assert date_from_iso == "2026-01-14T15:00:00.000000+00:00"
+        assert date_to_iso == "2026-01-15T14:59:59.999999+00:00"
+
+    def test_date_from_after_date_to(self) -> None:
+        with pytest.raises(ValueError, match="date_from"):
+            to_jst_range_iso("2026-01-16", "2026-01-15")
+
+    def test_invalid_format_propagates(self) -> None:
+        with pytest.raises(ValueError):
+            to_jst_range_iso("2026/01/15", "2026-01-15")
+
+
+class TestListSourcesByDateRange:
+    """MetadataDB.list_sources_by_date_range のテスト.
+
+    Note:
+        `_register` ヘルパは内部で `register_source` を呼ぶため、
+        テストデータの `published_at` は書き込み時に
+        `normalize_published_at()` で UTC マイクロ秒 6 桁固定 ISO 8601
+        に正規化されて格納される（例: 入力 `2026-01-15T00:00:00+09:00`
+        は格納時に `2026-01-14T15:00:00.000000+00:00` に変換）。
+        範囲境界（`to_jst_range_iso` の出力）も同書式に揃っているため、
+        SQLite の文字列比較で時系列順比較が成立する。
+    """
+
+    def test_empty(self, db: MetadataDB) -> None:
+        result = db.list_sources_by_date_range(
+            date_from_iso="2026-01-15T00:00:00.000000+09:00",
+            date_to_iso="2026-01-15T23:59:59.999999+09:00",
+            limit=10,
+        )
+        assert result == []
+
+    def test_inclusive_boundary_jst(self, db: MetadataDB) -> None:
+        """JST 境界の両端 inclusive を確認."""
+        _register(db, "start", published_at="2026-01-15T00:00:00+09:00")
+        _register(db, "mid", published_at="2026-01-15T12:00:00+09:00")
+        _register(db, "end", published_at="2026-01-15T23:59:59+09:00")
+        _register(db, "before", published_at="2026-01-14T23:59:59+09:00")
+        _register(db, "after", published_at="2026-01-16T00:00:00+09:00")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=10,
+            ascending=True,
+        )
+        assert [r.source_id for r in result] == ["start", "mid", "end"]
+
+    def test_utc_published_at_compared_at_jst_boundary(self, db: MetadataDB) -> None:
+        """`Z` 終端の UTC タイムスタンプも JST 境界での比較で正しく振り分く.
+
+        2026-01-15T00:00:00Z (= JST 2026-01-15 09:00) → 1/15 範囲に入る
+        2026-01-14T14:59:59Z (= JST 2026-01-14 23:59:59) → 1/15 範囲外
+        2026-01-15T15:00:00Z (= JST 2026-01-16 00:00) → 1/15 範囲外
+        """
+        _register(db, "early_utc_in", published_at="2026-01-15T00:00:00Z")
+        _register(db, "edge_jst_outside", published_at="2026-01-14T14:59:59Z")
+        _register(db, "edge_jst_next_day", published_at="2026-01-15T15:00:00Z")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=10,
+        )
+        ids = sorted(r.source_id for r in result)
+        assert ids == ["early_utc_in"]
+
+    def test_source_type_filter(self, db: MetadataDB) -> None:
+        _register(db, "j1", source_type="journal", published_at="2026-01-15T10:00:00+09:00")
+        _register(db, "b1", source_type="bluesky", published_at="2026-01-15T11:00:00+09:00")
+        _register(db, "z1", source_type="zenn", published_at="2026-01-15T12:00:00+09:00")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+
+        result_all = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=10,
+        )
+        assert sorted(r.source_id for r in result_all) == ["b1", "j1", "z1"]
+
+        result_journal = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            source_type="journal",
+            limit=10,
+        )
+        assert [r.source_id for r in result_journal] == ["j1"]
+
+    def test_order_desc_default(self, db: MetadataDB) -> None:
+        _register(db, "a", published_at="2026-01-15T01:00:00+09:00")
+        _register(db, "b", published_at="2026-01-15T05:00:00+09:00")
+        _register(db, "c", published_at="2026-01-15T10:00:00+09:00")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=10,
+        )
+        assert [r.source_id for r in result] == ["c", "b", "a"]
+
+    def test_limit(self, db: MetadataDB) -> None:
+        for i in range(5):
+            _register(
+                db, f"w{i}",
+                published_at=f"2026-01-15T{i:02d}:00:00+09:00",
+            )
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=2,
+        )
+        assert len(result) == 2
+
+    def test_excludes_deleted(self, db: MetadataDB) -> None:
+        _register(db, "active1", published_at="2026-01-15T10:00:00+09:00")
+        _register(db, "deleted1", published_at="2026-01-15T11:00:00+09:00", status="deleted")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            limit=10,
+        )
+        assert [r.source_id for r in result] == ["active1"]
+
+    def test_filters_by_meta(self, db: MetadataDB) -> None:
+        _register(
+            db, "j1",
+            source_type="journal",
+            published_at="2026-01-15T10:00:00+09:00",
+            meta=json.dumps({"repository": "rag-knowledge"}),
+        )
+        _register(
+            db, "j2",
+            source_type="journal",
+            published_at="2026-01-15T11:00:00+09:00",
+            meta=json.dumps({"repository": "other-repo"}),
+        )
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        result = db.list_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            filters={"repository": "rag-knowledge"},
+            limit=10,
+        )
+        assert [r.source_id for r in result] == ["j1"]
+
+    def test_filters_invalid_key(self, db: MetadataDB) -> None:
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        with pytest.raises(ValueError, match="フィルタキー名"):
+            db.list_sources_by_date_range(
+                date_from_iso=date_from_iso,
+                date_to_iso=date_to_iso,
+                filters={"bad-key!": "x"},
+                limit=10,
+            )
+
+
+class TestCountSourcesByDateRange:
+    """MetadataDB.count_sources_by_date_range のテスト."""
+
+    def test_count(self, db: MetadataDB) -> None:
+        for i in range(3):
+            _register(
+                db, f"w{i}",
+                published_at=f"2026-01-15T{i:02d}:00:00+09:00",
+            )
+        _register(db, "out", published_at="2026-01-16T00:00:00+09:00")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        assert db.count_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+        ) == 3
+
+    def test_count_with_source_type(self, db: MetadataDB) -> None:
+        _register(db, "j1", source_type="journal", published_at="2026-01-15T10:00:00+09:00")
+        _register(db, "b1", source_type="bluesky", published_at="2026-01-15T11:00:00+09:00")
+
+        date_from_iso, date_to_iso = to_jst_range_iso("2026-01-15", "2026-01-15")
+        assert db.count_sources_by_date_range(
+            date_from_iso=date_from_iso,
+            date_to_iso=date_to_iso,
+            source_type="journal",
+        ) == 1
+
+
+class TestListSourcesByDateRangeFormatter:
+    """stats_port.list_sources_by_date_range 共通関数のフォーマット検証."""
+
+    def test_empty_response(self, tmp_path: Path) -> None:
+        # 空 metadata.db を作成
+        db = MetadataDB(tmp_path / "metadata.db")
+        db.initialize()
+        db.close()
+
+        result = list_sources_by_date_range(
+            source_store_dir=str(tmp_path),
+            date_from="2026-01-15",
+            date_to="2026-01-15",
+            source_type=None,
+            limit=10,
+        )
+        assert "date_range: 2026-01-15〜2026-01-15" in result
+        assert "（all, 0件 / 全0件）" in result
+
+    def test_no_metadata_db(self, tmp_path: Path) -> None:
+        result = list_sources_by_date_range(
+            source_store_dir=str(tmp_path / "nonexistent"),
+            date_from="2026-01-15",
+            date_to="2026-01-15",
+            source_type=None,
+            limit=10,
+        )
+        assert "0件 / 全0件" in result
+
+    def test_invalid_date_format_returns_error(self, tmp_path: Path) -> None:
+        db = MetadataDB(tmp_path / "metadata.db")
+        db.initialize()
+        db.close()
+
+        result = list_sources_by_date_range(
+            source_store_dir=str(tmp_path),
+            date_from="2026/01/15",
+            date_to="2026-01-15",
+            source_type=None,
+            limit=10,
+        )
+        assert result.startswith("エラー:")
+        assert "YYYY-MM-DD" in result
+
+    def test_formatted_entries_include_type(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "metadata.db"
+        db = MetadataDB(db_path)
+        db.initialize()
+        db.register_source(
+            source_id="journal/test.md",
+            source_type="journal",
+            title="JournalEntry",
+            content_hash="h",
+            file_size=2048,
+            collected_at="2026-01-15T10:00:00+09:00",
+            updated_at="2026-01-15T10:00:00+09:00",
+            published_at="2026-01-15T10:00:00+09:00",
+            meta="{}",
+        )
+        db.register_source(
+            source_id="bluesky/post1",
+            source_type="bluesky",
+            title="Post",
+            content_hash="h2",
+            file_size=512,
+            collected_at="2026-01-15T11:00:00+09:00",
+            updated_at="2026-01-15T11:00:00+09:00",
+            published_at="2026-01-15T11:00:00+09:00",
+            meta="{}",
+        )
+        db.close()
+
+        result = list_sources_by_date_range(
+            source_store_dir=str(tmp_path),
+            date_from="2026-01-15",
+            date_to="2026-01-15",
+            source_type=None,
+            limit=10,
+        )
+        assert "date_range: 2026-01-15〜2026-01-15（all, 2件 / 全2件" in result
+        assert "Type: journal" in result
+        assert "Type: bluesky" in result
+        assert "JournalEntry" in result
+        assert "Post" in result
+
+    def test_formatted_with_source_type_filter(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "metadata.db"
+        db = MetadataDB(db_path)
+        db.initialize()
+        db.register_source(
+            source_id="journal/test.md",
+            source_type="journal",
+            title="JournalEntry",
+            content_hash="h",
+            file_size=2048,
+            collected_at="2026-01-15T10:00:00+09:00",
+            updated_at="2026-01-15T10:00:00+09:00",
+            published_at="2026-01-15T10:00:00+09:00",
+            meta="{}",
+        )
+        db.close()
+
+        result = list_sources_by_date_range(
+            source_store_dir=str(tmp_path),
+            date_from="2026-01-15",
+            date_to="2026-01-15",
+            source_type="journal",
+            limit=10,
+        )
+        assert "（journal, 1件 / 全1件" in result
+        assert "Type: journal" in result

--- a/tests/test_list_recent.py
+++ b/tests/test_list_recent.py
@@ -107,11 +107,13 @@ class TestListSources:
         assert result[1].source_id == "early_pub_late_collect"
 
     def test_published_at_fallback_to_collected_at(self, db: MetadataDB) -> None:
-        """published_at 未指定時は collected_at が使われる."""
+        """published_at 未指定時は collected_at が使われる（UTC マイクロ秒 6 桁固定 ISO 8601 に正規化される）."""
         _register(db, "no_pub", collected_at="2026-02-01T00:00:00Z")
 
         result = db.list_sources(source_type="web", limit=10)
-        assert result[0].published_at == "2026-02-01T00:00:00Z"
+        # register_source が published_at を normalize_published_at で正規化するため
+        # `Z` 終端は `+00:00` に統一され、マイクロ秒 6 桁が付与される
+        assert result[0].published_at == "2026-02-01T00:00:00.000000+00:00"
 
     def test_limit(self, db: MetadataDB) -> None:
         """limit で取得件数が制限される."""
@@ -227,7 +229,9 @@ class TestListRecentSources:
         assert "source_type: web（1件 / 全1件" in result
         assert "1. Sample Page" in result
         assert "Source: https://example.com/page" in result
-        assert "Published: 2026-06-15T10:30:00+09:00" in result
+        # published_at は register_source で UTC マイクロ秒 6 桁固定 ISO 8601 に正規化される
+        # JST 2026-06-15T10:30:00 → UTC 2026-06-15T01:30:00.000000+00:00
+        assert "Published: 2026-06-15T01:30:00.000000+00:00" in result
         assert "Size: 45.2 KB" in result
 
     def test_format_output_ascending(self, tmp_path: Path) -> None:

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -106,9 +106,10 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # 6件のマイグレーションが適用される
-        # (mode + filter_source_type + filter_path + published_at + file_path 移行 + meta)
-        assert len(applied) == 6
+        # 7件のマイグレーションが適用される
+        # (mode + filter_source_type + filter_path + published_at 列追加 + file_path 移行 + meta
+        #  + published_at の UTC 正規化)
+        assert len(applied) == 7
 
         # file_path カラムが削除されている
         cursor = db._connection.execute("PRAGMA table_info(sources)")
@@ -119,7 +120,8 @@ class TestMigrateExplicit:
         # source_id が file_path ベースに移行されている
         record = db.get_source("web/s1.html")
         assert record is not None
-        assert record.published_at == "2026-01-15T10:00:00Z"
+        # published_at が UTC マイクロ秒 6 桁固定 ISO 8601 に正規化されている
+        assert record.published_at == "2026-01-15T10:00:00.000000+00:00"
 
         # pipeline_history に mode / filter_source_type / filter_path 列が追加されている
         cursor = db._connection.execute("PRAGMA table_info(pipeline_history)")
@@ -166,7 +168,7 @@ class TestMigrateExplicit:
         db.initialize()
 
         first = db.migrate()
-        assert len(first) == 6
+        assert len(first) == 7
 
         second = db.migrate()
         assert len(second) == 0
@@ -224,13 +226,15 @@ class TestMigrateExplicit:
         db.initialize()
         applied = db.migrate()
 
-        # filter_source_type + filter_path + published_at + file_path 移行 + meta の 5 件
-        assert len(applied) == 5
+        # filter_source_type + filter_path + published_at 列追加 + file_path 移行 + meta
+        # + published_at UTC 正規化 = 6 件
+        assert len(applied) == 6
 
         for i in range(3):
             record = db.get_source(f"web/s{i}.html")
             assert record is not None
-            assert record.published_at == f"2026-01-{i+1:02d}T00:00:00Z"
+            # published_at が UTC マイクロ秒 6 桁固定 ISO 8601 に正規化されている
+            assert record.published_at == f"2026-01-{i+1:02d}T00:00:00.000000+00:00"
 
         db.close()
 
@@ -316,8 +320,8 @@ class TestMetaMigration:
         db.initialize()
         applied = db.migrate(source_store_dir=source_store)
 
-        # filter_source_type + filter_path + meta の 3 件
-        assert len(applied) == 3
+        # filter_source_type + filter_path + meta + published_at UTC 正規化 の 4 件
+        assert len(applied) == 4
         assert any("1 件" in m for m in applied)
 
         record = db.get_source("journal/repo-a/entry.md")
@@ -346,8 +350,8 @@ class TestMetaMigration:
         db.initialize()
         applied = db.migrate()
 
-        # filter_source_type + filter_path + meta の 3 件
-        assert len(applied) == 3
+        # filter_source_type + filter_path + meta + published_at UTC 正規化 の 4 件
+        assert len(applied) == 4
         assert any("0 件" in m for m in applied)
 
         record = db.get_source("local/test.md")


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装

## Summary

- 新規 MCP ツール `rag_list_by_date_range` を追加。`published_at` の日付範囲（JST 解釈、両端 inclusive）で取り込み済みソースを `source_type` 横断（任意指定）で取得できる
- CLI サブコマンド `list-by-date-range` を追加（MCP と同等のバリデーション・出力形式）
- 範囲フィルタの文字列比較を時系列順比較と一致させるため、`MetadataDB.register_source` / `update_source` の入口で `published_at` を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する `normalize_published_at()` を導入
- 既存データは `uv run python -m rag.cli migrate` で一括正規化（migrate サブコマンドに正規化ステップ追加、冪等）
- 既存 `rag_list_recent` の振る舞いは不変。`Published:` 表示は内部正規化により UTC マイクロ秒 6 桁固定 ISO 8601 表記になる
- 仕様書 `docs/specs/infrastructure/content-listing.md` に新ツール仕様・データ取得フロー・エッジケースを追記

## Test plan

- [x] L1 unit test: `tests/test_list_by_date_range.py` 新規 + 既存テスト追従修正、対象 4 ファイル 107 件 pass
- [x] ruff / mypy / markdownlint clean
- [x] L3 QA: real Zenn API で 10 記事（articles + scraps 計 20 件）取り込み → MCP `rag_list_by_date_range` で 5 月範囲 5 件・4 月 1 件・6 月 0 件・通年 17 件、source_type 絞り込み・order=asc・エラーケース（date_from>date_to / 不正フォーマット）全 OK、CLI と MCP の出力一致確認済み

## Related issues

Closes #789