### PR TITLE
fix(journal,source-store): ジャーナル published_at の JST→UTC 補正と migrate 責務再設計 (#795)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ HTTP モード（`/mcp` パスが必要）:
 | `list-recent` | 指定 source_type のソースを新しい順で一覧取得 |
 | `delete` | ソースをナレッジベースから論理削除 |
 | `rebuild` | ナレッジベースを再構築 |
-| `migrate` | metadata.db のスキーマをマイグレーション |
+| `migrate` | source_store のデータ補正（現在: journal の collected_at JST→UTC、Issue #795） |
 | `evaluate` | RAG 検索精度を評価 |
 | `init-test-db` | テスト用 ChromaDB・BM25 初期化 |
 | `generate-api-key` | Upload HTTP API 用の API キーを生成 |

--- a/docs/specs/infrastructure/content-listing.md
+++ b/docs/specs/infrastructure/content-listing.md
@@ -152,7 +152,6 @@ source_type: web（5件 / 全80件, 新しい順）
   - 例: `date_from=2026-01-15` → `2026-01-14T15:00:00.000000+00:00`
   - 例: `date_to=2026-01-15` → `2026-01-15T14:59:59.999999+00:00`
 - 表記揺れ（マイクロ秒の有無、`Z` vs `+09:00` 等の TZ オフセット表記差）は書き込み入口で吸収されるため、辞書順比較が時系列順比較と一致する
-- 既存データは `uv run python -m rag.cli migrate` を 1 回実行することで一括正規化される（初回適用後は冪等）
 - 範囲の両端は inclusive（`>=` / `<=`）
 
 出力:
@@ -326,7 +325,7 @@ flowchart TD
 | `published_at` が UTC（`Z` 終端）のソース | 書き込み入口で UTC マイクロ秒 6 桁固定 ISO 8601 に正規化済みのため、範囲境界との文字列比較が時系列順と一致する |
 | `published_at` が空文字列のソース | 書き込み入口で `collected_at` を fallback として適用するため通常は発生しない。万一空文字列が残った場合は範囲条件で除外される |
 | `published_at` が同一の複数ソース | ソート順序は不定 |
-| 同一 `source_id` の再取り込み | `register_source` の ON CONFLICT で `published_at` は **更新されない**（初回 INSERT 時の値が保持される）。再取り込みで `published_at` を更新したい場合は `update_source` で明示的に渡すか、`uv run python -m rag.cli migrate` を再実行する |
+| 同一 `source_id` の再取り込み | `register_source` の ON CONFLICT で `published_at` は **更新されない**（初回 INSERT 時の値が保持される）。再取り込みで `published_at` を更新したい場合は `update_source` で明示的に渡すか、`.meta` を書き換えて `rebuild --mode incremental` を実行する（META_ONLY 経路で `_handle_meta_only` が `update_source` を呼ぶ） |
 | 論理削除済みソース | 一覧に含めない（`status = 'active'` のみ対象） |
 | `filters` のキー名が不正 | エラーメッセージを返す |
 

--- a/docs/specs/ingesters/journal.md
+++ b/docs/specs/ingesters/journal.md
@@ -135,6 +135,23 @@ entry_id の決定権は本インジェスターに集約する（[content-uploa
 - 入力: `dir_path=/path/to/journal/`, `repository="rag-knowledge"`
 - `20260323-143000-session-summary.md` → `source_store/journal/rag-knowledge/20260323-143000-session-summary.md`
 
+### ファイル名の `YYYYMMDD-HHMMSS` プレフィックスの解釈
+
+外部由来（手動命名）のジャーナルファイル名に含まれる `YYYYMMDD-HHMMSS` プレフィックスは **JST 時刻として解釈** し、`collected_at` に保存する際は UTC に変換した ISO 8601 文字列とする。
+
+- 入力: ファイル名 `20260209-160629-retro.md`
+- 解釈: JST 2026-02-09 16:06:29 → UTC 2026-02-09 07:06:29
+- 保存: `collected_at: "2026-02-09T07:06:29+00:00"`
+- 境界例: ファイル名 `20260520-090000-noon.md` は JST 09:00:00 ちょうどとして解釈され、UTC 2026-05-20 00:00:00 に変換される（日付境界をまたぐが特別扱いなし）
+
+この JST→UTC 変換は、検索（`rag_list_by_date_range` 等）の JST 範囲フィルタが
+`published_at`（UTC マイクロ秒正規化済み）を JST に再換算する整合性を担保する。
+
+`migrate` CLI コマンドは、既存の `.meta` ファイルのうち JST 値が UTC タグ付けで
+保存されている行（数値完全一致 + マイクロ秒なし + `+00:00` 終端）を
+JST→UTC に再計算する補正処理を実行する。検出条件は `add-journal` 経路の
+正規データ（`datetime.now(UTC).isoformat()` 由来、マイクロ秒を含む）と構造的に区別される。
+
 ### .meta サイドカーファイル
 
 #### フィールド定義

--- a/docs/specs/pipeline-controller.md
+++ b/docs/specs/pipeline-controller.md
@@ -401,7 +401,7 @@ sequenceDiagram
 | コンバーターが予期しない例外を発生させたファイル | 該当ファイルのインデックス追加をスキップし、処理結果サマリの `errors` に `PipelineErrorEntry`（`{path, size_bytes, message, phase}`）として記録する。`ConversionFailedError`（JSON パースエラー等、ファイルが壊れている可能性がある失敗）は同じ `errors` 経路で捕捉するが、スタックトレース不要の想定される業務的失敗として `logger.error` で記録する（予期しない `Exception` は `logger.exception` でスタックトレース付き）。例外メッセージには `path` を含めず、`PipelineErrorEntry.path` フィールドと重複させない |
 | 大量のファイルが一度に変更された場合 | 全件を順次処理する。バッチサイズ制限は設けない |
 | source_store の git リポジトリが未初期化 | パイプライン初回実行時に `git init` を自動実行する |
-| .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータを更新する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |
+| .meta ファイルのみが変更された場合 | 拡張子 `.meta` で .meta ファイルを判定する。metadata.db のメタデータ（`title` / `collected_at` / `published_at` / `meta` JSON / `updated_at`）を `.meta` の値で更新する。`published_at` は `resolve_published_at` で source_type ごとの優先順位に従って導出する。コンバーターの再処理は行わない（データ本体に変更がないため）。インデックス側にメタデータ（title 等）を保持している場合は、インデクサーにメタデータ更新を指示する（チャンクの再生成は不要、メタデータのみ upsert） |
 | metadata.db の `status` が `deleted` のファイルが git diff に含まれる場合 | ファイルの変更種別に応じた処理を行う。`deleted` ステータスのファイルはインデックスに追加しない |
 | 再構築操作（全再構築・コンバートのみ・インデックスのみ）時に source_store に未コミットの変更がある場合 | エラーとして再構築を拒否する |
 | 差分更新時に source_store に未コミットの変更がある場合 | 自動コミットを実行してから差分更新を続行する |

--- a/docs/specs/source-store.md
+++ b/docs/specs/source-store.md
@@ -80,7 +80,11 @@ metadata.db、converted_store、検索インデックスは全て source_store �
 - SQLite WAL モードで運用する
 - metadata.db が破損した場合、source_store のファイルと `.meta` からの再構築が可能であること
 - バックアップ時は metadata.db の WAL をフラッシュするため、事前に `PRAGMA wal_checkpoint(TRUNCATE)` を実行すること
-- スキーマ変更（マイグレーション）は CLI `migrate` コマンドで明示的に実行する。`initialize()` はテーブル作成（`CREATE TABLE IF NOT EXISTS`）のみ行い、スキーマ変更は行わない
+- スキーマは `initialize()` のテーブル作成（`CREATE TABLE IF NOT EXISTS`）で最新形に揃える。旧スキーマからの移行コードは保持しない（単独運用前提・マイグレーション履歴の保全より最新スキーマへの追従を優先する運用方針）
+- CLI `migrate` コマンドは source_store の `.meta` データ補正に使用する。
+  `.meta` を書き換えた後、後続の `rebuild --mode incremental` が変更を検知して DB に反映する
+  （migrate 自体は DB を直接更新しない）。
+  現在の補正対象は journal の `collected_at` JST→UTC 変換のみ（Issue #795）
 
 本コンポーネントは外部 API 通信を行わないため、想定プロファイル・安全制約セクションは省略する。
 

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -736,7 +736,10 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     # migrate サブコマンド
     subparsers.add_parser(
         "migrate",
-        help="metadata.db のスキーマをマイグレーションする",
+        help=(
+            "source_store のデータ補正を実行する"
+            "（現在: journal の collected_at JST→UTC, Issue #795）"
+        ),
     )
 
     # stats サブコマンド

--- a/src/rag/pipeline/change_handler.py
+++ b/src/rag/pipeline/change_handler.py
@@ -142,12 +142,14 @@ class RealChangeHandler:
     async def _handle_meta_only(self, entry: ChangeEntry) -> None:
         """.meta のみ変更を処理する.
 
-        title・meta JSON に加え、`.meta` に `collected_at` が含まれていれば
-        `collected_at` / `published_at` も DB に反映する。
-        `published_at` は resolve_published_at で source_type ごとの
-        フィールド優先順位に従って導出する。
-        `.meta` に `collected_at` が無い場合は kwargs から除外して既存 DB 値を温存する
-        （`.meta` 手動編集等で一時的に欠落した場合に DB 上の正本を破壊しないため）。
+        `.meta` JSON と `updated_at` は常に反映する。`title` は `.meta` に値があれば
+        反映、`collected_at` / `published_at` は `.meta` に `collected_at` が含まれて
+        いれば反映する。各フィールドは独立条件で kwargs に積むため、`title` が空でも
+        他フィールドの反映はスキップされない。
+        `published_at` は resolve_published_at で source_type ごとのフィールド優先順位に
+        従って導出する。`.meta` に `collected_at` が無い場合は kwargs から除外して
+        既存 DB 値を温存する（`.meta` 手動編集等で一時的に欠落した場合に DB 上の正本を
+        破壊しないため）。
 
         `NO_META_TYPES`（local 等、`.meta` を持たない source_type）では DB 更新を
         スキップし、インデクサーのメタデータ更新のみ実行する。
@@ -161,31 +163,31 @@ class RealChangeHandler:
             meta_file = meta_path_for(full_path)
             if meta_file.exists():
                 meta_data = read_meta(full_path)
+                now = datetime.now(timezone.utc).isoformat()
+                meta_json = json.dumps(
+                    meta_data, ensure_ascii=False, default=str,
+                )
+                update_kwargs: dict[str, str] = {
+                    "updated_at": now,
+                    "meta": meta_json,
+                }
                 title = str(meta_data.get("title", ""))
                 if title:
-                    now = datetime.now(timezone.utc).isoformat()
-                    meta_json = json.dumps(
-                        meta_data, ensure_ascii=False, default=str,
+                    update_kwargs["title"] = title
+                if "collected_at" in meta_data:
+                    collected_at = str(meta_data["collected_at"])
+                    update_kwargs["collected_at"] = collected_at
+                    update_kwargs["published_at"] = resolve_published_at(
+                        source_type, meta_data, collected_at,
                     )
-                    update_kwargs: dict[str, str] = {
-                        "title": title,
-                        "updated_at": now,
-                        "meta": meta_json,
-                    }
-                    if "collected_at" in meta_data:
-                        collected_at = str(meta_data["collected_at"])
-                        update_kwargs["collected_at"] = collected_at
-                        update_kwargs["published_at"] = resolve_published_at(
-                            source_type, meta_data, collected_at,
-                        )
-                    try:
-                        self._db.update_source(source_id, **update_kwargs)
-                    except KeyError:
-                        logger.warning(
-                            "meta_only 更新対象が metadata.db にありません: %s",
-                            source_id,
-                        )
-                        return
+                try:
+                    self._db.update_source(source_id, **update_kwargs)
+                except KeyError:
+                    logger.warning(
+                        "meta_only 更新対象が metadata.db にありません: %s",
+                        source_id,
+                    )
+                    return
 
         # インデクサー: メタデータのみ更新
         metadata = self._metadata_builder.build_metadata(entry.file_path)

--- a/src/rag/pipeline/change_handler.py
+++ b/src/rag/pipeline/change_handler.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Protocol
 from rag.pipeline.models import ChangeEntry, ChangeStatus
 from rag.store.meta import meta_path_for, read_meta
 from rag.store.models import SourceStatus
+from rag.store.resolve import resolve_published_at
 from rag.store.source_store import NO_META_TYPES, detect_source_type
 
 if TYPE_CHECKING:
@@ -139,7 +140,18 @@ class RealChangeHandler:
         self._metadata_builder.register_in_db(entry.file_path)
 
     async def _handle_meta_only(self, entry: ChangeEntry) -> None:
-        """.meta のみ変更を処理する."""
+        """.meta のみ変更を処理する.
+
+        title・meta JSON に加え、`.meta` に `collected_at` が含まれていれば
+        `collected_at` / `published_at` も DB に反映する。
+        `published_at` は resolve_published_at で source_type ごとの
+        フィールド優先順位に従って導出する。
+        `.meta` に `collected_at` が無い場合は kwargs から除外して既存 DB 値を温存する
+        （`.meta` 手動編集等で一時的に欠落した場合に DB 上の正本を破壊しないため）。
+
+        `NO_META_TYPES`（local 等、`.meta` を持たない source_type）では DB 更新を
+        スキップし、インデクサーのメタデータ更新のみ実行する。
+        """
         source_id = self._metadata_builder.resolve_source_id(entry.file_path)
         source_type = detect_source_type(entry.file_path)
 
@@ -155,13 +167,19 @@ class RealChangeHandler:
                     meta_json = json.dumps(
                         meta_data, ensure_ascii=False, default=str,
                     )
-                    try:
-                        self._db.update_source(
-                            source_id,
-                            title=title,
-                            updated_at=now,
-                            meta=meta_json,
+                    update_kwargs: dict[str, str] = {
+                        "title": title,
+                        "updated_at": now,
+                        "meta": meta_json,
+                    }
+                    if "collected_at" in meta_data:
+                        collected_at = str(meta_data["collected_at"])
+                        update_kwargs["collected_at"] = collected_at
+                        update_kwargs["published_at"] = resolve_published_at(
+                            source_type, meta_data, collected_at,
                         )
+                    try:
+                        self._db.update_source(source_id, **update_kwargs)
                     except KeyError:
                         logger.warning(
                             "meta_only 更新対象が metadata.db にありません: %s",

--- a/src/rag/pipeline/ingesters/journal.py
+++ b/src/rag/pipeline/ingesters/journal.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import re
 import unicodedata
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 MAX_FILES_HARD_LIMIT = 500
 _ENTRY_ID_PATTERN = re.compile(r"^\d{8}-\d{6}-")
 _TOPIC_MAX_LENGTH = 50
+# ジャーナルファイル名の YYYYMMDD-HHMMSS プレフィックスは JST 時刻として解釈する。
+# 外部由来（手動命名）の既存ジャーナルが JST 想定で命名されているため。
+_JST_TZ = timezone(timedelta(hours=9))
 
 
 class JournalIngester(BaseIngester):
@@ -262,14 +265,16 @@ class JournalIngester(BaseIngester):
 def _parse_datetime_from_entry_id(entry_id: str) -> str | None:
     """ファイル名の YYYYMMDD-HHMMSS プレフィックスから ISO 8601 日時を生成する.
 
+    プレフィックスは JST 時刻として解釈し、UTC に変換した ISO 8601 文字列を返す。
+
     Returns:
-        ISO 8601 形式の日時文字列。パースできない場合は None。
+        UTC ISO 8601 形式の日時文字列。パースできない場合は None。
     """
     if not _ENTRY_ID_PATTERN.match(entry_id):
         return None
     try:
         dt = datetime.strptime(entry_id[:15], "%Y%m%d-%H%M%S")  # noqa: DTZ007
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=_JST_TZ).astimezone(timezone.utc)
         return dt.isoformat()
     except ValueError:
         return None

--- a/src/rag/store/metadata_db.py
+++ b/src/rag/store/metadata_db.py
@@ -8,7 +8,6 @@ WAL モードで運用し、source_store のファイルと .meta から再構�
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import sqlite3
@@ -60,6 +59,111 @@ def normalize_published_at(value: str) -> str:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=_JST_TZ)
     return dt.astimezone(UTC).isoformat(timespec="microseconds")
+
+
+# journal の YYYYMMDD-HHMMSS プレフィックスを検出する正規表現。
+_JOURNAL_ENTRY_TS_RE = re.compile(r"^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})")
+
+
+def _fix_journal_collected_at(
+    source_store_dir: Path,
+) -> tuple[int, int, int]:
+    """journal の .meta の collected_at を JST→UTC に補正する.
+
+    旧 ``migrate-journal`` CLI が ``datetime.strptime`` の naive 値に
+    ``replace(tzinfo=timezone.utc)`` でタグ付けしていたため、JST 値が
+    ``+00:00`` で保存されていた行を再計算する。
+
+    検出条件（誤検出を排除するため厳密にマッチさせる）:
+
+    - ファイル名プレフィックス ``YYYYMMDD-HHMMSS`` と ``collected_at`` の
+      先頭 19 文字（``YYYY-MM-DDTHH:MM:SS``）が完全一致
+    - ``collected_at`` がマイクロ秒部を含まない（小数点なし）
+    - ``collected_at`` の末尾が ``+00:00``
+
+    ``add-journal`` 経路の正規データは ``datetime.now(timezone.utc).isoformat()``
+    でマイクロ秒を含むため、この条件で誤検出しない。
+
+    Args:
+        source_store_dir: source_store のルートディレクトリ
+
+    Returns:
+        (補正件数, 既に正しい/対象外でスキップした件数, エラー件数)
+    """
+    from rag.store.meta import read_meta, write_meta
+
+    journal_dir = source_store_dir / "journal"
+    if not journal_dir.is_dir():
+        return (0, 0, 0)
+
+    fixed = 0
+    skipped = 0
+    errors = 0
+    # rglob の結果順序は OS 依存のためソートしてログ・テストの再現性を担保する
+    for meta_path in sorted(journal_dir.rglob("*.md.meta")):
+        # `.md.meta` → `.md` の対応データファイルパスを得る
+        data_path = meta_path.with_name(meta_path.name[: -len(".meta")])
+        entry_id = data_path.stem
+        m = _JOURNAL_ENTRY_TS_RE.match(entry_id)
+        if m is None:
+            skipped += 1
+            continue
+        # 1 件の .meta 異常で全件停止しないよう broad に捕捉してログ警告 + 件数集計に倒す。
+        # 想定例外は OSError / yaml.YAMLError / ValueError 系だが、想定外の例外も
+        # 握り潰さずスタックトレースを残すため exc_info=True とする。
+        try:
+            meta_dict = read_meta(data_path)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                ".meta ファイルの読み取りに失敗: %s", meta_path,
+                exc_info=True,
+            )
+            errors += 1
+            continue
+        raw = meta_dict.get("collected_at")
+        if not isinstance(raw, str):
+            skipped += 1
+            continue
+        # 検出条件: 19 文字数値一致 + マイクロ秒なし + +00:00 終端
+        y, mo, d, h, mi, s = m.groups()
+        expected_prefix = f"{y}-{mo}-{d}T{h}:{mi}:{s}"
+        if (
+            len(raw) != 25
+            or not raw.startswith(expected_prefix)
+            or "." in raw
+            or not raw.endswith("+00:00")
+        ):
+            skipped += 1
+            continue
+        # JST→UTC 変換: 数値部を JST として解釈し UTC に変換
+        try:
+            dt = datetime.strptime(  # noqa: DTZ007
+                expected_prefix, "%Y-%m-%dT%H:%M:%S",
+            ).replace(tzinfo=_JST_TZ).astimezone(UTC)
+        except ValueError:
+            logger.warning(
+                "collected_at のパースに失敗: %s value=%r", meta_path, raw,
+            )
+            errors += 1
+            continue
+        meta_dict["collected_at"] = dt.isoformat()
+        # write_meta の失敗も読み取り側と同様に broad 捕捉（理由は read_meta 側を参照）。
+        try:
+            write_meta(data_path, meta_dict)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                ".meta ファイルの書き込みに失敗: %s", meta_path,
+                exc_info=True,
+            )
+            errors += 1
+            continue
+        fixed += 1
+    if fixed > 0:
+        logger.info(
+            "journal の collected_at を JST→UTC 補正: 補正=%d, スキップ=%d, エラー=%d",
+            fixed, skipped, errors,
+        )
+    return (fixed, skipped, errors)
 
 
 # SQL 内の status リテラルは SourceStatus Enum の value から導出する。
@@ -127,238 +231,45 @@ class MetadataDB:
     def migrate(
         self, *, source_store_dir: Path | None = None,
     ) -> list[str]:
-        """既存テーブルのスキーマをマイグレーションする.
+        """source_store のデータ補正を実行する.
 
-        CLI の migrate コマンドから明示的に呼び出す。
-        initialize() からは呼び出されない。
-        各種機能は最新スキーマを前提とし、旧スキーマへのフォールバックは行わない。
+        CLI の migrate コマンドから明示的に呼び出す。initialize() からは呼び出されない。
+        DB スキーマは ``_SCHEMA_SQL`` で常に最新形に初期化される前提で、
+        旧スキーマからの移行コードは保持しない。
+
+        本実装は journal の `.meta` の `collected_at` を JST→UTC に補正する。
+        旧 `migrate-journal` CLI が naive datetime を UTC タグ付けで保存していた
+        バグデータを再計算する。DB 更新は本関数では行わず、後続の
+        `rag rebuild --mode incremental` が `.meta` 変更を検知して反映する。
 
         Args:
             source_store_dir: source_store のルートディレクトリ。
-                meta カラムマイグレーションで .meta ファイルを読み取るために必要。
+                journal の .meta を補正するために必要。None の場合は補正をスキップする。
 
         Returns:
-            適用されたマイグレーションの説明リスト（適用なしなら空リスト）
+            適用された処理の説明リスト（適用なしなら空リスト）
         """
         applied: list[str] = []
 
-        # pipeline_history に mode 列を追加（既存レコードは incremental 扱い）
-        cursor = self._connection.execute("PRAGMA table_info(pipeline_history)")
-        ph_columns = {row["name"] for row in cursor.fetchall()}
-        if "mode" not in ph_columns:
-            self._connection.execute(
-                "ALTER TABLE pipeline_history"
-                " ADD COLUMN mode TEXT NOT NULL DEFAULT 'incremental'"
+        if source_store_dir is None:
+            logger.warning(
+                "source_store_dir が未指定のため migrate の処理をスキップします"
             )
-            self._connection.commit()
-            applied.append("pipeline_history に mode 列を追加")
-            logger.info("pipeline_history に mode 列を追加しました")
+            return applied
 
-        # pipeline_history に filter_source_type / filter_path 列を追加
-        # （既存レコードは「未フィルタ」扱いで空文字列がデフォルト）
-        if "filter_source_type" not in ph_columns:
-            self._connection.execute(
-                "ALTER TABLE pipeline_history"
-                " ADD COLUMN filter_source_type TEXT NOT NULL DEFAULT ''"
-            )
-            self._connection.commit()
-            applied.append("pipeline_history に filter_source_type 列を追加")
-            logger.info(
-                "pipeline_history に filter_source_type 列を追加しました",
-            )
-        if "filter_path" not in ph_columns:
-            self._connection.execute(
-                "ALTER TABLE pipeline_history"
-                " ADD COLUMN filter_path TEXT NOT NULL DEFAULT ''"
-            )
-            self._connection.commit()
-            applied.append("pipeline_history に filter_path 列を追加")
-            logger.info(
-                "pipeline_history に filter_path 列を追加しました",
-            )
-
-        # sources に published_at 列を追加（既存レコードは collected_at で埋める）
-        cursor = self._connection.execute("PRAGMA table_info(sources)")
-        src_columns = {row["name"] for row in cursor.fetchall()}
-        if "published_at" not in src_columns:
-            self._connection.execute(
-                "ALTER TABLE sources"
-                " ADD COLUMN published_at TEXT NOT NULL DEFAULT ''"
-            )
-            self._connection.execute(
-                "UPDATE sources SET published_at = collected_at"
-                " WHERE published_at = ''"
-            )
-            self._connection.commit()
-            applied.append("sources に published_at 列を追加")
-            logger.info("sources に published_at 列を追加しました")
-
-        # source_id = file_path 統合: file_path カラムが残っている旧スキーマを移行
-        if "file_path" in src_columns:
-            # file_path を新 source_id として直接 INSERT（UPDATE での PK 衝突を回避）
-            self._connection.executescript(f"""\
-                DROP TABLE IF EXISTS sources_new;
-                CREATE TABLE sources_new (
-                    source_id    TEXT PRIMARY KEY,
-                    source_type  TEXT NOT NULL,
-                    title        TEXT NOT NULL,
-                    status       TEXT NOT NULL DEFAULT '{_STATUS_ACTIVE}',
-                    content_hash TEXT NOT NULL,
-                    file_size    INTEGER NOT NULL,
-                    collected_at TEXT NOT NULL,
-                    updated_at   TEXT NOT NULL,
-                    published_at TEXT NOT NULL DEFAULT ''
-                );
-                INSERT OR REPLACE INTO sources_new
-                    (source_id, source_type, title, status,
-                     content_hash, file_size, collected_at, updated_at, published_at)
-                    SELECT file_path, source_type, title, status,
-                           content_hash, file_size, collected_at, updated_at, published_at
-                    FROM sources;
-                DROP TABLE sources;
-                ALTER TABLE sources_new RENAME TO sources;
-            """)
-            self._connection.commit()
-            applied.append("sources の source_id を file_path ベースに移行")
-            logger.info(
-                "sources テーブルから file_path カラムを削除し"
-                " source_id を file_path ベースに移行しました"
-            )
-            # 再取得（テーブル再作成後のカラム情報を反映）
-            cursor = self._connection.execute("PRAGMA table_info(sources)")
-            src_columns = {row["name"] for row in cursor.fetchall()}
-
-        # sources に meta 列を追加し、.meta ファイルからデータを充填
-        if "meta" not in src_columns:
-            self._connection.execute(
-                "ALTER TABLE sources"
-                " ADD COLUMN meta TEXT NOT NULL DEFAULT '{}'"
-            )
-            self._connection.commit()
-
-            filled = self._fill_meta_from_files(source_store_dir)
+        fixed, skipped, errors = _fix_journal_collected_at(source_store_dir)
+        if fixed > 0:
             applied.append(
-                f"sources に meta 列を追加（{filled} 件の .meta データを充填）"
+                f"journal の .meta の collected_at を JST→UTC に補正"
+                f"（{fixed} 件補正, {skipped} 件スキップ, {errors} 件エラー）"
             )
-            logger.info(
-                "sources に meta 列を追加しました（%d 件充填）", filled,
-            )
-
-        # published_at を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する。
-        # rag_list_by_date_range の範囲フィルタが文字列比較で時系列順と
-        # 一致するようにするため、書き込み入口（register_source/update_source）
-        # と既存データの書式を揃える。冪等性は「正規化後と一致する行はスキップ」
-        # で確保する（migrate を再実行しても二重書き込みは発生しない）。
-        normalized_count, skipped_count, error_count = self._normalize_published_at_column()
-        if normalized_count > 0:
+        elif errors > 0:
             applied.append(
-                f"sources の published_at を UTC マイクロ秒 6 桁固定 ISO 8601"
-                f" に正規化（{normalized_count} 件更新, {skipped_count} 件スキップ,"
-                f" {error_count} 件パース失敗）"
-            )
-        elif error_count > 0:
-            # 更新は発生しなかったがパース失敗があった場合も applied に残す
-            # （冪等な再実行で失敗が握り潰されないようにするため）
-            applied.append(
-                f"sources の published_at 正規化中にパース失敗 {error_count} 件"
-                "（詳細はログ参照、対象行は元値のまま）"
+                f"journal の .meta 補正中にエラー {errors} 件"
+                "（詳細はログ参照、対象ファイルは元値のまま）"
             )
 
         return applied
-
-    def _normalize_published_at_column(self) -> tuple[int, int, int]:
-        """sources.published_at を UTC マイクロ秒 6 桁固定 ISO 8601 に正規化する.
-
-        既に正規化済み（normalize_published_at の出力と一致）の行は UPDATE しない。
-        パース不能な値はログ警告のみで UPDATE せず、`error_count` でカウントする。
-
-        Returns:
-            (更新件数, 既に正規化済みでスキップした件数, パース失敗でスキップした件数)
-        """
-        rows = self._connection.execute(
-            "SELECT source_id, published_at FROM sources"
-            " WHERE published_at != ''"
-        ).fetchall()
-        normalized_count = 0
-        skipped_count = 0
-        error_count = 0
-        for row in rows:
-            src_id = row["source_id"]
-            raw = row["published_at"]
-            try:
-                normalized = normalize_published_at(raw)
-            except ValueError as e:
-                logger.warning(
-                    "published_at 正規化失敗: source_id=%s, value=%r, error=%s",
-                    src_id, raw, e,
-                )
-                error_count += 1
-                continue
-            if normalized == raw:
-                skipped_count += 1
-                continue
-            self._connection.execute(
-                "UPDATE sources SET published_at = ? WHERE source_id = ?",
-                (normalized, src_id),
-            )
-            normalized_count += 1
-        if normalized_count > 0:
-            self._connection.commit()
-            logger.info(
-                "published_at を正規化しました: 更新=%d, スキップ=%d, 失敗=%d",
-                normalized_count, skipped_count, error_count,
-            )
-        return normalized_count, skipped_count, error_count
-
-    def _fill_meta_from_files(
-        self, source_store_dir: Path | None,
-    ) -> int:
-        """source_store の .meta ファイルを読み取り meta カラムに充填する.
-
-        Args:
-            source_store_dir: source_store のルートディレクトリ。
-                None の場合は充填をスキップする。
-
-        Returns:
-            充填した件数
-        """
-        if source_store_dir is None:
-            logger.warning(
-                "source_store_dir が未指定のため"
-                " meta カラムのデータ充填をスキップします"
-            )
-            return 0
-
-        from rag.store.meta import meta_path_for, read_meta
-
-        rows = self._connection.execute(
-            "SELECT source_id FROM sources WHERE meta = '{}'"
-        ).fetchall()
-
-        filled = 0
-        for row in rows:
-            source_id = row["source_id"]
-            file_path = source_store_dir / source_id
-            meta_file = meta_path_for(file_path)
-            if meta_file.exists():
-                try:
-                    meta_dict = read_meta(file_path)
-                    meta_json = json.dumps(
-                        meta_dict, ensure_ascii=False, default=str,
-                    )
-                    self._connection.execute(
-                        "UPDATE sources SET meta = ? WHERE source_id = ?",
-                        (meta_json, source_id),
-                    )
-                    filled += 1
-                except Exception:
-                    logger.warning(
-                        ".meta ファイルの読み取りに失敗: %s", source_id,
-                        exc_info=True,
-                    )
-
-        self._connection.commit()
-        return filled
 
     def __enter__(self) -> MetadataDB:
         return self

--- a/tests/test_journal_migration_datetime.py
+++ b/tests/test_journal_migration_datetime.py
@@ -1,7 +1,8 @@
 """journal migration のファイル名日時パースのテスト.
 
 テスト方針:
-- YYYYMMDD-HHMMSS パターンのファイル名から正しく日時が抽出される
+- YYYYMMDD-HHMMSS パターンのファイル名を JST として解釈し、UTC に変換した
+  ISO 8601 文字列が返ること（Issue #795）
 - パターンにマッチしないファイル名は None を返す
 """
 
@@ -13,15 +14,22 @@ from rag.pipeline.ingesters.journal import _parse_datetime_from_entry_id
 class TestParseDatetimeFromEntryId:
     """_parse_datetime_from_entry_id のテスト."""
 
-    def test_standard_entry_id(self) -> None:
-        """YYYYMMDD-HHMMSS-topic 形式から日時を抽出する."""
+    def test_standard_entry_id_jst_to_utc(self) -> None:
+        """YYYYMMDD-HHMMSS-topic 形式は JST 解釈で UTC に変換される."""
+        # JST 2026-04-04 01:20:30 → UTC 2026-04-03 16:20:30
         result = _parse_datetime_from_entry_id("20260404-012030-some-topic")
-        assert result == "2026-04-04T01:20:30+00:00"
+        assert result == "2026-04-03T16:20:30+00:00"
 
     def test_entry_id_without_topic(self) -> None:
         """YYYYMMDD-HHMMSS- のみ（トピック部分が短い）でもパース可能."""
+        # JST 2026-01-01 00:00:00 → UTC 2025-12-31 15:00:00
         result = _parse_datetime_from_entry_id("20260101-000000-x")
-        assert result == "2026-01-01T00:00:00+00:00"
+        assert result == "2025-12-31T15:00:00+00:00"
+
+    def test_jst_to_utc_crosses_date_boundary(self) -> None:
+        """JST 09:00:00 ちょうどは UTC 00:00:00 になる（日付境界の確認）."""
+        result = _parse_datetime_from_entry_id("20260520-090000-noon-jst")
+        assert result == "2026-05-20T00:00:00+00:00"
 
     def test_non_matching_entry_id(self) -> None:
         """パターンにマッチしないファイル名は None を返す."""

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -1,15 +1,21 @@
 """metadata.db マイグレーションのテスト.
 
 テスト方針:
-- migrate() を明示的に呼び出してスキーマ変更を適用
-- initialize() ではマイグレーションが走らないことを確認
-- published_at 列の追加、file_path → source_id 移行、meta 列追加を検証
+- migrate() の新ステップ「journal の .meta の collected_at JST→UTC 補正」を検証
+- 旧バグデータ（マイクロ秒なし + 数値完全一致 + +00:00 終端）のみ補正対象
+- マイクロ秒あり・数値不一致・他 TZ オフセット・非 journal は補正されない
+- 冪等: 再実行で 0 件
+- source_store_dir 未指定時は処理スキップ（applied 空）
+
+前提:
+- ヘルパー `_write_meta` は `yaml.safe_dump` で書き込み、`read_meta` 側の
+  `_normalize_timestamps` 経由で PyYAML が timestamp タグへ自動変換した datetime/date
+  を ISO 8601 文字列に再正規化する経路に依存する。テストはこの再正規化を前提に
+  collected_at の値を文字列として検証する。
 """
 
 from __future__ import annotations
 
-import json
-import sqlite3
 from pathlib import Path
 
 import yaml
@@ -17,345 +23,309 @@ import yaml
 from rag.store.metadata_db import MetadataDB
 
 
-class TestMigrateExplicit:
-    """明示的な migrate() 呼び出しのテスト."""
+def _write_meta(meta_path: Path, content: dict) -> None:
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        yaml.safe_dump(content, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
 
-    def test_initialize_does_not_run_migration(self, tmp_path: Path) -> None:
-        """initialize() だけではマイグレーションが走らない."""
-        db_path = tmp_path / "metadata.db"
 
-        # published_at なし + file_path ありの旧スキーマで DB を手動作成
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""\
-            CREATE TABLE sources (
-                source_id    TEXT PRIMARY KEY,
-                source_type  TEXT NOT NULL,
-                file_path    TEXT NOT NULL UNIQUE,
-                title        TEXT NOT NULL,
-                status       TEXT NOT NULL DEFAULT 'active',
-                content_hash TEXT NOT NULL,
-                file_size    INTEGER NOT NULL,
-                collected_at TEXT NOT NULL,
-                updated_at   TEXT NOT NULL
-            );
-            CREATE TABLE pipeline_history (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                from_commit_id TEXT NOT NULL,
-                to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL
-            );
-        """)
-        conn.execute(
-            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            ("s1", "web", "web/s1.html", "Title", "active",
-             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
-        )
-        conn.commit()
-        conn.close()
+def _read_collected_at(meta_path: Path) -> str:
+    return yaml.safe_load(meta_path.read_text(encoding="utf-8"))["collected_at"]
 
-        db = MetadataDB(db_path)
-        db.initialize()
 
-        # file_path カラムがまだ残っている（マイグレーション未適用）
-        cursor = db._connection.execute("PRAGMA table_info(sources)")
-        columns = {row["name"] for row in cursor.fetchall()}
-        assert "file_path" in columns
+class TestMigrateNoOp:
+    """無処理ケースのテスト."""
 
-        # source_id は旧値のまま（SQL で直接確認。get_source は旧スキーマでは動作しない）
-        row = db._connection.execute(
-            "SELECT source_id FROM sources WHERE source_id = ?", ("s1",)
-        ).fetchone()
-        assert row is not None
-
-        db.close()
-
-    def test_migrate_applies_all_migrations(self, tmp_path: Path) -> None:
-        """migrate() で全マイグレーションが適用される."""
-        db_path = tmp_path / "metadata.db"
-
-        # published_at なし + mode なし + file_path ありの最古スキーマ
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""\
-            CREATE TABLE sources (
-                source_id    TEXT PRIMARY KEY,
-                source_type  TEXT NOT NULL,
-                file_path    TEXT NOT NULL UNIQUE,
-                title        TEXT NOT NULL,
-                status       TEXT NOT NULL DEFAULT 'active',
-                content_hash TEXT NOT NULL,
-                file_size    INTEGER NOT NULL,
-                collected_at TEXT NOT NULL,
-                updated_at   TEXT NOT NULL
-            );
-            CREATE TABLE pipeline_history (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                from_commit_id TEXT NOT NULL,
-                to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL
-            );
-        """)
-        conn.execute(
-            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            ("s1", "web", "web/s1.html", "Title", "active",
-             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
-        )
-        conn.commit()
-        conn.close()
-
-        db = MetadataDB(db_path)
+    def test_migrate_without_source_store_dir_returns_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        """source_store_dir なしの場合は applied 空."""
+        db = MetadataDB(tmp_path / "metadata.db")
         db.initialize()
         applied = db.migrate()
-
-        # 7件のマイグレーションが適用される
-        # (mode + filter_source_type + filter_path + published_at 列追加 + file_path 移行 + meta
-        #  + published_at の UTC 正規化)
-        assert len(applied) == 7
-
-        # file_path カラムが削除されている
-        cursor = db._connection.execute("PRAGMA table_info(sources)")
-        columns = {row["name"] for row in cursor.fetchall()}
-        assert "file_path" not in columns
-        assert "published_at" in columns
-
-        # source_id が file_path ベースに移行されている
-        record = db.get_source("web/s1.html")
-        assert record is not None
-        # published_at が UTC マイクロ秒 6 桁固定 ISO 8601 に正規化されている
-        assert record.published_at == "2026-01-15T10:00:00.000000+00:00"
-
-        # pipeline_history に mode / filter_source_type / filter_path 列が追加されている
-        cursor = db._connection.execute("PRAGMA table_info(pipeline_history)")
-        ph_columns = {row["name"] for row in cursor.fetchall()}
-        assert "mode" in ph_columns
-        assert "filter_source_type" in ph_columns
-        assert "filter_path" in ph_columns
-
+        assert applied == []
         db.close()
 
-    def test_migrate_is_idempotent(self, tmp_path: Path) -> None:
-        """migrate() を2回呼んでも2回目は何もしない."""
-        db_path = tmp_path / "metadata.db"
-
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""\
-            CREATE TABLE sources (
-                source_id    TEXT PRIMARY KEY,
-                source_type  TEXT NOT NULL,
-                file_path    TEXT NOT NULL UNIQUE,
-                title        TEXT NOT NULL,
-                status       TEXT NOT NULL DEFAULT 'active',
-                content_hash TEXT NOT NULL,
-                file_size    INTEGER NOT NULL,
-                collected_at TEXT NOT NULL,
-                updated_at   TEXT NOT NULL
-            );
-            CREATE TABLE pipeline_history (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                from_commit_id TEXT NOT NULL,
-                to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL
-            );
-        """)
-        conn.execute(
-            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            ("s1", "web", "web/s1.html", "Title", "active",
-             "hash", 100, "2026-01-15T10:00:00Z", "2026-01-15T10:00:00Z"),
-        )
-        conn.commit()
-        conn.close()
-
-        db = MetadataDB(db_path)
-        db.initialize()
-
-        first = db.migrate()
-        assert len(first) == 7
-
-        second = db.migrate()
-        assert len(second) == 0
-
-        db.close()
-
-    def test_migrate_on_latest_schema(self, tmp_path: Path) -> None:
-        """最新スキーマの DB に対して migrate() は何もしない."""
-        db_path = tmp_path / "metadata.db"
-
-        db = MetadataDB(db_path)
-        db.initialize()
-
-        applied = db.migrate()
-        assert len(applied) == 0
-
-        db.close()
-
-    def test_migrate_multiple_records(self, tmp_path: Path) -> None:
-        """複数レコードの published_at が collected_at で埋まる."""
-        db_path = tmp_path / "metadata.db"
-
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""\
-            CREATE TABLE sources (
-                source_id    TEXT PRIMARY KEY,
-                source_type  TEXT NOT NULL,
-                file_path    TEXT NOT NULL UNIQUE,
-                title        TEXT NOT NULL,
-                status       TEXT NOT NULL DEFAULT 'active',
-                content_hash TEXT NOT NULL,
-                file_size    INTEGER NOT NULL,
-                collected_at TEXT NOT NULL,
-                updated_at   TEXT NOT NULL
-            );
-            CREATE TABLE pipeline_history (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                from_commit_id TEXT NOT NULL,
-                to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL,
-                mode           TEXT NOT NULL DEFAULT 'incremental'
-            );
-        """)
-        for i in range(3):
-            conn.execute(
-                "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (f"s{i}", "web", f"web/s{i}.html", f"Title {i}", "active",
-                 "hash", 100, f"2026-01-{i+1:02d}T00:00:00Z",
-                 f"2026-01-{i+1:02d}T00:00:00Z"),
-            )
-        conn.commit()
-        conn.close()
-
-        db = MetadataDB(db_path)
-        db.initialize()
-        applied = db.migrate()
-
-        # filter_source_type + filter_path + published_at 列追加 + file_path 移行 + meta
-        # + published_at UTC 正規化 = 6 件
-        assert len(applied) == 6
-
-        for i in range(3):
-            record = db.get_source(f"web/s{i}.html")
-            assert record is not None
-            # published_at が UTC マイクロ秒 6 桁固定 ISO 8601 に正規化されている
-            assert record.published_at == f"2026-01-{i+1:02d}T00:00:00.000000+00:00"
-
-        db.close()
-
-
-class TestMetaMigration:
-    """meta カラムマイグレーションのテスト."""
-
-    def _create_pre_meta_db(self, db_path: Path) -> None:
-        """meta カラムなしの DB を作成する."""
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""\
-            CREATE TABLE sources (
-                source_id    TEXT PRIMARY KEY,
-                source_type  TEXT NOT NULL,
-                title        TEXT NOT NULL,
-                status       TEXT NOT NULL DEFAULT 'active',
-                content_hash TEXT NOT NULL,
-                file_size    INTEGER NOT NULL,
-                collected_at TEXT NOT NULL,
-                updated_at   TEXT NOT NULL,
-                published_at TEXT NOT NULL DEFAULT ''
-            );
-            CREATE TABLE pipeline_history (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                from_commit_id TEXT NOT NULL,
-                to_commit_id   TEXT NOT NULL,
-                processed_at   TEXT NOT NULL,
-                mode           TEXT NOT NULL DEFAULT 'incremental'
-            );
-        """)
-        conn.close()
-
-    def test_migrate_adds_meta_column(self, tmp_path: Path) -> None:
-        """migrate() で meta カラムが追加される."""
-        db_path = tmp_path / "metadata.db"
-        self._create_pre_meta_db(db_path)
-
-        db = MetadataDB(db_path)
-        db.initialize()
-        applied = db.migrate()
-
-        # filter_source_type + filter_path + meta の 3 件
-        assert len(applied) == 3
-        assert any("meta" in m for m in applied)
-
-        cursor = db._connection.execute("PRAGMA table_info(sources)")
-        columns = {row["name"] for row in cursor.fetchall()}
-        assert "meta" in columns
-
-        db.close()
-
-    def test_migrate_fills_meta_from_files(self, tmp_path: Path) -> None:
-        """migrate() が .meta ファイルからデータを充填する."""
+    def test_migrate_with_no_journal_dir_returns_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        """journal ディレクトリが存在しない場合は applied 空."""
         source_store = tmp_path / "source_store"
         source_store.mkdir()
-        db_path = source_store / "metadata.db"
-        self._create_pre_meta_db(db_path)
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+        assert applied == []
+        db.close()
 
-        # ソースレコードを事前登録
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            ("journal/repo-a/entry.md", "journal", "Entry", "active",
-             "hash", 100, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z",
-             "2026-01-01T00:00:00Z"),
+    def test_migrate_on_clean_journal_returns_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        """補正対象がない（全て正常データ）の場合は applied 空."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260101-000000-entry.md").write_text("content")
+        # マイクロ秒あり = 正規データ → 補正対象外
+        _write_meta(
+            journal / "20260101-000000-entry.md.meta",
+            {
+                "title": "Entry",
+                "collected_at": "2026-01-01T00:00:00.123456+00:00",
+                "repository": "repo-a",
+            },
         )
-        conn.commit()
-        conn.close()
 
-        # .meta ファイルを作成
-        journal_dir = source_store / "journal" / "repo-a"
-        journal_dir.mkdir(parents=True)
-        (journal_dir / "entry.md").write_text("content")
-        meta_content = {
-            "title": "Entry",
-            "repository": "repo-a",
-            "collected_at": "2026-01-01T00:00:00Z",
-        }
-        with open(journal_dir / "entry.md.meta", "w", encoding="utf-8") as f:
-            yaml.safe_dump(meta_content, f)
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+        assert applied == []
+        db.close()
 
-        db = MetadataDB(db_path)
+
+class TestMigrateJSTtoUTC:
+    """JST→UTC 補正の本処理テスト."""
+
+    def test_buggy_meta_is_fixed(self, tmp_path: Path) -> None:
+        """検出条件マッチの .meta は JST→UTC に補正される."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260209-160629-retro.md").write_text("content")
+        # JST 16:06:29 を UTC タグで保存（旧バグ）
+        _write_meta(
+            journal / "20260209-160629-retro.md.meta",
+            {
+                "title": "retro",
+                "collected_at": "2026-02-09T16:06:29+00:00",
+                "repository": "repo-a",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
         db.initialize()
         applied = db.migrate(source_store_dir=source_store)
 
-        # filter_source_type + filter_path + meta + published_at UTC 正規化 の 4 件
-        assert len(applied) == 4
-        assert any("1 件" in m for m in applied)
+        assert len(applied) == 1
+        assert "1 件補正" in applied[0]
 
-        record = db.get_source("journal/repo-a/entry.md")
-        assert record is not None
-        meta = json.loads(record.meta)
-        assert meta["repository"] == "repo-a"
-
+        # JST 16:06:29 → UTC 07:06:29
+        fixed = _read_collected_at(journal / "20260209-160629-retro.md.meta")
+        assert fixed == "2026-02-09T07:06:29+00:00"
         db.close()
 
-    def test_migrate_without_source_store_dir(self, tmp_path: Path) -> None:
-        """source_store_dir なしでもカラム追加は行われる（データ充填はスキップ）."""
-        db_path = tmp_path / "metadata.db"
-        self._create_pre_meta_db(db_path)
-
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "INSERT INTO sources VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            ("local/test.md", "local", "Test", "active",
-             "hash", 10, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z",
-             "2026-01-01T00:00:00Z"),
+    def test_with_microseconds_is_not_fixed(self, tmp_path: Path) -> None:
+        """マイクロ秒ありは正規データ扱いで補正されない."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260513-202146-entry.md").write_text("content")
+        _write_meta(
+            journal / "20260513-202146-entry.md.meta",
+            {
+                "title": "entry",
+                "collected_at": "2026-05-13T11:22:58.466305+00:00",
+                "repository": "repo-a",
+            },
         )
