### PR TITLE
fix(site-ingest): 単一URL投入時のサイト全体クロール巻き込みを構造的に解消 (#797)

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -28,7 +28,7 @@ argument-hint: ""
 QA 検証グループ:
 
   A) Local    — add-document, crawl-documents, add-journal, migrate-journal
-  B) Web      — site-ingest（クロール + 複数URL）
+  B) Web      — site-crawl（クロール）と site-ingest（取得、リンク辿りなし）
   C) SNS      — crawl-zenn, crawl-bluesky
   D) YouTube  — ingest-youtube, ingest-youtube-playlist（実行前にユーザー確認）
   E) Aozora   — update-aozora-catalog, search-aozora, ingest-aozora
@@ -207,8 +207,8 @@ NG を検出した場合、Issue 起票を提案する。
 | A) Local | crawl-documents | リポジトリの `docs/specs/` ディレクトリ全体 |
 | A) Local | add-journal | `.qa/journal_add_test.md`（`--title "コンテンツ一覧取得機能の実装"` `--repository rag-knowledge`） |
 | A) Local | migrate-journal | `.qa/journals/`（古いジャーナル 10 件、`--repository rag-knowledge`） |
-| B) Web | site-ingest（クロール） | `https://www.stat.go.jp/`（`--max-pages 20`） |
-| B) Web | site-ingest（複数URL） | `https://www.stat.go.jp/data/jinsui/` と `https://www.stat.go.jp/data/roudou/` |
+| B) Web | site-crawl（クロール、リンク辿りあり） | `https://www.stat.go.jp/`（`--max-pages 20`） |
+| B) Web | site-ingest（取得、リンク辿りなし） | `https://www.stat.go.jp/data/jinsui/` と `https://www.stat.go.jp/data/roudou/` |
 | C) SNS | Zenn ユーザー | `testuser`（fake モード） / `rhythmcan`（real モード） |
 | C) SNS | BlueSky ハンドル | `rhythmcan.bsky.social` |
 | C) SNS | BlueSky --max-posts | `5`（メディア付き投稿を含むため増加） |
@@ -272,10 +272,15 @@ MCP 対応コマンド:
 
 | # | コマンド（CLI） | 期待結果 | 検証種別 |
 |---|----------------|---------|---------|
-| 1 | `site-ingest https://www.stat.go.jp/ --max-pages 20` | Scrapy クロールモード一括取り込み成功 | `ingest` |
-| 2 | `site-ingest https://www.stat.go.jp/data/jinsui/ https://www.stat.go.jp/data/roudou/` | 複数 URL モードで 2 件取得成功（クロールなし） | `ingest` |
+| 1 | `site-crawl https://www.stat.go.jp/ --max-pages 20` | Scrapy クロール（リンク辿りあり）で一括取り込み成功 | `ingest` |
+| 2 | `site-ingest https://www.stat.go.jp/data/jinsui/ https://www.stat.go.jp/data/roudou/` | 指定 2 URL を取得成功（リンク辿りが発生しないことを ingest 件数で確認: 取得 URL 数と配置件数が一致） | `ingest` |
+| 3 | `site-ingest https://www.stat.go.jp/data/jinsui/` | 単一 URL 投入で 1 件のみ取得成功（**サイト全体クロールが発動しないこと** を ingest 件数 = 1 で確認、Issue #797 回帰検証） | `ingest` |
 
-MCP 対応: `rag_site_ingest`（`url` パラメータ / `urls` パラメータ）
+MCP 対応: `rag_site_crawl`（クロール）/ `rag_site_ingest`（取得）
+
+**Issue #797 回帰検証ポイント:**
+
+- B-3 で配置件数が 1 件のみ（リンク辿りで増えていない）であることを確認する。複数件配置されている場合は no-crawl 経路が機能していない
 
 ### C) SNS
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ HTTP モード（`/mcp` パスが必要）:
 | `ingest-youtube-playlist` | YouTube プレイリストを一括取り込み |
 | `add-document` | ドキュメントファイルを取り込み |
 | `crawl-documents` | ディレクトリ内ドキュメントを一括取り込み |
-| `site-ingest` | Scrapy でサイトを一括取り込み（大規模サイト向け） |
+| `site-crawl` | Scrapy で単一 URL 起点にサイトをクロール（リンク辿りあり、大規模サイト向け） |
+| `site-ingest` | 指定 URL の Web ページを取得（リンク辿りなし、複数 URL 可） |
 | `update-aozora-catalog` | 青空文庫カタログを更新 |
 | `search-aozora` | 青空文庫カタログを検索 |
 | `ingest-aozora` | 青空文庫の作品を取り込み |
@@ -359,6 +360,20 @@ uv run python -m rag.cli rebuild --mode incremental
 >   （従来: 0 件配置の `IngestResult` を返す → 変更後: `ValueError`「人物 ID '...' がカタログに見つかりません」を送出）
 > - `add_work` 側（`rag_add_aozora` / `ingest-aozora`）の `book_id` 不一致時挙動と対称化。
 >   `person_id` がカタログに存在し取り込み可能作品が 0 件の場合（全作品が著作権あり等）は従来通り 0 件 `IngestResult` を返す
+>
+> **破壊的変更（Issue #797）**:
+>
+> - `site-ingest` の **入口分離**: クロール（リンク辿り）専用に CLI `site-crawl` / MCP `rag_site_crawl` を新設し、
+>   既存の `site-ingest` / `rag_site_ingest` は **指定 URL 取得（リンク辿りなし）** に再定義
+>   （単一 URL 投入で意図しないサイト全体クロールが発動する巻き込みバグの構造的解消）
+> - CLI: 旧 `--force` を `--restart` にリネーム（JOBDIR レジュームを使わず最初から再実行する意味を明示）
+> - CLI: 旧 `site-ingest <単一URL> --max-pages N` は `site-crawl <URL> --max-pages N` に書き換え必要。
+>   `--url-pattern` / `--max-pages` / `--restart`（旧 `--force`）は `site-ingest` 側から消滅し `site-crawl` 専用に
+> - MCP: 旧 `rag_site_ingest(url=..., url_pattern=..., max_pages=..., force=...)` 単一 URL クロール呼び出しは廃止。
+>   `rag_site_crawl(url=..., url_pattern=..., max_pages=..., restart=...)` に置換（`force` → `restart` も同時リネーム）
+> - MCP: `rag_site_ingest` は `urls: list[str]` のみを受け付け、`url` / クロール固有パラメータを **持たない**
+> - BlueSky 投稿内 URL の自動取り込みは取得入口（`WebDelegator.fetch_urls`）に固定され、
+>   投稿内 web URL が 1 本だけの場合でもクロール巻き込みは発生しない
 
 ## Journal CLI
 

--- a/docs/specs/infrastructure/fake-adapters/scrapy.md
+++ b/docs/specs/infrastructure/fake-adapters/scrapy.md
@@ -188,24 +188,25 @@ flowchart TB
 
 | ケース | 振る舞い |
 |---|---|
-| Fake Runner で `failure` シナリオ指定時 | `CrawlResult.success=False` / `exit_code=1` を返却。`WebIngester.crawl_urls` は Bridge を呼ばずに `no_output=True` で早期 return（jsonl_path が空のため） |
+| Fake Runner で `failure` シナリオ指定時 | `CrawlResult.success=False` / `exit_code=1` を返却。`WebIngester.crawl_url` / `WebIngester.fetch_urls` のどちらの入口でも Bridge を呼ばずに `no_output=True` で早期 return（jsonl_path が空のため） |
 | Fake Runner で `empty` シナリオ指定時 | JSONL が空のため Bridge が呼ばれても 0 件処理。`SiteIngestExecution.no_output=False`（jsonl は存在する）+ `ingest.placed=0` |
 | Fake Runner で `partial` シナリオ指定時 | Bridge が JSONL の invalid 行を `parse_errors` でカウント。`SiteIngestExecution.parse_errors > 0` |
 | 入力 URL が `test.invalid`（DNS 解決不可） | `validate_url` / `check_ssrf` で拒否される（DNS 解決失敗）。Fake テストでは `example.com` 等の実在ドメインを使うこと |
 | Fake モードで運用環境（本番）起動 | `_fake/` ディレクトリが production パッケージに含まれるため動作する。WARNING ログで `[FAKE MODE: web]` を明示 |
 | `RAG_SCRAPY_FAKE_FIXTURE_DIR` で指定したパスが存在しない | 起動時に `FileNotFoundError` で fail-fast |
-| MCP 応答ラベル | fake モード時、`rag_site_ingest` 応答冒頭に `[FAKE MODE: web]` を付与。Embedding fake も同時有効なら `[FAKE MODE: embedding]` も並列出力 |
+| MCP 応答ラベル | fake モード時、`rag_site_ingest` / `rag_site_crawl` 応答冒頭に `[FAKE MODE: web]` を付与。Embedding fake も同時有効なら `[FAKE MODE: embedding]` も並列出力 |
 | `RAG_WEB_FAKE_MODE` と `RAG_SCRAPY_FAKE_MODE` の両方が `.env` で明示 | `RAG_SCRAPY_FAKE_MODE` が優先（`_EnvLoader.model_validator` の派生は None の場合のみ）。**ただし `RAG_SCRAPY_FAKE_MODE` env は本 Issue では未公開**（必要になった時点で追加可能） |
 
 ## QA シナリオ（fake モード）
 
 QA スキルで実 Web アクセスなしで通すべき検証項目:
 
-1. **rag_site_ingest** の単一 URL モード（クロールモード）で取り込み完了
-2. **rag_site_ingest** の複数 URL モード（`urls` パラメータ）で取り込み完了
-3. **rag_crawl_bluesky** で web URL を含む投稿を取り込み → site-ingest 委譲経由で fake が動作（Bluesky 投稿内 URL 自動取り込みの結合 QA）
-4. MCP 応答冒頭に `[FAKE MODE: web]` ラベルが付与されていること（Embedding fake も同時有効なら `[FAKE MODE: embedding]` も並列出力）
-5. 起動ログに `[FAKE MODE: web] Web (scrapy) は FAKE モードで起動中` が出力されていること
+1. **rag_site_crawl**（クロール入口、リンク辿りあり）で取り込み完了
+2. **rag_site_ingest**（取得入口、リンク辿りなし）で複数 URL の取り込み完了
+3. **rag_site_ingest** に単一 URL を指定してもリンク辿りクロールが発動しないこと（Issue #797 回帰確認）
+4. **rag_crawl_bluesky** で web URL を含む投稿を取り込み → site-ingest 取得入口委譲経由（`WebDelegator.fetch_urls`、リンク辿りなし）で fake が動作。投稿内 web URL が 1 本だけでもサイト全体クロールが発生しないこと
+5. MCP 応答冒頭に `[FAKE MODE: web]` ラベルが付与されていること（Embedding fake も同時有効なら `[FAKE MODE: embedding]` も並列出力）
+6. 起動ログに `[FAKE MODE: web] Web (scrapy) は FAKE モードで起動中` が出力されていること
 
 QA 結果はジャーナル または Issue コメントに記録する。
 

--- a/docs/specs/ingesters/bluesky.md
+++ b/docs/specs/ingesters/bluesky.md
@@ -609,7 +609,7 @@ BlueSky 投稿内に含まれる URL を抽出し、URL の種別に応じて si
 | YouTube 動画 URL（対応する具体パターンは [youtube.md](youtube.md) を参照） | YoutubeDelegator.ingest_videos | YouTube 動画の字幕・文字起こしを取り込む |
 | 不正な YouTube 動画 URL（パターンには該当するが video_id 形式が不正） | エラー扱いでスキップ | site_ingest に流すと無駄な HTTP アクセスが発生し、リスクもあるため取り込まない。`errors` カウンタを増やし、`error_details` に記録する |
 | `bsky.app/profile/` | スキップ | BlueSky 投稿は既にインジェスト対象 |
-| 上記以外の HTTP/HTTPS URL | site_ingest（複数 URL モード） | Web ページをバッチ取得する。YouTube チャンネル URL（`/@handle`, `/c/`, `/channel/`）・プレイリスト URL（`/playlist?list=`）はこの分類に含まれる |
+| 上記以外の HTTP/HTTPS URL | site_ingest（取得入口、リンク辿りなし） | Web ページをバッチ取得する。`WebDelegator.fetch_urls` 経由で固定（Issue #797: リンク辿りクロールは絶対に発動させない）。YouTube チャンネル URL（`/@handle`, `/c/`, `/channel/`）・プレイリスト URL（`/playlist?list=`）はこの分類に含まれる |
 
 YouTube 動画 URL の判定は YouTube インジェスター側で SSoT として定義された判定関数を使用する。ここに URL パターンを直接列挙すると分類器（BlueSky 側）と抽出器（YouTube 側）で drift する恐れがあるため、参照リンクで一元化する。
 
@@ -625,7 +625,8 @@ YouTube 動画 URL の判定は YouTube インジェスター側で SSoT とし�
 1. 受け取った配置済み投稿の JSON から URL を一括抽出する
 2. 抽出した URL を重複排除する（同一 URL が複数投稿に出現する場合）
 3. URL 種別を判定し、Web / YouTube / スキップに分類する
-4. Web URL を全てバッチ収集し、site-ingest（複数 URL モード）の Python API を直接呼び出して取り込む。
+4. Web URL を全てバッチ収集し、`WebDelegator.fetch_urls`（site-ingest 取得入口、リンク辿りなし）の Python API を直接呼び出して取り込む。
+   - **クロール経路は使用しない**（Issue #797）。投稿内 web URL の件数によらず、リンク辿り（サイト配下の意図しない巻き込み）は構造的に発生しない
    - 子 CLI subprocess として起動しない理由: BlueSky 取り込みの呼び出し元 CLI が既に source_store の write_lock を保持しており、子プロセス側での再取得がロック競合で失敗するため
    - site-ingest 内部の Scrapy subprocess 起動は維持される（reactor 制約のため）
    - bridge 結果は新規配置（`placed`）と上書き（`overwritten`）を **内訳として分離** して BlueSky 側の集計に反映する（合算ではなく排他カウントを別キーで保持）
@@ -833,7 +834,7 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | 投稿内の URL が既に source_store に存在する | Web/YouTube インジェスターの既存の重複検出でスキップされる |
 | 投稿内の URL 先の取り込みに失敗 | エラーをログに記録してスキップする。BlueSky 投稿の取り込みには影響しない |
 | 同一 URL が複数投稿に出現 | URL 抽出時に重複排除し、1 回のみ取り込む |
-| URL 先が Safe Browsing で危険判定 | 複数 URL モードでは Safe Browsing チェックは実行されない（大量 URL への API 呼び出しは非現実的なため）。SSRF チェック（プライベート IP 拒否）のみ実行される |
+| URL 先が Safe Browsing で危険判定 | site_ingest 取得入口では Safe Browsing チェックは実行されない（大量 URL への API 呼び出しは非現実的なため）。SSRF チェック（プライベート IP 拒否）のみ実行される |
 | YouTube URL の字幕取得に失敗 | YouTube インジェスターの既存のエラーハンドリングでスキップされる |
 | 投稿内の URL が「不正な YouTube 動画 URL」（パターン該当・video_id 形式不正） | 警告ログを出力し、いずれのインジェスターにも委譲しない。詳細は「URL 種別判定と委譲先」を参照 |
 | Web URL が 0 件の場合 | site_ingest 呼び出しをスキップする |