-        conn.commit()
-        conn.close()
 
-        db = MetadataDB(db_path)
+        db = MetadataDB(source_store / "metadata.db")
         db.initialize()
-        applied = db.migrate()
+        applied = db.migrate(source_store_dir=source_store)
 
-        # filter_source_type + filter_path + meta + published_at UTC 正規化 の 4 件
-        assert len(applied) == 4
-        assert any("0 件" in m for m in applied)
+        assert applied == []
+        original = _read_collected_at(journal / "20260513-202146-entry.md.meta")
+        assert original == "2026-05-13T11:22:58.466305+00:00"
+        db.close()
 
-        record = db.get_source("local/test.md")
-        assert record is not None
-        assert record.meta == "{}"
+    def test_numeric_mismatch_is_not_fixed(self, tmp_path: Path) -> None:
+        """ファイル名と collected_at の数値が一致しないものは補正されない."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260219-115900session2-late-import.md").write_text("x")
+        _write_meta(
+            journal / "20260219-115900session2-late-import.md.meta",
+            {
+                "title": "late",
+                "collected_at": "2026-04-15T22:36:42+00:00",
+                "repository": "repo-a",
+            },
+        )
 
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        assert applied == []
+        db.close()
+
+    def test_non_utc_offset_is_not_fixed(self, tmp_path: Path) -> None:
+        """+00:00 以外の TZ オフセットは補正されない."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260209-160629-entry.md").write_text("x")
+        # 数値一致だが既に JST タグなら補正されない（既に正しい）
+        _write_meta(
+            journal / "20260209-160629-entry.md.meta",
+            {
+                "title": "e",
+                "collected_at": "2026-02-09T16:06:29+09:00",
+                "repository": "repo-a",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        assert applied == []
+        db.close()
+
+    def test_migrate_is_idempotent(self, tmp_path: Path) -> None:
+        """補正後に再実行すると 0 件（冪等性）."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260101-000000-entry.md").write_text("x")
+        _write_meta(
+            journal / "20260101-000000-entry.md.meta",
+            {
+                "title": "e",
+                "collected_at": "2026-01-01T00:00:00+00:00",
+                "repository": "repo-a",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+
+        first = db.migrate(source_store_dir=source_store)
+        assert len(first) == 1
+
+        second = db.migrate(source_store_dir=source_store)
+        assert second == []
+        db.close()
+
+    def test_non_journal_dir_is_not_touched(self, tmp_path: Path) -> None:
+        """非 journal ディレクトリの .meta は走査対象外で補正されない."""
+        source_store = tmp_path / "source_store"
+        # journal ディレクトリには補正対象を 1 件配置
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        (journal / "20260101-000000-entry.md").write_text("x")
+        _write_meta(
+            journal / "20260101-000000-entry.md.meta",
+            {
+                "title": "e",
+                "collected_at": "2026-01-01T00:00:00+00:00",
+                "repository": "repo-a",
+            },
+        )
+        # web ディレクトリには検出条件にマッチする「ように見える」値を配置（補正されないこと）
+        web = source_store / "web" / "example.com"
+        web.mkdir(parents=True)
+        (web / "20260101-000000.html").write_text("<html/>")
+        _write_meta(
+            web / "20260101-000000.html.meta",
+            {
+                "title": "page",
+                "collected_at": "2026-01-01T00:00:00+00:00",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        assert len(applied) == 1
+        assert "1 件補正" in applied[0]
+        # journal 配下は補正される
+        assert _read_collected_at(
+            journal / "20260101-000000-entry.md.meta"
+        ) == "2025-12-31T15:00:00+00:00"
+        # web 配下は不変
+        assert _read_collected_at(
+            web / "20260101-000000.html.meta"
+        ) == "2026-01-01T00:00:00+00:00"
+        db.close()
+
+    def test_invalid_date_value_counts_as_error(self, tmp_path: Path) -> None:
+        """ファイル名は数値形式だが datetime としてパース不能な値はエラーに計上される."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+        # 2026 年は閏年ではないが 02-29 のファイル名で配置
+        (journal / "20260229-000000-leap.md").write_text("x")
+        _write_meta(
+            journal / "20260229-000000-leap.md.meta",
+            {
+                "title": "leap",
+                # 検出条件を満たすが datetime としては不正な値（2026-02-29 は存在しない）
+                "collected_at": "2026-02-29T00:00:00+00:00",
+                "repository": "repo-a",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        # 補正 0 + エラー 1 → applied にエラーメッセージのみ
+        assert len(applied) == 1
+        assert "エラー 1 件" in applied[0]
+        # 元値は保持される
+        assert _read_collected_at(
+            journal / "20260229-000000-leap.md.meta"
+        ) == "2026-02-29T00:00:00+00:00"
+        db.close()
+
+    def test_multiple_files_mixed(self, tmp_path: Path) -> None:
+        """複数ファイルの混在（補正対象 + 対象外）が正しく分類される."""
+        source_store = tmp_path / "source_store"
+        journal = source_store / "journal" / "repo-a"
+        journal.mkdir(parents=True)
+
+        # 補正対象 2 件
+        for stem, ca in [
+            ("20260101-000000-a", "2026-01-01T00:00:00+00:00"),
+            ("20260202-120000-b", "2026-02-02T12:00:00+00:00"),
+        ]:
+            (journal / f"{stem}.md").write_text("x")
+            _write_meta(
+                journal / f"{stem}.md.meta",
+                {"title": stem, "collected_at": ca, "repository": "repo-a"},
+            )
+        # 対象外 1 件（マイクロ秒あり）
+        (journal / "20260303-090000-c.md").write_text("x")
+        _write_meta(
+            journal / "20260303-090000-c.md.meta",
+            {
+                "title": "c",
+                "collected_at": "2026-03-03T00:00:00.000000+00:00",
+                "repository": "repo-a",
+            },
+        )
+
+        db = MetadataDB(source_store / "metadata.db")
+        db.initialize()
+        applied = db.migrate(source_store_dir=source_store)
+
+        assert len(applied) == 1
+        assert "2 件補正" in applied[0]
+
+        # 補正対象は JST→UTC 変換
+        assert _read_collected_at(
+            journal / "20260101-000000-a.md.meta"
+        ) == "2025-12-31T15:00:00+00:00"
+        assert _read_collected_at(
+            journal / "20260202-120000-b.md.meta"
+        ) == "2026-02-02T03:00:00+00:00"
+        # 対象外は不変
+        assert _read_collected_at(
+            journal / "20260303-090000-c.md.meta"
+        ) == "2026-03-03T00:00:00.000000+00:00"
         db.close()

--- a/tests/test_metadata_db_migration.py
+++ b/tests/test_metadata_db_migration.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import yaml
 
+from rag.store.meta import read_meta
 from rag.store.metadata_db import MetadataDB
 
 
@@ -32,7 +33,10 @@ def _write_meta(meta_path: Path, content: dict) -> None:
 
 
 def _read_collected_at(meta_path: Path) -> str:
-    return yaml.safe_load(meta_path.read_text(encoding="utf-8"))["collected_at"]
+    # 本番経路と同じ `read_meta` を使い、PyYAML の timestamp 自動変換を
+    # `_normalize_timestamps` で ISO 8601 文字列に再正規化した値で検証する
+    data_path = meta_path.with_name(meta_path.name[: -len(".meta")])
+    return str(read_meta(data_path)["collected_at"])
 
 
 class TestMigrateNoOp:

--- a/tests/test_pipeline_controller.py
+++ b/tests/test_pipeline_controller.py
@@ -466,6 +466,12 @@ class TestRunIncremental:
         assert converter.converted == []
         # インデクサーはメタデータ更新のみ
         assert "web/example.com/page.html" in indexer.upserted
+        # DB の collected_at / published_at が .meta の値で更新される（Issue #795）
+        record = ctrl.db.get_source("web/example.com/page.html")
+        assert record is not None
+        assert record.collected_at == "2026-01-01T00:00:00+00:00"
+        # published_at は normalize_published_at でマイクロ秒 6 桁固定 UTC に正規化される
+        assert record.published_at == "2026-01-01T00:00:00.000000+00:00"
 
     async def test_error_skips_file_no_history(
         self,


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] feat: `_handle_meta_only` 拡張（collected_at / published_at 反映）
- [x] docs: 仕様書更新

## Summary

Issue #795 の修正。ジャーナル `.meta` の `collected_at` が JST 値を UTC タグで保存していたバグを解消する。

### 直接修正

- **`_parse_datetime_from_entry_id` (journal.py)**: ファイル名 `YYYYMMDD-HHMMSS` を **JST 解釈** で **UTC 変換** するよう修正（旧: naive datetime に `+00:00` 後付け）。将来の `migrate-journal` 実行で同じバグが再発しないよう ingest 経路を是正
- **`MetadataDB.migrate()` の中身を完全入れ替え**: 既存ステップ 1〜6（スキーマ移行 + published_at 正規化）+ ヘルパー（`_normalize_published_at_column` / `_fill_meta_from_files`）を削除し、journal の `.meta` JST→UTC 補正を新ステップとして実装。検出条件は「数値完全一致 + マイクロ秒なし + `+00:00` 終端」で `add-journal` 経路の正規データ（マイクロ秒あり）と構造的に区別
- **`migrate` の責務再設計**: `.meta` を書き換えるのみ、DB は触らない。後続の `rag rebuild --mode incremental` が `_auto_commit_for_incremental` で commit → `META_ONLY` 経路で DB に伝播

### 関連修正

- **`_handle_meta_only` 拡張 (change_handler.py)**: `.meta` 変更時に `collected_at` / `published_at` も `update_source` に渡す（機能不足の解消）。`.meta` 欠落時は kwargs から除外して既存 DB 値を温存（defensive）
- **仕様書更新**: journal.md, source-store.md, pipeline-controller.md, content-listing.md, README.md

## Test plan

- [x] L1 Unit Test: 81 passed（ファイル名 JST→UTC 変換 / 補正対象判定 / 冪等性 / 非 journal 除外 / ValueError 経路 / `_handle_meta_only` の collected_at/published_at 伝播）
- [x] ruff / mypy: All checks passed
- [x] markdownlint: 0 error
- [x] L3 本番相当 QA: 隔離サンプル 7 件（バグ 4 件 + 正常 3 件）で migrate 実行 → 4 件補正 / 3 件スキップ / 冪等性 OK / Issue 本文の再現ケース（`retro-graceful-shutdown`）の JST 換算が補正後に一致確認
- [x] code-reviewer / doc-reviewer 指摘 12 件対応 + 3 件現状維持判定

### 運用フロー（本 PR マージ後）

1. `rag migrate` 実行 → source_store の 528 件の `.meta` JST→UTC 補正
2. `rag rebuild --mode incremental` 実行 → `_auto_commit_for_incremental` で commit → META_ONLY 経路で DB の `collected_at` / `published_at` 反映

## Related issues

Closes #795