@@ -846,7 +847,7 @@ AppView のベース URL は設定可能とし、デフォルトは `https://pub
 | `rag_add_bluesky` に指定された URL の投稿が未取り込み | 新規配置として扱う（`placed` に計上） |
 | `rag_add_bluesky` で `resolveHandle` が失敗 | エラーメッセージを返す（DID 解決なしには `getPosts` を呼べない） |
 | `rag_add_bluesky` で対象投稿に YouTube URL が含まれる | YouTube インジェスターに委譲して再取得する（振る舞いの詳細は [投稿取得フロー（rag_add_bluesky）](#投稿取得フローrag_add_bluesky) のステップ 8 を参照） |
-| `rag_add_bluesky` で対象投稿に Web URL が含まれる | site_ingest（複数 URL モード）に委譲して取得する。site_ingest の Bridge は既存ファイルを上書きするため、URL 先データの修復経路として機能する |
+| `rag_add_bluesky` で対象投稿に Web URL が含まれる | site_ingest（取得入口、リンク辿りなし）に委譲して取得する。site_ingest の Bridge は既存ファイルを上書きするため、URL 先データの修復経路として機能する |
 
 以下の `media_download` 系失敗はすべて `partial_failures` に計上する。投稿 JSON 自体の取り込みには影響しない（親成功）:
 

--- a/docs/specs/rag-knowledge.md
+++ b/docs/specs/rag-knowledge.md
@@ -255,7 +255,7 @@ flowchart TD
 | `tools/ingest_youtube.py` | `rag_add_youtube`, `rag_crawl_youtube` |
 | `tools/ingest_local.py` | `rag_add_document`, `rag_crawl_documents`, `rag_add_journal` |
 | `tools/ingest_aozora.py` | `rag_update_aozora_catalog`, `rag_search_aozora`, `rag_add_aozora`, `rag_crawl_aozora` |
-| `tools/ingest_site.py` | `rag_site_ingest` |
+| `tools/ingest_site.py` | `rag_site_ingest`, `rag_site_crawl` |
 | `tools/delete.py` | `rag_delete` |
 | `tools/rebuild.py` | `rag_rebuild` |
 | `tools/listing.py` | `rag_list_recent`, `rag_stats` |
@@ -404,16 +404,27 @@ YouTube プレイリスト内の動画を一括取り込みする。詳細は [i
 
 #### rag_site_ingest
 
-Scrapy subprocess で対象サイトをクロールし、source_store に配置後、パイプライン処理を実行する。単一 URL はリンク追従クロール、複数 URL は指定 URL のみ取得。詳細は [site-ingest.md](site-ingest.md) を参照。
+指定 URL の Web ページを取得（リンク辿りなし）し source_store に配置後、パイプライン処理を実行する。
+リンク辿りクロールが必要な場合は [`rag_site_crawl`](#rag_site_crawl) を使用する
+（Issue #797 で入口分離。単一 URL 投入での意図しないサイト全体クロールを構造的に防止）。
+詳細は [site-ingest.md](site-ingest.md) を参照。
 
 | 引数 | 型 | 必須 | デフォルト | 説明 |
 |------|-----|------|-----------|------|
-| `url` | str | No | `""` | クロール開始 URL（クロールモード、`urls` と排他） |
-| `urls` | list[str] \| None | No | None | 取得対象 URL のリスト（複数 URL モード、`url` と排他） |
-| `url_pattern` | str | No | `""` | URL フィルタパターン（正規表現、クロールモードのみ） |
-| `max_pages` | int \| None | No | None（設定値を使用） | ページ数上限（クロールモードのみ） |
-| `force` | bool | No | `false` | JOBDIR を削除して最初からクロール（クロールモードのみ） |
-| `skip_pipeline` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行（CLI の `--skip-pipeline` と等価。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様)）|
+| `urls` | list[str] | Yes | — | 取得対象 URL のリスト（1 件以上必須） |
+| `skip_pipeline` | bool | No | `false` | パイプライン処理をスキップし、Scrapy 取得 + Bridge のみ実行（共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様)）|
+
+#### rag_site_crawl
+
+Scrapy subprocess で開始 URL からリンクを辿ってサイトをクロールし、source_store に配置後、パイプライン処理を実行する。詳細は [site-ingest.md](site-ingest.md) を参照。
+
+| 引数 | 型 | 必須 | デフォルト | 説明 |
+|------|-----|------|-----------|------|
+| `url` | str | Yes | — | クロール開始 URL（単一） |
+| `url_pattern` | str | No | `""` | URL フィルタパターン（正規表現） |
+| `max_pages` | int \| None | No | None（設定値を使用） | ページ数上限 |
+| `restart` | bool | No | `false` | JOBDIR + 一時 HTML/JSONL を削除して最初から再クロール |
+| `skip_pipeline` | bool | No | `false` | パイプライン処理をスキップし、Scrapy クロール + Bridge のみ実行 |
 
 #### rag_delete
 
@@ -483,7 +494,7 @@ Scrapy subprocess で対象サイトをクロールし、source_store に配置�
 ### 取り込みツールの出力形式
 
 取り込みツール（rag_crawl_zenn、rag_crawl_bluesky、rag_add_youtube、rag_crawl_youtube、
-rag_add_document、rag_crawl_documents、rag_add_journal、rag_site_ingest、
+rag_add_document、rag_crawl_documents、rag_add_journal、rag_site_ingest、rag_site_crawl、
 rag_add_aozora、rag_crawl_aozora）は、
 source_store への配置結果とパイプライン処理結果を統合したサマリーを返す。
 配置結果には配置ファイル数・スキップ数・エラー数を含み、
@@ -626,7 +637,8 @@ MCP サーバーの全ツールは CLI サブプロセスに委譲する。設�
 | `rag_add_document` | `add-document` | stdin 入力（後述） |
 | `rag_crawl_documents` | `crawl-documents` | |
 | `rag_add_journal` | `add-journal` | stdin 入力（後述） |
-| `rag_site_ingest` | `site-ingest` | |
+| `rag_site_ingest` | `site-ingest` | bulk 対応 (`urls: list[str]`)、リンク辿りなし |
+| `rag_site_crawl` | `site-crawl` | 単一 URL 起点クロール（Issue #797 で新設） |
 | `rag_add_aozora` | `ingest-aozora` | bulk 対応 (`book_ids: list[str]`) |
 | `rag_crawl_aozora` | `ingest-aozora-author` | |
 | `rag_delete` | `delete` | bulk 対応 (`source_ids: list[str]`) |

--- a/docs/specs/site-ingest.md
+++ b/docs/specs/site-ingest.md
@@ -2,23 +2,23 @@
 
 ## 概要
 
-Scrapy を subprocess 方式で起動し、Web ページを一括取り込みする機能。2 つの動作モードを提供する:
+Scrapy を subprocess 方式で起動し、Web ページを一括取り込みする機能。**入口を 2 つに物理分離** して提供する（Issue #797 で件数ヒューリスティック起因の意図しないクロール巻き込みを構造的に排除）:
 
-- **クロールモード**（単一 URL）: 開始 URL からリンクを辿り、数千ページ規模の大規模サイトを一括取り込みする
-- **複数 URL モード**（複数 URL）: 指定された URL のみを取得する（リンク辿りなし）。BlueSky インジェスターの URL 先取り込み等、バッチ取得に使用する
+- **クロール入口**: CLI `site-crawl` / MCP `rag_site_crawl` — 単一 URL を起点にリンクを辿り、数千ページ規模の大規模サイトを一括取り込みする。クロール固有オプション（`--url-pattern` / `--max-pages` / `--restart`）を持つ
+- **取得入口**: CLI `site-ingest` / MCP `rag_site_ingest` — 指定された URL リストのみを取得する（リンク辿りなし）。複数 URL OK。BlueSky インジェスターの URL 先取り込み等、バッチ取得に使用する。クロール固有オプションは持たない
 
-Scrapy の汎用 Spider でページを取得し、HTML ファイルとメタデータ JSONL をブリッジ層で source_store に変換した後、パイプライン制御で converter → indexer を実行する。
+両入口とも内部では同じ Scrapy Spider / Runner / Bridge を共有するが、引数の系統が物理的に分かれているため、件数や曖昧なヒューリスティックでモードが切り替わることはない。BlueSky 投稿内 URL の自動取り込みは取得入口に固定する。
 
-MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つのインターフェースを提供する。
+**用語**: 本仕様では「**入口**」を CLI / MCP の外部公開コマンド/ツール名の文脈で使い、「**モード**」を Runner 内部の引数判定（`start_url` / `start_urls`）の文脈で使う。両者は 1:1 対応する（クロール入口 ⇔ クロールモード、取得入口 ⇔ 取得モード）。
 
 スコープ:
 
-- Scrapy subprocess によるサイトクロール / 複数 URL 一括取得
+- Scrapy subprocess によるサイトクロール（単一 URL 起点） / 複数 URL 一括取得
 - 汎用 Spider のパラメータ化（URL、ドメイン制約、URL パターン）
 - JSONL メタデータ + HTML ファイルの一時保存
 - ブリッジ層による一時保存データから source_store への変換・配置
-- JOBDIR による中断再開（クロールモードのみ）
-- MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の提供
+- JOBDIR による中断再開（クロール入口のみ）
+- MCP ツール `rag_site_crawl` / `rag_site_ingest` と CLI コマンド `site-crawl` / `site-ingest` の提供
 
 スコープ外:
 
@@ -53,20 +53,17 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 ### ドメイン制約
 
-- **クロールモード**: Scrapy の `allowed_domains` により、クロール対象を開始 URL と同一ドメインに制限する。リンク辿りで発見された URL は同一ドメイン制約で自動的に制限される
-- **複数 URL モード**: 全 URL のドメインの和集合を `allowed_domains` に設定する。リンク辿りは行わないため、指定 URL 以外のページは取得されない
+- **クロール入口（`site-crawl` / `rag_site_crawl`）**: Scrapy の `allowed_domains` により、クロール対象を開始 URL と同一ドメインに制限する。リンク辿りで発見された URL は同一ドメイン制約で自動的に制限される
+- **取得入口（`site-ingest` / `rag_site_ingest`）**: 全 URL のドメインの和集合を `allowed_domains` に設定する。リンク辿りは行わないため、指定 URL 以外のページは取得されない
 
-### 複数 URL モード
+### モード判定（入口分離による物理切替）
 
-- `urls` パラメータで 2 つ以上の URL を指定した場合、複数 URL モードで動作する
-- 指定された URL のみを取得し、リンク辿り（クロール）は行わない
-- `url_pattern` は無視される（パターンフィルタ不要）
-- `max_pages` は無視される（取得ページ数 = 指定 URL 数）
-- JOBDIR によるレジュームは使用しない（指定 URL を毎回取得する）
-- `--force` は無効（JOBDIR が存在しないため）
-- 単一 URL 指定時（`url` パラメータ、または `urls` が 1 件のみ）は既存のクロール動作を維持する
+モードは **入口（コマンド／ツール）の物理分離** で切り替える。Runner 内部の引数も `start_url`（クロール）と `start_urls`（取得）の 2 系統に明示分離され、同時指定は ValueError。Issue #797 以前の「件数で自動判定（URL 1 件 → クロール、2 件以上 → 取得）」は廃止済み。
 
-### パスプレフィックス制約
+- **クロール入口**: 単一 URL を必須引数とする。`--url-pattern` / `--max-pages` / `--restart` を受け付ける
+- **取得入口**: 1 件以上の URL リストを必須引数とする。クロール固有オプションは存在しない（引数として受け付けない）。リンク辿りは行わず、JOBDIR は使用しない（取得対象 URL = 配置 URL）
+
+### パスプレフィックス制約（クロール入口のみ）
 
 - `url_pattern` が未指定の場合、開始 URL のパスプレフィックスから正規表現パターンを自動生成する
 - 例: `https://example.com/docs/` → `^https://example\.com/docs(?:/|$)`
@@ -82,7 +79,8 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 ### Safe Browsing チェック
 
-- 数千件規模の URL に対する Google Safe Browsing API 呼び出しは非現実的なためスキップする
+- クロール入口（`rag_site_crawl`）の起点 URL に対してのみ Google Safe Browsing API を呼び出す
+- 取得入口（`rag_site_ingest`）では数十〜数百件の URL を受ける可能性があるため、Safe Browsing 呼び出しはスキップする
 - SSRF チェックは 2 層で実施する:
   1. **初回 URL チェック**: ユーザー入力の開始 URL に対して、クロール開始前に `check_ssrf` で検証する
   2. **per-request チェック**: Scrapy Downloader Middleware で、各リクエストの送信前に DNS 解決 → IP 検証を実行する。DNS リバインディング攻撃（初回解決時はパブリック IP、実際のリクエスト時にプライベート IP に切り替わる手法）に対応する
@@ -142,42 +140,51 @@ MCP ツール `rag_site_ingest` と CLI コマンド `site-ingest` の 2 つの�
 
 | ツール | 入力 | 振る舞い |
 |--------|------|---------|
-| `rag_site_ingest` | `url` または `urls`（排他）、`url_pattern`（任意）、`max_pages`（任意）、`force`（任意）、`skip_pipeline`（任意） | Scrapy subprocess でページを取得し、HTML を source_store に配置後、パイプライン処理を実行する（`skip_pipeline=true` 時はパイプライン処理をスキップ）。結果サマリー（取得ページ数、エラー数、所要時間）を返す |
+| `rag_site_crawl` | `url`、`url_pattern`（任意）、`max_pages`（任意）、`restart`（任意）、`skip_pipeline`（任意） | Scrapy subprocess で開始 URL からリンクを辿ってクロールし、HTML を source_store に配置後、パイプライン処理を実行する |
+| `rag_site_ingest` | `urls`、`skip_pipeline`（任意） | 指定 URL のページを取得（リンク辿りなし）し、source_store に配置後、パイプライン処理を実行する |
+
+#### `rag_site_crawl` パラメータ
+
+| パラメータ | 型 | デフォルト | 説明 |
+|-----------|-----|-----------|------|
+| `url` | str | — | クロール開始 URL（必須、単一） |
+| `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
+| `max_pages` | int | `site_ingest_max_pages` | ページ数上限。config.toml の値を上書き可能 |
+| `restart` | bool | `false` | `true` の場合、クロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする |
+| `skip_pipeline` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
 
 #### `rag_site_ingest` パラメータ
 
 | パラメータ | 型 | デフォルト | 説明 |
 |-----------|-----|-----------|------|
-| `url` | str | `""` | クロール開始 URL（クロールモード）。`urls` と排他 |
-| `urls` | list[str] | `[]` | 取得対象 URL のリスト（複数 URL モード）。`url` と排他。2 件以上でクロール無効 |
-| `url_pattern` | str | なし | クロール対象 URL のフィルタパターン（正規表現）。クロールモードのみ有効。未指定時は開始 URL のパスプレフィックスから自動生成する（例: `https://example.com/docs/` → `^https://example\.com/docs/`）。パスが `/` のみの場合はパターンなし（ドメイン全体が対象）。明示的に指定した場合はその値を優先する |
-| `max_pages` | int | `site_ingest_max_pages` | ページ数上限。クロールモードのみ有効。config.toml の値を上書き可能 |
-| `force` | bool | `false` | `true` の場合、クロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする。クロールモードのみ有効 |
-| `skip_pipeline` | bool | `false` | `true` の場合、Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。source_store への commit は実行されるため、後から `rag_rebuild`（incremental）で差分処理可能。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
+| `urls` | list[str] | — | 取得対象 URL のリスト（必須、1 件以上）。**リンク辿りは行わない** |
+| `skip_pipeline` | bool | `false` | `true` の場合、Scrapy 取得 + Bridge まで実行し、パイプライン処理（converter + indexer）をスキップする |
 
-`url` と `urls` の入力規則:
-
-- `url` のみ指定: クロールモード（既存動作）
-- `urls` のみ指定（2 件以上）: 複数 URL モード（リンク辿りなし）
-- `urls` が 1 件のみ: クロールモード（`url` 指定と同等）
-- 両方指定: バリデーションエラー
-- 両方未指定: バリデーションエラー
+`rag_site_ingest` は `url`（単数 str）/ `url_pattern` / `max_pages` / `restart` / `force` パラメータを **持たない**。リンク辿りクロールが必要な場合は `rag_site_crawl` を使用する。
 
 ### CLI コマンド
 
 | コマンド | 振る舞い |
 |---------|---------|
+| `site-crawl` | MCP ツール `rag_site_crawl` と同等の機能を CLI で提供する |
 | `site-ingest` | MCP ツール `rag_site_ingest` と同等の機能を CLI で提供する |
+
+#### `site-crawl` オプション
+
+| オプション | 型 | デフォルト | 説明 |
+|-----------|-----|-----------|------|
+| `url`（位置引数） | str（単数） | — | クロール開始 URL |
+| `--url-pattern` | str | なし | URL フィルタパターン |
+| `--max-pages` | int | `site_ingest_max_pages` | ページ数上限 |
+| `--restart` | フラグ | `false` | クロールディレクトリ全体を削除して再クロール |
+| `--skip-pipeline` | フラグ | `false` | Scrapy クロール + Bridge までで停止。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
 
 #### `site-ingest` オプション
 
 | オプション | 型 | デフォルト | 説明 |
 |-----------|-----|-----------|------|
-| `url`（位置引数） | str（1 つ以上） | — | 取得対象 URL。1 件: クロールモード、2 件以上: 複数 URL モード |
-| `--url-pattern` | str | なし | URL フィルタパターン（クロールモードのみ） |
-| `--max-pages` | int | `site_ingest_max_pages` | ページ数上限（クロールモードのみ） |
-| `--force` | フラグ | `false` | クロールディレクトリ全体を削除して再クロール（クロールモードのみ） |
-| `--skip-pipeline` | フラグ | `false` | Scrapy クロール + Bridge（source_store 配置 + git commit）まで実行し、パイプライン処理（converter + indexer）をスキップする。共通仕様は [ingesters/common.md](ingesters/common.md#--skip-pipeline-フラグ共通仕様) を参照 |
+| `url`（位置引数） | str（1 つ以上） | — | 取得対象 URL。リンク辿りなし |
+| `--skip-pipeline` | フラグ | `false` | Scrapy 取得 + Bridge までで停止 |
 
 ### 取り込み結果の出力形式
 
@@ -208,7 +215,7 @@ flowchart TD
     IDX["インデクサー"]
     RESULT["結果サマリー"]
 
-    USER -->|"rag_site_ingest(url, ...)"| CMD
+    USER -->|"rag_site_crawl(url, ...) or rag_site_ingest(urls)"| CMD
     CMD --> VALID
     VALID --> SPIDER
     SPIDER -->|"HTML ファイル + JSONL"| TMPDIR
@@ -237,20 +244,20 @@ flowchart TD
 
 | パラメータ | 用途 |
 |-----------|------|
-| `start_url` | クロール開始 URL（クロールモード時。`start_urls` と排他） |
-| `start_urls` | 取得対象 URL のリスト（複数 URL モード時。JSON 配列文字列。`start_url` と排他） |
+| `start_url` | クロール開始 URL（クロール入口経由。`start_urls_json` と排他） |
+| `start_urls_json` | 取得対象 URL の JSON 配列文字列（取得入口経由。`start_url` と排他。Spider 引数として subprocess 経由で渡すため文字列化する） |
 | `allowed_domains` | ドメイン制約（URL から自動導出） |
-| `url_pattern` | URL フィルタ（正規表現、任意。クロールモードのみ） |
+| `url_pattern` | URL フィルタ（正規表現、任意。クロール入口のみ） |
 | `output_dir` | HTML ファイルの保存先ディレクトリ |
 | `max_pages` | ページ数上限（200 OK カウント）。外部インターフェースでは pydantic Field の許容範囲でクランプされる（CLI で明示的にクランプ処理を実施）。Spider 内部では 0 を無制限として扱うが、CLI/MCP からは入力されない |
-| `no_follow` | リンク辿りを無効化するフラグ（複数 URL モード時に `true`） |
+| `no_follow` | リンク辿りを無効化するフラグ（取得入口経由時に `true`） |
 
 Spider の振る舞い:
 
-- **クロールモード**（`no_follow` が `false`）: `start_url` からクロールを開始し、ページ内のリンクを辿る。リンク辿り時はクエリ文字列を除去して canonical URL に正規化する（静的サイトを主要ユースケースとする設計判断。`?page=2` 等のクエリでページが区別されるサイトでは一部ページが欠落する可能性がある）
-- **複数 URL モード**（`no_follow` が `true`）: `start_urls` の全 URL を取得するが、ページ内のリンクは辿らない
+- **クロール入口経由**（`no_follow` が `false`）: `start_url` からクロールを開始し、ページ内のリンクを辿る。リンク辿り時はクエリ文字列を除去して canonical URL に正規化する（静的サイトを主要ユースケースとする設計判断。`?page=2` 等のクエリでページが区別されるサイトでは一部ページが欠落する可能性がある）
+- **取得入口経由**（`no_follow` が `true`）: `start_urls_json` の全 URL を取得するが、ページ内のリンクは辿らない
 - `allowed_domains` に含まれないドメインへのリクエストは自動的にフィルタされる
-- `url_pattern` が指定されている場合、パターンに一致する URL のみ取得・保存する（クロールモードのみ）
+- `url_pattern` が指定されている場合、パターンに一致する URL のみ取得・保存する（クロール入口のみ）
 - 取得した HTML をファイルとして `output_dir` に保存する。URL パスのディレクトリ構造を維持する（例: `https://example.com/docs/api/auth.html` → `output_dir/docs/api/auth.html`）
 - URL パスが `.html`, `.htm` 等の Web 系拡張子で終わっている場合は `.html` を付加しない。拡張子がないパス（`/docs/api/` 等）のみ `.html` を付加する
 - `start_requests` をオーバーライドし `dont_filter=False` でリクエストを発行する。これにより start_url のフィンガープリントが重複フィルタに記録され、リンク辿りでの再取得を防止する
@@ -264,7 +271,7 @@ Scrapy プロセスの subprocess ラッパー。
 
 振る舞い:
 
-- `run()` メソッドはクロールモード（`start_url` 引数）と複数 URL モード（`start_urls` 引数）の 2 つの呼び出し方をサポートする
+- `run()` メソッドは引数の明示分離でモードを切り替える: `start_url` 指定 ⇒ クロールモード、`start_urls` 指定 ⇒ 取得モード（リンク辿りなし）。両方指定または両方未指定は `ValueError`
 - `asyncio.create_subprocess_exec` で Scrapy を起動し、インラインスクリプト内で `CrawlerProcess(settings=...)` を構成する
 - stdin は `DEVNULL` に設定する（MCP stdio モードでの親プロセス stdin 干渉を防止）
 - stderr はファイルにリダイレクトする（Twisted の子プロセス/スレッドが stderr パイプを継承し、メインプロセス終了後もパイプが閉じない Windows 固有の問題を回避）
@@ -285,7 +292,7 @@ Scrapy に渡す設定:
 | `SCHEDULER_MEMORY_QUEUE` | `scrapy.squeues.FifoMemoryQueue`（固定、BFS） |
 | `CLOSESPIDER_TIMEOUT` | `site_ingest_timeout_sec`（config.toml） |
 | `CLOSESPIDER_ERRORCOUNT` | `site_ingest_error_count`（config.toml） |
-| `JOBDIR` | クロールディレクトリ内の `jobdir/`（`{domain}/{crawl_key}/jobdir/`） |
+| `JOBDIR` | クロールディレクトリ内の `jobdir/`（`{domain}/{crawl_key}/jobdir/`）。**クロール入口経由のみ設定し、取得入口経由では未設定**（取得入口はレジューム不要） |
 | `FEEDS` | JSONL 出力パス |
 | `DOWNLOADER_MIDDLEWARES` | SSRF Middleware を有効化（優先度 50） |
 | `LOG_LEVEL` | `INFO` |
@@ -354,19 +361,20 @@ JSONL の各行から .meta サイドカーファイルへの変換:
 
 `status`, `depth` は .meta に含めない（source_store メタデータとして不要）。
 
-### 中断再開
+### 中断再開（クロール入口のみ）
 
 - JOBDIR にスケジューラキューと重複フィルタが永続化される
 - 同じ JOBDIR で再実行すると、処理済み URL をスキップして続きから取得
-- JOBDIR のレジュームは「重複スキップ付き再クロール」として動作する（Scrapy Issue #4106）。プロセス強制終了時にキューが失われる場合がある
-- `--force` オプション指定時はクロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする
+- JOBDIR のレジュームは「重複スキップ付き再クロール」として動作する（Scrapy Issue 4106）。プロセス強制終了時にキューが失われる場合がある
+- `--restart` オプション指定時はクロールディレクトリ全体（JOBDIR、HTML、JSONL）を削除して最初からクロールする
+- 取得入口（`site-ingest`）では JOBDIR を使用しない（毎回指定 URL を取得）
 
 ### JOBDIR の分離
 
 一時保存ディレクトリは `{domain}/{crawl_key}/` の 2 階層で管理する。
 
-- **クロールモード**: `crawl_key` は `start_url` と effective `url_pattern`（自動生成後の値）の SHA-256 先頭 16 文字。同じパラメータなら同じディレクトリでレジューム可能
-- **複数 URL モード**: `crawl_key` はソート済み URL リストの SHA-256 先頭 16 文字。`domain` は `_multi_` 固定（複数ドメインの場合があるため）。JOBDIR は使用しない（レジューム不要）
+- **クロール入口経由**: `crawl_key` は `start_url` と effective `url_pattern`（自動生成後の値）の SHA-256 先頭 16 文字。同じパラメータなら同じディレクトリでレジューム可能
+- **取得入口経由**: `crawl_key` はソート済み URL リストの SHA-256 先頭 16 文字。`domain` は `_multi_` 固定（複数ドメインの場合があるため）。JOBDIR は使用しない（レジューム不要）
 
 ### 一時保存ディレクトリ
 
@@ -387,7 +395,8 @@ Scrapy 正常完了 + bridge 完了後、クロールディレクトリ（`{doma
 | 条件 | クリーンアップ |
 |------|-------------|
 | Scrapy 正常完了 + bridge 完了 | 実行する（`--skip-pipeline` の有無を問わない。bridge 完了時点で source_store に配置済み） |
-| Scrapy 異常終了（exit_code != 0） | 実行しない（JOBDIR によるレジュームを維持） |
+| Scrapy 異常終了（exit_code != 0、クロール入口経由） | 実行しない（JOBDIR によるレジュームを維持） |
+| Scrapy 異常終了（exit_code != 0、取得入口経由） | 実行しない（レジュームしない方針のため、次回呼び出し時に該当ディレクトリを上書きクリアして再取得する） |
 | クリーンアップ自体が失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする |
 
 ### 処理フロー
@@ -402,7 +411,7 @@ sequenceDiagram
     participant SS as source_store
     participant PC as PipelineController
 
-    USER->>CMD: rag_site_ingest(url, ...)
+    USER->>CMD: rag_site_crawl(url, ...) or rag_site_ingest(urls)
     CMD->>CMD: URL バリデーション + SSRF チェック
     CMD->>CMD: 一時保存ディレクトリ準備
     CMD->>RUNNER: Scrapy 起動要求
@@ -449,21 +458,21 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 | ケース | 振る舞い |
 |--------|---------|
 | 非テキストレスポンス（動画埋め込み等） | Spider 内で Content-Type を検査し、テキスト系でないレスポンスはスキップする |
-| Scrapy プロセスが異常終了した場合 | Runner がエラーログを出力し、JSONL が部分的に出力されていれば、出力済み分を source_store に配置する。未出力分は次回再実行時に取得される（JOBDIR が残存している場合） |
-| JOBDIR が破損している場合 | Scrapy がエラーで終了する。`--force` で JOBDIR を削除して再実行する |
+| Scrapy プロセスが異常終了した場合 | Runner がエラーログを出力し、JSONL が部分的に出力されていれば、出力済み分を source_store に配置する。未出力分は次回再実行時に取得される（クロール入口は JOBDIR が残存している場合のみ） |
+| JOBDIR が破損している場合 | Scrapy がエラーで終了する。`--restart` で JOBDIR を削除して再実行する |
 | 一時保存ディレクトリのディスク容量不足 | Scrapy プロセスが I/O エラーで終了する。エラーログに記録する |
 | JSONL に記載されているが HTML ファイルが存在しない場合 | ブリッジ層で当該エントリをスキップし、エラーとして計上（`ingest.errors` / `error_details`）してエラーログを出力する |
 | 同一 URL が既に source_store に存在する場合 | `SourceStore.place_file_from_url` が既存ファイルを上書きする（通常の重複検出動作） |
 | `url_pattern` が無効な正規表現の場合 | バリデーションエラーとして拒否する |
-| Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--force` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
+| Windows でのファイルロック | Scrapy プロセス終了後に JOBDIR のファイルがロックされている場合、`--restart` による JOBDIR 削除が失敗する可能性がある。リトライまたは手動削除を案内する |
 | DNS リバインディングによるプライベート IP への誘導 | SSRF Middleware が各リクエストの DNS 解決結果を検証し、プライベート IP へのアクセスを `IgnoreRequest` で拒否する。該当リクエストは Scrapy の統計に失敗として記録される |
 | SSRF Middleware での DNS 解決失敗 | DNS 解決に失敗した場合、そのリクエストを `IgnoreRequest` で拒否する。ネットワーク障害等による一時的な DNS エラーは Scrapy のリトライ対象外となる |
 | `--skip-pipeline` 指定時にパイプライン処理が必要な場合 | MCP: `rag_rebuild`（mode: full, source_type: web）、CLI: `uv run python -m rag.cli rebuild --mode full --source-type web` で後からパイプライン処理を実行する。incremental モードでも可（source_store への配置が git commit されていれば差分検知される） |
 | 同一ドメインへの異なるパラメータでの複数回クロール | クロールキー（`start_url` + effective `url_pattern` のハッシュ）により JOBDIR が分離されるため、前回クロールの URL キューが残留しない |
-| 複数 URL モードで無効なスキームの URL が混在 | バリデーションで全 URL を検証し、不正な URL があればエラーを返す |
-| 複数 URL モードで SSRF 対象の URL が混在 | 全 URL に対して SSRF チェックを実行し、1 つでも違反があればエラーを返す |
-| 複数 URL モードで一部の URL が取得失敗 | 取得可能な URL のみ処理する。失敗した URL はエラーとして計上する |
-| `url` と `urls` の両方が指定された場合 | バリデーションエラーとして拒否する |
+| 取得入口（`site-ingest`）で無効なスキームの URL が混在 | バリデーションで全 URL を検証し、不正な URL があればエラーを返す |
+| 取得入口（`site-ingest`）で SSRF 対象の URL が混在 | 全 URL に対して SSRF チェックを実行し、1 つでも違反があればエラーを返す |
+| 取得入口（`site-ingest`）で一部の URL が取得失敗 | 取得可能な URL のみ処理する。失敗した URL はエラーとして計上する |
+| Runner.run に `start_url` と `start_urls` の両方が指定された場合 | `ValueError` を送出する（入口分離の不変条件） |
 | 正常完了後のクリーンアップ失敗（Windows ファイルロック等） | 警告ログを出力し、処理全体は成功扱いとする。一時ディレクトリは手動削除が必要 |
 
 ## 関連ドキュメント
@@ -473,4 +482,4 @@ Scrapy は独立した Python パッケージとして `pyproject.toml` に依�
 - [pipeline-controller.md](pipeline-controller.md) — パイプライン制御仕様
 - [converter.md](converter.md) — コンバーター仕様
 - [ingesters/common.md](ingesters/common.md) — インジェスター共通仕様
-- [ingesters/bluesky.md](ingesters/bluesky.md) — BlueSky インジェスター仕様（複数 URL モードの利用元）
+- [ingesters/bluesky.md](ingesters/bluesky.md) — BlueSky インジェスター仕様（取得入口の利用元）

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -926,14 +926,38 @@ def _build_parser() -> "_JsonAwareArgumentParser":
     _add_skip_pipeline_option(crawldoc_parser)
     _add_output_option(crawldoc_parser)
 
-    # site-ingest: Scrapy によるサイト一括取り込み
-    siteingest_parser = subparsers.add_parser("site-ingest", help="Scrapy でサイトを一括取り込み（大規模サイト向け）")
-    siteingest_parser.add_argument("url", nargs="+", help="取得対象 URL（1件: クロールモード、2件以上: 複数URLモード）")
-    siteingest_parser.add_argument("--url-pattern", default="", help="URL フィルタパターン（正規表現、クロールモードのみ）")
-    siteingest_parser.add_argument("--max-pages", type=int, default=None, help="ページ数上限（クロールモードのみ）")
-    siteingest_parser.add_argument("--force", action="store_true", help="JOBDIR を削除して再クロール（クロールモードのみ）")
+    # site-ingest: 指定 URL のページ取得（リンク辿りなし、複数 URL OK）
+    siteingest_parser = subparsers.add_parser(
+        "site-ingest",
+        help="指定 URL の Web ページを取得（リンク辿りなし、複数 URL 可）",
+    )
+    siteingest_parser.add_argument(
+        "url",
+        nargs="+",
+        help="取得対象 URL（1 件以上）。リンク辿りは行わない",
+    )
     _add_skip_pipeline_option(siteingest_parser)
     _add_output_option(siteingest_parser)
+
+    # site-crawl: Scrapy による単一 URL 起点のサイトクロール（リンク辿りあり）
+    sitecrawl_parser = subparsers.add_parser(
+        "site-crawl",
+        help="単一 URL を起点に Scrapy でサイトをクロール（リンク辿りあり）",
+    )
+    sitecrawl_parser.add_argument("url", help="クロール開始 URL（単一）")
+    sitecrawl_parser.add_argument(
+        "--url-pattern", default="", help="URL フィルタパターン（正規表現）",
+    )
+    sitecrawl_parser.add_argument(
+        "--max-pages", type=int, default=None, help="ページ数上限",
+    )
+    sitecrawl_parser.add_argument(
+        "--restart",
+        action="store_true",
+        help="JOBDIR + 一時 HTML/JSONL を削除して最初から再クロール",
+    )
+    _add_skip_pipeline_option(sitecrawl_parser)
+    _add_output_option(sitecrawl_parser)
 
     # update-aozora-catalog: 青空文庫カタログ更新
     update_aozora_parser = subparsers.add_parser("update-aozora-catalog", help="青空文庫カタログを更新")
@@ -1012,6 +1036,7 @@ def main() -> None:
         "add-document": run_add_document,
         "crawl-documents": run_crawl_documents,
         "site-ingest": run_site_ingest,
+        "site-crawl": run_site_crawl,
         "update-aozora-catalog": run_update_aozora_catalog,
         "ingest-aozora": run_ingest_aozora,
         "ingest-aozora-author": run_ingest_aozora_author,
@@ -3540,8 +3565,11 @@ async def run_crawl_documents(args: argparse.Namespace) -> None:
 
 
 async def run_site_ingest(args: argparse.Namespace) -> None:
-    """Scrapy によるサイト一括取り込み."""
-    import re
+    """指定 URL リストを取得（リンク辿りなし）して source_store に配置する.
+
+    Issue #797: クロールモード（リンク辿り）は `site-crawl` サブコマンドに分離済み。
+    本コマンドはリンク辿りを発動しない（取得対象 URL = 配置 URL）。
+    """
     import time as time_mod
 
     from .pipeline.ingesters.web import WebIngester
@@ -3552,7 +3580,6 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
     progress_cb = _output_progress if json_out else None
 
     urls: list[str] = args.url  # nargs='+' なのでリスト
-    multi_url_mode = len(urls) >= 2
 
     # 全 URL バリデーション
     validated_urls: list[str] = []
@@ -3567,49 +3594,22 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             logger.error("エラー: %s", e)
             sys.exit(1)
 
-    # クロールモード固有のバリデーション
-    if not multi_url_mode and args.url_pattern:
-        try:
-            re.compile(args.url_pattern)
-        except re.error as e:
-            if json_out:
-                _output_error(CliErrorCode.VALIDATION_ERROR, f"無効な正規表現パターン: {e}")
-            logger.error("無効な正規表現パターン: %s", e)
-            sys.exit(1)
-
     controller, settings = _build_cli_pipeline_controller()
 
     with _write_lock_or_exit(
         Path(controller.source_store.root_dir), json_out=json_out,
     ):
-        # max_pages のクランプ（クロールモードのみ）
-        effective_max_pages: int | None = None
-        if not multi_url_mode:
-            effective_max_pages = (
-                args.max_pages if args.max_pages is not None
-                else settings.site_ingest_max_pages
-            )
-            if effective_max_pages < 1:
-                effective_max_pages = 1
-                logger.warning("max_pages を 1 にクランプしました")
-            elif effective_max_pages > 1000:
-                effective_max_pages = 1000
-                logger.warning("max_pages を 1000 にクランプしました")
-
         outer_start = time_mod.monotonic()
         web_ingester = WebIngester(
             controller.source_store,
             scrapy_runner=create_scrapy_runner(settings),
         )
-        execution = await web_ingester.crawl_urls(
-            urls=validated_urls,
-            url_pattern=args.url_pattern if not multi_url_mode else None,
-            max_pages=effective_max_pages,
-            force=args.force if not multi_url_mode else False,
-        )
+        execution = await web_ingester.fetch_urls(urls=validated_urls)
 
         display_url = (
-            validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
+            validated_urls[0]
+            if len(validated_urls) == 1
+            else f"{len(validated_urls)} URLs"
         )
 
         if execution.no_output:
@@ -3650,6 +3650,136 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
             execution.crawl_result.cleanup()
 
         # 操作全体の所要時間（クロール + Bridge + パイプライン）
+        elapsed = time_mod.monotonic() - outer_start
+
+        if json_out:
+            data: dict[str, object] = _ingest_result_to_dict(
+                execution.ingest, pipeline_summary,
+            )
+            data["elapsed"] = round(elapsed, 1)
+            data["skip_pipeline"] = skip_pipeline
+            if not execution.scrapy_success:
+                data["scrapy_exit_code"] = execution.scrapy_exit_code
+            _output_result(data)
+        else:
+            _print_ingest_result(
+                execution.ingest,
+                pipeline_summary,
+                context=f"サイト: {display_url}",
+                json_output=False,
+            )
+            print(f"所要時間: {elapsed:.1f}秒")
+            if skip_pipeline:
+                _print_skip_pipeline_notice(json_out=False)
+            if not execution.scrapy_success:
+                print(
+                    f"Scrapy exit_code={execution.scrapy_exit_code}（部分的な結果）",
+                )
+
+
+async def run_site_crawl(args: argparse.Namespace) -> None:
+    """Scrapy による単一 URL 起点のサイトクロール（リンク辿りあり）."""
+    import re
+    import time as time_mod
+
+    from .pipeline.ingesters.web import WebIngester
+    from .scrapy.runner import create_scrapy_runner
+    from .utils.url import check_ssrf, validate_url
+
+    json_out = _is_json_output(args)
+    progress_cb = _output_progress if json_out else None
+
+    url: str = args.url
+    try:
+        validated_url = validate_url(url)
+        check_ssrf(validated_url)
+    except ValueError as e:
+        if json_out:
+            _output_error(CliErrorCode.VALIDATION_ERROR, str(e))
+        logger.error("エラー: %s", e)
+        sys.exit(1)
+
+    if args.url_pattern:
+        try:
+            re.compile(args.url_pattern)
+        except re.error as e:
+            if json_out:
+                _output_error(
+                    CliErrorCode.VALIDATION_ERROR, f"無効な正規表現パターン: {e}",
+                )
+            logger.error("無効な正規表現パターン: %s", e)
+            sys.exit(1)
+
+    controller, settings = _build_cli_pipeline_controller()
+
+    with _write_lock_or_exit(
+        Path(controller.source_store.root_dir), json_out=json_out,
+    ):
+        # max_pages のクランプ
+        effective_max_pages = (
+            args.max_pages if args.max_pages is not None
+            else settings.site_ingest_max_pages
+        )
+        if effective_max_pages < 1:
+            effective_max_pages = 1
+            logger.warning("max_pages を 1 にクランプしました")
+        elif effective_max_pages > 1000:
+            effective_max_pages = 1000
+            logger.warning("max_pages を 1000 にクランプしました")
+
+        outer_start = time_mod.monotonic()
+        web_ingester = WebIngester(
+            controller.source_store,
+            scrapy_runner=create_scrapy_runner(settings),
+        )
+        execution = await web_ingester.crawl_url(
+            url=validated_url,
+            url_pattern=args.url_pattern,
+            max_pages=effective_max_pages,
+            restart=args.restart,
+        )
+
+        display_url = validated_url
+
+        if execution.no_output:
+            elapsed = time_mod.monotonic() - outer_start
+            if json_out:
+                _output_result({
+                    "placed": 0,
+                    "overwritten": 0,
+                    "skipped": 0,
+                    "errors": 0,
+                    "elapsed": round(elapsed, 1),
+                    "scrapy_exit_code": execution.scrapy_exit_code,
+                    "no_output": True,
+                })
+            else:
+                print(
+                    f"クロールが完了しましたが、メタデータが出力されませんでした。"
+                    f" exit_code={execution.scrapy_exit_code},"
+                    f" 所要時間={elapsed:.1f}秒",
+                )
+            return
+
+        # パイプライン処理
+        skip_pipeline = _is_skip_pipeline(args)
+        pipeline_summary = None
+        has_changes = (execution.ingest.placed + execution.ingest.overwritten) > 0
+        if has_changes and not skip_pipeline:
+            pipeline_summary = await controller.ingest_and_index(
+                f"ingest(web): site-crawl {display_url}",
+                progress_callback=progress_cb,
+                concurrency=settings.rag_embedding_concurrency,
+            )
+        elif has_changes and skip_pipeline:
+            controller.commit(
+                f"ingest(web): site-crawl {display_url} (skip_pipeline)",
+            )
+
+        # 正常完了後のクリーンアップ（仕様: docs/specs/site-ingest.md）
+        if execution.scrapy_success and execution.crawl_result is not None:
+            execution.crawl_result.cleanup()
+
         elapsed = time_mod.monotonic() - outer_start
 
         if json_out:

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -3626,7 +3626,7 @@ async def run_site_ingest(args: argparse.Namespace) -> None:
                 })
             else:
                 print(
-                    f"クロールが完了しましたが、メタデータが出力されませんでした。"
+                    f"取得が完了しましたが、メタデータが出力されませんでした。"
                     f" exit_code={execution.scrapy_exit_code},"
                     f" 所要時間={elapsed:.1f}秒",
                 )

--- a/src/rag/pipeline/ingesters/bluesky/delegations.py
+++ b/src/rag/pipeline/ingesters/bluesky/delegations.py
@@ -44,9 +44,10 @@ async def follow_urls(
 ) -> dict[str, int]:
     """配置済み投稿から URL を抽出し、Web/YouTube 委譲先に取り込ませる.
 
-    Web URL は ``WebDelegator.run_for_urls`` でバッチ取得（subprocess 直起動を
-    回避するため Python API 経由）。YouTube URL は ``YoutubeDelegator.ingest_videos``
-    で個別取り込み（URL 間にレート制限スリープ）。
+    Web URL は ``WebDelegator.fetch_urls`` でバッチ取得（リンク辿りなしの取得
+    経路に固定。Issue #797 で件数ヒューリスティック起因のクロール巻き込みを
+    構造的に防止）。YouTube URL は ``YoutubeDelegator.ingest_videos`` で個別
+    取り込み（URL 間にレート制限スリープ）。
 
     各 placed_item の ``_suppress_youtube_reingest`` フラグにより YouTube 抑制対象
     判定を行う。抑制対象（True）の URL は ``force_youtube_reingest`` が True の場合
@@ -228,10 +229,14 @@ async def _fetch_web_urls(
     *,
     web_delegator: WebDelegator,
 ) -> tuple[int, int, int, list[IngestErrorDetail]]:
-    """Web URL を WebDelegator（複数 URL モード）の Python API で取得する.
+    """Web URL を WebDelegator の取得経路（リンク辿りなし）で取り込む.
 
     親プロセスが既に write_lock を保持している前提で、subprocess を介さず同一
     プロセス内で WebIngester のコア処理を呼び出す（#686）。
+
+    取得経路（``fetch_urls``）に固定するため、投稿内 web URL がいくつであっても
+    リンク辿りクロールは発動しない（Issue #797: 件数ヒューリスティックによる
+    単一 URL クロール巻き込み事故の構造的解消）。
 
     URL バリデーション (validate_url) と SSRF チェック (check_ssrf) を冒頭で
     実施する。subprocess 経由から Python API 直呼出しに変更したことで、従来
@@ -248,7 +253,7 @@ async def _fetch_web_urls(
     from rag.utils.url import check_ssrf, validate_url
 
     logger.info(
-        "site-ingest（複数 URL モード）で %d 件の Web URL を取り込みます",
+        "site-ingest（取得モード）で %d 件の Web URL を取り込みます",
         len(urls),
     )
 
@@ -273,7 +278,7 @@ async def _fetch_web_urls(
         return 0, 0, len(validation_errors), validation_errors
 
     try:
-        execution = await web_delegator.run_for_urls(validated_urls)
+        execution = await web_delegator.fetch_urls(validated_urls)
     except Exception as exc:
         logger.exception("web 取り込みの実行に失敗: %d 件", len(validated_urls))
         execute_errors: list[IngestErrorDetail] = [

--- a/src/rag/pipeline/ingesters/web/_facade.py
+++ b/src/rag/pipeline/ingesters/web/_facade.py
@@ -72,28 +72,61 @@ class WebIngester(BaseIngester):
         super().__init__(source_store)
         self._scrapy_runner = scrapy_runner
 
-    async def crawl_urls(
+    async def crawl_url(
         self,
-        urls: list[str],
+        url: str,
         *,
         url_pattern: str | None = None,
         max_pages: int | None = None,
-        force: bool = False,
+        restart: bool = False,
     ) -> SiteIngestExecution:
-        """指定 URL 群を Scrapy 経由でクロールし source_store に配置する.
+        """単一 URL を起点にリンク辿りクロールを実行し source_store に配置する.
 
-        URL 値のバリデーション（スキーム、SSRF 等）は呼び出し元で実施済み
-        である前提。本メソッドでは空リストのみプログラミング契約として弾く。
+        URL バリデーション（スキーム、SSRF 等）は呼び出し元で実施済みである前提。
 
         Args:
-            urls: 取得対象 URL のリスト。**1 件以上必須**（空リストは不可）
-            url_pattern: URL フィルタ正規表現（クロールモードのみ有効）
-            max_pages: ページ数上限（クロールモードのみ有効）
-            force: クロールディレクトリを削除して再実行する
+            url: クロール開始 URL
+            url_pattern: URL フィルタ正規表現
+            max_pages: ページ数上限
+            restart: JOBDIR + 一時 HTML/JSONL を削除して最初から再実行する
 
         Returns:
             実行結果。``ingest`` は配置結果、``scrapy_*`` は Scrapy の終了状態、
             ``no_output`` は JSONL が出力されなかった場合に True。
+
+        Raises:
+            ValueError: ``url`` が空文字列の場合（呼び出し元の契約違反）
+        """
+        if not url:
+            raise ValueError("url is required")
+
+        allowed_domains = urlparse(url).hostname or ""
+
+        crawl_result = await self._scrapy_runner.run(
+            start_url=url,
+            allowed_domains=allowed_domains,
+            url_pattern=url_pattern or "",
+            max_pages=max_pages,
+            restart=restart,
+        )
+
+        return self._finalize_execution(crawl_result)
+
+    async def fetch_urls(
+        self,
+        urls: list[str],
+    ) -> SiteIngestExecution:
+        """指定 URL リストを取得（リンク辿りなし）し source_store に配置する.
+
+        URL バリデーション（スキーム、SSRF 等）は呼び出し元で実施済みである前提。
+        リンク辿りを行わないため、Issue #797 の単一 URL での意図しないクロール
+        巻き込みは構造的に発生しない。
+
+        Args:
+            urls: 取得対象 URL のリスト。**1 件以上必須**
+
+        Returns:
+            実行結果。
 
         Raises:
             ValueError: ``urls`` が空リストの場合（呼び出し元の契約違反）
@@ -101,33 +134,22 @@ class WebIngester(BaseIngester):
         if not urls:
             raise ValueError("urls must contain at least one URL")
 
-        multi_url_mode = len(urls) >= 2
+        domains: list[str] = []
+        for u in urls:
+            hostname = urlparse(u).hostname
+            if hostname and hostname not in domains:
+                domains.append(hostname)
+        allowed_domains = ",".join(domains)
 
-        if multi_url_mode:
-            domains: list[str] = []
-            for u in urls:
-                hostname = urlparse(u).hostname
-                if hostname and hostname not in domains:
-                    domains.append(hostname)
-            allowed_domains = ",".join(domains)
-        else:
-            parsed = urlparse(urls[0])
-            allowed_domains = parsed.hostname or ""
+        crawl_result = await self._scrapy_runner.run(
+            start_urls=urls,
+            allowed_domains=allowed_domains,
+        )
 
-        if multi_url_mode:
-            crawl_result = await self._scrapy_runner.run(
-                start_urls=urls,
-                allowed_domains=allowed_domains,
-            )
-        else:
-            crawl_result = await self._scrapy_runner.run(
-                start_url=urls[0],
-                allowed_domains=allowed_domains,
-                url_pattern=url_pattern or "",
-                max_pages=max_pages,
-                force=force,
-            )
+        return self._finalize_execution(crawl_result)
 
+    def _finalize_execution(self, crawl_result: CrawlResult) -> SiteIngestExecution:
+        """Scrapy 完了結果を SiteIngestExecution にまとめ、bridge 処理を行う."""
         execution = SiteIngestExecution(
             scrapy_exit_code=crawl_result.exit_code,
             scrapy_success=crawl_result.success,

--- a/src/rag/pipeline/ingesters/web/web_delegator.py
+++ b/src/rag/pipeline/ingesters/web/web_delegator.py
@@ -24,21 +24,21 @@ class WebDelegator(Protocol):
 
     仕様: docs/specs/architecture.md §3.3
 
-    bluesky 等の他 Ingester からの委譲経路として用いる。Real 実装は
-    ``WebIngester.crawl_urls`` をそのまま呼び出す薄いブリッジ。
+    bluesky 等の他 Ingester から WebIngester を越境直 import せずに利用するための
+    抽象。**リンク辿りを発動させない取得経路のみ** を公開する（Issue #797 の単一
+    URL 巻き込みクロール問題を構造的に防ぐため、クロール委譲は提供しない）。
 
-    ``source_store`` は実装時にバインド済み（factory 経由で WebIngester
-    に注入される）のため、呼び出しごとに渡す必要はない。
+    ``source_store`` は実装時にバインド済み（factory 経由で WebIngester に注入される）
+    のため、呼び出しごとに渡す必要はない。
     """
 
-    async def run_for_urls(
+    async def fetch_urls(
         self,
         urls: list[str],
     ) -> SiteIngestExecution:
-        """指定 URL 群に対して WebIngester による取り込みを実行する.
+        """指定 URL リストを取得（リンク辿りなし）し source_store に配置する.
 
-        URL 値のバリデーション（スキーム、SSRF 等）は呼び出し元で実施済み
-        である前提。
+        URL バリデーション（スキーム、SSRF 等）は呼び出し元で実施済みである前提。
 
         Args:
             urls: 取得対象 URL のリスト（1 件以上必須）
@@ -62,11 +62,11 @@ class RealWebDelegator:
     def __init__(self, *, web_ingester: WebIngester) -> None:
         self._web_ingester = web_ingester
 
-    async def run_for_urls(
+    async def fetch_urls(
         self,
         urls: list[str],
     ) -> SiteIngestExecution:
-        return await self._web_ingester.crawl_urls(urls=urls)
+        return await self._web_ingester.fetch_urls(urls=urls)
 
 
 def create_web_delegator(

--- a/src/rag/scrapy/_fake/__init__.py
+++ b/src/rag/scrapy/_fake/__init__.py
@@ -59,23 +59,27 @@ class FakeScrapyRunner:
         allowed_domains: str = "",
         url_pattern: str = "",
         max_pages: int | None = None,
-        force: bool = False,
+        restart: bool = False,
     ) -> CrawlResult:
         """Fake クロールを実行する.
 
         Real と同じディレクトリ構造（``<domain>/<crawl_key>/{html, metadata.jsonl}``）
         を tmp_dir に作成し、fixture の内容を展開する。
         """
-        del allowed_domains, force  # Fake では使わない（呼び出し契約のため受け付け）
+        del allowed_domains, restart, max_pages  # Fake では使わない（呼び出し契約のため受け付け）
 
-        urls = list(start_urls or ([start_url] if start_url else []))
-        if not urls:
+        _urls = start_urls or []
+        if start_url and _urls:
+            raise ValueError("start_url と start_urls は排他です")
+        if not start_url and not _urls:
             raise ValueError("start_url または start_urls は必須です")
+
+        fetch_mode = bool(_urls)
+        urls = _urls if fetch_mode else [start_url]
 
         # Real と整合する一時ディレクトリ構造を生成
         # （_crawl_key は url_pattern も key 算出に使うため、Real と同じく url_pattern を渡す）
-        multi_url_mode = len(urls) >= 2
-        if multi_url_mode:
+        if fetch_mode:
             domain = "_multi_"
             key = _multi_url_key(urls)
         else:

--- a/src/rag/scrapy/runner.py
+++ b/src/rag/scrapy/runner.py
@@ -99,17 +99,22 @@ class ScrapyRunner(Protocol):
         allowed_domains: str = "",
         url_pattern: str = "",
         max_pages: int | None = None,
-        force: bool = False,
+        restart: bool = False,
     ) -> CrawlResult:
         """Scrapy クロールを実行する.
 
+        モードは引数で明示的に切り替える。``start_url`` 指定はクロールモード
+        （リンク辿りあり、単一 URL 起点）、``start_urls`` 指定は取得モード
+        （リンク辿りなし、指定 URL のみ取得）。両方指定・両方未指定は ValueError。
+
         Args:
-            start_url: クロール開始 URL（クロールモード、start_urls と排他）
-            start_urls: 取得対象 URL のリスト（複数 URL モード、start_url と排他）
+            start_url: クロール開始 URL（クロールモード、``start_urls`` と排他）
+            start_urls: 取得対象 URL のリスト（取得モード、``start_url`` と排他）
             allowed_domains: ドメイン制約（カンマ区切り）
             url_pattern: URL フィルタ正規表現（クロールモードのみ）
             max_pages: ページ数上限（None の場合は実装依存のデフォルト）
-            force: True の場合、クロールディレクトリ全体を削除して最初からクロール
+            restart: True の場合、JOBDIR + 一時 HTML/JSONL を削除して最初から
+                再実行（クロールモードのみ有効。取得モードでは無視）
 
         Returns:
             クロール実行結果
@@ -149,48 +154,50 @@ class RealScrapyRunner:
         allowed_domains: str = "",
         url_pattern: str = "",
         max_pages: int | None = None,
-        force: bool = False,
+        restart: bool = False,
     ) -> CrawlResult:
         """Scrapy Spider を subprocess で起動してクロールを実行する.
 
+        モードは引数で明示的に切り替える。件数ヒューリスティック（Issue #797）は
+        廃止済み。``start_url`` 指定 ⇒ クロールモード、``start_urls`` 指定 ⇒
+        取得モード（リンク辿りなし）。
+
         Args:
-            start_url: クロール開始 URL（クロールモード、start_urls と排他）
-            start_urls: 取得対象 URL のリスト（複数 URL モード、start_url と排他）
+            start_url: クロール開始 URL（クロールモード、``start_urls`` と排他）
+            start_urls: 取得対象 URL のリスト（取得モード、``start_url`` と排他）
             allowed_domains: ドメイン制約（カンマ区切り）
             url_pattern: URL フィルタ正規表現（クロールモードのみ）
             max_pages: ページ数上限（None の場合はインスタンス設定値を使用）
-            force: True の場合、クロールディレクトリ全体を削除して最初からクロール
+            restart: True の場合、JOBDIR + 一時 HTML/JSONL を削除して最初から
+                再実行（クロールモードのみ有効。取得モードでは無視）
 
         Returns:
             クロール実行結果
         """
-        # 複数 URL モード判定
         _urls = start_urls or []
-        multi_url_mode = len(_urls) >= 2
+        if start_url and _urls:
+            raise ValueError("start_url と start_urls は排他です")
+        if not start_url and not _urls:
+            raise ValueError("start_url または start_urls は必須です")
 
-        if multi_url_mode:
-            # 複数 URL モード: リンク辿りなし
+        fetch_mode = bool(_urls)
+
+        if fetch_mode:
+            # 取得モード: リンク辿りなし、URL リストをそのまま取得
             effective_start_urls = _urls
             effective_start_url = ""
             no_follow = True
             effective_max_pages = 0  # 無制限（URL 数 = ページ数）
             url_pattern = ""  # パターンフィルタ無効
-        elif len(_urls) == 1:
-            # urls が 1 件のみ: クロールモードとして扱う
-            effective_start_url = _urls[0]
-            effective_start_urls = []
-            no_follow = False
-            effective_max_pages = max_pages if max_pages is not None else self._max_pages
-        elif start_url:
+        else:
+            # クロールモード: 単一 URL 起点、リンク辿りあり
             effective_start_url = start_url
             effective_start_urls = []
             no_follow = False
             effective_max_pages = max_pages if max_pages is not None else self._max_pages
-        else:
-            raise ValueError("start_url または start_urls は必須です")
 
         # クロールモード: url_pattern 未指定時は自動生成
-        if not multi_url_mode:
+        if not fetch_mode:
             parsed = urlparse(effective_start_url)
             if not url_pattern:
                 path = parsed.path.rstrip("/")
@@ -210,7 +217,7 @@ class RealScrapyRunner:
                     logger.info("url_pattern を自動生成: %s", url_pattern)
 
         # 一時保存ディレクトリの決定
-        if multi_url_mode:
+        if fetch_mode:
             domain = "_multi_"
             key = _multi_url_key(effective_start_urls)
         else:
@@ -223,28 +230,29 @@ class RealScrapyRunner:
         jsonl_path = crawl_dir / "metadata.jsonl"
         jobdir = crawl_dir / "jobdir"
 
-        # --force: クロールディレクトリ全体をクリア（クロールモードのみ有効）
-        if force and not multi_url_mode and crawl_dir.exists():
-            logger.info("--force: クロールディレクトリを削除します: %s", crawl_dir)
+        # --restart: クロールディレクトリ全体をクリア（クロールモードのみ有効）
+        if restart and not fetch_mode and crawl_dir.exists():
+            logger.info("--restart: クロールディレクトリを削除します: %s", crawl_dir)
             try:
                 shutil.rmtree(crawl_dir)
             except OSError as exc:
-                msg = f"--force 指定時にクロールディレクトリの削除に失敗しました: {crawl_dir}"
+                msg = (
+                    f"--restart 指定時にクロールディレクトリの削除に失敗しました: {crawl_dir}"
+                )
                 logger.error(msg, exc_info=True)
                 raise RuntimeError(msg) from exc
 
-        # 複数 URL モード: 前回の一時ディレクトリをクリア（レジューム不要）
-        if multi_url_mode and crawl_dir.exists():
+        # 取得モード: 前回の一時ディレクトリをクリア（レジューム不要）
+        if fetch_mode and crawl_dir.exists():
             try:
                 shutil.rmtree(crawl_dir)
             except OSError:
                 logger.warning(
-                    "複数 URL モードの一時ディレクトリ削除に失敗: %s", crawl_dir, exc_info=True,
+                    "取得モードの一時ディレクトリ削除に失敗: %s", crawl_dir, exc_info=True,
                 )
 
-        # ディレクトリ準備
+        # ディレクトリ準備（html_dir.mkdir で親の crawl_dir も自動生成される）
         html_dir.mkdir(parents=True, exist_ok=True)
-        crawl_dir.mkdir(parents=True, exist_ok=True)
 
         # パラメータを JSON ファイルに書き出し（コードインジェクション防止）
         params_path = crawl_dir / "spider_params.json"
@@ -261,7 +269,7 @@ class RealScrapyRunner:
             "error_count": self._error_count,
             "no_follow": no_follow,
         }
-        if multi_url_mode:
+        if fetch_mode:
             params["start_urls_json"] = json.dumps(effective_start_urls)
             params["start_url"] = ""
         else:
@@ -278,15 +286,18 @@ class RealScrapyRunner:
         env["PYTHONUTF8"] = "1"
         env["PYTHONIOENCODING"] = "utf-8"
 
-        if multi_url_mode:
+        if fetch_mode:
             preview = ", ".join(effective_start_urls[:3])
             log_url = f"{preview}..." if len(effective_start_urls) > 3 else preview
+            # 取得モードは max_pages=0（無制限）固定。値だけだと「上限ゼロ」と誤読されうるため補足する
+            max_pages_display = "0 (mode=fetch, unlimited)"
         else:
             log_url = effective_start_url
+            max_pages_display = str(effective_max_pages)
         logger.info(
-            "Scrapy Spider を起動: url=%s, max_pages=%d, delay=%.2f, no_follow=%s",
+            "Scrapy Spider を起動: url=%s, max_pages=%s, delay=%.2f, no_follow=%s",
             log_url,
-            effective_max_pages,
+            max_pages_display,
             self._delay_sec,
             no_follow,
         )

--- a/src/rag/scrapy/spider.py
+++ b/src/rag/scrapy/spider.py
@@ -29,11 +29,11 @@ class SiteSpider(scrapy.Spider):  # type: ignore[misc]
 
     パラメータ（Spider 引数）で動作をカスタマイズする:
     - start_url: クロール開始 URL（クロールモード、start_urls_json と排他）
-    - start_urls_json: 取得対象 URL の JSON 配列文字列（複数 URL モード）
+    - start_urls_json: 取得対象 URL の JSON 配列文字列（取得モード、start_url と排他）
     - allowed_domains: ドメイン制約（カンマ区切り）
     - url_pattern: URL フィルタ正規表現（任意、クロールモードのみ）
     - output_dir: HTML ファイルの保存先ディレクトリ
-    - no_follow: リンク辿りを無効化（複数 URL モード時に true）
+    - no_follow: リンク辿りを無効化（取得モード時に true）
     """
 
     name = "site_spider"

--- a/src/rag/server/__init__.py
+++ b/src/rag/server/__init__.py
@@ -87,7 +87,7 @@ from .tools.ingest_aozora import (  # noqa: E402, F401
     rag_search_aozora,
     rag_update_aozora_catalog,
 )
-from .tools.ingest_site import rag_site_ingest  # noqa: E402, F401
+from .tools.ingest_site import rag_site_crawl, rag_site_ingest  # noqa: E402, F401
 from .tools.delete import rag_delete  # noqa: E402, F401
 from .tools.rebuild import rag_rebuild  # noqa: E402, F401
 from .tools.listing import (  # noqa: E402, F401

--- a/src/rag/server/tools/ingest_site.py
+++ b/src/rag/server/tools/ingest_site.py
@@ -1,6 +1,12 @@
-"""rag_site_ingest MCP tool.
+"""rag_site_ingest / rag_site_crawl MCP tools.
 
 仕様: docs/specs/site-ingest.md
+
+Issue #797 により、`site-ingest` の 2 つの責務（リンク辿りクロール vs 指定 URL 取得）を
+別ツールに物理分離した:
+
+- ``rag_site_ingest``: 指定 URL リストの取得（リンク辿りなし）。複数 URL 可
+- ``rag_site_crawl``: 単一 URL を起点にリンクを辿るクロール。クロール固有オプションあり
 """
 
 from __future__ import annotations
@@ -16,34 +22,29 @@ from ...safe_browsing import SafeBrowsingConfigError, SafetyCheckError
 
 logger = logging.getLogger("rag.server")
 
+# rag_site_crawl も web + embedding の fake source を利用する。再エイリアスで明示する
+_SITE_CRAWL_FAKE_SOURCES = _SITE_INGEST_FAKE_SOURCES
+
 
 @mcp.tool()
 async def rag_site_ingest(
-    url: str = "",
-    urls: list[str] | None = None,
-    url_pattern: str = "",
-    max_pages: int | None = None,
-    force: bool = False,
+    urls: list[str],
     skip_pipeline: bool = False,
     ctx: MCPContext | None = None,
 ) -> str:
-    """[rag-knowledge] RAG site ingest - Scrapy でサイトを一括取り込み.
+    """[rag-knowledge] RAG site ingest - 指定 URL のページを取得（リンク辿りなし）.
 
-    knowledge base, bulk ingest, site crawl, large scale, scrapy, multi url.
-    Scrapy subprocess で Web ページを一括取り込みする。
-    単一 URL: リンクを辿るクロールモード（大規模サイト向け）。
-    複数 URL: 指定 URL のみ取得する複数 URL モード。
+    knowledge base, bulk ingest, fetch pages, multi url, no follow.
+    指定された URL の Web ページを取得し source_store に配置する。
+    **リンクは辿らない**（Issue #797 で導入された安全側デフォルト）。
+    クロール（リンク辿り）が必要な場合は ``rag_site_crawl`` を使用する。
 
     並行実行非対応: Bridge が source_store へのファイル配置をロック保護外で
-    実行するため、同一サイトに対する同時実行はデータ競合のリスクがある。
+    実行するため、同じ URL 群に対する同時実行はデータ競合のリスクがある。
 
     Args:
-        url: クロール開始 URL（クロールモード、urls と排他）
-        urls: 取得対象 URL のリスト（複数 URL モード、url と排他）
-        url_pattern: URL フィルタパターン（正規表現、クロールモードのみ）
-        max_pages: ページ数上限（クロールモードのみ、未指定時は設定値を使用）
-        force: True の場合、JOBDIR を削除して最初からクロール（クロールモードのみ）
-        skip_pipeline: True の場合、Scrapy クロール + Bridge まで実行し、
+        urls: 取得対象 URL のリスト（1 件以上必須）
+        skip_pipeline: True の場合、Scrapy 取得 + Bridge まで実行し、
             パイプライン処理（コンバート・インデックス構築）をスキップする。
             CLI の --skip-pipeline フラグと等価。共通仕様は
             docs/specs/ingesters/common.md「--skip-pipeline フラグ共通仕様」を参照
@@ -55,22 +56,11 @@ async def rag_site_ingest(
 
     label = _fake_mode_labels(_SITE_INGEST_FAKE_SOURCES)
 
-    # url / urls の排他チェック
-    effective_urls = urls or []
-    if url and effective_urls:
-        return label + "エラー: url と urls は排他です。どちらか一方のみ指定してください"
-    if not url and not effective_urls:
-        return label + "エラー: url または urls を指定してください"
+    if not urls:
+        return label + "エラー: urls には 1 件以上の URL を指定してください"
 
-    # 単一 URL モード → リストに統一
-    if url:
-        effective_urls = [url]
-
-    multi_url_mode = len(effective_urls) >= 2
-
-    # 全 URL バリデーション
     validated_urls: list[str] = []
-    for u in effective_urls:
+    for u in urls:
         try:
             validated = validate_url(u)
             check_ssrf(validated)
@@ -78,47 +68,124 @@ async def rag_site_ingest(
         except ValueError as e:
             return label + f"エラー: {e}"
 
-    # Safe Browsing チェック（クロールモードのみ: 起点 URL）
-    # 複数 URL モードでは数百件の URL に対する Google Safe Browsing API 呼び出しは
-    # 非現実的なためスキップする（仕様: site-ingest.md「Safe Browsing チェック」）
-    if not multi_url_mode:
-        try:
-            sb_client = safe_browsing_wiring._get_safe_browsing_client()
-            if sb_client is not None:
-                sb_result = await sb_client.check_url(validated_urls[0])
-                if not sb_result.is_safe:
-                    threat_types = ", ".join(t.threat_type.value for t in sb_result.threats)
-                    return label + f"エラー: 起点URLが安全でないと判定されました: {threat_types} — {validated_urls[0]}"
-        except SafeBrowsingConfigError:
-            logger.warning("Safe Browsing の設定エラーのためチェックをスキップします: %s", validated_urls[0])
-        except SafetyCheckError as e:
-            return label + f"エラー: URL安全性チェックに失敗しました: {e}"
-
     # CLI subprocess に委譲
     # オプション注入対策: ユーザー入力の positional 群（validated_urls）は `--` 以降に置く。
-    # validate_url + check_ssrf を通過済みだが、一貫性とフォールバック安全性のため separator を入れる。
     cli_args: list[str] = []
-    if not multi_url_mode:
-        if url_pattern:
-            import re
-            try:
-                re.compile(url_pattern)
-            except re.error as e:
-                return label + f"エラー: 無効な正規表現パターン: {e}"
-            cli_args.extend(["--url-pattern", url_pattern])
-        if max_pages is not None:
-            cli_args.extend(["--max-pages", str(max_pages)])
-        if force:
-            cli_args.append("--force")
     if skip_pipeline:
         cli_args.append("--skip-pipeline")
     cli_args.append("--")
     cli_args.extend(validated_urls)
 
-    display_url = validated_urls[0] if not multi_url_mode else f"{len(validated_urls)} URLs"
+    display_url = (
+        validated_urls[0]
+        if len(validated_urls) == 1
+        else f"{len(validated_urls)} URLs"
+    )
 
     try:
         result = await cli_subprocess._run_cli_subprocess("site-ingest", cli_args, ctx=ctx)
-        return label + cli_subprocess._format_cli_ingest_result(result, context=f"サイト: {display_url}")
+        return label + cli_subprocess._format_cli_ingest_result(
+            result, context=f"サイト: {display_url}",
+        )
     except CLISubprocessError as e:
-        return label + e.format_mcp_error(f"サイト取り込みに失敗しました（{display_url}）")
+        return label + e.format_mcp_error(
+            f"サイト取り込みに失敗しました（{display_url}）",
+        )
+
+
+@mcp.tool()
+async def rag_site_crawl(
+    url: str,
+    url_pattern: str = "",
+    max_pages: int | None = None,
+    restart: bool = False,
+    skip_pipeline: bool = False,
+    ctx: MCPContext | None = None,
+) -> str:
+    """[rag-knowledge] RAG site crawl - 単一 URL 起点でサイトをクロール（リンク辿りあり）.
+
+    knowledge base, bulk ingest, site crawl, large scale, scrapy, follow links.
+    Scrapy subprocess で開始 URL からリンクを辿り、サイト配下のページを一括取り込みする。
+    リンク辿りなしの取得のみが必要な場合は ``rag_site_ingest`` を使用する。
+
+    並行実行非対応: Bridge が source_store へのファイル配置をロック保護外で
+    実行するため、同一サイトに対する同時実行はデータ競合のリスクがある。
+
+    Args:
+        url: クロール開始 URL（単一）
+        url_pattern: URL フィルタパターン（正規表現）。未指定時は開始 URL の
+            パスプレフィックスから自動生成する
+        max_pages: ページ数上限（未指定時は設定値を使用）
+        restart: True の場合、JOBDIR + 一時 HTML/JSONL を削除して最初から再クロール
+        skip_pipeline: True の場合、Scrapy クロール + Bridge まで実行し、
+            パイプライン処理（コンバート・インデックス構築）をスキップする
+
+    Returns:
+        取り込み結果のサマリー
+    """
+    from ...utils.url import check_ssrf, validate_url
+
+    label = _fake_mode_labels(_SITE_CRAWL_FAKE_SOURCES)
+
+    if not url:
+        return label + "エラー: url を指定してください"
+
+    try:
+        validated_url = validate_url(url)
+        check_ssrf(validated_url)
+    except ValueError as e:
+        return label + f"エラー: {e}"
+
+    # Safe Browsing チェック（起点 URL のみ）
+    try:
+        sb_client = safe_browsing_wiring._get_safe_browsing_client()
+        if sb_client is not None:
+            sb_result = await sb_client.check_url(validated_url)
+            if not sb_result.is_safe:
+                threat_types = ", ".join(
+                    t.threat_type.value for t in sb_result.threats
+                )
+                return label + (
+                    f"エラー: 起点URLが安全でないと判定されました: "
+                    f"{threat_types} — {validated_url}"
+                )
+    except SafeBrowsingConfigError:
+        logger.warning(
+            "Safe Browsing の設定エラーのためチェックをスキップします: %s",
+            validated_url,
+        )
+    except SafetyCheckError as e:
+        return label + f"エラー: URL安全性チェックに失敗しました: {e}"
+
+    # url_pattern バリデーション
+    if url_pattern:
+        import re
+        try:
+            re.compile(url_pattern)
+        except re.error as e:
+            return label + f"エラー: 無効な正規表現パターン: {e}"
+
+    # CLI subprocess に委譲
+    cli_args: list[str] = []
+    if url_pattern:
+        cli_args.extend(["--url-pattern", url_pattern])
+    if max_pages is not None:
+        cli_args.extend(["--max-pages", str(max_pages)])
+    if restart:
+        cli_args.append("--restart")
+    if skip_pipeline:
+        cli_args.append("--skip-pipeline")
+    cli_args.append("--")
+    cli_args.append(validated_url)
+
+    try:
+        result = await cli_subprocess._run_cli_subprocess(
+            "site-crawl", cli_args, ctx=ctx,
+        )
+        return label + cli_subprocess._format_cli_ingest_result(
+            result, context=f"サイト: {validated_url}",
+        )
+    except CLISubprocessError as e:
+        return label + e.format_mcp_error(
+            f"サイトクロールに失敗しました（{validated_url}）",
+        )

--- a/tests/e2e/test_ingest_mcp_scrapy.py
+++ b/tests/e2e/test_ingest_mcp_scrapy.py
@@ -38,7 +38,7 @@ _FAKE_PAGE_URL = "https://example.com/page1"
 
 
 class TestMcpSiteIngest:
-    """MCP 経由の site-ingest 動作確認."""
+    """MCP 経由の site-ingest（取得入口）動作確認."""
 
     async def test_ingest_then_search_returns_chunk(
         self,
@@ -54,7 +54,7 @@ class TestMcpSiteIngest:
         ingest_response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_site_ingest",
-            {"url": _FAKE_PAGE_URL},
+            {"urls": [_FAKE_PAGE_URL]},
         )
         assert "完了" in ingest_response or "placed" in ingest_response.lower(), (
             f"取り込み完了を示すテキストが応答に含まれていない: {ingest_response}"
@@ -81,17 +81,17 @@ class TestMcpSiteIngest:
         response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_site_ingest",
-            {"url": _FAKE_PAGE_URL},
+            {"urls": [_FAKE_PAGE_URL]},
         )
         assert "[FAKE MODE: web]" in response, (
             f"fake モードラベルが応答に含まれていない: {response[:500]}"
         )
 
-    async def test_multi_url_mode(
+    async def test_multi_url(
         self,
         e2e_mcp_server: str,
     ) -> None:
-        """複数 URL モード（urls 引数）でも取り込みが完了する."""
+        """複数 URL の取得入口でも取り込みが完了する."""
         response = await call_mcp_tool(
             e2e_mcp_server,
             "rag_site_ingest",
@@ -103,12 +103,30 @@ class TestMcpSiteIngest:
             },
         )
         assert "完了" in response or "placed" in response.lower(), (
-            f"複数 URL モード取り込みが完了していない: {response[:500]}"
+            f"複数 URL 取り込みが完了していない: {response[:500]}"
+        )
+
+
+class TestMcpSiteCrawl:
+    """MCP 経由の site-crawl（クロール入口）動作確認."""
+
+    async def test_crawl_completes(
+        self,
+        e2e_mcp_server: str,
+    ) -> None:
+        """rag_site_crawl で単一 URL 起点のクロールが完了する."""
+        response = await call_mcp_tool(
+            e2e_mcp_server,
+            "rag_site_crawl",
+            {"url": _FAKE_PAGE_URL},
+        )
+        assert "完了" in response or "placed" in response.lower(), (
+            f"クロール完了を示すテキストが応答に含まれていない: {response}"
         )
 
 
 class TestCliSiteIngest:
-    """CLI 経由の site-ingest 動作確認."""
+    """CLI 経由の site-ingest（取得入口）動作確認."""
 
     def test_cli_site_ingest_succeeds(
         self,
@@ -123,6 +141,30 @@ class TestCliSiteIngest:
         """
         result: subprocess.CompletedProcess[str] = run_cli(
             ["site-ingest", _FAKE_PAGE_URL],
+            env=e2e_subprocess_env,
+            timeout=120.0,
+        )
+        assert result.returncode == 0, (
+            f"CLI が非ゼロ終了: returncode={result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined = result.stdout + result.stderr
+        assert "完了" in combined or "placed" in combined.lower(), (
+            f"CLI 出力に取り込み完了の証跡なし:\n{combined[:1000]}"
+        )
+
+
+class TestCliSiteCrawl:
+    """CLI 経由の site-crawl（クロール入口）動作確認."""
+
+    def test_cli_site_crawl_succeeds(
+        self,
+        e2e_subprocess_env: dict[str, str],
+        e2e_mcp_server: str,  # noqa: ARG002 - ChromaDB を auto_start させるため依存
+    ) -> None:
+        """CLI から site-crawl を実行できる（subprocess 越境）."""
+        result: subprocess.CompletedProcess[str] = run_cli(
+            ["site-crawl", _FAKE_PAGE_URL],
             env=e2e_subprocess_env,
             timeout=120.0,
         )

--- a/tests/expected_tools.py
+++ b/tests/expected_tools.py
@@ -11,7 +11,7 @@ EXPECTED_MCP_TOOL_NAMES: frozenset[str] = frozenset({
     "rag_crawl_bluesky", "rag_add_bluesky",
     "rag_add_youtube", "rag_crawl_youtube",
     "rag_add_document", "rag_add_journal", "rag_crawl_documents",
-    "rag_site_ingest",
+    "rag_site_ingest", "rag_site_crawl",
     "rag_update_aozora_catalog", "rag_search_aozora",
     "rag_add_aozora", "rag_crawl_aozora",
     "rag_delete", "rag_rebuild", "rag_stats",

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -333,19 +333,22 @@ class TestCommandsHaveOutputOption:
         "delete",
         "rebuild",
         "site-ingest",
+        "site-crawl",
     ]
 
-    def test_all_13_commands_have_output_option(self) -> None:
-        """cli.py のソースに 13 コマンド分の _add_output_option 呼び出しがある."""
+    def test_all_commands_have_output_option(self) -> None:
+        """cli.py のソースに _add_output_option 呼び出しが対象コマンド分以上ある."""
         import inspect
         import rag.cli as cli_module
 
         source = inspect.getsource(cli_module)
         count = source.count("_add_output_option(")
         # ヘルパー関数の定義 (def _add_output_option) は除外して呼び出しだけ数える
-        # 定義は 1 つ、呼び出しが 13 個で合計 14 回出現
-        assert count >= 13 + 1, (
-            f"_add_output_option の出現回数が {count} 回（期待: 定義1 + 呼び出し13 = 14）"
+        # 定義 1 + 呼び出しが対象コマンド分以上
+        expected_min = len(self.TARGET_COMMANDS) + 1
+        assert count >= expected_min, (
+            f"_add_output_option の出現回数が {count} 回（期待: 定義1 + 呼び出し >= "
+            f"{len(self.TARGET_COMMANDS)} = {expected_min}）"
         )
 
     @pytest.mark.parametrize("command", TARGET_COMMANDS)
@@ -369,6 +372,7 @@ class TestCommandsHaveOutputOption:
             "delete": "run_delete",
             "rebuild": "run_rebuild",
             "site-ingest": "run_site_ingest",
+            "site-crawl": "run_site_crawl",
         }
 
         func_name = func_names[command]

--- a/tests/test_cli_json_output.py
+++ b/tests/test_cli_json_output.py
@@ -347,8 +347,9 @@ class TestCommandsHaveOutputOption:
         # 定義 1 + 呼び出しが対象コマンド分以上
         expected_min = len(self.TARGET_COMMANDS) + 1
         assert count >= expected_min, (
-            f"_add_output_option の出現回数が {count} 回（期待: 定義1 + 呼び出し >= "
-            f"{len(self.TARGET_COMMANDS)} = {expected_min}）"
+            f"_add_output_option の出現回数が {count} 回"
+            f"（期待: 定義1 + 呼び出し {len(self.TARGET_COMMANDS)} 件以上 = "
+            f"合計 {expected_min} 件以上）"
         )
 
     @pytest.mark.parametrize("command", TARGET_COMMANDS)

--- a/tests/test_cli_skip_pipeline.py
+++ b/tests/test_cli_skip_pipeline.py
@@ -35,6 +35,7 @@ class TestNoPipelineParserRegistration:
             ["ingest-zenn", "https://zenn.dev/u/articles/x", "--skip-pipeline"],
             ["crawl-documents", "/tmp/docs", "--skip-pipeline"],
             ["site-ingest", "https://example.com/", "--skip-pipeline"],
+            ["site-crawl", "https://example.com/", "--skip-pipeline"],
             ["ingest-aozora", "12345", "--skip-pipeline"],
             ["ingest-aozora-author", "00001", "--skip-pipeline"],
             ["delete", "local/.upload/2026/05/10/x.md", "--skip-pipeline"],

--- a/tests/test_pipeline_ingesters_bluesky_delegations.py
+++ b/tests/test_pipeline_ingesters_bluesky_delegations.py
@@ -63,7 +63,7 @@ class TestFollowUrlsClassification:
     @pytest.mark.asyncio
     async def test_skips_bluesky_urls(self) -> None:
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls([
             "https://bsky.app/profile/x.bsky.social/post/r1",
         ])]
@@ -75,7 +75,7 @@ class TestFollowUrlsClassification:
             youtube_request_interval=0.0,
         )
         assert stats["skipped"] == 1
-        runner.run_for_urls.assert_not_called()
+        runner.fetch_urls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_invalid_youtube_url_recorded_as_error(self) -> None:
@@ -98,7 +98,7 @@ class TestFollowUrlsWebDelegation:
     @pytest.mark.asyncio
     async def test_web_url_passed_to_runner(self) -> None:
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             return_value=_make_execution(placed=1),
         )
         items = [_item_with_urls(["https://example.com/article"])]
@@ -110,12 +110,50 @@ class TestFollowUrlsWebDelegation:
             youtube_request_interval=0.0,
         )
         assert stats["web_placed"] == 1
-        runner.run_for_urls.assert_awaited_once()
+        runner.fetch_urls.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_single_web_url_uses_fetch_not_crawl(self) -> None:
+        """**Issue #797 回帰防止**: 投稿内 web URL が 1 本だけのときも fetch_urls を使う.
+
+        旧実装では「web URL が 1 本のとき crawl_urls で start_url=...（クロール
+        モード）にフォールバック → サイト全体クロールに化ける」事故が発生していた。
+        本テストは web_delegator がリンク辿りクロールに分岐しないことを担保する
+        ため、`crawl_*` 系メソッドが呼ばれていないことも合わせて確認する。
+        """
+        runner = AsyncMock()
+        runner.fetch_urls = AsyncMock(
+            return_value=_make_execution(placed=1),
+        )
+        # クロール経路が誤って呼ばれないことを保証するため、属性を意図的に
+        # AsyncMock として並べておく（呼ばれたら最後の assert_not_called で検出）
+        runner.crawl_url = AsyncMock()
+        runner.crawl_urls = AsyncMock()
+        runner.run_for_urls = AsyncMock()  # 旧 Protocol 名
+
+        # 投稿内に web URL が 1 本だけ存在するケース
+        items = [_item_with_urls(["https://example.com/single-page"])]
+        stats = await follow_urls(
+            items,
+            classifier=RealYoutubeClassifier(),
+            youtube_delegator=None,
+            web_delegator=runner,
+            youtube_request_interval=0.0,
+        )
+
+        assert stats["web_placed"] == 1
+        runner.fetch_urls.assert_awaited_once()
+        called_urls = runner.fetch_urls.await_args[0][0]
+        assert called_urls == ["https://example.com/single-page"]
+        # クロール経路はいずれも呼ばれていない
+        runner.crawl_url.assert_not_called()
+        runner.crawl_urls.assert_not_called()
+        runner.run_for_urls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_web_dedup_across_items(self) -> None:
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             return_value=_make_execution(placed=1),
         )
         items = [
@@ -129,14 +167,14 @@ class TestFollowUrlsWebDelegation:
             web_delegator=runner,
             youtube_request_interval=0.0,
         )
-        # run_for_urls には 1 件だけ
-        called_urls = runner.run_for_urls.await_args[0][0]
+        # fetch_urls には 1 件だけ
+        called_urls = runner.fetch_urls.await_args[0][0]
         assert called_urls == ["https://example.com/dup"]
 
     @pytest.mark.asyncio
     async def test_runner_failure_recorded(self) -> None:
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             side_effect=RuntimeError("scrapy failed"),
         )
         result = IngestResult()
@@ -165,7 +203,7 @@ class TestFollowUrlsYoutubeDelegation:
         yt_result.placed = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
         stats = await follow_urls(
             items,
@@ -180,7 +218,7 @@ class TestFollowUrlsYoutubeDelegation:
     @pytest.mark.asyncio
     async def test_youtube_skipped_when_delegator_none(self) -> None:
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
         stats = await follow_urls(
             items,
@@ -197,7 +235,7 @@ class TestFollowUrlsYoutubeDelegation:
         delegator = AsyncMock()
         delegator.unload_whisper = MagicMock()
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(
             ["https://youtu.be/abcdEFG1234"], suppress=True,
         )]
@@ -220,7 +258,7 @@ class TestFollowUrlsYoutubeDelegation:
         yt_result.placed = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(
             ["https://youtu.be/abcdEFG1234"], suppress=True,
         )]
@@ -242,7 +280,7 @@ class TestFollowUrlsYoutubeDelegation:
             side_effect=RuntimeError("yt failed"),
         )
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         result = IngestResult()
         items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
         stats = await follow_urls(
@@ -274,7 +312,7 @@ class TestFollowUrlsYoutubeDelegation:
         yt_result.placed = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls([
             "https://youtu.be/abcdEFG1234",
             "https://youtu.be/abcdEFG5678",
@@ -302,7 +340,7 @@ class TestFollowUrlsYoutubeDelegation:
         yt_result.placed = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [
             _item_with_urls(["https://youtu.be/abcdEFG1234"], suppress=True),
             _item_with_urls(["https://youtu.be/abcdEFG1234"], suppress=False),
@@ -362,7 +400,7 @@ class TestFollowUrlsOverwriteBreakdown:
     async def test_web_overwritten_counted_separately(self) -> None:
         """web の上書きのみのケースで web_overwritten が計上される."""
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             return_value=_make_execution(placed=0, overwritten=1),
         )
         items = [_item_with_urls(["https://example.com/article"])]
@@ -391,7 +429,7 @@ class TestFollowUrlsOverwriteBreakdown:
         yt_result.overwritten = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(return_value=_make_execution())
+        runner.fetch_urls = AsyncMock(return_value=_make_execution())
         items = [_item_with_urls(["https://youtu.be/abcdEFG1234"])]
         stats = await follow_urls(
             items,
@@ -414,7 +452,7 @@ class TestFollowUrlsOverwriteBreakdown:
         yt_b.overwritten = 1
         delegator.ingest_videos = AsyncMock(side_effect=[[yt_a], [yt_b]])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             return_value=_make_execution(placed=2, overwritten=1),
         )
         items = [_item_with_urls([
@@ -449,7 +487,7 @@ class TestFollowUrlsOverwriteBreakdown:
         yt_result.overwritten = 1
         delegator.ingest_videos = AsyncMock(return_value=[yt_result])
         runner = AsyncMock()
-        runner.run_for_urls = AsyncMock(
+        runner.fetch_urls = AsyncMock(
             return_value=_make_execution(placed=1, overwritten=2),
         )
         items = [_item_with_urls([

--- a/tests/test_pipeline_ingesters_bluesky_fetcher.py
+++ b/tests/test_pipeline_ingesters_bluesky_fetcher.py
@@ -82,13 +82,14 @@ class TestProtocolDefinitions:
         # 仕様: docs/specs/ingesters/youtube.md「Whisper モデルライフサイクル」
         assert names == {"ingest_videos", "unload_whisper"}
 
-    def test_web_delegator_protocol_has_run_for_urls(self) -> None:
+    def test_web_delegator_protocol_has_only_fetch_urls(self) -> None:
+        """WebDelegator は fetch_urls のみを公開する（Issue #797: クロール委譲を提供しない）."""
         names = {
             name
             for name, member in inspect.getmembers(WebDelegator)
             if not name.startswith("_") and inspect.isfunction(member)
         }
-        assert names == {"run_for_urls"}
+        assert names == {"fetch_urls"}
 
 
 class TestBlueskyFakeModeSettings:

--- a/tests/test_pipeline_ingesters_web.py
+++ b/tests/test_pipeline_ingesters_web.py
@@ -4,16 +4,23 @@
 仕様: docs/specs/site-ingest.md
 
 テスト方針:
-- WebIngester.crawl_urls が ScrapyRunner と Bridge を正しく呼び出すこと
-- 単一 URL（クロールモード）と複数 URL（複数 URL モード）で正しい引数が渡ること
+- WebIngester.crawl_url（クロール、リンク辿りあり）が ScrapyRunner.run(start_url=...)
+  と Bridge を正しく呼び出すこと
+- WebIngester.fetch_urls（取得、リンク辿りなし）が ScrapyRunner.run(start_urls=...)
+  と Bridge を正しく呼び出すこと
+- 1 件のみの URL でも fetch_urls 経路はリンク辿りを発動しないこと（Issue #797 回帰防止）
 - JSONL 未出力時の早期 return（no_output=True）
-- 空 URL リストの拒否
+- 空 URL リスト / 空 URL の拒否
 - crawl_result が SiteIngestExecution に保持されること（cleanup 責務は呼び出し元）
 
-背景: #686 — site-ingest コア処理を Python API として切り出し、bluesky から
-subprocess を介さず直接呼び出せるようにした。
-#706 — site_ingest_runner.py を ingesters/web/ パッケージに統合し WebIngester に
-リネーム。ScrapyRunner Protocol を Fetcher 相当依存として注入する構造に整理。
+背景:
+- #686 — site-ingest コア処理を Python API として切り出し、bluesky から
+  subprocess を介さず直接呼び出せるようにした
+- #706 — site_ingest_runner.py を ingesters/web/ パッケージに統合し WebIngester に
+  リネーム。ScrapyRunner Protocol を Fetcher 相当依存として注入する構造に整理
+- #797 — 単一 URL 投入時に件数ヒューリスティックでクロールに化ける巻き込み事故を
+  構造的に排除するため crawl_urls を crawl_url（単一 URL）/ fetch_urls（複数 URL）に
+  物理分離
 """
 
 from __future__ import annotations
@@ -42,18 +49,18 @@ def _make_web_ingester(
 
 
 @pytest.mark.asyncio
-class TestWebIngesterCrawlUrls:
-    async def test_empty_urls_raises(self) -> None:
-        """URL 0 件で ValueError を送出すること."""
+class TestWebIngesterCrawlUrl:
+    """クロール入口（``crawl_url``）の検証."""
+
+    async def test_empty_url_raises(self) -> None:
+        """url 空文字で ValueError を送出すること."""
         scrapy_runner = MagicMock()
         ingester = WebIngester(MagicMock(), scrapy_runner=scrapy_runner)
-        with pytest.raises(ValueError, match="at least one URL"):
-            await ingester.crawl_urls(
-                urls=[],
-            )
+        with pytest.raises(ValueError, match="url is required"):
+            await ingester.crawl_url(url="")
 
-    async def test_single_url_dispatches_crawl_mode(self) -> None:
-        """1 URL でクロールモード（start_url）として ScrapyRunner.run を呼ぶこと."""
+    async def test_dispatches_crawl_mode(self) -> None:
+        """ScrapyRunner.run を start_url + クロール固有引数で呼ぶこと."""
         crawl_result = CrawlResult(
             exit_code=0,
             output_dir=Path("/tmp/out"),
@@ -62,11 +69,11 @@ class TestWebIngesterCrawlUrls:
         )
         ingester, scrapy_runner, _ = _make_web_ingester(crawl_result)
 
-        execution = await ingester.crawl_urls(
-            urls=["https://example.com/page"],
+        execution = await ingester.crawl_url(
+            url="https://example.com/page",
             url_pattern="^https://example\\.com/",
             max_pages=10,
-            force=True,
+            restart=True,
         )
 
         kwargs = scrapy_runner.run.await_args.kwargs
@@ -74,13 +81,13 @@ class TestWebIngesterCrawlUrls:
         assert kwargs["allowed_domains"] == "example.com"
         assert kwargs["url_pattern"] == "^https://example\\.com/"
         assert kwargs["max_pages"] == 10
-        assert kwargs["force"] is True
+        assert kwargs["restart"] is True
         assert "start_urls" not in kwargs
         assert execution.no_output is True
         assert execution.crawl_result is crawl_result
 
-    async def test_multi_url_dispatches_multi_mode(self) -> None:
-        """2 URL 以上で複数 URL モード（start_urls）として呼ぶこと."""
+    async def test_url_pattern_defaults_to_empty(self) -> None:
+        """url_pattern 未指定時に空文字列を渡すこと."""
         crawl_result = CrawlResult(
             exit_code=0,
             output_dir=Path("/tmp/out"),
@@ -89,7 +96,62 @@ class TestWebIngesterCrawlUrls:
         )
         ingester, scrapy_runner, _ = _make_web_ingester(crawl_result)
 
-        execution = await ingester.crawl_urls(
+        await ingester.crawl_url(url="https://example.com/")
+
+        kwargs = scrapy_runner.run.await_args.kwargs
+        assert kwargs["url_pattern"] == ""
+        assert kwargs["restart"] is False
+
+
+@pytest.mark.asyncio
+class TestWebIngesterFetchUrls:
+    """取得入口（``fetch_urls``）の検証."""
+
+    async def test_empty_urls_raises(self) -> None:
+        """URL 0 件で ValueError を送出すること."""
+        scrapy_runner = MagicMock()
+        ingester = WebIngester(MagicMock(), scrapy_runner=scrapy_runner)
+        with pytest.raises(ValueError, match="at least one URL"):
+            await ingester.fetch_urls(urls=[])
+
+    async def test_single_url_does_not_trigger_crawl(self) -> None:
+        """**Issue #797**: 単一 URL でも fetch_urls 経路は start_urls 系統で呼び出す.
+
+        従来は crawl_urls(urls=[single]) で件数ヒューリスティックにより
+        start_url 系統（クロール）にフォールバックしていたため、BlueSky 経路で
+        投稿内 web URL が 1 本だったときにサイト全体クロールに化けていた。
+        本テストは fetch_urls が**常に** start_urls 系統で Runner を呼び出す
+        ことを保証する。
+        """
+        crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/out"),
+            jsonl_path=Path("/tmp/out/nonexistent.jsonl"),
+            success=True,
+        )
+        ingester, scrapy_runner, _ = _make_web_ingester(crawl_result)
+
+        await ingester.fetch_urls(urls=["https://example.com/page"])
+
+        kwargs = scrapy_runner.run.await_args.kwargs
+        assert kwargs["start_urls"] == ["https://example.com/page"]
+        assert "start_url" not in kwargs
+        # クロール固有オプションは渡らない
+        assert "url_pattern" not in kwargs
+        assert "max_pages" not in kwargs
+        assert "restart" not in kwargs
+
+    async def test_multi_url_dispatches_with_allowed_domains_union(self) -> None:
+        """2 URL 以上で start_urls + ドメインの和集合で呼ぶこと."""
+        crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/out"),
+            jsonl_path=Path("/tmp/out/nonexistent.jsonl"),
+            success=True,
+        )
+        ingester, scrapy_runner, _ = _make_web_ingester(crawl_result)
+
+        await ingester.fetch_urls(
             urls=["https://a.example.com/x", "https://b.example.com/y"],
         )
 
@@ -97,13 +159,15 @@ class TestWebIngesterCrawlUrls:
         assert kwargs["start_urls"] == [
             "https://a.example.com/x", "https://b.example.com/y",
         ]
-        # ドメインの和集合
         assert set(kwargs["allowed_domains"].split(",")) == {
             "a.example.com", "b.example.com",
         }
         assert "start_url" not in kwargs
-        assert "url_pattern" not in kwargs
-        assert execution.no_output is True
+
+
+@pytest.mark.asyncio
+class TestWebIngesterBridge:
+    """Bridge 呼び出し・SiteIngestExecution 構築の検証."""
 
     async def test_invokes_bridge_when_jsonl_exists(self, tmp_path: Path) -> None:
         """JSONL が存在する場合、Bridge を呼び出して bridge 結果を保持すること."""
@@ -128,9 +192,7 @@ class TestWebIngesterCrawlUrls:
             "rag.pipeline.ingesters.web._facade.import_to_source_store",
             return_value=bridge_result,
         ) as mock_bridge:
-            execution = await ingester.crawl_urls(
-                urls=["https://example.com/page"],
-            )
+            execution = await ingester.fetch_urls(urls=["https://example.com/page"])
 
         mock_bridge.assert_called_once_with(
             jsonl_path=jsonl_path,
@@ -159,9 +221,7 @@ class TestWebIngesterCrawlUrls:
             "rag.pipeline.ingesters.web._facade.import_to_source_store",
             return_value=BridgeResult(),
         ):
-            execution = await ingester.crawl_urls(
-                urls=["https://example.com/p"],
-            )
+            execution = await ingester.fetch_urls(urls=["https://example.com/p"])
 
         crawl_result.cleanup.assert_not_called()
         assert execution.crawl_result is crawl_result

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -1045,8 +1045,8 @@ class TestRagRebuildTool:
         assert "エラー" in result
 
 
-class TestRagSiteIngestSafeBrowsing:
-    """rag_site_ingest の Safe Browsing チェックテスト（#481）."""
+class TestRagSiteCrawlSafeBrowsing:
+    """rag_site_crawl の Safe Browsing チェックテスト（#481 / Issue #797 で rag_site_crawl に移動）."""
 
     @pytest.mark.asyncio
     async def test_unsafe_url_returns_error(self) -> None:
@@ -1077,7 +1077,7 @@ class TestRagSiteIngestSafeBrowsing:
             patch("rag.config.get_settings", return_value=mock_settings),
             patch("rag.utils.url.check_ssrf"),
         ):
-            result = await mod.rag_site_ingest("https://malicious.example.com")
+            result = await mod.rag_site_crawl("https://malicious.example.com")
 
         assert "エラー" in result
         assert "安全でない" in result
@@ -1095,7 +1095,7 @@ class TestRagSiteIngestSafeBrowsing:
             patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_cli_result) as mock_run,
             patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="取り込み完了"),
         ):
-            result = await mod.rag_site_ingest(url="https://example.com")
+            result = await mod.rag_site_crawl(url="https://example.com")
 
         # Safe Browsing でブロックされず、CLI 委譲まで到達していること
         mock_run.assert_called_once()

--- a/tests/test_scrapy_runner.py
+++ b/tests/test_scrapy_runner.py
@@ -6,7 +6,7 @@
 - subprocess ラッパーのモックテスト（Scrapy プロセスの起動・終了・エラーハンドリング）
 - _build_spider_script の設定値埋め込み（JSON ファイル経由）
 - ディレクトリ構造の準備（crawl_dir, html_dir, jobdir）
-- --force オプションによるクロールディレクトリ削除
+- --restart オプションによるクロールディレクトリ削除（旧 --force、Issue #797 でリネーム）
 - クロールキーによる JOBDIR 分離
 """
 
@@ -355,8 +355,8 @@ class TestRealScrapyRunnerRun:
         assert result.output_dir.parent.parent.name == "docs.example.com"
 
     @pytest.mark.asyncio()
-    async def test_force_deletes_crawl_dir(self, tmp_path: Path) -> None:
-        """--force でクロールディレクトリが削除されること."""
+    async def test_restart_deletes_crawl_dir(self, tmp_path: Path) -> None:
+        """--restart でクロールディレクトリが削除されること（旧 --force）."""
         runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
 
         crawl_dir = _expected_crawl_dir(tmp_path, "https://example.com")
@@ -378,7 +378,7 @@ class TestRealScrapyRunnerRun:
         mock_process.stderr = _async_lines_iter([])
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
-            await runner.run(start_url="https://example.com", force=True)
+            await runner.run(start_url="https://example.com", restart=True)
 
         # 旧ファイルが全て削除されている（run 内で mkdir されるのでディレクトリ自体は再作成される）
         assert not (jobdir / "requests.seen").exists()
@@ -705,8 +705,8 @@ class TestJobdirIsolation:
         assert result_1.jsonl_path == result_2.jsonl_path
 
     @pytest.mark.asyncio()
-    async def test_force_does_not_affect_other_crawl(self, tmp_path: Path) -> None:
-        """--force は対象クロールのディレクトリのみ削除し、他のクロールに影響しない."""
+    async def test_restart_does_not_affect_other_crawl(self, tmp_path: Path) -> None:
+        """--restart は対象クロールのディレクトリのみ削除し、他のクロールに影響しない."""
         runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
 
         mock_process = AsyncMock()
@@ -723,13 +723,86 @@ class TestJobdirIsolation:
         marker_file = result_a.output_dir / "marker.html"
         marker_file.write_text("data", encoding="utf-8")
 
-        # 2回目のクロール（b.html）を --force で実行
+        # 2回目のクロール（b.html）を --restart で実行
         with patch("asyncio.create_subprocess_exec", return_value=mock_process):
             await runner.run(
                 start_url="https://example.com/b.html",
                 url_pattern="b",
-                force=True,
+                restart=True,
             )
 
         # a のマーカーファイルは影響を受けていない
         assert marker_file.exists()
+
+
+# --- 入口分離（Issue #797 回帰防止）テスト ---
+
+
+class TestEntryPointSeparation:
+    """`start_url` / `start_urls` の入口分離を検証する（Issue #797）.
+
+    旧 runner は ``start_urls`` が 1 件のときクロールモードに自動切替する
+    件数ヒューリスティックを持っており、BlueSky 経路で「投稿内 web URL が
+    たまたま 1 本」のときサイト全体クロールに化ける巻き込みバグが発生していた。
+    本テストはこの動作が再発しないことを保証する。
+    """
+
+    @pytest.mark.asyncio()
+    async def test_start_urls_single_url_does_not_trigger_crawl(
+        self, tmp_path: Path,
+    ) -> None:
+        """start_urls に 1 件だけ渡しても no_follow=True（リンク辿りなし）になること."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_urls=["https://example.com/page"])
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        # 取得モード: no_follow=True、url_pattern は無効化、max_pages は無制限（0）
+        assert params["no_follow"] is True
+        assert params["url_pattern"] == ""
+        assert params["max_pages"] == 0
+        # ドメインは _multi_（複数 URL 経路の共通配置）
+        assert result.output_dir.parent.parent.name == "_multi_"
+
+    @pytest.mark.asyncio()
+    async def test_start_url_triggers_crawl_mode(self, tmp_path: Path) -> None:
+        """start_url を明示指定したときは no_follow=False（クロール）になること."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+
+        mock_process = AsyncMock()
+        mock_process.wait.return_value = 0
+        mock_process.stderr = _async_lines_iter([])
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_process):
+            result = await runner.run(start_url="https://example.com/docs/")
+
+        params_path = result.output_dir.parent / "spider_params.json"
+        params = json.loads(params_path.read_text(encoding="utf-8"))
+        assert params["no_follow"] is False
+        # ドメインは実ホスト
+        assert result.output_dir.parent.parent.name == "example.com"
+
+    @pytest.mark.asyncio()
+    async def test_start_url_and_start_urls_both_raises(self, tmp_path: Path) -> None:
+        """start_url と start_urls の同時指定は ValueError を送出する."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+        with pytest.raises(ValueError, match="排他"):
+            await runner.run(
+                start_url="https://example.com/",
+                start_urls=["https://example.com/p1"],
+            )
+
+    @pytest.mark.asyncio()
+    async def test_neither_start_url_nor_start_urls_raises(
+        self, tmp_path: Path,
+    ) -> None:
+        """start_url / start_urls 両方未指定は ValueError を送出する."""
+        runner = RealScrapyRunner(**make_scrapy_runner_args(temp_dir=tmp_path))
+        with pytest.raises(ValueError, match="必須"):
+            await runner.run()

--- a/tests/test_scrapy_site_ingest.py
+++ b/tests/test_scrapy_site_ingest.py
@@ -1,23 +1,28 @@
-"""site-ingest の MCP ツール / CLI コマンド統合テスト.
+"""site-ingest / site-crawl の MCP ツール / CLI コマンド統合テスト.
 
 仕様: docs/specs/site-ingest.md
 
+Issue #797 で入口を 2 つに物理分離した:
+- MCP ``rag_site_ingest`` / CLI ``site-ingest`` — 取得入口（リンク辿りなし、複数 URL OK）
+- MCP ``rag_site_crawl`` / CLI ``site-crawl`` — クロール入口（リンク辿りあり、単一 URL）
+
 テスト方針:
-- MCP ツール（rag_site_ingest）の入力バリデーション・CLI 委譲フロー
-- CLI コマンド（site-ingest）の入力バリデーション・全体フロー
+- MCP ツールの入力バリデーション・CLI 委譲フロー
+- CLI コマンドの入力バリデーション・全体フロー
 - URL バリデーション（空、スキーム不正）
 - SSRF チェック（プライベート IP 拒否）
-- url_pattern の正規表現バリデーション
-- max_pages のクランプ（下限 1、上限 1000）— CLI レイヤーでテスト
+- url_pattern の正規表現バリデーション（site-crawl のみ）
+- max_pages のクランプ（下限 1、上限 1000）— CLI レイヤーでテスト（site-crawl のみ）
 - MCP は _run_cli_subprocess に委譲 → 引数とフォーマットを検証
 - ScrapyRunner → Bridge → pipeline の統合フロー（CLI テスト、モック）
-- Config 設定値の反映
+- site-ingest は単一 URL でもリンク辿りクロールに化けないこと（Issue #797 回帰）
 """
 
 from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 from importlib import import_module
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -37,282 +42,17 @@ def _reset_global_state() -> None:
 def _bypass_write_lock():
     """CLI の write_lock 取得を no-op にする.
 
-    本ファイルの CLI 統合テストは `_build_cli_pipeline_controller` を
+    本ファイルの CLI 統合テストは ``_build_cli_pipeline_controller`` を
     MagicMock で置き換える都合上、controller.source_store.root_dir が
-    MagicMock オブジェクトになる。そのまま `_write_lock_or_exit` を通すと
-    実際に `Path(MagicMock)` から `MagicMock/mock.source_store.root_dir/...`
+    MagicMock オブジェクトになる。そのまま ``_write_lock_or_exit`` を通すと
+    実際に ``Path(MagicMock)`` から ``MagicMock/mock.source_store.root_dir/...``
     ディレクトリが作成されてしまうため、ヘルパーを no-op に差し替える。
-
-    トレードオフ:
-    - メリット: 各テストで tmp_path fixture を引き回して
-      `mock_controller.source_store.root_dir = tmp_path` を設定する
-      ボイラープレートが不要になる（修正が 1 箇所で済む）
-    - デメリット: 本ファイルの CLI 統合テストでは write_lock の挙動
-      （競合時の exit、kind 伝搬）自体は検証されない。これらは
-      `tests/test_cli_lock_conflict.py`（ユニット）と
-      `tests/test_file_lock_subprocess.py`（実 subprocess での OS 自動解放）
-      で個別に担保している。本ファイルは site-ingest のフロー検証が主眼のため、
-      ロック挙動を bypass してもカバレッジに穴は空かない
     """
     with patch(
         "rag.cli._write_lock_or_exit",
         new=lambda *args, **kwargs: contextlib.nullcontext(),
     ):
         yield
-
-
-# --- MCP ツール rag_site_ingest テスト ---
-
-
-class TestMcpSiteIngestToolRegistered:
-    """MCP サーバーにツールが登録されていること."""
-
-    @pytest.mark.asyncio
-    async def test_rag_site_ingest_in_tool_list(self) -> None:
-        """rag_site_ingest がツール一覧に含まれること."""
-        mod = import_module("rag.server")
-        tools = await mod.mcp.list_tools()
-        tool_names = {t.name for t in tools}
-        assert "rag_site_ingest" in tool_names
-
-
-class TestMcpSiteIngestValidation:
-    """rag_site_ingest の入力バリデーションテスト."""
-
-    @pytest.mark.asyncio
-    async def test_empty_url_returns_error(self) -> None:
-        """空 URL がエラーを返すこと."""
-        mod = import_module("rag.server")
-        result = await mod.rag_site_ingest(url="", url_pattern="", max_pages=None, force=False)
-        assert "エラー" in result
-
-    @pytest.mark.asyncio
-    async def test_invalid_scheme_returns_error(self) -> None:
-        """http/https 以外のスキームがエラーを返すこと."""
-        mod = import_module("rag.server")
-        result = await mod.rag_site_ingest(url="ftp://example.com", url_pattern="", max_pages=None, force=False)
-        assert "エラー" in result
-
-    @pytest.mark.asyncio
-    async def test_ssrf_private_ip_returns_error(self) -> None:
-        """プライベート IP がエラーを返すこと."""
-        mod = import_module("rag.server")
-        result = await mod.rag_site_ingest(url="http://192.168.1.1/page", url_pattern="", max_pages=None, force=False)
-        assert "エラー" in result
-
-    @pytest.mark.asyncio
-    async def test_ssrf_localhost_returns_error(self) -> None:
-        """localhost がエラーを返すこと."""
-        mod = import_module("rag.server")
-        result = await mod.rag_site_ingest(url="http://localhost/page", url_pattern="", max_pages=None, force=False)
-        assert "エラー" in result
-
-    @pytest.mark.asyncio
-    async def test_invalid_regex_pattern_returns_error(self) -> None:
-        """不正な正規表現パターンがエラーを返すこと."""
-        mod = import_module("rag.server")
-        with patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None):
-            result = await mod.rag_site_ingest(
-                url="https://example.com",
-                url_pattern="[invalid(",
-                max_pages=None,
-                force=False,
-            )
-        assert "エラー" in result
-        assert "正規表現" in result
-
-    @pytest.mark.asyncio
-    async def test_url_and_urls_exclusive_returns_error(self) -> None:
-        """url と urls の同時指定がエラーを返すこと."""
-        mod = import_module("rag.server")
-        result = await mod.rag_site_ingest(
-            url="https://example.com",
-            urls=["https://example.org"],
-            max_pages=None,
-            force=False,
-        )
-        assert "エラー" in result
-        assert "排他" in result
-
-
-class TestMcpSiteIngestCliDelegation:
-    """rag_site_ingest が _run_cli_subprocess に正しく委譲すること."""
-
-    @pytest.mark.asyncio
-    async def test_single_url_delegates_to_cli(self) -> None:
-        """単一 URL モードで正しい CLI 引数が渡されること."""
-        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
-            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK") as mock_format,
-        ):
-            result = await mod.rag_site_ingest(
-                url="https://example.com",
-                url_pattern="",
-                max_pages=10,
-                force=False,
-            )
-            mock_cli.assert_called_once()
-            call_args = mock_cli.call_args
-            assert call_args[0][0] == "site-ingest"
-            cli_args = call_args[0][1]
-            assert "https://example.com" in cli_args
-            assert "--max-pages" in cli_args
-            assert "10" in cli_args
-            mock_format.assert_called_once()
-            # fake モード時は応答冒頭に [FAKE MODE: web] ラベルが付与されるため endswith で検証
-            assert result.endswith("OK")
-
-    @pytest.mark.asyncio
-    async def test_single_url_with_pattern_and_force(self) -> None:
-        """url_pattern と force が CLI 引数に含まれること."""
-        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
-            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
-        ):
-            await mod.rag_site_ingest(
-                url="https://example.com",
-                url_pattern=r"/docs/.*",
-                max_pages=50,
-                force=True,
-            )
-            cli_args = mock_cli.call_args[0][1]
-            assert "--url-pattern" in cli_args
-            assert r"/docs/.*" in cli_args
-            assert "--force" in cli_args
-            assert "--max-pages" in cli_args
-            assert "50" in cli_args
-
-    @pytest.mark.asyncio
-    async def test_multi_url_delegates_to_cli(self) -> None:
-        """複数 URL モードで正しい CLI 引数が渡されること."""
-        mock_result = {"placed": 2, "skipped": 0, "overwritten": 0, "errors": 0}
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
-            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
-        ):
-            await mod.rag_site_ingest(
-                urls=["https://example.com/a", "https://example.com/b"],
-                max_pages=None,
-                force=False,
-            )
-            cli_args = mock_cli.call_args[0][1]
-            assert "https://example.com/a" in cli_args
-            assert "https://example.com/b" in cli_args
-            # 複数 URL モードでは url_pattern/max_pages/force は含まれない
-            assert "--url-pattern" not in cli_args
-            assert "--max-pages" not in cli_args
-            assert "--force" not in cli_args
-
-    @pytest.mark.asyncio
-    async def test_skip_pipeline_flag_passed(self) -> None:
-        """skip_pipeline フラグが CLI 引数に --skip-pipeline として含まれること."""
-        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
-            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
-        ):
-            await mod.rag_site_ingest(
-                url="https://example.com",
-                skip_pipeline=True,
-            )
-            cli_args = mock_cli.call_args[0][1]
-            assert "--skip-pipeline" in cli_args
-
-    @pytest.mark.asyncio
-    async def test_cli_subprocess_error_returns_error_message(self) -> None:
-        """CLISubprocessError が適切なエラーメッセージに変換されること."""
-        from rag.server.cli_subprocess import CLISubprocessError
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, side_effect=CLISubprocessError("failed")),
-        ):
-            result = await mod.rag_site_ingest(
-                url="https://example.com",
-                max_pages=10,
-                force=False,
-            )
-            assert "エラー" in result
-            assert "失敗" in result
-
-    @pytest.mark.asyncio
-    async def test_lock_conflict_returns_specific_error(self) -> None:
-        """ロック競合時に専用エラーメッセージが返ること."""
-        from rag.server.cli_subprocess import CLISubprocessError
-
-        mod = import_module("rag.server")
-        with (
-            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
-            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, side_effect=CLISubprocessError("lock", code="LOCK_CONFLICT")),
-        ):
-            result = await mod.rag_site_ingest(
-                url="https://example.com",
-                max_pages=10,
-                force=False,
-            )
-            assert "エラー" in result
-            assert "ロックを保持しています" in result
-
-
-# --- CLI コマンド site-ingest テスト ---
-
-
-class TestCliSiteIngestValidation:
-    """CLI run_site_ingest の入力バリデーションテスト."""
-
-    @pytest.mark.asyncio
-    async def test_empty_url_exits(self) -> None:
-        """空 URL で sys.exit(1) すること."""
-        from rag.cli import run_site_ingest
-
-        args = argparse.Namespace(url=[""], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
-        with pytest.raises(SystemExit) as exc_info:
-            await run_site_ingest(args)
-        assert exc_info.value.code == 1
-
-    @pytest.mark.asyncio
-    async def test_invalid_scheme_exits(self) -> None:
-        """不正スキームで sys.exit(1) すること."""
-        from rag.cli import run_site_ingest
-
-        args = argparse.Namespace(url=["ftp://example.com"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
-        with pytest.raises(SystemExit) as exc_info:
-            await run_site_ingest(args)
-        assert exc_info.value.code == 1
-
-    @pytest.mark.asyncio
-    async def test_ssrf_private_ip_exits(self) -> None:
-        """プライベート IP で sys.exit(1) すること."""
-        from rag.cli import run_site_ingest
-
-        args = argparse.Namespace(url=["http://10.0.0.1/page"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
-        with pytest.raises(SystemExit) as exc_info:
-            await run_site_ingest(args)
-        assert exc_info.value.code == 1
-
-    @pytest.mark.asyncio
-    async def test_invalid_regex_pattern_exits(self) -> None:
-        """不正な正規表現パターンで sys.exit(1) すること."""
-        from rag.cli import run_site_ingest
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="[bad(", max_pages=None, force=False, skip_pipeline=False)
-        with pytest.raises(SystemExit) as exc_info:
-            await run_site_ingest(args)
-        assert exc_info.value.code == 1
 
 
 def _make_cli_mock_settings() -> MagicMock:
@@ -331,93 +71,301 @@ def _make_cli_mock_settings() -> MagicMock:
     s.site_ingest_timeout_sec = 0
     s.site_ingest_error_count = 0
     s.rag_scrapy_fake_mode = False
+    s.rag_embedding_concurrency = 1
     return s
 
 
-class TestCliSiteIngestMaxPagesClamp:
-    """CLI の max_pages クランプ処理テスト."""
+# --- MCP ツール登録テスト ---
+
+
+class TestMcpToolsRegistered:
+    """MCP サーバーに 2 ツールが登録されていること."""
 
     @pytest.mark.asyncio
-    async def test_max_pages_clamped_to_1_when_negative(self) -> None:
-        """max_pages=-1 が 1 にクランプされること."""
-        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
-
-        mock_crawl_result = CrawlResult(
-            exit_code=0,
-            output_dir=Path("/tmp/test"),
-            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
-            success=True,
-        )
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=-1, force=False, skip_pipeline=False)
-
-        with (
-            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
-            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
-        ):
-            from rag.cli import run_site_ingest
-
-            await run_site_ingest(args)
-            call_kwargs = mock_run.call_args.kwargs
-            assert call_kwargs["max_pages"] == 1
+    async def test_rag_site_ingest_in_tool_list(self) -> None:
+        """rag_site_ingest がツール一覧に含まれること."""
+        mod = import_module("rag.server")
+        tools = await mod.mcp.list_tools()
+        tool_names = {t.name for t in tools}
+        assert "rag_site_ingest" in tool_names
 
     @pytest.mark.asyncio
-    async def test_max_pages_clamped_to_1000(self) -> None:
-        """max_pages=999999 が 1000 にクランプされること."""
-        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+    async def test_rag_site_crawl_in_tool_list(self) -> None:
+        """rag_site_crawl がツール一覧に含まれること（Issue #797 で新設）."""
+        mod = import_module("rag.server")
+        tools = await mod.mcp.list_tools()
+        tool_names = {t.name for t in tools}
+        assert "rag_site_crawl" in tool_names
 
-        mock_crawl_result = CrawlResult(
-            exit_code=0,
-            output_dir=Path("/tmp/test"),
-            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
-            success=True,
-        )
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=999999, force=False, skip_pipeline=False)
+# --- MCP ツール rag_site_ingest（取得入口）テスト ---
 
-        with (
-            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
-            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
-        ):
-            from rag.cli import run_site_ingest
 
-            await run_site_ingest(args)
-            call_kwargs = mock_run.call_args.kwargs
-            assert call_kwargs["max_pages"] == 1000
+class TestMcpSiteIngestValidation:
+    """rag_site_ingest の入力バリデーションテスト."""
 
     @pytest.mark.asyncio
-    async def test_max_pages_uses_settings_default(self) -> None:
-        """max_pages 未指定時に設定値が使われること."""
-        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+    async def test_empty_urls_returns_error(self) -> None:
+        """urls が空リストでエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_ingest(urls=[])
+        assert "エラー" in result
 
-        mock_crawl_result = CrawlResult(
-            exit_code=0,
-            output_dir=Path("/tmp/test"),
-            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
-            success=True,
-        )
+    @pytest.mark.asyncio
+    async def test_invalid_scheme_returns_error(self) -> None:
+        """http/https 以外のスキームがエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_ingest(urls=["ftp://example.com"])
+        assert "エラー" in result
 
-        mock_settings = _make_cli_mock_settings()
-        mock_settings.site_ingest_max_pages = 800
+    @pytest.mark.asyncio
+    async def test_ssrf_private_ip_returns_error(self) -> None:
+        """プライベート IP がエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_ingest(urls=["http://192.168.1.1/page"])
+        assert "エラー" in result
 
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=None, force=False, skip_pipeline=False)
 
+class TestMcpSiteIngestCliDelegation:
+    """rag_site_ingest が _run_cli_subprocess に正しく委譲すること."""
+
+    @pytest.mark.asyncio
+    async def test_single_url_delegates_to_cli(self) -> None:
+        """単一 URL でも CLI site-ingest コマンドに委譲され、クロール固有引数が付与されないこと."""
+        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
+
+        mod = import_module("rag.server")
         with (
-            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
-            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), mock_settings)),
+            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
+            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
         ):
-            from rag.cli import run_site_ingest
+            result = await mod.rag_site_ingest(urls=["https://example.com"])
 
+        mock_cli.assert_called_once()
+        call_args = mock_cli.call_args
+        assert call_args[0][0] == "site-ingest"
+        cli_args = call_args[0][1]
+        assert "https://example.com" in cli_args
+        # クロール固有オプションは存在しない（Issue #797 で site-ingest からは消滅）
+        assert "--url-pattern" not in cli_args
+        assert "--max-pages" not in cli_args
+        assert "--force" not in cli_args
+        assert "--restart" not in cli_args
+        assert result.endswith("OK")
+
+    @pytest.mark.asyncio
+    async def test_multi_url_delegates_to_cli(self) -> None:
+        """複数 URL で全 URL が CLI 引数に含まれること."""
+        mock_result = {"placed": 2, "skipped": 0, "overwritten": 0, "errors": 0}
+
+        mod = import_module("rag.server")
+        with (
+            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
+            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
+        ):
+            await mod.rag_site_ingest(
+                urls=["https://example.com/a", "https://example.com/b"],
+            )
+        cli_args = mock_cli.call_args[0][1]
+        assert "https://example.com/a" in cli_args
+        assert "https://example.com/b" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_skip_pipeline_flag_passed(self) -> None:
+        """skip_pipeline=True で --skip-pipeline が CLI 引数に含まれること."""
+        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
+
+        mod = import_module("rag.server")
+        with (
+            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
+            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
+        ):
+            await mod.rag_site_ingest(
+                urls=["https://example.com"], skip_pipeline=True,
+            )
+        cli_args = mock_cli.call_args[0][1]
+        assert "--skip-pipeline" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_cli_subprocess_error_returns_error_message(self) -> None:
+        """CLISubprocessError が適切なエラーメッセージに変換されること."""
+        from rag.server.cli_subprocess import CLISubprocessError
+
+        mod = import_module("rag.server")
+        with patch(
+            "rag.server.cli_subprocess._run_cli_subprocess",
+            new_callable=AsyncMock,
+            side_effect=CLISubprocessError("failed"),
+        ):
+            result = await mod.rag_site_ingest(urls=["https://example.com"])
+        assert "エラー" in result
+        assert "失敗" in result
+
+
+# --- MCP ツール rag_site_crawl（クロール入口）テスト ---
+
+
+class TestMcpSiteCrawlValidation:
+    """rag_site_crawl の入力バリデーションテスト."""
+
+    @pytest.mark.asyncio
+    async def test_empty_url_returns_error(self) -> None:
+        """url が空文字でエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_crawl(url="")
+        assert "エラー" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_scheme_returns_error(self) -> None:
+        """http/https 以外のスキームがエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_crawl(url="ftp://example.com")
+        assert "エラー" in result
+
+    @pytest.mark.asyncio
+    async def test_ssrf_private_ip_returns_error(self) -> None:
+        """プライベート IP がエラーを返すこと."""
+        mod = import_module("rag.server")
+        result = await mod.rag_site_crawl(url="http://192.168.1.1/page")
+        assert "エラー" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_regex_pattern_returns_error(self) -> None:
+        """不正な正規表現パターンがエラーを返すこと."""
+        mod = import_module("rag.server")
+        with patch(
+            "rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client",
+            return_value=None,
+        ):
+            result = await mod.rag_site_crawl(
+                url="https://example.com",
+                url_pattern="[invalid(",
+            )
+        assert "エラー" in result
+        assert "正規表現" in result
+
+
+class TestMcpSiteCrawlCliDelegation:
+    """rag_site_crawl が _run_cli_subprocess に正しく委譲すること."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_cli_with_options(self) -> None:
+        """url_pattern / max_pages / restart が CLI 引数に含まれること."""
+        mock_result = {"placed": 5, "skipped": 0, "overwritten": 0, "errors": 0}
+
+        mod = import_module("rag.server")
+        with (
+            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
+            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
+            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
+        ):
+            await mod.rag_site_crawl(
+                url="https://example.com",
+                url_pattern=r"/docs/.*",
+                max_pages=50,
+                restart=True,
+            )
+        call_args = mock_cli.call_args
+        assert call_args[0][0] == "site-crawl"
+        cli_args = call_args[0][1]
+        assert "https://example.com" in cli_args
+        assert "--url-pattern" in cli_args
+        assert r"/docs/.*" in cli_args
+        assert "--max-pages" in cli_args
+        assert "50" in cli_args
+        assert "--restart" in cli_args
+
+    @pytest.mark.asyncio
+    async def test_minimal_invocation_omits_optional_args(self) -> None:
+        """オプション未指定時に CLI 引数が最小限になること."""
+        mock_result = {"placed": 1, "skipped": 0, "overwritten": 0, "errors": 0}
+
+        mod = import_module("rag.server")
+        with (
+            patch("rag.server.tools.ingest_site.safe_browsing_wiring._get_safe_browsing_client", return_value=None),
+            patch("rag.server.cli_subprocess._run_cli_subprocess", new_callable=AsyncMock, return_value=mock_result) as mock_cli,
+            patch("rag.server.cli_subprocess._format_cli_ingest_result", return_value="OK"),
+        ):
+            await mod.rag_site_crawl(url="https://example.com")
+        cli_args = mock_cli.call_args[0][1]
+        assert "--url-pattern" not in cli_args
+        assert "--max-pages" not in cli_args
+        assert "--restart" not in cli_args
+
+
+# --- CLI コマンド site-ingest（取得入口）テスト ---
+
+
+class TestCliSiteIngestValidation:
+    """CLI run_site_ingest の入力バリデーションテスト."""
+
+    @pytest.mark.asyncio
+    async def test_empty_url_exits(self) -> None:
+        """空 URL で sys.exit(1) すること."""
+        from rag.cli import run_site_ingest
+
+        args = argparse.Namespace(url=[""], skip_pipeline=False)
+        with pytest.raises(SystemExit) as exc_info:
             await run_site_ingest(args)
-            call_kwargs = mock_run.call_args.kwargs
-            assert call_kwargs["max_pages"] == 800
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_scheme_exits(self) -> None:
+        """不正スキームで sys.exit(1) すること."""
+        from rag.cli import run_site_ingest
+
+        args = argparse.Namespace(url=["ftp://example.com"], skip_pipeline=False)
+        with pytest.raises(SystemExit) as exc_info:
+            await run_site_ingest(args)
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ssrf_private_ip_exits(self) -> None:
+        """プライベート IP で sys.exit(1) すること."""
+        from rag.cli import run_site_ingest
+
+        args = argparse.Namespace(url=["http://10.0.0.1/page"], skip_pipeline=False)
+        with pytest.raises(SystemExit) as exc_info:
+            await run_site_ingest(args)
+        assert exc_info.value.code == 1
 
 
 class TestCliSiteIngestFlow:
     """CLI run_site_ingest の統合フローテスト."""
 
     @pytest.mark.asyncio
-    async def test_no_jsonl_returns_without_bridge(self, capsys: pytest.CaptureFixture[str]) -> None:
+    async def test_single_url_does_not_invoke_crawl_mode(self) -> None:
+        """**Issue #797 回帰**: 単一 URL でもリンク辿りクロールを発動しない.
+
+        WebIngester.fetch_urls 経由（start_urls 系統、no_follow=True）で呼ばれる
+        ことを ScrapyRunner.run の kwargs で確認する。
+        """
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/test"),
+            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
+            success=True,
+        )
+        args = argparse.Namespace(
+            url=["https://example.com/page"], skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
+        ):
+            from rag.cli import run_site_ingest
+
+            await run_site_ingest(args)
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs.get("start_urls") == ["https://example.com/page"]
+            assert "start_url" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_jsonl_returns_without_bridge(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
         """JSONL 未出力時に Bridge を呼ばず早期リターンすること."""
         from rag.scrapy.runner import CrawlResult, RealScrapyRunner
 
@@ -427,9 +375,9 @@ class TestCliSiteIngestFlow:
             jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
             success=True,
         )
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
-
+        args = argparse.Namespace(
+            url=["https://example.com"], skip_pipeline=False,
+        )
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
@@ -441,92 +389,35 @@ class TestCliSiteIngestFlow:
             assert "メタデータが出力されませんでした" in captured.out
 
     @pytest.mark.asyncio
-    async def test_successful_ingest_prints_summary(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """正常な取り込みで結果サマリーが出力されること."""
-        import json
-
-        from rag.pipeline.ingesters._common import IngestResult
-        from rag.scrapy.bridge import BridgeResult
-        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
-
-        jsonl_path = tmp_path / "metadata.jsonl"
-        jsonl_path.write_text(
-            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
-            encoding="utf-8",
-        )
-
-        mock_crawl_result = CrawlResult(
-            exit_code=0,
-            output_dir=tmp_path,
-            jsonl_path=jsonl_path,
-            success=True,
-        )
-
-        mock_bridge_result = BridgeResult(
-            ingest=IngestResult(placed=5, skipped=2, overwritten=3, errors=1),
-            total_lines=8,
-            parse_errors=0,
-        )
-
-        mock_pipeline_summary = MagicMock()
-        mock_pipeline_summary.processed = 5
-        mock_pipeline_summary.errors = []
-        mock_pipeline_summary.warnings = []
-
-        mock_controller = MagicMock()
-        mock_controller.source_store = MagicMock()
-        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
-
-        with (
-            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
-            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
-            patch("rag.pipeline.ingesters.web._facade.import_to_source_store", return_value=mock_bridge_result),
-        ):
-            from rag.cli import run_site_ingest
-
-            # exit code は 2 値（0=成功 / 1=致命的失敗）のため errors>0 でも exit 0
-            # 3 値 exit code 化（aborted/errors を exit に反映）は Issue #605 で実装
-            await run_site_ingest(args)
-            captured = capsys.readouterr()
-            # site-ingest の text 出力は IngestResult.summary() 経由で統一される
-            # (仕様: docs/specs/ingesters/common.md)
-            assert "完了: 5件配置" in captured.out
-            assert "上書き: 3件" in captured.out
-            assert "スキップ: 2件" in captured.out
-            assert "エラー: 1件" in captured.out
-            assert "パイプライン: 5件処理" in captured.out
-
-    @pytest.mark.asyncio
     async def test_text_output_uses_ingest_result_summary(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """site-ingest の text 出力が IngestResult.summary() を経由すること.
+        """site-ingest の text 出力が IngestResult.summary() を経由して partial_failures を可視化すること.
 
-        他 ingest コマンドと同じく _print_ingest_result 経由で出力される
-        ことにより、partial_failures / aborted 等の観測性フィールドが
-        欠落なく表示される。
+        他 ingest コマンドと同じく `_print_ingest_result` 経由で出力される
+        ことにより、`partial_failures` / `aborted` 等の観測性フィールドが
+        欠落なく表示される。`_print_ingest_result` 内で partial_failures だけ
+        抜け落ちる退化を防ぐための observability 不変条件テスト。
         """
-        import json
-
         from rag.pipeline.ingesters._common import IngestResult
         from rag.scrapy.bridge import BridgeResult
         from rag.scrapy.runner import CrawlResult, RealScrapyRunner
 
         jsonl_path = tmp_path / "metadata.jsonl"
         jsonl_path.write_text(
-            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
+            json.dumps({
+                "url": "https://example.com/p", "title": "T", "status": 200,
+                "depth": 0, "collected_at": "2025-01-01T00:00:00Z",
+                "filepath": "p.html",
+            }) + "\n",
             encoding="utf-8",
         )
-
         mock_crawl_result = CrawlResult(
             exit_code=0,
             output_dir=tmp_path,
             jsonl_path=jsonl_path,
             success=True,
         )
-
         mock_bridge_result = BridgeResult(
             ingest=IngestResult(
                 placed=2,
@@ -539,18 +430,18 @@ class TestCliSiteIngestFlow:
             total_lines=2,
             parse_errors=0,
         )
-
         mock_pipeline_summary = MagicMock()
         mock_pipeline_summary.processed = 2
         mock_pipeline_summary.errors = []
         mock_pipeline_summary.warnings = []
-
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
-        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
-
+        mock_controller.ingest_and_index = AsyncMock(
+            return_value=mock_pipeline_summary,
+        )
+        args = argparse.Namespace(
+            url=["https://example.com"], skip_pipeline=False,
+        )
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
@@ -565,11 +456,315 @@ class TestCliSiteIngestFlow:
             # context（サイト: ...）が summary に含まれる
             assert "サイト:" in captured.out
 
-    @pytest.mark.asyncio
-    async def test_cleanup_on_success(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        """正常完了時にクロールディレクトリが削除されること."""
-        import json
 
+# --- CLI コマンド site-crawl（クロール入口）テスト ---
+
+
+class TestCliSiteCrawlValidation:
+    """CLI run_site_crawl の入力バリデーションテスト."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_scheme_exits(self) -> None:
+        """不正スキームで sys.exit(1) すること."""
+        from rag.cli import run_site_crawl
+
+        args = argparse.Namespace(
+            url="ftp://example.com",
+            url_pattern="",
+            max_pages=None,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            await run_site_crawl(args)
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_ssrf_private_ip_exits(self) -> None:
+        """プライベート IP で sys.exit(1) すること."""
+        from rag.cli import run_site_crawl
+
+        args = argparse.Namespace(
+            url="http://10.0.0.1/page",
+            url_pattern="",
+            max_pages=None,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            await run_site_crawl(args)
+        assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_regex_pattern_exits(self) -> None:
+        """不正な正規表現パターンで sys.exit(1) すること."""
+        from rag.cli import run_site_crawl
+
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="[bad(",
+            max_pages=None,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            await run_site_crawl(args)
+        assert exc_info.value.code == 1
+
+
+class TestCliSiteCrawlMaxPagesClamp:
+    """CLI run_site_crawl の max_pages クランプ処理テスト."""
+
+    @pytest.mark.asyncio
+    async def test_max_pages_clamped_to_1_when_negative(self) -> None:
+        """max_pages=-1 が 1 にクランプされること."""
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/test"),
+            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
+            success=True,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=-1,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            assert mock_run.call_args.kwargs["max_pages"] == 1
+
+    @pytest.mark.asyncio
+    async def test_max_pages_clamped_to_1000(self) -> None:
+        """max_pages=999999 が 1000 にクランプされること."""
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/test"),
+            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
+            success=True,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=999999,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            assert mock_run.call_args.kwargs["max_pages"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_max_pages_uses_settings_default(self) -> None:
+        """max_pages 未指定時に設定値が使われること."""
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/test"),
+            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
+            success=True,
+        )
+        mock_settings = _make_cli_mock_settings()
+        mock_settings.site_ingest_max_pages = 800
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=None,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result) as mock_run,
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), mock_settings)),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            assert mock_run.call_args.kwargs["max_pages"] == 800
+
+
+class TestCliSiteCrawlFlow:
+    """CLI run_site_crawl の統合フローテスト."""
+
+    @pytest.mark.asyncio
+    async def test_no_jsonl_returns_without_bridge(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """JSONL 未出力時に Bridge を呼ばず早期リターンすること."""
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=Path("/tmp/test"),
+            jsonl_path=Path("/tmp/test/nonexistent.jsonl"),
+            success=True,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=10,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(MagicMock(), _make_cli_mock_settings())),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            captured = capsys.readouterr()
+            assert "メタデータが出力されませんでした" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_successful_crawl_prints_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """正常なクロールで結果サマリーが出力されること."""
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({
+                "url": "https://example.com/p", "title": "T", "status": 200,
+                "depth": 0, "collected_at": "2025-01-01T00:00:00Z",
+                "filepath": "p.html",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+        )
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(placed=5, skipped=2, overwritten=3, errors=1),
+            total_lines=8,
+            parse_errors=0,
+        )
+        mock_pipeline_summary = MagicMock()
+        mock_pipeline_summary.processed = 5
+        mock_pipeline_summary.errors = []
+        mock_pipeline_summary.warnings = []
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+        mock_controller.ingest_and_index = AsyncMock(
+            return_value=mock_pipeline_summary,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=10,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
+            patch("rag.pipeline.ingesters.web._facade.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            captured = capsys.readouterr()
+            assert "完了: 5件配置" in captured.out
+            assert "上書き: 3件" in captured.out
+            assert "スキップ: 2件" in captured.out
+            assert "エラー: 1件" in captured.out
+            assert "パイプライン: 5件処理" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_text_output_uses_ingest_result_summary(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """site-crawl の text 出力が IngestResult.summary() を経由して partial_failures を可視化すること.
+
+        他 ingest コマンドと同じく `_print_ingest_result` 経由で出力される
+        ことにより、`partial_failures` / `aborted` 等の観測性フィールドが
+        欠落なく表示される。`_print_ingest_result` 内で partial_failures だけ
+        抜け落ちる退化を防ぐための observability 不変条件テスト。
+        """
+        from rag.pipeline.ingesters._common import IngestResult
+        from rag.scrapy.bridge import BridgeResult
+        from rag.scrapy.runner import CrawlResult, RealScrapyRunner
+
+        jsonl_path = tmp_path / "metadata.jsonl"
+        jsonl_path.write_text(
+            json.dumps({
+                "url": "https://example.com/p", "title": "T", "status": 200,
+                "depth": 0, "collected_at": "2025-01-01T00:00:00Z",
+                "filepath": "p.html",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        mock_crawl_result = CrawlResult(
+            exit_code=0,
+            output_dir=tmp_path,
+            jsonl_path=jsonl_path,
+            success=True,
+        )
+        mock_bridge_result = BridgeResult(
+            ingest=IngestResult(
+                placed=2,
+                skipped=0,
+                partial_failures=1,
+                partial_failure_details=[
+                    {"target": "https://example.com/img.png", "category": "media_download"},
+                ],
+            ),
+            total_lines=2,
+            parse_errors=0,
+        )
+        mock_pipeline_summary = MagicMock()
+        mock_pipeline_summary.processed = 2
+        mock_pipeline_summary.errors = []
+        mock_pipeline_summary.warnings = []
+        mock_controller = MagicMock()
+        mock_controller.source_store = MagicMock()
+        mock_controller.ingest_and_index = AsyncMock(
+            return_value=mock_pipeline_summary,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=10,
+            restart=False,
+            skip_pipeline=False,
+        )
+        with (
+            patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
+            patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
+            patch("rag.pipeline.ingesters.web._facade.import_to_source_store", return_value=mock_bridge_result),
+        ):
+            from rag.cli import run_site_crawl
+
+            await run_site_crawl(args)
+            captured = capsys.readouterr()
+            assert "部分失敗: 1件" in captured.out
+            assert "サイト:" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_cleanup_on_success(self, tmp_path: Path) -> None:
+        """正常完了時にクロールディレクトリが削除されること."""
         from rag.pipeline.ingesters._common import IngestResult
         from rag.scrapy.bridge import BridgeResult
         from rag.scrapy.runner import CrawlResult, RealScrapyRunner
@@ -577,13 +772,15 @@ class TestCliSiteIngestFlow:
         crawl_dir = tmp_path / "crawl"
         crawl_dir.mkdir()
         (crawl_dir / "dummy.txt").write_text("data", encoding="utf-8")
-
         jsonl_path = tmp_path / "metadata.jsonl"
         jsonl_path.write_text(
-            json.dumps({"url": "https://example.com/p", "title": "T", "status": 200, "depth": 0, "collected_at": "2025-01-01T00:00:00Z", "filepath": "p.html"}) + "\n",
+            json.dumps({
+                "url": "https://example.com/p", "title": "T", "status": 200,
+                "depth": 0, "collected_at": "2025-01-01T00:00:00Z",
+                "filepath": "p.html",
+            }) + "\n",
             encoding="utf-8",
         )
-
         mock_crawl_result = CrawlResult(
             exit_code=0,
             output_dir=tmp_path,
@@ -591,29 +788,32 @@ class TestCliSiteIngestFlow:
             success=True,
             crawl_dir=crawl_dir,
         )
-
         mock_bridge_result = BridgeResult(
             ingest=IngestResult(placed=1, skipped=0, errors=0),
             total_lines=1,
             parse_errors=0,
         )
-
         mock_pipeline_summary = MagicMock()
         mock_pipeline_summary.processed = 1
         mock_pipeline_summary.errors = []
-
         mock_controller = MagicMock()
         mock_controller.source_store = MagicMock()
-        mock_controller.ingest_and_index = AsyncMock(return_value=mock_pipeline_summary)
-
-        args = argparse.Namespace(url=["https://example.com"], url_pattern="", max_pages=10, force=False, skip_pipeline=False)
-
+        mock_controller.ingest_and_index = AsyncMock(
+            return_value=mock_pipeline_summary,
+        )
+        args = argparse.Namespace(
+            url="https://example.com",
+            url_pattern="",
+            max_pages=10,
+            restart=False,
+            skip_pipeline=False,
+        )
         with (
             patch.object(RealScrapyRunner, "run", new_callable=AsyncMock, return_value=mock_crawl_result),
             patch("rag.cli._build_cli_pipeline_controller", return_value=(mock_controller, _make_cli_mock_settings())),
             patch("rag.pipeline.ingesters.web._facade.import_to_source_store", return_value=mock_bridge_result),
         ):
-            from rag.cli import run_site_ingest
+            from rag.cli import run_site_crawl
 
-            await run_site_ingest(args)
+            await run_site_crawl(args)
             assert not crawl_dir.exists()

--- a/tests/test_web_delegator.py
+++ b/tests/test_web_delegator.py
@@ -24,22 +24,39 @@ from rag.store.source_store import SourceStore
 
 class TestRealWebDelegator:
     @pytest.mark.asyncio
-    async def test_run_for_urls_delegates_to_web_ingester(self) -> None:
+    async def test_fetch_urls_delegates_to_web_ingester(self) -> None:
+        """RealWebDelegator.fetch_urls が WebIngester.fetch_urls に委譲すること.
+
+        Issue #797: WebDelegator はクロール委譲を提供しない設計（投稿内 URL
+        自動取り込みでサイト全体クロールへ意図せず化けることを構造的に防ぐ）。
+        """
         expected = SiteIngestExecution()
         web_ingester = AsyncMock(spec=WebIngester)
-        web_ingester.crawl_urls = AsyncMock(return_value=expected)
+        web_ingester.fetch_urls = AsyncMock(return_value=expected)
         delegator = RealWebDelegator(web_ingester=web_ingester)
         urls = ["https://a.example", "https://b.example"]
 
-        result = await delegator.run_for_urls(urls)
+        result = await delegator.fetch_urls(urls)
 
         assert result is expected
-        web_ingester.crawl_urls.assert_awaited_once_with(urls=urls)
+        web_ingester.fetch_urls.assert_awaited_once_with(urls=urls)
 
 
 class TestProtocolContract:
     def test_protocol_is_importable(self) -> None:
         assert WebDelegator is not None
+
+    def test_protocol_has_no_crawl_method(self) -> None:
+        """WebDelegator Protocol に crawl 系の委譲メソッドが存在しないこと.
+
+        BlueSky 等の委譲経路から意図しないクロールを構造的に防ぐ不変条件
+        （Issue #797）。
+        """
+        assert hasattr(WebDelegator, "fetch_urls")
+        # crawl 系メソッド・旧名 run_for_urls は公開しない
+        assert not hasattr(WebDelegator, "crawl_url")
+        assert not hasattr(WebDelegator, "crawl_urls")
+        assert not hasattr(WebDelegator, "run_for_urls")
 
 
 class TestCreateWebDelegator:


### PR DESCRIPTION
## Change type

- [x] ★ fix: バグ修正
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

> **破壊的変更を含む**: CLI `site-ingest` / MCP `rag_site_ingest` の API が変更され、新たに CLI `site-crawl` / MCP `rag_site_crawl` が追加されます。詳細は README の破壊的変更ノートを参照。

## Summary

`site-ingest` が単一 URL 投入時にサイト全体クロールに切り替わる件数ヒューリスティック起因の巻き込みバグ（pc.watch.impress.co.jp の 502 ページ巻き込み・github.com/meta-quest/agentic-tools の 32 ページ巻き込み等）を、入口の物理分離で構造的に解消します。

- **入口分離**: クロール（リンク辿り）専用に CLI `site-crawl` / MCP `rag_site_crawl` を新設、既存の `site-ingest` / `rag_site_ingest` は指定 URL 取得（リンク辿りなし）に再定義
- `RealScrapyRunner.run` の件数ヒューリスティック削除（`start_url` / `start_urls` 排他、同時指定で `ValueError`）
- `WebIngester.crawl_urls` を `crawl_url`（単一クロール）/ `fetch_urls`（複数取得）に分離
- `WebDelegator` Protocol を `fetch_urls` 専用に（クロール委譲は提供しない構造的保証）
- BlueSky 投稿内 URL 自動取り込みを `WebDelegator.fetch_urls` 経路に固定
- `--force` → `--restart` リネーム（JOBDIR レジュームを使わず再実行する意味を明示、MCP `force` → `restart` も同時）
- 仕様書（`docs/specs/site-ingest.md` / `docs/specs/ingesters/bluesky.md` / `docs/specs/rag-knowledge.md` 等）改訂、README に破壊的変更ノート追加、QA SKILL.md に Issue #797 回帰検証ステップ追加
- 回帰防止テスト追加: `start_urls` 1 件で `no_follow=True` 維持、BlueSky 経路がクロール系メソッドを呼ばないモック検証、`WebDelegator` に `crawl_*` メソッドが存在しないことのリフレクション検証

## Test plan

- [x] `uv run pytest`（L1 Unit Test）: 2210 件全 pass
- [x] `uv run pytest tests/e2e/ -m e2e -n0`（L2 Mock E2E）: 6 件全 pass
- [x] `uv run ruff check .` / `uv run mypy src`: clean
- [x] `markdownlint-cli2`（プロジェクト設定）: 0 errors
- [x] L3 本番相当 QA（実 LM Studio・実 ChromaDB・実 stat.go.jp・実 BlueSky API）:
  - B-1 `rag_site_crawl(stat.go.jp, max_pages=20)`: 20 件配置（リンク辿り発動 ✓）
  - B-2 `rag_site_ingest(urls=[jinsui, roudou])`: 2 件のみ配置（クロール非発動 ✓）
  - B-3 `rag_site_ingest(urls=[kakei])`: 単一 URL でも 1 件のみ配置（Issue #797 中核回帰検証 ✓）
  - C-2 `rag_crawl_bluesky(rhythmcan, max_posts=5)`: `URL 自動取り込み: Web 2件` — **agentic-tools 投稿で 1 ページのみ取得、巻き込み非発動を本番相当環境で確認** ✓

## Related issues

Closes #797